### PR TITLE
feature: add endpoint to retrieve botanix gateway address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,6 +307,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "axum"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags 1.3.2",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "backon"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,7 +479,7 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "peeking_take_while",
- "prettyplease",
+ "prettyplease 0.2.4",
  "proc-macro2 1.0.63",
  "quote 1.0.28",
  "regex",
@@ -469,6 +514,7 @@ dependencies = [
  "bitcoin_hashes",
  "hex_lit",
  "secp256k1",
+ "serde",
 ]
 
 [[package]]
@@ -484,6 +530,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
 dependencies = [
  "bitcoin-private",
+ "serde",
 ]
 
 [[package]]
@@ -734,6 +781,7 @@ dependencies = [
  "lazy_static",
  "miniscript",
  "rand 0.6.5",
+ "reqwest",
  "reth-primitives",
  "secp256k1",
 ]
@@ -965,6 +1013,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
 dependencies = [
  "os_str_bytes",
+]
+
+[[package]]
+name = "client"
+version = "0.1.0"
+dependencies = [
+ "prost",
+ "tokio",
+ "tonic",
+ "tonic-build",
 ]
 
 [[package]]
@@ -1708,7 +1766,7 @@ dependencies = [
  "rand 0.8.5",
  "rlp",
  "smallvec",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1735,7 +1793,7 @@ checksum = "53ecafc952c4528d9b51a458d1a8904b81783feff9fde08ab6ed2545ff396872"
 dependencies = [
  "cfg-if",
  "libc",
- "socket2",
+ "socket2 0.4.9",
  "winapi",
 ]
 
@@ -2078,7 +2136,7 @@ dependencies = [
  "ethers-core",
  "eyre",
  "hex",
- "prettyplease",
+ "prettyplease 0.2.4",
  "proc-macro2 1.0.63",
  "quote 1.0.28",
  "regex",
@@ -2340,6 +2398,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "flate2"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2363,6 +2427,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -2925,7 +3004,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -2959,6 +3038,31 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -3242,7 +3346,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd302af1b90f2463a98fa5ad469fc212c8e3175a41c3068601bfa2727591c5be"
 dependencies = [
- "socket2",
+ "socket2 0.4.9",
  "widestring",
  "winapi",
  "winreg",
@@ -3550,9 +3654,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.141"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libloading"
@@ -3722,6 +3826,12 @@ name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "matchit"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed1202b2a6f884ae56f04cff409ab315c5ce26b5e58d7412e484f01fd52f52ef"
 
 [[package]]
 name = "memchr"
@@ -3930,6 +4040,30 @@ name = "more-asserts"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
+
+[[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
 
 [[package]]
 name = "nibble_vec"
@@ -4154,10 +4288,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "729b745ad4a5575dd06a3e1af1414bd330ee561c01b3899eb584baeaa8def17e"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2 1.0.63",
+ "quote 1.0.28",
+ "syn 2.0.18",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "866b5f16f90776b9bb8dc1e1802ac6f0513de3a7a7465867bfbc563dc737faac"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "ordered-float"
@@ -4345,6 +4517,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
+name = "petgraph"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
+dependencies = [
+ "fixedbitset",
+ "indexmap 1.9.3",
+]
+
+[[package]]
 name = "pharos"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4418,9 +4600,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
 
 [[package]]
 name = "pin-utils"
@@ -4594,6 +4776,16 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
+dependencies = [
+ "proc-macro2 1.0.63",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "prettyplease"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ceca8aaf45b5c46ec7ed39fff75f57290368c1846d33d24a122ca81416ab058"
@@ -4711,6 +4903,60 @@ dependencies = [
  "proc-macro2 0.4.30",
  "quote 0.6.13",
  "syn 0.15.44",
+]
+
+[[package]]
+name = "prost"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
+dependencies = [
+ "bytes",
+ "heck",
+ "itertools",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease 0.1.25",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 1.0.109",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2 1.0.63",
+ "quote 1.0.28",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -5123,10 +5369,12 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -5134,6 +5382,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
+ "tokio-native-tls",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -5867,6 +6116,7 @@ dependencies = [
  "bitcoin",
  "btc-wallet",
  "bytes",
+ "client",
  "ethers-core",
  "futures",
  "hex",
@@ -5902,6 +6152,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "tonic",
  "tower",
  "tracing",
  "tracing-futures",
@@ -6957,6 +7208,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "soketto"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7148,6 +7409,12 @@ dependencies = [
  "quote 1.0.28",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "synstructure"
@@ -7379,11 +7646,11 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.2"
+version = "1.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
+checksum = "40de3a2ba249dcb097e01be5e67a5ff53cf250397715a071a81543e8a832a920"
 dependencies = [
- "autocfg 1.1.0",
+ "backtrace",
  "bytes",
  "libc",
  "mio",
@@ -7391,9 +7658,19 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.5.3",
  "tokio-macros",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -7405,6 +7682,16 @@ dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.28",
  "syn 2.0.18",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -7498,6 +7785,47 @@ dependencies = [
  "serde_spanned",
  "toml_datetime",
  "winnow",
+]
+
+[[package]]
+name = "tonic"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64 0.21.0",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6fdaae4c2c638bb70fe42803a26fbd6fc6ac8c72f5c59f67ecc2a2dcabf4b07"
+dependencies = [
+ "prettyplease 0.1.25",
+ "proc-macro2 1.0.63",
+ "prost-build",
+ "quote 1.0.28",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7998,6 +8326,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "vergen"
 version = "8.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8144,6 +8478,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa54963694b65584e170cf5dc46aeb4dcaa5584e652ff5f3952e56d66aff0125"
 dependencies = [
  "rustls-webpki",
+]
+
+[[package]]
+name = "which"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ dependencies = [
  "itertools",
  "proc-macro-error",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "syn 1.0.109",
 ]
 
@@ -218,13 +218,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.68"
+version = "0.1.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
+checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
- "syn 2.0.18",
+ "quote 1.0.30",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -287,7 +287,7 @@ checksum = "fee3da8ef1276b0bee5dd1c7258010d8fffd31801447323115a25560e1327b89"
 dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "syn 1.0.109",
 ]
 
@@ -460,7 +460,7 @@ dependencies = [
  "lazycell",
  "peeking_take_while",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "regex",
  "rustc-hash",
  "shlex",
@@ -481,11 +481,11 @@ dependencies = [
  "peeking_take_while",
  "prettyplease 0.2.4",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -690,8 +690,8 @@ version = "0.16.0"
 source = "git+https://github.com/boa-dev/boa#0e1b32a232109fc0e192c1297a7274091af2ac61"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
- "syn 2.0.18",
+ "quote 1.0.30",
+ "syn 2.0.29",
  "synstructure 0.13.0",
 ]
 
@@ -776,6 +776,7 @@ name = "btc-wallet"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bitcoin",
  "hex",
  "lazy_static",
@@ -993,7 +994,7 @@ dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "syn 1.0.109",
 ]
 
@@ -1047,9 +1048,9 @@ dependencies = [
  "convert_case 0.6.0",
  "parity-scale-codec",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "serde",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1378,7 +1379,7 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
- "quote 1.0.28",
+ "quote 1.0.30",
  "syn 1.0.109",
 ]
 
@@ -1437,7 +1438,7 @@ dependencies = [
  "codespan-reporting",
  "once_cell",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "scratch",
  "syn 1.0.109",
 ]
@@ -1455,7 +1456,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "086c685979a698443656e5cf7856c95c642295a38599f12fb1ff76fb28d19892"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "syn 1.0.109",
 ]
 
@@ -1498,7 +1499,7 @@ dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "strsim 0.9.3",
  "syn 1.0.109",
 ]
@@ -1512,7 +1513,7 @@ dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "strsim 0.10.0",
  "syn 1.0.109",
 ]
@@ -1526,9 +1527,9 @@ dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "strsim 0.10.0",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1538,7 +1539,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core 0.10.2",
- "quote 1.0.28",
+ "quote 1.0.30",
  "syn 1.0.109",
 ]
 
@@ -1549,7 +1550,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b36230598a2d5de7ec1c6f51f72d8a99a9208daff41de2084d06e3fd3ea56685"
 dependencies = [
  "darling_core 0.14.3",
- "quote 1.0.28",
+ "quote 1.0.30",
  "syn 1.0.109",
 ]
 
@@ -1560,8 +1561,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
 dependencies = [
  "darling_core 0.20.1",
- "quote 1.0.28",
- "syn 2.0.18",
+ "quote 1.0.30",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1619,7 +1620,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cdeb9ec472d588e539a818b2dee436825730da08ad0017c4b1a17676bdc8b7"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "syn 1.0.109",
 ]
 
@@ -1632,7 +1633,7 @@ dependencies = [
  "darling 0.10.2",
  "derive_builder_core",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "syn 1.0.109",
 ]
 
@@ -1644,7 +1645,7 @@ checksum = "2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef"
 dependencies = [
  "darling 0.10.2",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "syn 1.0.109",
 ]
 
@@ -1656,7 +1657,7 @@ checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case 0.4.0",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "rustc_version",
  "syn 1.0.109",
 ]
@@ -1781,8 +1782,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
- "syn 2.0.18",
+ "quote 1.0.30",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1860,7 +1861,7 @@ checksum = "cb0188e3c3ba8df5753894d54461f0e39bc91741dc5b22e1c46999ec2c71f4e4"
 dependencies = [
  "enum-ordinalize",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "syn 1.0.109",
 ]
 
@@ -1957,7 +1958,7 @@ checksum = "570d109b813e904becc80d8d5da38376818a143348413f7149f1340fe04754d4"
 dependencies = [
  "heck",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "syn 1.0.109",
 ]
 
@@ -1969,7 +1970,7 @@ checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
 dependencies = [
  "heck",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "syn 1.0.109",
 ]
 
@@ -1982,7 +1983,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "rustc_version",
  "syn 1.0.109",
 ]
@@ -1994,8 +1995,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48016319042fb7c87b78d2993084a831793a897a5cd1a2a67cab9d1eeb4b7d76"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
- "syn 2.0.18",
+ "quote 1.0.30",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -2138,11 +2139,11 @@ dependencies = [
  "hex",
  "prettyplease 0.2.4",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "regex",
  "serde",
  "serde_json",
- "syn 2.0.18",
+ "syn 2.0.29",
  "toml 0.7.5",
  "walkdir",
 ]
@@ -2158,9 +2159,9 @@ dependencies = [
  "ethers-core",
  "hex",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "serde_json",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -2186,7 +2187,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "syn 2.0.18",
+ "syn 2.0.29",
  "tempfile",
  "thiserror",
  "tiny-keccak",
@@ -2535,8 +2536,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
- "syn 2.0.18",
+ "quote 1.0.30",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -3173,7 +3174,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b728b9421e93eff1d9f8681101b78fa745e0748c95c655c83f337044a7e10"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "syn 1.0.109",
 ]
 
@@ -3261,7 +3262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "syn 1.0.109",
 ]
 
@@ -3539,7 +3540,7 @@ dependencies = [
  "heck",
  "proc-macro-crate",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "syn 1.0.109",
 ]
 
@@ -3894,7 +3895,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "731f8ecebd9f3a4aa847dfe75455e4757a45da40a7793d2f0b1f9b6ed18b23f3"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "syn 1.0.109",
 ]
 
@@ -4010,7 +4011,7 @@ checksum = "832663583d5fa284ca8810bf7015e46c9fff9622d3cf34bd1eea5003fec06dd0"
 dependencies = [
  "cfg-if",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "syn 1.0.109",
 ]
 
@@ -4031,7 +4032,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "syn 1.0.109",
 ]
 
@@ -4227,8 +4228,8 @@ checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
- "syn 2.0.18",
+ "quote 1.0.30",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -4283,7 +4284,7 @@ checksum = "003b2be5c6c53c1cfeb0a238b8a1c3915cd410feb684457a36c10038f764bb1c"
 dependencies = [
  "bytes",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "syn 1.0.109",
 ]
 
@@ -4309,8 +4310,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
- "syn 2.0.18",
+ "quote 1.0.30",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -4404,7 +4405,7 @@ checksum = "86b26a931f824dd4eca30b3e43bb4f31cd5f0d3a403c5f5ff27106b805bfde7b"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "syn 1.0.109",
 ]
 
