### PR TITLE
btc network config taken from cli flag

### DIFF
--- a/Dockerfile.testnet
+++ b/Dockerfile.testnet
@@ -46,4 +46,4 @@ COPY LICENSE-* ./
 
 EXPOSE 30303 30303/udp 9001 8545 8546
 
-CMD ["/usr/local/bin/reth", "node", "--chain", "botanix_testnet", "--datadir", "/reth/botanix_testnet", "--http", "--http.corsdomain", "*", "--http.port", "8545", "--http.addr", "0.0.0.0", "--http.api", "eth,net,trace,txpool,web3,rpc", "-vvv", "--auto-mine", "--disable-discovery", "--btc-server", "btc_server", "--btc-block-source", "https://mempool.space/signet/api" ]
+CMD ["/usr/local/bin/reth", "node", "--chain", "botanix_testnet", "--datadir", "/reth/botanix_testnet", "--http", "--http.corsdomain", "*", "--http.port", "8545", "--http.addr", "0.0.0.0", "--http.api", "eth,net,trace,txpool,web3,rpc", "-vvv", "--auto-mine", "--disable-discovery", "--btc-server", "btc_server", "--btc-block-source", "https://mempool.space/signet/api", "btc-network", "--signet"]

--- a/Makefile
+++ b/Makefile
@@ -263,4 +263,5 @@ start-reth-server:
 	--datadir ${DB_DIR} \
 	--auto-mine \
 	--btc-server localhost:8080 \
-	--btc-block-source "https://mempool.space/signet/api"
+	--btc-block-source "https://mempool.space/signet/api" \
+	--btc-network "signet"

--- a/bin/reth/src/args/rpc_server_args.rs
+++ b/bin/reth/src/args/rpc_server_args.rs
@@ -194,6 +194,10 @@ pub struct RpcServerArgs {
     /// The metrics will be served at the given interface and port.
     #[arg(long, value_name = "BITCOIN_BLOCK_SOURCE", value_parser = parse_url, help_heading = "Btc_block_source")]
     pub btc_block_source: Url,
+
+    /// The bitcoin network to operate on.
+    #[arg(long, value_name = "BITCOIN_NETWORK", help_heading = "Btc_network", required = true)]
+    pub btc_network: bitcoin::Network,
 }
 
 impl RpcServerArgs {
@@ -510,6 +514,7 @@ impl Default for RpcServerArgs {
             rpc_state_cache: RpcStateCacheArgs::default(),
             btc_server: "127.0.0.1:8080".parse().expect("valid grpc address"),
             btc_block_source: Url::parse("https://mempool.space/signet/api").expect("valid url"),
+            btc_network: bitcoin::Network::Signet,
         }
     }
 }

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -987,7 +987,9 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
             },
         };
 
-        let factory = factory.with_stack_config(stack_config);
+        let factory = factory
+            .with_stack_config(stack_config)
+            .with_bitcoin_config(self.rpc.btc_network.clone());
 
         let prune_modes = prune_config.map(|prune| prune.segments).unwrap_or_default();
 

