### PR TITLE
refactor: update chainId to 3636 to match chainlist

### DIFF
--- a/crates/primitives/src/chain/mod.rs
+++ b/crates/primitives/src/chain/mod.rs
@@ -51,7 +51,7 @@ impl Chain {
 
     /// Returns the botanix testnet chain.
     pub const fn botanix_testnet() -> Self {
-        Chain::Id(444)
+        Chain::Id(3636)
     }
 
     /// The id of the chain


### PR DESCRIPTION
Metamask is expecting chainId 3636 based on 
https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-3636.json

there is an open pr with that repo to update our details (rpc, explorer, etc)
https://github.com/ethereum-lists/chains/pull/3735