@@ -4565,7 +4566,7 @@ dependencies = [
  "phf_generator",
  "phf_shared",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "syn 1.0.109",
 ]
 
@@ -4594,8 +4595,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
- "syn 2.0.18",
+ "quote 1.0.30",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -4791,7 +4792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ceca8aaf45b5c46ec7ed39fff75f57290368c1846d33d24a122ca81416ab058"
 dependencies = [
  "proc-macro2 1.0.63",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -4826,7 +4827,7 @@ checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "syn 1.0.109",
  "version_check",
 ]
@@ -4838,7 +4839,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "version_check",
 ]
 
@@ -4946,7 +4947,7 @@ dependencies = [
  "anyhow",
  "itertools",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "syn 1.0.109",
 ]
 
@@ -5028,9 +5029,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "5907a1b7c277254a8b15170f6e7c97cfa60ee7872a3217663bb81151e48184bb"
 dependencies = [
  "proc-macro2 1.0.63",
 ]
@@ -5860,10 +5861,10 @@ dependencies = [
  "metrics",
  "once_cell",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "regex",
  "serial_test 0.10.0",
- "syn 2.0.18",
+ "syn 2.0.29",
  "trybuild",
 ]
 
@@ -6103,8 +6104,8 @@ name = "reth-rlp-derive"
 version = "0.1.0-alpha.1"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
