### PR TITLE
refactor(async_worker): only store most recent bitcoin block header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,12 +1093,12 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bitcoin 0.30.1",
+ "ethers",
  "hex",
  "lazy_static",
  "miniscript 10.0.0",
  "rand 0.6.5",
  "reqwest",
- "reth-primitives",
  "secp256k1 0.27.0",
 ]
 

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -254,8 +254,8 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
                 .expect("connect to btc_server");
         info!(target: "reth::cli", "Btc server connected");
 
-        let bitcoin_block_headers: Arc<RwLock<Vec<bitcoin::block::Header>>> =
-            Arc::new(RwLock::new(Vec::new()));
+        let bitcoin_block_headers: Arc<RwLock<Option<bitcoin::block::Header>>> =
+            Arc::new(RwLock::new(None));
         let bitcoin_block_headers_clone = bitcoin_block_headers.clone();
         let block_source = MempoolSpace::new(self.rpc.btc_block_source.to_string().clone());
 
@@ -272,10 +272,10 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
                         let block_hash = block_source.get_block_hash(current_tip).await.unwrap();
                         let block_header = block_source.get_block_header(block_hash).await.unwrap();
 
-                        header_write.push(block_header);
+                        // TODO (armins) in v1 we will need the nth deep block header not tip
+                        *header_write = Some(block_header);
                         tip = current_tip;
                     }
-                    println!("header_write, {:?}", bitcoin_block_headers);
                     tokio::time::sleep(sleep_ms).await;
                 }
             }),

--- a/crates/consensus/auto-seal/src/lib.rs
+++ b/crates/consensus/auto-seal/src/lib.rs
@@ -104,7 +104,7 @@ pub struct AutoSealBuilder<Client, Pool> {
     to_engine: UnboundedSender<BeaconEngineMessage>,
     canon_state_notification: CanonStateNotificationSender,
     btc_server: BtcServerClient<tonic::transport::Channel>,
-    bitcoin_block_headers: Arc<RwLock<Vec<bitcoin::block::Header>>>,
+    bitcoin_block_header: Arc<RwLock<Option<bitcoin::block::Header>>>,
     bitcoin_block_source_address: Url,
 }
 
@@ -124,7 +124,7 @@ where
         canon_state_notification: CanonStateNotificationSender,
         mode: MiningMode,
         btc_server: BtcServerClient<tonic::transport::Channel>,
-        bitcoin_block_headers: Arc<RwLock<Vec<bitcoin::block::Header>>>,
+        bitcoin_block_header: Arc<RwLock<Option<bitcoin::block::Header>>>,
         bitcoin_block_source_address: Url,
     ) -> Self {
         let latest_header = client
@@ -142,7 +142,7 @@ where
             to_engine,
             canon_state_notification,
             btc_server,
-            bitcoin_block_headers,
+            bitcoin_block_header,
             bitcoin_block_source_address,
         }
     }
@@ -165,7 +165,7 @@ where
             storage,
             to_engine,
             canon_state_notification,
-            bitcoin_block_headers,
+            bitcoin_block_header,
             bitcoin_block_source_address,
         } = self;
         let auto_client = AutoSealClient::new(storage.clone());
@@ -178,7 +178,7 @@ where
             client,
             pool,
             btc_server,
-            bitcoin_block_headers,
+            bitcoin_block_header,
             bitcoin_block_source_address,
         );
         (consensus, auto_client, task)
