### PR TITLE
fix: add dependencies for btc-server

### DIFF
--- a/bin/btc-server/src/main.rs
+++ b/bin/btc-server/src/main.rs
@@ -36,6 +36,10 @@ use reth_btc_wallet::TAPROOT_KEYSPEND_SATISFACTION_WEIGHT;
 
 use crate::{database::Utxo, util::OutPointExt};
 
+use bdk::{miniscript::psbt::Error as PsbtError, Error as BdkError};
+use database::Error as DbError;
+use thiserror::Error;
+
 lazy_static::lazy_static! {
     static ref SECP: secp256k1::Secp256k1<secp256k1::All> = secp256k1::Secp256k1::new();
 }


### PR DESCRIPTION
some dependencies are missing in btc-server so it won't build...they are included in this pr: https://github.com/botanix-labs/Macbeth/pull/48

i want to incude them in a separate pr so can test btc-server as it is now