- "syn 2.0.18",
+ "quote 1.0.30",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -6523,7 +6524,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e33d7b2abe0c340d8797fe2907d3f20d3b5ea5908683618bfe80df7f621f672a"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "syn 1.0.109",
 ]
 
@@ -6714,7 +6715,7 @@ checksum = "61fa974aea2d63dd18a4ec3a49d59af9f34178c73a4f56d2f18205628d00681e"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "syn 1.0.109",
 ]
 
@@ -6876,8 +6877,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
- "syn 2.0.18",
+ "quote 1.0.30",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -6936,7 +6937,7 @@ checksum = "a1966009f3c05f095697c537312f5415d1e3ed31ce0a56942bac4c771c5c335e"
 dependencies = [
  "darling 0.14.3",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "syn 1.0.109",
 ]
 
@@ -6975,7 +6976,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b64f9e531ce97c88b4778aad0ceee079216071cffec6ac9b904277f8f92e7fe3"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "syn 1.0.109",
 ]
 
@@ -6986,8 +6987,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
- "syn 2.0.18",
+ "quote 1.0.30",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -7311,7 +7312,7 @@ checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
  "heck",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "rustversion",
  "syn 1.0.109",
 ]
@@ -7395,18 +7396,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "unicode-ident",
 ]
 
@@ -7423,7 +7424,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "syn 1.0.109",
  "unicode-xid 0.2.4",
 ]
@@ -7435,8 +7436,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "285ba80e733fac80aa4270fbcdf83772a79b80aa35c97075320abfee4a915b06"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
- "syn 2.0.18",
+ "quote 1.0.30",
+ "syn 2.0.29",
  "unicode-xid 0.2.4",
 ]
 
@@ -7494,7 +7495,7 @@ checksum = "385624eb0031d550fe1bf99c08af79b838605fc4fcec2c4d55e229a2c342fdd0"
 dependencies = [
  "cargo_metadata",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "serde",
  "strum_macros",
 ]
@@ -7510,9 +7511,9 @@ dependencies = [
  "itertools",
  "lazy_static",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "subprocess",
- "syn 2.0.18",
+ "syn 2.0.29",
  "test-fuzz-internal",
  "toolchain_find",
 ]
@@ -7559,8 +7560,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
- "syn 2.0.18",
+ "quote 1.0.30",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -7680,8 +7681,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
- "syn 2.0.18",
+ "quote 1.0.30",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -7824,7 +7825,7 @@ dependencies = [
  "prettyplease 0.1.25",
  "proc-macro2 1.0.63",
  "prost-build",
- "quote 1.0.28",
+ "quote 1.0.30",
  "syn 1.0.109",
 ]
 
@@ -7935,7 +7936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "syn 1.0.109",
 ]
 
@@ -8020,7 +8021,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "258bc1c4f8e2e73a977812ab339d503e6feeb92700f6d07a6de4d321522d5c08"
 dependencies = [
  "lazy_static",
- "quote 1.0.28",
+ "quote 1.0.30",
  "syn 1.0.109",
 ]
 
@@ -8415,7 +8416,7 @@ dependencies = [
  "log",
  "once_cell",
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
@@ -8438,7 +8439,7 @@ version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
- "quote 1.0.28",
+ "quote 1.0.30",
  "wasm-bindgen-macro-support",
 ]
 
@@ -8449,7 +8450,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -8788,7 +8789,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af46c169923ed7516eef0aa32b56d2651b229f57458ebe46b49ddd6efef5b7a2"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "syn 1.0.109",
  "synstructure 0.12.6",
 ]
@@ -8809,7 +8810,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4eae7c1f7d4b8eafce526bc0771449ddc2f250881ae31c50d22c032b5a1c499"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "syn 1.0.109",
  "synstructure 0.12.6",
 ]
@@ -8830,8 +8831,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
- "syn 2.0.18",
+ "quote 1.0.30",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -8852,7 +8853,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "486558732d5dde10d0f8cb2936507c1bb21bc539d924c949baf5f36a58e51bac"
 dependencies = [
  "proc-macro2 1.0.63",
- "quote 1.0.28",
+ "quote 1.0.30",
  "syn 1.0.109",
  "synstructure 0.12.6",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,6 +293,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
+dependencies = [
+ "autocfg 1.1.0",
+]
+
+[[package]]
+name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
@@ -370,6 +379,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dabbe35f96fb9507f7330793dc490461b2962659ac5d427181e451a623751d1"
 
 [[package]]
+name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+
+[[package]]
 name = "beef"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,6 +457,34 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitcoin"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e99ff7289b20a7385f66a0feda78af2fc119d28fb56aea8886a9cd0a4abdd75"
+dependencies = [
+ "bech32 0.9.1",
+ "bitcoin-private",
+ "bitcoin_hashes",
+ "hex_lit",
+ "secp256k1",
+]
+
+[[package]]
+name = "bitcoin-private"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
+dependencies = [
+ "bitcoin-private",
+]
 
 [[package]]
 name = "bitflags"
@@ -682,6 +725,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "btc-wallet"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bitcoin",
+ "hex",
+ "lazy_static",
+ "miniscript",
+ "rand 0.6.5",
+ "reth-primitives",
+ "secp256k1",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -911,6 +968,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "cobs"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -981,7 +1047,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b949a1c63fb7eb591eb7ba438746326aedf0ae843e51ec92ba6bec5bb382c4f"
 dependencies = [
  "base64 0.21.0",
- "bech32",
+ "bech32 0.7.3",
  "bs58",
  "digest 0.10.6",
  "generic-array",
@@ -1179,7 +1245,7 @@ version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "cfg-if",
  "crossbeam-utils",
  "memoffset",
@@ -2314,6 +2380,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2731,6 +2803,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
+name = "hex_lit"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
+
+[[package]]
 name = "hkdf"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3095,7 +3173,7 @@ version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "hashbrown 0.12.3",
  "serde",
 ]
@@ -3566,7 +3644,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "scopeguard",
 ]
 
@@ -3666,7 +3744,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -3767,6 +3845,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniscript"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1eb102b66b2127a872dbcc73095b7b47aeb9d92f7b03c2b2298253ffc82c7594"
+dependencies = [
+ "bitcoin",
+ "bitcoin-private",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -3910,7 +3998,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "num-integer",
  "num-traits",
  "serde",
@@ -3941,7 +4029,7 @@ version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "num-traits",
 ]
 