@@ -323,7 +323,7 @@ impl StorageInner {
         block: &Block,
         executor: &mut Executor<DB>,
         senders: Vec<Address>,
-        recent_block_headers: Option<Vec<bitcoin::block::Header>>,
+        recent_block_header: Option<bitcoin::block::Header>,
     ) -> Result<(PostState, u64), BlockExecutionError> {
         trace!(target: "consensus::auto", transactions=?&block.body, "executing transactions");
 
@@ -331,7 +331,7 @@ impl StorageInner {
             block,
             U256::ZERO,
             Some(senders),
-            recent_block_headers,
+            recent_block_header,
         )?;
 
         // apply post block changes
@@ -376,7 +376,7 @@ impl StorageInner {
         transactions: Vec<TransactionSigned>,
         executor: &mut Executor<DB>,
         chain_spec: Arc<ChainSpec>,
-        recent_block_headers: Option<Vec<bitcoin::block::Header>>,
+        recent_block_header: Option<bitcoin::block::Header>,
     ) -> Result<(SealedHeader, PostState), BlockExecutionError> {
         let header = self.build_header_template(&transactions, chain_spec);
 
@@ -389,15 +389,7 @@ impl StorageInner {
 
         // now execute the block
         let (post_state, gas_used) =
-            self.execute(&block, executor, senders, recent_block_headers)?;
-
-        // TODO (armins) should return Err if the only tx in block in invalid
-        // let reciepts = post_state.receipts(block.number);
-        // if reciepts.len() == 1 {
-        //     if let None =  reciepts.iter().find(|&&receipt| receipt.success == true ) {
-        //         return
-        //     }
-        // }
+            self.execute(&block, executor, senders, recent_block_header)?;
 
         let Block { header, body, .. } = block;
         let body = BlockBody { transactions: body, ommers: vec![], withdrawals: None };

--- a/crates/consensus/auto-seal/src/task.rs
+++ b/crates/consensus/auto-seal/src/task.rs
@@ -54,7 +54,7 @@ pub struct MiningTask<Client, Pool: TransactionPool> {
     /// BTC Server client
     btc_server: BtcServerClient<tonic::transport::Channel>,
     /// Recent bitcoin block headers
-    bitcoin_block_headers: Arc<RwLock<Vec<bitcoin::block::Header>>>,
+    bitcoin_block_header: Arc<RwLock<Option<bitcoin::block::Header>>>,
     /// Bitcoin block source url
     bitcoin_block_source_address: Url,
 }
@@ -72,7 +72,7 @@ impl<Client, Pool: TransactionPool> MiningTask<Client, Pool> {
         client: Client,
         pool: Pool,
         btc_server: BtcServerClient<tonic::transport::Channel>,
-        bitcoin_block_headers: Arc<RwLock<Vec<bitcoin::block::Header>>>,
+        bitcoin_block_header: Arc<RwLock<Option<bitcoin::block::Header>>>,
         bitcoin_block_source_address: Url,
     ) -> Self {
         Self {
@@ -87,7 +87,7 @@ impl<Client, Pool: TransactionPool> MiningTask<Client, Pool> {
             queued: Default::default(),
             pipe_line_events: None,
             btc_server,
-            bitcoin_block_headers,
+            bitcoin_block_header,
             bitcoin_block_source_address,
         }
     }
@@ -140,13 +140,13 @@ where
                 let events = this.pipe_line_events.take();
                 let canon_state_notification = this.canon_state_notification.clone();
                 let mut btc_server = this.btc_server.clone();
-                let bitcoin_block_headers = this.bitcoin_block_headers.clone();
+                let bitcoin_block_header = this.bitcoin_block_header.clone();
                 let block_source =
                     MempoolSpace::new(this.bitcoin_block_source_address.clone().to_string());
                 // Create the mining future that creates a block, notifies the engine that drives
                 // the pipeline
                 this.insert_task = Some(Box::pin(async move {
-                    let recent_block_headers = bitcoin_block_headers.read().await.clone();
+                    let recent_block_header = bitcoin_block_header.read().await.clone();
                     let mut storage = storage.write().await;
 
                     let (transactions, senders): (Vec<_>, Vec<_>) = transactions
@@ -165,7 +165,7 @@ where
                         transactions.clone(),
                         &mut executor,
                         chain_spec,
-                        Some(recent_block_headers),
+                        recent_block_header,
                     ) {
                         Ok((new_header, post_state)) => {
                             let state = ForkchoiceState {

--- a/crates/revm/src/executor.rs
+++ b/crates/revm/src/executor.rs
@@ -7,7 +7,7 @@ use crate::{
     to_reth_acc,
 };
 use botanix_lib::mint_validation::{
-    parse_pegin_topic, parse_pegout_topic, MINT_CONTRACT_ADDRESS, MINT_TOPIC, BURN_TOPIC,
+    parse_pegin_topic, parse_pegout_topic, BURN_TOPIC, MINT_CONTRACT_ADDRESS, MINT_TOPIC,
 };
 use reth_consensus_common::calc;
 use reth_interfaces::executor::{BlockExecutionError, BlockValidationError};
@@ -16,7 +16,6 @@ use reth_primitives::{
     ReceiptWithBloom, TransactionSigned, Withdrawal, H256, U256,
 };
 use reth_provider::{BlockExecutor, PostState, StateProvider};
-use reth_tasks::{TaskManager, TaskSpawner};
 use revm::{
     db::{AccountState, CacheDB, DatabaseRef},
     primitives::{
@@ -25,19 +24,14 @@ use revm::{
     },
     EVM,
 };
-use tracing::{error, warn};
 use std::{
     collections::{BTreeMap, HashMap},
     sync::Arc,
-    thread, time,
 };
-
-use btc_wallet::block_source::{BlockSource, MempoolSpace};
-use tokio::sync::mpsc;
+use tracing::{error, warn};
 
 lazy_static::lazy_static! {
     static ref SECP: secp256k1::Secp256k1<secp256k1::All> = secp256k1::Secp256k1::new();
-    static ref BLOCK_SOURCE: btc_wallet::block_source::MempoolSpace = MempoolSpace::new("https://mempool.space/testnet/api".to_string());
 }
 
 /// Main block executor
@@ -65,38 +59,27 @@ where
 
 fn botanix_mint_contract_checks(
     result: &ExecutionResult,
-    recent_block_headers: Option<Vec<bitcoin::block::Header>>,
+    recent_block_header: Option<bitcoin::block::Header>,
 ) -> Result<(), BlockExecutionError> {
     for log in result.logs() {
-        let block_source_clone = BLOCK_SOURCE.to_owned();
-
-        if log.topics.get(0) == Some(&MINT_TOPIC) {
+        if log.topics.get(0) == Some(&MINT_TOPIC) && recent_block_header.is_some() {
             let pegin_data = parse_pegin_topic(&log).map_err(|e| {
                 error!("Failed to parse pegin topic! {:?}", e);
                 BlockValidationError::MintContractViolation
             })?;
 
-            let blockhash = pegin_data.meta.block_header.block_hash();
-            let pegin_header = recent_block_headers
-                //TODO(stevenroose) under what circumstances would we not have them?
-                //we could alternatively return the same error as on violation
-                .expect("can't pegin without recent headers known")
-                .iter().find(|h| h.block_hash() == blockhash)
-                .ok_or_else(|| {
-                    warn!("Failed pegin attempt Could not find block header in list of recent headers");
-                    BlockExecutionError::FailedToGetBitcoinHeader
-                })?;
-
-            if let Err(e) = pegin_data.validate(&SECP, &pegin_header) {
+            if let Err(e) =
+                pegin_data.validate(&SECP, &recent_block_header.expect("valid header").block_hash())
+            {
                 warn!("Failed pegin attempt! {:?}", e);
-                return Err(BlockValidationError::MintContractViolation.into());
+                return Err(BlockValidationError::MintContractViolation.into())
             }
         }
 
         if log.topics.get(0) == Some(&BURN_TOPIC) {
             if let Err(e) = parse_pegout_topic(&log) {
                 error!("Failed to parse pegout topic! {:?}", e);
-                return Err(BlockValidationError::MintContractViolation.into());
+                return Err(BlockValidationError::MintContractViolation.into())
             }
         }
     }
@@ -234,7 +217,7 @@ where
         &mut self,
         transaction: &TransactionSigned,
         sender: Address,
-        recent_block_headers: Option<Vec<bitcoin::block::Header>>,
+        recent_block_header: Option<bitcoin::block::Header>,
     ) -> Result<ResultAndState, BlockExecutionError> {
         // Fill revm structure.
         fill_tx_env(&mut self.evm.env.tx, transaction, sender);
@@ -257,7 +240,7 @@ where
         // Botanix mint contract validation
         if let Ok(ResultAndState { ref result, .. }) = out {
             if result.is_success() && transaction.to() == Some(*MINT_CONTRACT_ADDRESS) {
-                botanix_mint_contract_checks(&result, recent_block_headers)?;
+                botanix_mint_contract_checks(&result, recent_block_header)?;
             }
         }
 
@@ -279,7 +262,7 @@ where
         block: &Block,
         total_difficulty: U256,
         senders: Option<Vec<Address>>,
-        recent_block_headers: Option<Vec<bitcoin::block::Header>>,
+        recent_block_header: Option<bitcoin::block::Header>,
     ) -> Result<(PostState, u64), BlockExecutionError> {
         // perf: do not execute empty blocks
         if block.body.is_empty() {
@@ -303,9 +286,8 @@ where
                 .into())
             }
             // Execute transaction.
-            let ResultAndState { result, state } = self.transact(
-                transaction, sender, recent_block_headers,
-            )?;
+            let ResultAndState { result, state } =
+                self.transact(transaction, sender, recent_block_header)?;
 
             // commit changes
             self.commit_changes(
@@ -374,10 +356,10 @@ where
         block: &Block,
         total_difficulty: U256,
         senders: Option<Vec<Address>>,
-        recent_block_headers: Option<Vec<bitcoin::block::Header>>,
+        recent_block_header: Option<bitcoin::block::Header>,
     ) -> Result<PostState, BlockExecutionError> {
         let (post_state, cumulative_gas_used) =
-            self.execute_transactions(block, total_difficulty, senders, recent_block_headers)?;
+            self.execute_transactions(block, total_difficulty, senders, recent_block_header)?;
 
         // Check if gas used matches the value set in header.
         if block.gas_used != cumulative_gas_used {
@@ -396,9 +378,9 @@ where
         block: &Block,
         total_difficulty: U256,
         senders: Option<Vec<Address>>,
-        recent_block_headers: Option<Vec<bitcoin::block::Header>>,
+        recent_block_header: Option<bitcoin::block::Header>,
     ) -> Result<PostState, BlockExecutionError> {
-        let post_state = self.execute(block, total_difficulty, senders, recent_block_headers)?;
+        let post_state = self.execute(block, total_difficulty, senders, recent_block_header)?;
 
         // TODO Before Byzantium, receipts contained state root that would mean that expensive
         // operation as hashing that is needed for state root got calculated in every
@@ -875,7 +857,8 @@ mod tests {
 
         // execute chain and verify receipts
         let mut executor = Executor::new(chain_spec, db);
-        let post_state = executor.execute_and_verify_receipt(&block, U256::ZERO, None, None).unwrap();
+        let post_state =
+            executor.execute_and_verify_receipt(&block, U256::ZERO, None, None).unwrap();
 
         let base_block_reward = ETH_TO_WEI * 2;
         let block_reward = calc::block_reward(base_block_reward, 1);
@@ -1109,7 +1092,7 @@ mod tests {
 
         // execute chain and verify receipts
         let mut executor = Executor::new(chain_spec, db);
-        let out = executor.execute_and_verify_receipt(&block, U256::ZERO, None, None, ).unwrap();
+        let out = executor.execute_and_verify_receipt(&block, U256::ZERO, None, None).unwrap();
 
         assert_eq!(out.bytecodes().len(), 0, "Should have zero new bytecodes");
 

--- a/crates/storage/provider/src/test_utils/executor.rs
+++ b/crates/storage/provider/src/test_utils/executor.rs
@@ -12,7 +12,7 @@ impl<SP: StateProvider> BlockExecutor<SP> for TestExecutor {
         _block: &Block,
         _total_difficulty: U256,
         _senders: Option<Vec<Address>>,
-        _recent_block_headers: Option<Vec<bitcoin::block::Header>>,
+        _recent_block_headers: Option<bitcoin::block::Header>,
     ) -> Result<PostState, BlockExecutionError> {
         self.0.clone().ok_or(BlockExecutionError::UnavailableForTest)
     }
@@ -22,7 +22,7 @@ impl<SP: StateProvider> BlockExecutor<SP> for TestExecutor {
         _block: &Block,
         _total_difficulty: U256,
         _senders: Option<Vec<Address>>,
-        _recent_block_headers: Option<Vec<bitcoin::block::Header>>,
+        _recent_block_headers: Option<bitcoin::block::Header>,
     ) -> Result<PostState, BlockExecutionError> {
         self.0.clone().ok_or(BlockExecutionError::UnavailableForTest)
     }

--- a/crates/storage/provider/src/traits/executor.rs
+++ b/crates/storage/provider/src/traits/executor.rs
@@ -33,7 +33,7 @@ pub trait BlockExecutor<SP: StateProvider> {
         block: &Block,
         total_difficulty: U256,
         senders: Option<Vec<Address>>,
-        recent_block_headers: Option<Vec<bitcoin::block::Header>>,
+        recent_block_header: Option<bitcoin::block::Header>,
     ) -> Result<PostState, BlockExecutionError>;
 
     /// Executes the block and checks receipts
@@ -42,6 +42,6 @@ pub trait BlockExecutor<SP: StateProvider> {
         block: &Block,
         total_difficulty: U256,
         senders: Option<Vec<Address>>,
-        recent_block_headers: Option<Vec<bitcoin::block::Header>>
+        recent_block_header: Option<bitcoin::block::Header>
     ) -> Result<PostState, BlockExecutionError>;
 }


### PR DESCRIPTION
This is actually the original design as defined in https://github.com/botanix-labs/botanix/blob/master/docs/pegin.md
User provides n block headers. The nth block header should be the tip that we store in reth. For v0 we only care about 1 conf. Going forward it will be m confs.


in a future PR. We will mine the block with the mth bitcoin block header in the botanix block header. 