### PR TITLE
WIP: ssp spend - Do not merge

### DIFF
--- a/crates/btc-wallet/src/address.rs
+++ b/crates/btc-wallet/src/address.rs
@@ -1,10 +1,13 @@
 use std::io::Write;
 
-use bitcoin::absolute::LockTime;
-use bitcoin::hashes::{sha256, Hash};
-use bitcoin::script::Builder;
-use bitcoin::taproot::{Error, TaprootBuilder, TaprootSpendInfo};
-use bitcoin::{opcodes, Address, Network, ScriptBuf};
+use bitcoin::{
+    absolute::LockTime,
+    hashes::{sha256, Hash},
+    opcodes,
+    script::Builder,
+    taproot::{Error as TaprootError, TaprootBuilder, TaprootSpendInfo},
+    Address, Network, ScriptBuf,
+};
 use secp256k1::{PublicKey, Scalar, Secp256k1, SecretKey, Verification};
 
 pub trait EthAddress {
@@ -25,8 +28,9 @@ impl EthAddress for Vec<u8> {
 
 // Unused, spend safe path only requires a single signer for now
 // Keep commented out till we use a multisig
-// const SAFE_SPEND_PATH_QUORUM: i64 = 3;
+const SAFE_SPEND_PATH_QUORUM: i64 = 3;
 const SAFE_SPEND_TIMELOCK_SECOND: u32 = 1653195600;
+const SAFE_SPEND_PATH_TAP_LEAF_DEPTH: u8 = 0u8;
 
 lazy_static::lazy_static! {
     /// Compressed 33 byte public key of the recovery signer
@@ -65,18 +69,14 @@ fn _build_safe_spend_path_script_check_sig_add(
     let mut script = Builder::new()
         .push_lock_time(lock_time)
         .push_key(&bitcoin::PublicKey::new(
-            *public_keys
-                .get(0)
-                .expect("There is always a 0th public key"),
+            *public_keys.get(0).expect("There is always a 0th public key"),
         ))
         .push_opcode(opcodes::all::OP_CHECKSIG);
 
     for i in 1..public_keys.len() {
         script = script
             .push_key(&bitcoin::PublicKey::new(
-                *(public_keys
-                    .get(i)
-                    .expect(format!("should find pubkey at {}", i).as_str())),
+                *(public_keys.get(i).expect(format!("should find pubkey at {}", i).as_str())),
             ))
             .push_opcode(opcodes::all::OP_CHECKSIGADD);
     }
@@ -98,21 +98,24 @@ fn build_safe_spend_path_script_check_sig_verify(
     Ok(script.into_script())
 }
 
+pub fn build_safe_spend_path_scriptbuf() -> Result<ScriptBuf, SafeSpendPathError> {
+    let lock_time = LockTime::from_time(SAFE_SPEND_TIMELOCK_SECOND).expect("valid time");
+    let recovery_key = *RECOVERY_PK;
+    let script = build_safe_spend_path_script_check_sig_verify(lock_time, recovery_key)?;
+
+    Ok(script)
+}
+
 pub fn generate_taproot_spend_info(
     secp: &Secp256k1<impl Verification>,
     tweaked_public_key: &PublicKey,
-) -> Result<TaprootSpendInfo, Error> {
-    let lock_time = LockTime::from_time(SAFE_SPEND_TIMELOCK_SECOND).expect("valid time");
+) -> Result<TaprootSpendInfo, TaprootError> {
     let builder = TaprootBuilder::new()
-        .add_leaf(
-            0u8,
-            build_safe_spend_path_script_check_sig_verify(lock_time, *RECOVERY_PK).unwrap(),
-        )
+        .add_leaf(SAFE_SPEND_PATH_TAP_LEAF_DEPTH, build_safe_spend_path_scriptbuf()?)
         .expect("Couldn't add timelock leaf");
 
-    let finalized_taproot = builder
-        .finalize(&secp, tweaked_public_key.x_only_public_key().0)
-        .unwrap();
+    let finalized_taproot =
+        builder.finalize(&secp, tweaked_public_key.x_only_public_key().0).unwrap();
 
     Ok(finalized_taproot)
 }
@@ -189,7 +192,6 @@ pub fn generate_taproot_change_scriptpubkey(
     secp: &Secp256k1<impl Verification>,
     public_key: &PublicKey,
 ) -> ScriptBuf {
-    // Address::p2tr(secp, public_key.x_only_public_key().0, None, network).script_pubkey()
     let taproot_spend_info =
         generate_taproot_spend_info(secp, public_key).expect("Valid spend info");
     bitcoin::ScriptBuf::new_v1_p2tr(secp, (*public_key).into(), taproot_spend_info.merkle_root())
@@ -225,9 +227,7 @@ mod tests {
         let secp = Secp256k1::new();
         let network: Network = Network::Testnet;
         let eth_addr = ethers::abi::Address::from_slice(
-            hex::decode("86Bb524A1c7703C02BcEc36D1C4218aADb7D643D")
-                .expect("hex decode")
-                .as_slice(),
+            hex::decode("86Bb524A1c7703C02BcEc36D1C4218aADb7D643D").expect("hex decode").as_slice(),
         );
         let key_pair = KeyPair::from_seckey_str(
             &SECP,
@@ -235,8 +235,7 @@ mod tests {
         )
         .unwrap();
 
-        let gateway =
-            gateway_address(&secp, &key_pair.public_key(), &eth_addr, network).unwrap();
+        let gateway = gateway_address(&secp, &key_pair.public_key(), &eth_addr, network).unwrap();
         assert_eq!(
             gateway.to_string(),
             "tb1pjutmjkwrwjejxn988mt35528schetrrsgexhv24fxhn7nk6pvs7qd66dne"

--- a/crates/btc-wallet/src/transaction.rs
+++ b/crates/btc-wallet/src/transaction.rs
@@ -1,11 +1,14 @@
-use bitcoin::secp256k1::{KeyPair, SecretKey};
 use bitcoin::{
     psbt::{self, PartiallySignedTransaction},
+    secp256k1::{KeyPair, SecretKey},
     sighash::TapSighashType,
+    taproot::{LeafVersion, TapLeafHash},
+    OutPoint, TxOut,
 };
-use bitcoin::{OutPoint, TxOut};
 
-use crate::address::{generate_taproot_spend_info, generate_tweaked_secret_key};
+use crate::address::{
+    build_safe_spend_path_scriptbuf, generate_taproot_spend_info, generate_tweaked_secret_key,
+};
 
 const USER_ETH_ADDRESS_FIELD: u8 = 1;
 
@@ -81,9 +84,7 @@ pub fn sign_psbt(
         let input = &psbt.inputs[i];
         // Get address tweaks if applicaple
         let eth_address_tweak = input.proprietary.get(&ETH_ADDRESS_FIELD);
-
         let aggregate_pk = secret_key.public_key(&secp);
-
         let mut internal_sk = secret_key.clone();
 
         // Not signing change
@@ -93,8 +94,7 @@ pub fn sign_psbt(
                 &eth_address_tweak.expect("eth address tweak").as_slice(),
             );
 
-            internal_sk =
-                generate_tweaked_secret_key(&eth_address, &aggregate_pk, &secret_key);
+            internal_sk = generate_tweaked_secret_key(&eth_address, &aggregate_pk, &secret_key);
         }
 
         let internal = KeyPair::from_secret_key(&secp, &internal_sk);
@@ -106,11 +106,8 @@ pub fn sign_psbt(
             taproot_spend_info.merkle_root(),
         );
         let signature = {
-            let prevouts = psbt
-                .inputs
-                .iter()
-                .map(|i| i.witness_utxo.as_ref().unwrap())
-                .collect::<Vec<_>>();
+            let prevouts =
+                psbt.inputs.iter().map(|i| i.witness_utxo.as_ref().unwrap()).collect::<Vec<_>>();
             let sighash = sighashcache
                 .taproot_signature_hash(
                     i,
@@ -122,10 +119,7 @@ pub fn sign_psbt(
                 .expect("error calculating taproot keyspend sighash");
             let msg = bitcoin::secp256k1::Message::from_slice(&sighash[..]).expect("sane sighash");
             let sig = secp.sign_schnorr(&msg, &keypair.to_inner());
-            bitcoin::taproot::Signature {
-                sig,
-                hash_ty: TapSighashType::All,
-            }
+            bitcoin::taproot::Signature { sig, hash_ty: TapSighashType::All }
         };
         // modify the psbt input by placing the signature
         psbt.inputs.get_mut(i).unwrap().sighash_type = Some(TapSighashType::All.into());
@@ -135,4 +129,75 @@ pub fn sign_psbt(
     }
 
     Ok(())
+}
+
+#[derive(Debug)]
+pub enum SignSafeSpendPathError {
+    NonceProvidedMissingEthTweak,
+    FailedToGetTaprootInfo(bitcoin::taproot::Error),
+}
+
+pub fn sign_spend_path(
+    secp: &bitcoin::secp256k1::Secp256k1<bitcoin::secp256k1::All>,
+    secret_key: &SecretKey,
+    psbt: &mut PartiallySignedTransaction,
+) {
+    let mut sighashcache = bitcoin::sighash::SighashCache::new(&psbt.unsigned_tx);
+    for i in 0..psbt.inputs.len() {
+        let input = &psbt.inputs[i];
+        // Get address tweaks if applicaple
+        let eth_address_tweak = input.proprietary.get(&ETH_ADDRESS_FIELD);
+        let aggregate_pk = secret_key.public_key(&secp);
+        let mut internal_sk = secret_key.clone();
+
+        // need to tweak the key before signing
+        if eth_address_tweak.is_some() {
+            let eth_address = ethers::types::Address::from_slice(
+                &eth_address_tweak.expect("eth address tweak").as_slice(),
+            );
+
+            internal_sk = generate_tweaked_secret_key(&eth_address, &aggregate_pk, &secret_key);
+        }
+
+        let internal_key = KeyPair::from_secret_key(&secp, &internal_sk);
+        let taproot_spend_info = generate_taproot_spend_info(&secp, &internal_key.public_key())
+            .map_err(|e| SignPsbtError::FailedToGetTaprootInfo(e))
+            .unwrap();
+
+        let keypair = bitcoin::key::TapTweak::tap_tweak(
+            internal_key.clone(),
+            &secp,
+            taproot_spend_info.merkle_root(),
+        );
+        let ssp_scriptbuf = build_safe_spend_path_scriptbuf().unwrap();
+        let control_block = taproot_spend_info
+            .control_block(&(ssp_scriptbuf, LeafVersion::TapScript))
+            .expect("valid control block");
+        let tap_leaf_hash = TapLeafHash::from_script(&ssp_scriptbuf, LeafVersion::TapScript);
+
+        let signature = {
+            let prevouts =
+                psbt.inputs.iter().map(|i| i.witness_utxo.as_ref().unwrap()).collect::<Vec<_>>();
+            let sighash = sighashcache
+                .taproot_signature_hash(
+                    i,
+                    &psbt::Prevouts::All(&prevouts),
+                    None, // always leave annex None
+                    // https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#cite_note-5
+                    Some((tap_leaf_hash, 0u32)),
+                    TapSighashType::All,
+                )
+                .expect("error calculating taproot keyspend sighash");
+            let msg = bitcoin::secp256k1::Message::from_slice(&sighash[..]).expect("sane sighash");
+            let sig = secp.sign_schnorr(&msg, &keypair.to_inner());
+            bitcoin::taproot::Signature { sig, hash_ty: TapSighashType::All }
+        };
+        // modify the psbt input by placing the signature
+        psbt.inputs.get_mut(i).unwrap().sighash_type = Some(TapSighashType::All.into());
+        psbt.inputs.get_mut(i).unwrap().tap_internal_key = Some(internal_key.x_only_public_key().0);
+
+        // TODO include the control block in the psbt
+        psbt.inputs.get_mut(i).unwrap().tap_key_sig = Some(signature);
+        psbt.inputs.get_mut(i).unwrap().tap_merkle_root = taproot_spend_info.merkle_root()
+    }
 }


### PR DESCRIPTION
Just started to look over again at the safe spend path. The following code attempts to spend from a single key tapscript path. The same mechanism can be used to for a tapscript multisig where participants pass around a PSBT. 

The majority of the complexity is going to be
- Updating the UTXO set across all nodes
- Key management and backups