@@ -3951,7 +4039,7 @@ version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "num-integer",
  "num-traits",
 ]
@@ -3962,7 +4050,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -3974,7 +4062,7 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "libm 0.2.6",
 ]
 
@@ -4607,7 +4695,7 @@ dependencies = [
  "quick-error 2.0.1",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "rand_xorshift",
+ "rand_xorshift 0.3.0",
  "regex-syntax 0.6.29",
  "rusty-fork",
  "tempfile",
@@ -4725,6 +4813,25 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+dependencies = [
+ "autocfg 0.1.8",
+ "libc",
+ "rand_chacha 0.1.1",
+ "rand_core 0.4.2",
+ "rand_hc 0.1.0",
+ "rand_isaac",
+ "rand_jitter",
+ "rand_os",
+ "rand_pcg",
+ "rand_xorshift 0.1.1",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -4733,7 +4840,7 @@ dependencies = [
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
- "rand_hc",
+ "rand_hc 0.2.0",
 ]
 
 [[package]]
@@ -4745,6 +4852,16 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
+dependencies = [
+ "autocfg 0.1.8",
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -4769,6 +4886,21 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+
+[[package]]
+name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
@@ -4787,11 +4919,73 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_isaac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_jitter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
+dependencies = [
+ "libc",
+ "rand_core 0.4.2",
+ "winapi",
+]
+
+[[package]]
+name = "rand_os"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+dependencies = [
+ "cloudabi",
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.4.2",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
+dependencies = [
+ "autocfg 0.1.8",
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -4832,6 +5026,15 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
  "num_cpus",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -5376,7 +5579,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pprof",
  "rand 0.8.5",
- "rand_xorshift",
+ "rand_xorshift 0.3.0",
  "reth-mdbx-sys",
  "tempfile",
  "thiserror",
@@ -5661,6 +5864,8 @@ version = "0.1.0-alpha.1"
 dependencies = [
  "assert_matches",
  "async-trait",
+ "bitcoin",
+ "btc-wallet",
  "bytes",
  "ethers-core",
  "futures",
@@ -5670,6 +5875,7 @@ dependencies = [
  "hyper",
  "jsonrpsee",
  "jsonwebtoken",
+ "lazy_static",
  "pin-project",
  "rand 0.8.5",
  "reth-consensus-common",
@@ -6335,6 +6541,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
+ "bitcoin_hashes",
  "rand 0.8.5",
  "secp256k1-sys",
  "serde",
@@ -6715,7 +6922,7 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -7176,7 +7383,7 @@ version = "1.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "bytes",
  "libc",
  "mio",

--- a/crates/rpc/rpc-api/src/eth.rs
+++ b/crates/rpc/rpc-api/src/eth.rs
@@ -39,7 +39,7 @@ pub trait EthApi {
 
     /// Returns the Bitcoin pegin gateway address
     #[method(name = "getGatewayAddress")]
-    async fn gateway_address(&self, eth_address: Address, nonce: u64, aggregate_public_key: String) -> RpcResult<Option<String>>;
+    async fn gateway_address(&self, eth_address: Address, nonce: u64) -> RpcResult<Option<String>>;
 
     /// Returns information about a block by hash.
     #[method(name = "getBlockByHash")]

--- a/crates/rpc/rpc-api/src/eth.rs
+++ b/crates/rpc/rpc-api/src/eth.rs
@@ -37,6 +37,10 @@ pub trait EthApi {
     #[method(name = "chainId")]
     async fn chain_id(&self) -> RpcResult<Option<U64>>;
 
+    /// Returns the Bitcoin pegin gateway address
+    #[method(name = "getGatewayAddress")]
+    async fn gateway_address(&self, eth_address: Address, nonce: u64, aggregate_public_key: String) -> RpcResult<Option<String>>;
+
     /// Returns information about a block by hash.
     #[method(name = "getBlockByHash")]
     async fn block_by_hash(&self, hash: H256, full: bool) -> RpcResult<Option<RichBlock>>;

--- a/crates/rpc/rpc-api/src/eth.rs
+++ b/crates/rpc/rpc-api/src/eth.rs
@@ -5,7 +5,7 @@ use reth_primitives::{
 };
 use reth_rpc_types::{
     state::StateOverride, BlockOverrides, CallRequest, EIP1186AccountProofResponse, FeeHistory,
-    Index, RichBlock, SyncStatus, Transaction, TransactionReceipt, TransactionRequest, Work,
+    Index, RichBlock, SyncStatus, Transaction, TransactionReceipt, TransactionRequest, Work, GatewayAddress,
 };
 
 /// Eth rpc interface: <https://ethereum.github.io/execution-apis/api-documentation/>
@@ -39,7 +39,7 @@ pub trait EthApi {
 
     /// Returns the Bitcoin pegin gateway address
     #[method(name = "getGatewayAddress")]
-    async fn gateway_address(&self, eth_address: Address, nonce: u64) -> RpcResult<Option<String>>;
+    async fn gateway_address(&self, eth_address: Address, nonce: u64) -> RpcResult<Option<GatewayAddress>>;
 
     /// Returns information about a block by hash.
     #[method(name = "getBlockByHash")]

--- a/crates/rpc/rpc-builder/src/auth.rs
+++ b/crates/rpc/rpc-builder/src/auth.rs
@@ -14,7 +14,7 @@ use reth_provider::{
     BlockReaderIdExt, EvmEnvProvider, HeaderProvider, ReceiptProviderIdExt, StateProviderFactory,
 };
 use reth_rpc::{
-    eth::{cache::EthStateCache, gas_oracle::GasPriceOracle},
+    eth::{cache::EthStateCache, gas_oracle::GasPriceOracle, botanix_config::{BotanixConfig, Botanix}},
     AuthLayer, Claims, EngineEthApi, EthApi, EthFilter, EthSubscriptionIdProvider,
     JwtAuthValidator, JwtSecret,
 };
@@ -55,6 +55,7 @@ where
     let eth_cache =
         EthStateCache::spawn_with(provider.clone(), Default::default(), executor.clone());
     let gas_oracle = GasPriceOracle::new(provider.clone(), Default::default(), eth_cache.clone());
+    let botanix_provider = Botanix::new(BotanixConfig::default());
     let eth_api = EthApi::with_spawner(
         provider.clone(),
         pool.clone(),
@@ -62,6 +63,7 @@ where
         eth_cache.clone(),
         gas_oracle,
         Box::new(executor.clone()),
+        botanix_provider
     );
     let eth_filter = EthFilter::new(
         provider,

--- a/crates/rpc/rpc-builder/src/eth.rs
+++ b/crates/rpc/rpc-builder/src/eth.rs
@@ -1,5 +1,6 @@
 use reth_rpc::{
     eth::{
+        botanix_config::BotanixConfig,
         cache::{EthStateCache, EthStateCacheConfig},
         gas_oracle::GasPriceOracleConfig,
     },
@@ -33,6 +34,8 @@ pub struct EthConfig {
     pub cache: EthStateCacheConfig,
     /// Settings for the gas price oracle
     pub gas_oracle: GasPriceOracleConfig,
+    /// Botanix related configs
+    pub botanix_config: BotanixConfig,
     /// The maximum number of tracing calls that can be executed in concurrently.
     pub max_tracing_requests: u32,
     /// Maximum number of logs that can be returned in a single response in `eth_getLogs` calls.
@@ -44,6 +47,7 @@ impl Default for EthConfig {
         Self {
             cache: EthStateCacheConfig::default(),
             gas_oracle: GasPriceOracleConfig::default(),
+            botanix_config: BotanixConfig::default(),
             max_tracing_requests: DEFAULT_MAX_TRACING_REQUESTS,
             max_logs_per_response: DEFAULT_MAX_LOGS_PER_RESPONSE,
         }
@@ -60,6 +64,12 @@ impl EthConfig {
     /// Configures the gas price oracle settings
     pub fn gpo_config(mut self, gas_oracle_config: GasPriceOracleConfig) -> Self {
         self.gas_oracle = gas_oracle_config;
+        self
+    }
+
+    /// Configures the botanix RPC configurables
+    pub fn botanix_config(mut self, botanix_config: BotanixConfig) -> Self {
+        self.botanix_config = botanix_config;
         self
     }
 

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -118,6 +118,7 @@ use reth_provider::{
 };
 use reth_rpc::{
     eth::{
+        botanix_config::{Botanix, BotanixConfig},
         cache::{cache_new_blocks_task, EthStateCache},
         gas_oracle::GasPriceOracle,
     },
@@ -907,6 +908,9 @@ where
                 self.config.eth.gas_oracle.clone(),
                 cache.clone(),
             );
+
+            let botanix_provider = Botanix::new(self.config.eth.botanix_config.clone());
+
             let new_canonical_blocks = self.events.canonical_state_stream();
             let c = cache.clone();
             self.executor.spawn_critical(
@@ -924,6 +928,7 @@ where
                 cache.clone(),
                 gas_oracle,
                 executor.clone(),
+                botanix_provider,
             );
             let filter = EthFilter::new(
                 self.provider.clone(),

--- a/crates/rpc/rpc-types/src/botanix.rs
+++ b/crates/rpc/rpc-types/src/botanix.rs
@@ -1,0 +1,15 @@
+use reth_primitives::Address;
+use serde::{Serialize, Deserialize};
+
+/// Information about the Botanix Pegin Gateway Address
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GatewayAddress {
+    /// Bitcoin Pegin Address
+    pub gateway_address: String,
+    /// Aggregated public key used as internal taproot key
+    pub aggregate_public_key: String,
+    /// User provided nonce
+    pub nonce: u64,
+    /// User Eth account
+    pub eth_address: Address,
+}

--- a/crates/rpc/rpc-types/src/lib.rs
+++ b/crates/rpc/rpc-types/src/lib.rs
@@ -18,7 +18,10 @@
 mod admin;
 mod eth;
 mod rpc;
+mod botanix;
 
 pub use admin::*;
 pub use eth::*;
 pub use rpc::*;
+pub use botanix::*;
+

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -63,8 +63,12 @@ futures = { workspace = true }
 
 # Botanix Btc wallet
 btc-wallet = { path = "../../../../btc-wallet" }
+# Botanix Btc server gRPC client
+client = {path = "../../../../btc-server/client"}
+
 lazy_static = "1.4.0"
-bitcoin = "0.30.1"
+bitcoin = {version = "0.30.1", features = ["serde"]}
+tonic = "0.9.2"
 
 [dev-dependencies]
 jsonrpsee = { version = "0.18", features = ["client"] }

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -61,6 +61,11 @@ tracing-futures = "0.2"
 schnellru = "0.2"
 futures = { workspace = true }
 
+# Botanix Btc wallet
+btc-wallet = { path = "../../../../btc-wallet" }
+lazy_static = "1.4.0"
+bitcoin = "0.30.1"
+
 [dev-dependencies]
 jsonrpsee = { version = "0.18", features = ["client"] }
 assert_matches = "1.5.0"

--- a/crates/rpc/rpc/src/eth/api/mod.rs
+++ b/crates/rpc/rpc/src/eth/api/mod.rs
@@ -53,7 +53,7 @@ pub trait EthApiSpec: EthTransactions + Send + Sync {
         &self,
         eth_address: Address,
         nonce: u64,
-    ) -> std::result::Result<bitcoin::Address, GatewayAddressRPCError>;
+    ) -> std::result::Result<(bitcoin::Address, secp256k1::PublicKey), GatewayAddressRPCError>;
 
     /// Returns a list of addresses owned by provider.
     fn accounts(&self) -> Vec<Address>;
@@ -253,9 +253,9 @@ where
         &self,
         eth_address: Address,
         nonce: u64,
-    ) -> std::result::Result<bitcoin::Address, GatewayAddressRPCError> {
-        let address = self.inner.botanix_provider.get_gateway_address(eth_address, nonce).await?;
-        Ok(address)
+    ) -> std::result::Result<(bitcoin::Address, secp256k1::PublicKey), GatewayAddressRPCError> {
+        let pegin_info = self.inner.botanix_provider.get_gateway_address(eth_address, nonce).await?;
+        Ok(pegin_info)
     }
 
     /// Returns the current info for the chain

--- a/crates/rpc/rpc/src/eth/api/mod.rs
+++ b/crates/rpc/rpc/src/eth/api/mod.rs
@@ -17,7 +17,6 @@ use reth_provider::{BlockReaderIdExt, EvmEnvProvider, StateProviderBox, StatePro
 use reth_rpc_types::{SyncInfo, SyncStatus};
 use reth_tasks::{TaskSpawner, TokioTaskExecutor};
 use reth_transaction_pool::TransactionPool;
-use secp256k1::PublicKey;
 use std::{future::Future, sync::Arc};
 use tokio::sync::oneshot;
 
@@ -31,18 +30,10 @@ mod transactions;
 
 pub use transactions::{EthTransactions, TransactionSource};
 
-use btc_wallet::address::gateway_address;
+use super::botanix_config::{Botanix, GatewayAddressRPCError};
 
-lazy_static::lazy_static! {
-    static ref SECP: secp256k1::Secp256k1<secp256k1::All> = secp256k1::Secp256k1::new();
-}
 
-#[derive(Debug)]
-pub enum GatewayAddressRPCError {
-    FailedToDecodeAggregatePublicKey(hex::FromHexError),
-    InvalidParam(&'static str),
-    FailedToGenerateGatewayAddress,
-}
+
 /// `Eth` API trait.
 ///
 /// Defines core functionality of the `eth` API implementation.
@@ -58,12 +49,10 @@ pub trait EthApiSpec: EthTransactions + Send + Sync {
     fn chain_info(&self) -> Result<ChainInfo>;
 
     /// Returns gateway address
-    fn get_gateway_address(
+    async fn get_gateway_address(
         &self,
         eth_address: Address,
         nonce: u64,
-        // TODO Hex encoded string because Bitcoin public key doesnt implement deserialize
-        aggregate_public_key: String,
     ) -> std::result::Result<bitcoin::Address, GatewayAddressRPCError>;
 
     /// Returns a list of addresses owned by provider.
@@ -100,6 +89,7 @@ where
         network: Network,
         eth_cache: EthStateCache,
         gas_oracle: GasPriceOracle<Provider>,
+        botanix_provider: Botanix,
     ) -> Self {
         Self::with_spawner(
             provider,
@@ -108,6 +98,7 @@ where
             eth_cache,
             gas_oracle,
             Box::<TokioTaskExecutor>::default(),
+            botanix_provider
         )
     }
 
@@ -119,6 +110,8 @@ where
         eth_cache: EthStateCache,
         gas_oracle: GasPriceOracle<Provider>,
         task_spawner: Box<dyn TaskSpawner>,
+        botanix_provider: Botanix
+
     ) -> Self {
         // get the block number of the latest block
         let latest_block = provider
@@ -137,6 +130,7 @@ where
             gas_oracle,
             starting_block: U256::from(latest_block),
             task_spawner,
+            botanix_provider
         };
         Self { inner: Arc::new(inner) }
     }
@@ -255,25 +249,12 @@ where
         U64::from(self.network().chain_id())
     }
 
-    fn get_gateway_address(
+    async fn get_gateway_address(
         &self,
         eth_address: Address,
         nonce: u64,
-        // TODO Hex encoded string because Bitcoin public key doesnt implement deserialize
-        aggregate_public_key: String,
     ) -> std::result::Result<bitcoin::Address, GatewayAddressRPCError> {
-        // let address = gate
-        let pk_vec = hex::decode(aggregate_public_key)
-            .map_err(|e| GatewayAddressRPCError::FailedToDecodeAggregatePublicKey(e))?;
-
-        let pk = PublicKey::from_slice(pk_vec.as_slice()).map_err(|_e| {
-            GatewayAddressRPCError::InvalidParam("Failed to derive aggregate public key from input")
-        })?;
-        // TODO (armins) network needs to come from config
-        let network = bitcoin::Network::Signet;
-        let address = gateway_address(&SECP, &pk, &eth_address, network, nonce)
-            .map_err(|_e| GatewayAddressRPCError::FailedToGenerateGatewayAddress)?;
-
+        let address = self.inner.botanix_provider.get_gateway_address(eth_address, nonce).await?;
         Ok(address)
     }
 
@@ -328,4 +309,6 @@ struct EthApiInner<Provider, Pool, Network> {
     starting_block: U256,
     /// The type that can spawn tasks which would otherwise block.
     task_spawner: Box<dyn TaskSpawner>,
+    /// Botanix bitcoin network
+    botanix_provider: Botanix,
 }

--- a/crates/rpc/rpc/src/eth/api/mod.rs
+++ b/crates/rpc/rpc/src/eth/api/mod.rs
@@ -17,6 +17,7 @@ use reth_provider::{BlockReaderIdExt, EvmEnvProvider, StateProviderBox, StatePro
 use reth_rpc_types::{SyncInfo, SyncStatus};
 use reth_tasks::{TaskSpawner, TokioTaskExecutor};
 use reth_transaction_pool::TransactionPool;
+use secp256k1::PublicKey;
 use std::{future::Future, sync::Arc};
 use tokio::sync::oneshot;
 
@@ -30,6 +31,18 @@ mod transactions;
 
 pub use transactions::{EthTransactions, TransactionSource};
 
+use btc_wallet::address::gateway_address;
+
+lazy_static::lazy_static! {
+    static ref SECP: secp256k1::Secp256k1<secp256k1::All> = secp256k1::Secp256k1::new();
+}
+
+#[derive(Debug)]
+pub enum GatewayAddressRPCError {
+    FailedToDecodeAggregatePublicKey(hex::FromHexError),
+    InvalidParam(&'static str),
+    FailedToGenerateGatewayAddress,
+}
 /// `Eth` API trait.
 ///
 /// Defines core functionality of the `eth` API implementation.
@@ -43,6 +56,15 @@ pub trait EthApiSpec: EthTransactions + Send + Sync {
 
     /// Returns provider chain info
     fn chain_info(&self) -> Result<ChainInfo>;
+
+    /// Returns gateway address
+    fn get_gateway_address(
+        &self,
+        eth_address: Address,
+        nonce: u64,
+        // TODO Hex encoded string because Bitcoin public key doesnt implement deserialize
+        aggregate_public_key: String,
+    ) -> std::result::Result<bitcoin::Address, GatewayAddressRPCError>;
 
     /// Returns a list of addresses owned by provider.
     fn accounts(&self) -> Vec<Address>;
@@ -231,6 +253,28 @@ where
     /// Returns the chain id
     fn chain_id(&self) -> U64 {
         U64::from(self.network().chain_id())
+    }
+
+    fn get_gateway_address(
+        &self,
+        eth_address: Address,
+        nonce: u64,
+        // TODO Hex encoded string because Bitcoin public key doesnt implement deserialize
+        aggregate_public_key: String,
+    ) -> std::result::Result<bitcoin::Address, GatewayAddressRPCError> {
+        // let address = gate
+        let pk_vec = hex::decode(aggregate_public_key)
+            .map_err(|e| GatewayAddressRPCError::FailedToDecodeAggregatePublicKey(e))?;
+
+        let pk = PublicKey::from_slice(pk_vec.as_slice()).map_err(|_e| {
+            GatewayAddressRPCError::InvalidParam("Failed to derive aggregate public key from input")
+        })?;
+        // TODO (armins) network needs to come from config
+        let network = bitcoin::Network::Signet;
+        let address = gateway_address(&SECP, &pk, &eth_address, network, nonce)
+            .map_err(|_e| GatewayAddressRPCError::FailedToGenerateGatewayAddress)?;
+
+        Ok(address)
     }
 
     /// Returns the current info for the chain

--- a/crates/rpc/rpc/src/eth/api/server.rs
+++ b/crates/rpc/rpc/src/eth/api/server.rs
@@ -96,15 +96,9 @@ where
     }
 
     /// Handler for: `eth_getGatewayAddress`
-    async fn gateway_address(
-        &self,
-        eth_address: Address,
-        nonce: u64,
-        // TODO Hex encoded string because Bitcoin public key doesnt implement deserialize
-        aggregate_public_key: String,
-    ) -> Result<Option<String>> {
-        trace!(target: "rpc::eth", ?eth_address, ?nonce, ?aggregate_public_key, "Serving eth_getGateWayAddress");
-        let address = match EthApi::get_gateway_address(self, eth_address, nonce, aggregate_public_key) {
+    async fn gateway_address(&self, eth_address: Address, nonce: u64) -> Result<Option<String>> {
+        trace!(target: "rpc::eth", ?eth_address, ?nonce, "Serving eth_getGateWayAddress");
+        let address = match EthApi::get_gateway_address(self, eth_address, nonce).await {
             Ok(value) => Some(value.to_string()),
             Err(_) => None,
         };
@@ -407,7 +401,7 @@ where
 #[cfg(test)]
 mod tests {
     use crate::{
-        eth::{cache::EthStateCache, gas_oracle::GasPriceOracle},
+        eth::{cache::EthStateCache, gas_oracle::GasPriceOracle, botanix_config::Botanix},
         EthApi,
     };
     use jsonrpsee::types::error::INVALID_PARAMS_CODE;
@@ -443,6 +437,8 @@ mod tests {
             NoopNetwork,
             cache.clone(),
             GasPriceOracle::new(provider, Default::default(), cache),
+            // TODO (armins) reading default config
+            Botanix::new(Default::default()),
         )
     }
 

--- a/crates/rpc/rpc/src/eth/api/server.rs
+++ b/crates/rpc/rpc/src/eth/api/server.rs
@@ -22,7 +22,7 @@ use reth_provider::{
 use reth_rpc_api::EthApiServer;
 use reth_rpc_types::{
     state::StateOverride, BlockOverrides, CallRequest, EIP1186AccountProofResponse, FeeHistory,
-    Index, RichBlock, SyncStatus, TransactionReceipt, TransactionRequest, Work,
+    GatewayAddress, Index, RichBlock, SyncStatus, TransactionReceipt, TransactionRequest, Work,
 };
 use reth_transaction_pool::TransactionPool;
 use serde_json::Value;
@@ -96,10 +96,19 @@ where
     }
 
     /// Handler for: `eth_getGatewayAddress`
-    async fn gateway_address(&self, eth_address: Address, nonce: u64) -> Result<Option<String>> {
+    async fn gateway_address(
+        &self,
+        eth_address: Address,
+        nonce: u64,
+    ) -> Result<Option<GatewayAddress>> {
         trace!(target: "rpc::eth", ?eth_address, ?nonce, "Serving eth_getGateWayAddress");
         let address = match EthApi::get_gateway_address(self, eth_address, nonce).await {
-            Ok(value) => Some(value.to_string()),
+            Ok(value) => Some(GatewayAddress {
+                gateway_address: value.0.to_string(),
+                aggregate_public_key: value.1.to_string(),
+                nonce,
+                eth_address,
+            }),
             Err(_) => None,
         };
         Ok(address)
@@ -401,7 +410,7 @@ where
 #[cfg(test)]
 mod tests {
     use crate::{
-        eth::{cache::EthStateCache, gas_oracle::GasPriceOracle, botanix_config::Botanix},
+        eth::{botanix_config::Botanix, cache::EthStateCache, gas_oracle::GasPriceOracle},
         EthApi,
     };
     use jsonrpsee::types::error::INVALID_PARAMS_CODE;

--- a/crates/rpc/rpc/src/eth/api/server.rs
+++ b/crates/rpc/rpc/src/eth/api/server.rs
@@ -95,6 +95,22 @@ where
         Ok(EthApi::rpc_block(self, number, full).await?)
     }
 
+    /// Handler for: `eth_getGatewayAddress`
+    async fn gateway_address(
+        &self,
+        eth_address: Address,
+        nonce: u64,
+        // TODO Hex encoded string because Bitcoin public key doesnt implement deserialize
+        aggregate_public_key: String,
+    ) -> Result<Option<String>> {
+        trace!(target: "rpc::eth", ?eth_address, ?nonce, ?aggregate_public_key, "Serving eth_getGateWayAddress");
+        let address = match EthApi::get_gateway_address(self, eth_address, nonce, aggregate_public_key) {
+            Ok(value) => Some(value.to_string()),
+            Err(_) => None,
+        };
+        Ok(address)
+    }
+
     /// Handler for: `eth_getBlockTransactionCountByHash`
     async fn block_transaction_count_by_hash(&self, hash: H256) -> Result<Option<U256>> {
         trace!(target: "rpc::eth", ?hash, "Serving eth_getBlockTransactionCountByHash");

--- a/crates/rpc/rpc/src/eth/botanix_config.rs
+++ b/crates/rpc/rpc/src/eth/botanix_config.rs
@@ -1,9 +1,11 @@
 //! Defines structure for botanix RPC configurables and business logic
 
-use btc_wallet::address::gateway_address;
+use std::str::FromStr;
+
 use secp256k1::PublicKey;
 use serde::{Deserialize, Serialize};
 
+// TODO Secp should be getting pulled from provider
 lazy_static::lazy_static! {
     static ref SECP: secp256k1::Secp256k1<secp256k1::All> = secp256k1::Secp256k1::new();
 }
@@ -33,14 +35,21 @@ impl BotanixConfig {
     }
 }
 
+/// Errors from get gateway address RPC endpoint
 #[derive(Debug)]
 pub enum GatewayAddressRPCError {
+    /// Failed to decode value recieved from `btc_server`
     FailedToDecodeAggregatePublicKey(hex::FromHexError),
+    /// Invalid param recieved from client
     InvalidParam(&'static str),
+    /// Address generation failed
     FailedToGenerateGatewayAddress,
 }
 
+/// Botanix config
+#[derive(Debug)]
 pub struct Botanix {
+    /// Botanix config
     botanix_rpc_config: BotanixConfig,
 }
 
@@ -55,6 +64,8 @@ impl Botanix {
         &self.botanix_rpc_config
     }
 
+    /// Function calls btc_server to get "aggregated public key" and generated taproot gateway
+    /// address
     pub async fn get_gateway_address(
         &self,
         eth_address: reth_primitives::Address,
@@ -69,15 +80,13 @@ impl Botanix {
         let response = client.get_public_key(request).await.unwrap();
         let pk_hex = response.into_inner().publickey;
 
-        let pk_vec = hex::decode(pk_hex)
-            .map_err(|e| GatewayAddressRPCError::FailedToDecodeAggregatePublicKey(e))?;
-
-        let pk = PublicKey::from_slice(pk_vec.as_slice()).map_err(|_e| {
+        let pk = PublicKey::from_str(pk_hex.as_str()).map_err(|_e| {
             GatewayAddressRPCError::InvalidParam("Failed to derive aggregate public key from input")
         })?;
         let network = self.botanix_rpc_config.bitcoin_network;
-        let address = gateway_address(&SECP, &pk, &eth_address, network, nonce)
-            .map_err(|_e| GatewayAddressRPCError::FailedToGenerateGatewayAddress)?;
+        let address =
+            btc_wallet::address::gateway_address(&SECP, &pk, &eth_address, network, nonce)
+                .map_err(|_e| GatewayAddressRPCError::FailedToGenerateGatewayAddress)?;
 
         Ok((address, pk))
     }

--- a/crates/rpc/rpc/src/eth/botanix_config.rs
+++ b/crates/rpc/rpc/src/eth/botanix_config.rs
@@ -59,7 +59,7 @@ impl Botanix {
         &self,
         eth_address: reth_primitives::Address,
         nonce: u64,
-    ) -> std::result::Result<bitcoin::Address, GatewayAddressRPCError> {
+    ) -> std::result::Result<(bitcoin::Address, secp256k1::PublicKey), GatewayAddressRPCError> {
         let mut client =
             client::BtcServerClient::connect(self.botanix_rpc_config.btc_server_url.clone())
                 .await
@@ -79,6 +79,6 @@ impl Botanix {
         let address = gateway_address(&SECP, &pk, &eth_address, network, nonce)
             .map_err(|_e| GatewayAddressRPCError::FailedToGenerateGatewayAddress)?;
 
-        Ok(address)
+        Ok((address, pk))
     }
 }

--- a/crates/rpc/rpc/src/eth/botanix_config.rs
+++ b/crates/rpc/rpc/src/eth/botanix_config.rs
@@ -1,0 +1,84 @@
+//! Defines structure for botanix RPC configurables and business logic
+
+use btc_wallet::address::gateway_address;
+use secp256k1::PublicKey;
+use serde::{Deserialize, Serialize};
+
+lazy_static::lazy_static! {
+    static ref SECP: secp256k1::Secp256k1<secp256k1::All> = secp256k1::Secp256k1::new();
+}
+
+/// Settings for the [BotanixConfig]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct BotanixConfig {
+    /// Bitcoin network
+    pub bitcoin_network: bitcoin::Network,
+
+    /// The gRPC url for the bitcoin signer
+    pub btc_server_url: String,
+}
+
+impl Default for BotanixConfig {
+    fn default() -> Self {
+        BotanixConfig {
+            bitcoin_network: bitcoin::Network::Signet,
+            btc_server_url: "http://localhost:8080".to_string(),
+        }
+    }
+}
+
+impl BotanixConfig {
+    fn new(bitcoin_network: bitcoin::Network, btc_server_url: String) -> Self {
+        BotanixConfig { bitcoin_network, btc_server_url }
+    }
+}
+
+#[derive(Debug)]
+pub enum GatewayAddressRPCError {
+    FailedToDecodeAggregatePublicKey(hex::FromHexError),
+    InvalidParam(&'static str),
+    FailedToGenerateGatewayAddress,
+}
+
+pub struct Botanix {
+    botanix_rpc_config: BotanixConfig,
+}
+
+impl Botanix {
+    /// Creates and returns instance of [Botanix]
+    pub fn new(config: BotanixConfig) -> Self {
+        Self { botanix_rpc_config: config }
+    }
+
+    /// Returns the configuration of botanix provider
+    pub fn config(&self) -> &BotanixConfig {
+        &self.botanix_rpc_config
+    }
+
+    pub async fn get_gateway_address(
+        &self,
+        eth_address: reth_primitives::Address,
+        nonce: u64,
+    ) -> std::result::Result<bitcoin::Address, GatewayAddressRPCError> {
+        let mut client =
+            client::BtcServerClient::connect(self.botanix_rpc_config.btc_server_url.clone())
+                .await
+                .unwrap();
+        let request = tonic::Request::new(client::Empty {});
+
+        let response = client.get_public_key(request).await.unwrap();
+        let pk_hex = response.into_inner().publickey;
+
+        let pk_vec = hex::decode(pk_hex)
+            .map_err(|e| GatewayAddressRPCError::FailedToDecodeAggregatePublicKey(e))?;
+
+        let pk = PublicKey::from_slice(pk_vec.as_slice()).map_err(|_e| {
+            GatewayAddressRPCError::InvalidParam("Failed to derive aggregate public key from input")
+        })?;
+        let network = self.botanix_rpc_config.bitcoin_network;
+        let address = gateway_address(&SECP, &pk, &eth_address, network, nonce)
+            .map_err(|_e| GatewayAddressRPCError::FailedToGenerateGatewayAddress)?;
+
+        Ok(address)
+    }
+}

--- a/crates/rpc/rpc/src/eth/mod.rs
+++ b/crates/rpc/rpc/src/eth/mod.rs
@@ -5,6 +5,7 @@ pub mod cache;
 pub mod error;
 mod filter;
 pub mod gas_oracle;
+pub mod botanix_config;
 mod id_provider;
 mod logs_utils;
 mod pubsub;

--- a/crates/rpc/rpc/src/layers/jwt_validator.rs
+++ b/crates/rpc/rpc/src/layers/jwt_validator.rs
@@ -51,6 +51,7 @@ fn get_bearer(headers: &HeaderMap) -> Option<String> {
     let auth: &str = header.to_str().ok()?;
     let prefix = "Bearer ";
     let index = auth.find(prefix)?;
+
     let token: &str = &auth[index + prefix.len()..];
     Some(token.into())
 }

--- a/crates/storage/provider/src/lib.rs
+++ b/crates/storage/provider/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(is_some_and)]
+
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",


### PR DESCRIPTION
Tested using rpc example: ` cargo run --example rpc-db`

And `curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_getGatewayAddress","params":[ "0xA65812Bac44dadb79C3e4930dBD98d5a75376b2A", 100, "02e2af4a49570e224fdddc6443863281ff9d96e6311547943a7628ed925e767a7a"],"id":1}' 127.0.0.1:8545`


Result: 
```json
{"jsonrpc":"2.0","result":"tb1pauwffg9tcaqx4ncf7lkmthtj8gy39tsf722k4q0nppgpach2sxsqq0hljg","id":1}
```