--- a/crates/botanix-lib/src/mint_validation.rs
+++ b/crates/botanix-lib/src/mint_validation.rs
@@ -84,14 +84,17 @@ pub fn parse_pegin_reth_log_topic(
 
 pub fn parse_pegout_reth_log_topic(
     log: &reth_primitives::Log,
+    btc_network: Option<bitcoin::Network>,
 ) -> Result<PegoutData, MintConsensusError> {
     let revm_log =
         Log { address: log.address, topics: log.topics.clone(), data: log.data.clone().into() };
 
-    parse_pegout_topic(&revm_log)
+    parse_pegout_topic(&revm_log, btc_network)
 }
 
-pub fn parse_pegin_topic(log: &Log) -> Result<PeginData, MintConsensusError> {
+pub fn parse_pegin_topic(
+    log: &Log,
+) -> Result<PeginData, MintConsensusError> {
     if log.address != *MINT_CONTRACT_ADDRESS {
         return Err(MintConsensusError::MintContractDidNotEmitMintTopic())
     }
@@ -158,7 +161,10 @@ pub fn parse_pegin_topic(log: &Log) -> Result<PeginData, MintConsensusError> {
     Err(MintConsensusError::MintContractDidNotEmitRelevantTopic())
 }
 
-pub fn parse_pegout_topic(log: &Log) -> Result<PegoutData, MintConsensusError> {
+pub fn parse_pegout_topic(
+    log: &Log,
+    btc_network: Option<bitcoin::Network>,
+) -> Result<PegoutData, MintConsensusError> {
     if log.address != *MINT_CONTRACT_ADDRESS {
         return Err(MintConsensusError::MintContractDidNotEmitMintTopic())
     }
@@ -199,7 +205,7 @@ pub fn parse_pegout_topic(log: &Log) -> Result<PegoutData, MintConsensusError> {
             let btc_amount = bitcoin::Amount::from_wei_floor(amount)
                 .ok_or(MintConsensusError::PegoutAmountIsInvalid())?;
 
-            let pegout = PegoutData::new(btc_amount, destination)
+            let pegout = PegoutData::new(btc_amount, destination, btc_network)
                 .map_err(|e| MintConsensusError::PegoutValidationFailed(e))?;
 
             return Ok(pegout)

--- a/crates/botanix-lib/src/peg_contract.rs
+++ b/crates/botanix-lib/src/peg_contract.rs
@@ -218,9 +218,13 @@ pub struct PegoutData {
 }
 
 impl PegoutData {
-    pub fn new(amount: bitcoin::Amount, address: String) -> Result<Self, PegoutError> {
+    pub fn new(
+        amount: bitcoin::Amount,
+        address: String,
+        btc_network: Option<bitcoin::Network>,
+    ) -> Result<Self, PegoutError> {
         // TODO (armins) This should be coming from config
-        let network = bitcoin::Network::Signet;
+        let network = btc_network.unwrap_or(bitcoin::Network::Signet);
         // Check for valid addres
         let destination: bitcoin::address::Address<bitcoin::address::NetworkUnchecked> =
             bitcoin::address::Address::from_str(address.as_str())

--- a/crates/consensus/auto-seal/src/lib.rs
+++ b/crates/consensus/auto-seal/src/lib.rs
@@ -112,6 +112,7 @@ pub struct AutoSealBuilder<Client, Pool> {
     bitcoin_block_header: Arc<RwLock<Option<(bitcoin::block::Header, u32)>>>,
     bitcoin_block_source_address: Url,
     payload_store: PayloadBuilderHandle,
+    btc_network: Option<bitcoin::Network>,
 }
 
 // === impl AutoSealBuilder ===
@@ -152,6 +153,7 @@ where
             bitcoin_block_header,
             bitcoin_block_source_address,
             payload_store,
+            btc_network: None,
         }
     }
 
@@ -176,6 +178,7 @@ where
             bitcoin_block_header,
             bitcoin_block_source_address,
             payload_store,
+            btc_network,
         } = self;
         let auto_client = AutoSealClient::new(storage.clone());
         let task = MiningTask::new(
@@ -190,6 +193,7 @@ where
             bitcoin_block_header,
             bitcoin_block_source_address,
             payload_store,
+            btc_network,
         );
         (consensus, auto_client, task)
     }
@@ -243,6 +247,8 @@ pub(crate) struct StorageInner {
     pub(crate) best_hash: B256,
     /// The total difficulty of the chain until this block
     pub(crate) total_difficulty: U256,
+    /// Bitcoin network
+    pub(crate) btc_network: Option<bitcoin::Network>,
 }
 
 // === impl StorageInner ===
@@ -426,7 +432,8 @@ impl StorageInner {
             .with_database_boxed(Box::new(StateProviderDatabase::new(client.latest().unwrap())))
             .with_bundle_update()
             .build();
-        let mut executor = EVMProcessor::new_with_state(chain_spec.clone(), db);
+        let mut executor =
+            EVMProcessor::new_with_state(chain_spec.clone(), db, self.btc_network.clone());
 
         let (bundle_state, gas_used) =
             self.execute(&block, &mut executor, senders, recent_block_header)?;

--- a/crates/consensus/auto-seal/src/task.rs
+++ b/crates/consensus/auto-seal/src/task.rs
@@ -60,6 +60,8 @@ pub struct MiningTask<Client, Pool: TransactionPool> {
     bitcoin_block_source_address: Url,
     /// Payload store
     payload_store: PayloadBuilderHandle,
+    /// Bitcoin network
+    btc_network: Option<bitcoin::Network>,
 }
 
 // === impl MiningTask ===
@@ -78,6 +80,7 @@ impl<Client, Pool: TransactionPool> MiningTask<Client, Pool> {
         bitcoin_block_header: Arc<RwLock<Option<(bitcoin::block::Header, u32)>>>,
         bitcoin_block_source_address: Url,
         payload_store: PayloadBuilderHandle,
+        btc_network: Option<bitcoin::Network>,
     ) -> Self {
         Self {
             chain_spec,
@@ -94,6 +97,7 @@ impl<Client, Pool: TransactionPool> MiningTask<Client, Pool> {
             bitcoin_block_header,
             bitcoin_block_source_address,
             payload_store,
+            btc_network,
         }
     }
 
@@ -152,6 +156,7 @@ where
                     MempoolSpace::new(this.bitcoin_block_source_address.clone().to_string());
 
                 let payload_store = this.payload_store.clone();
+                let btc_network = this.btc_network.clone();
                 // Create the mining future that creates a block, notifies the engine that drives
                 // the pipeline
                 this.insert_task = Some(Box::pin(async move {
@@ -294,9 +299,11 @@ where
                                                         // TODO (armins): obv
                                                         let fee_rate = 30u32;
                                                         info!("Parsing and sending withdrawal event to btc_server");
-                                                        let pegout =
-                                                            parse_pegout_reth_log_topic(&log)
-                                                                .expect("valid pegout request");
+                                                        let pegout = parse_pegout_reth_log_topic(
+                                                            &log,
+                                                            btc_network.clone(),
+                                                        )
+                                                        .expect("valid pegout request");
                                                         let request = MakeTxRequest {
                                                             address: pegout.destination.to_string(),
                                                             value: pegout.amount.to_sat(),

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -1559,8 +1559,6 @@ mod tests {
     use bytes::BytesMut;
     use std::{collections::HashMap, str::FromStr};
 
-    use super::BOTANIX_TESTNET;
-
     #[cfg(feature = "optimism")]
     use crate::OP_GOERLI;
 

--- a/crates/revm/src/factory.rs
+++ b/crates/revm/src/factory.rs
@@ -12,17 +12,24 @@ use std::sync::Arc;
 pub struct EvmProcessorFactory {
     chain_spec: Arc<ChainSpec>,
     stack: Option<InspectorStack>,
+    btc_network: Option<bitcoin::Network>,
 }
 
 impl EvmProcessorFactory {
     /// Create new factory
     pub fn new(chain_spec: Arc<ChainSpec>) -> Self {
-        Self { chain_spec, stack: None }
+        Self { chain_spec, stack: None, btc_network: None }
     }
 
     /// Sets the inspector stack for all generated executors.
     pub fn with_stack(mut self, stack: InspectorStack) -> Self {
         self.stack = Some(stack);
+        self
+    }
+
+    /// adds bitcoin network information
+    pub fn with_bitcoin_config(mut self, btc_network: bitcoin::Network) -> Self {
+        self.btc_network = Some(btc_network);
         self
     }
 
@@ -39,7 +46,11 @@ impl ExecutorFactory for EvmProcessorFactory {
         sp: SP,
     ) -> Box<dyn PrunableBlockExecutor + 'a> {
         let database_state = StateProviderDatabase::new(sp);
-        let mut evm = Box::new(EVMProcessor::new_with_db(self.chain_spec.clone(), database_state));
+        let mut evm = Box::new(EVMProcessor::new_with_db(
+            self.chain_spec.clone(),
+            database_state,
+            self.btc_network.clone(),
+        ));
         if let Some(ref stack) = self.stack {
             evm.set_stack(stack.clone());
         }

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -81,6 +81,8 @@ pub struct EVMProcessor<'a> {
     pruning_address_filter: Option<(u64, Vec<Address>)>,
     /// Execution stats
     pub(crate) stats: BlockExecutorStats,
+    /// Bitcoin network configuration
+    pub btc_network: Option<bitcoin::Network>,
 }
 
 impl<'a> EVMProcessor<'a> {
@@ -102,6 +104,7 @@ impl<'a> EVMProcessor<'a> {
             prune_modes: PruneModes::none(),
             pruning_address_filter: None,
             stats: BlockExecutorStats::default(),
+            btc_network: None,
         }
     }
 
@@ -109,19 +112,21 @@ impl<'a> EVMProcessor<'a> {
     pub fn new_with_db<DB: StateProvider + 'a>(
         chain_spec: Arc<ChainSpec>,
         db: StateProviderDatabase<DB>,
+        btc_network: Option<bitcoin::Network>,
     ) -> Self {
         let state = State::builder()
             .with_database_boxed(Box::new(db))
             .with_bundle_update()
             .without_state_clear()
             .build();
-        EVMProcessor::new_with_state(chain_spec, state)
+        EVMProcessor::new_with_state(chain_spec, state, btc_network)
     }
 
     /// Create a new EVM processor with the given revm state.
     pub fn new_with_state(
         chain_spec: Arc<ChainSpec>,
         revm_state: StateDBBox<'a, ProviderError>,
+        btc_network: Option<bitcoin::Network>,
     ) -> Self {
         let mut evm = EVM::new();
         evm.database(revm_state);
@@ -135,6 +140,7 @@ impl<'a> EVMProcessor<'a> {
             prune_modes: PruneModes::none(),
             pruning_address_filter: None,
             stats: BlockExecutorStats::default(),
+            btc_network,
         }
     }
 
@@ -254,6 +260,7 @@ impl<'a> EVMProcessor<'a> {
     fn botanix_mint_contract_checks(
         result: &ExecutionResult,
         recent_block_header: Option<(bitcoin::block::Header, u32)>,
+        btc_network: Option<bitcoin::Network>,
     ) -> Result<(), BlockExecutionError> {
         for log in result.logs() {
             if log.topics.get(0) == Some(&MINT_TOPIC) && recent_block_header.is_some() {
@@ -278,7 +285,7 @@ impl<'a> EVMProcessor<'a> {
             }
 
             if log.topics.get(0) == Some(&BURN_TOPIC) {
-                if let Err(e) = parse_pegout_topic(&log) {
+                if let Err(e) = parse_pegout_topic(&log, btc_network) {
                     error!("Failed to parse pegout topic! {:?}", e);
                     return Err(BlockValidationError::MintContractViolation.into())
                 }
@@ -327,7 +334,11 @@ impl<'a> EVMProcessor<'a> {
         let out = match out {
             Ok(ResultAndState { ref result, ref state }) => {
                 if result.is_success() && transaction.to() == Some(*MINT_CONTRACT_ADDRESS) {
-                    match Self::botanix_mint_contract_checks(&result, recent_block_header) {
+                    match Self::botanix_mint_contract_checks(
+                        &result,
+                        recent_block_header,
+                        self.btc_network,
+                    ) {
                         Ok(()) => out,
                         Err(e) => Ok({
                             error!("Botanix mint contract validation failed: {:?}", e);
@@ -776,7 +787,8 @@ mod tests {
         );
 
         // execute invalid header (no parent beacon block root)
-        let mut executor = EVMProcessor::new_with_db(chain_spec, StateProviderDatabase::new(db));
+        let mut executor =
+            EVMProcessor::new_with_db(chain_spec, StateProviderDatabase::new(db), None);
 
         // attempt to execute a block without parent beacon block root, expect err
         let err = executor
@@ -852,7 +864,8 @@ mod tests {
                 .build(),
         );
 
-        let mut executor = EVMProcessor::new_with_db(chain_spec, StateProviderDatabase::new(db));
+        let mut executor =
+            EVMProcessor::new_with_db(chain_spec, StateProviderDatabase::new(db), None);
         executor.init_env(&header, U256::ZERO);
 
         // get the env
@@ -903,7 +916,8 @@ mod tests {
                 .build(),
         );
 
-        let mut executor = EVMProcessor::new_with_db(chain_spec, StateProviderDatabase::new(db));
+        let mut executor =
+            EVMProcessor::new_with_db(chain_spec, StateProviderDatabase::new(db), None);
 
         // construct the header for block one
         let header = Header {
@@ -960,7 +974,8 @@ mod tests {
 
         let mut header = chain_spec.genesis_header();
 
-        let mut executor = EVMProcessor::new_with_db(chain_spec, StateProviderDatabase::new(db));
+        let mut executor =
+            EVMProcessor::new_with_db(chain_spec, StateProviderDatabase::new(db), None);
         executor.init_env(&header, U256::ZERO);
 
         // attempt to execute the genesis block with non-zero parent beacon block root, expect err
@@ -1038,7 +1053,8 @@ mod tests {
         );
 
         // execute header
-        let mut executor = EVMProcessor::new_with_db(chain_spec, StateProviderDatabase::new(db));
+        let mut executor =
+            EVMProcessor::new_with_db(chain_spec, StateProviderDatabase::new(db), None);
         executor.init_env(&header, U256::ZERO);
 
         // ensure that the env is configured with a base fee


### PR DESCRIPTION
This PR aims at providing the user with the ability to tell which btc network the reth cli is to use as the latter is needed for pegins and pegouts and it used to be hardcoded in the code. The cli arg is completely optional and if not used, the signet shall be used as the default one.