### PR TITLE
rpc: Rename RPC method getBtcFees to GetBtcFeeRate and change usage

### DIFF
--- a/crates/consensus/auto-seal/src/task.rs
+++ b/crates/consensus/auto-seal/src/task.rs
@@ -215,14 +215,14 @@ where
                                             }
                                             Ok(GenesisContractEvents::BurnEvent) => {
                                                 // TODO (armins): obv
-                                                let fee = 30u32;
+                                                let fee_rate = 30u32;
                                                 info!("Parsing and sending withdrawal event to btc_server");
                                                 let pegout = parse_pegout_reth_log_topic(&log)
                                                     .expect("valid pegout request");
                                                 let request = MakeTxRequest {
                                                     address: pegout.destination.to_string(),
                                                     value: pegout.amount.to_sat(),
-                                                    fee,
+                                                    fee_rate,
                                                 };
 
                                                 match btc_server.make_tx(request).await {

--- a/crates/rpc/rpc-api/src/eth.rs
+++ b/crates/rpc/rpc-api/src/eth.rs
@@ -54,9 +54,9 @@ pub trait EthApi {
         block_hash: String,
     ) -> RpcResult<Bytes>;
 
-    /// Returns the Bitcoin fees for a pegout transaction
-    #[method(name = "getBtcFees")]
-    async fn btc_fees(&self) -> RpcResult<Option<U256>>;
+    /// Returns the Bitcoin fee rate for a pegout transaction in sat/vb.
+    #[method(name = "getBtcFeeRate")]
+    async fn btc_fee_rate(&self) -> RpcResult<Option<U256>>;
 
     /// Returns information about a block by hash.
     #[method(name = "getBlockByHash")]

--- a/crates/rpc/rpc/src/eth/api/mod.rs
+++ b/crates/rpc/rpc/src/eth/api/mod.rs
@@ -76,8 +76,8 @@ pub trait EthApiSpec: EthTransactions + Send + Sync {
         block_hash: String,
     ) -> std::result::Result<Vec<u8>, MerkleProofRPCError>;
 
-    /// Returns btc fees for a pegout transaction
-    async fn get_btc_fees(&self) -> std::result::Result<U256, BtcFeesRPCError>;
+    /// Returns the BTC fee rate for a pegout transaction in sat/vb.
+    async fn get_btc_fee_rate(&self) -> std::result::Result<U256, BtcFeesRPCError>;
 
     /// Returns a list of addresses owned by provider.
     fn accounts(&self) -> Vec<Address>;
@@ -394,9 +394,9 @@ where
         Ok(pegin_info)
     }
 
-    async fn get_btc_fees(&self) -> std::result::Result<U256, BtcFeesRPCError> {
-        let btc_fees = self.inner.botanix_provider.get_btc_fees().await?;
-        Ok(btc_fees)
+    async fn get_btc_fee_rate(&self) -> std::result::Result<U256, BtcFeesRPCError> {
+        let fee_rate = self.inner.botanix_provider.get_btc_fee_rate().await?;
+        Ok(fee_rate)
     }
 
     /// Returns the current info for the chain

--- a/crates/rpc/rpc/src/eth/api/server.rs
+++ b/crates/rpc/rpc/src/eth/api/server.rs
@@ -128,14 +128,14 @@ where
         Ok(merkle_proof)
     }
 
-    /// Handler for: `eth_getBtcFees`
-    async fn btc_fees(&self) -> Result<Option<U256>> {
-        trace!(target: "rpc::eth", "Serving eth_getBtcFees");
-        let btc_fees = match EthApi::get_btc_fees(self).await {
+    /// Handler for: `eth_getBtcFeeRate`
+    async fn btc_fee_rate(&self) -> Result<Option<U256>> {
+        trace!(target: "rpc::eth", "Serving eth_getBtcFeeRate");
+        let fee_rate = match EthApi::get_btc_fee_rate(self).await {
             Ok(value) => Some(value),
             Err(_) => None
         };
-        Ok(btc_fees)
+        Ok(fee_rate)
     }
 
     /// Handler for: `eth_getBlockTransactionCountByHash`

--- a/crates/rpc/rpc/src/eth/botanix_config.rs
+++ b/crates/rpc/rpc/src/eth/botanix_config.rs
@@ -199,9 +199,10 @@ impl Botanix {
         Ok(bitcoin::consensus::serialize(&pmt))
     }
 
-    /// Function calls btc_server to get btc fees for a pegout transaction:
-    /// currently returns a static fee without calling btc_server
-    pub async fn get_btc_fees(&self) -> std::result::Result<U256, BtcFeesRPCError> {
+    /// Function calls btc_server to get btc fee rate in sat/vb for a pegout transaction.
+    ///
+    /// Currently returns a static fee rate without calling btc_server.
+    pub async fn get_btc_fee_rate(&self) -> std::result::Result<U256, BtcFeesRPCError> {
         Ok(U256::from(30u32))
     }
 }


### PR DESCRIPTION
Depends on https://github.com/botanix-labs/botanix/pull/151.

Does this affect SideCar at all? I don't fully grasp who is using these RPC methods, they seem like they might be used internally only..