### PR TITLE
extended Makefile, updated readme and Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,6 @@
 [workspace]
+resolver = "2"
+
 members = [
     "bin/reth/",
     "bin/btc-server",
@@ -61,7 +63,6 @@ default-members = ["bin/reth"]
 
 # Explicitly set the resolver to version 2, which is the default for packages with edition >= 2021
 # https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html
-resolver = "2"
 
 [workspace.package]
 version = "0.1.0-alpha.13"

--- a/Makefile
+++ b/Makefile
@@ -232,3 +232,35 @@ update-book-cli: ## Update book cli documentation.
 .PHONY: maxperf
 maxperf:
 	RUSTFLAGS="-C target-cpu=native" cargo build --profile maxperf --features jemalloc
+
+fmt:
+	@cargo fmt --all --
+
+fmt-check:
+	@cargo fmt --all -- --check
+
+lint:
+	@cargo clippy --bins --lib --tests --examples --all-features --fix -- -D warnings
+
+doc:
+	@cargo doc --no-deps --open
+
+start-btc-server:
+	cd ./bin/btc-server && \
+	cargo run --bin btc-server -- --network testnet --pkey ./key.hex --db "./db"
+
+start-reth-server:
+	cd ./bin/reth && \
+	cargo run --bin reth node \
+	--chain botanix_testnet \
+	--disable-discovery \
+	--http \
+	--http.corsdomain "*" \
+	-vvv \
+	--metrics 127.0.0.1:9001 \
+	--authrpc.addr 127.0.0.1 \
+	--authrpc.port 8551 \
+	--datadir ${DB_DIR} \
+	--auto-mine \
+	--btc-server localhost:8080 \
+	--btc-block-source "https://mempool.space/signet/api"

--- a/README.md
+++ b/README.md
@@ -141,3 +141,21 @@ None of this would have been possible without them, so big shoutout to the teams
 
 [book]: https://paradigmxyz.github.io/reth/
 [tg-url]: https://t.me/paradigm_reth
+
+### Requirements
+
+To run the stack locally, please go through the following steps to ensure you have all necessary prerequisites:
+
+1. Install rust (best way to install it is through the rustup toolchain: `https://rustup.rs/` - for any OS). Default to nightly version.
+2. Install docker on your OS - simply follow the instructions here: `https://docs.docker.com/engine/install/`
+3. Install foundry on your system - simply follow the instructions here: `https://book.getfoundry.sh/getting-started/installation`
+4. Set up git to use ssh. Currently all git submodules are set up via ssh and other authentication methods wont work.
+5. Once you have cloned the Botanix monorepo, initialize gitmodules: `git submodule init`
+6. Pull the git submodules and their deps recursively: `git submodule update --init --recursive`
+7. Install protobuf native dependencies: `apt update && apt upgrade -y && apt install -y protobuf-compiler libprotobuf-dev` (for ubuntu only)
+8. Install libclang dependeny: `sudo apt-get install libclang-dev` (for ubuntu only)
+
+### Run locally the stack
+
+1. Run: `start-btc-server` to spin up the btc server
+2. Run: `start-reth-server` to spin up the EVM Botanix node


### PR DESCRIPTION
This PR adds:
- some instructions reg. requirements and prerequisites needed for setting up the system
- some additional Makefile commands (also for spinning up the reth and btc servers)
- slightly rearranged Cargo.toml file