### PR TITLE
feature: nodes should propagate txs in mempool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,3 +264,41 @@ start-reth-server:
 	--auto-mine \
 	--btc-server localhost:8080 \
 	--btc-block-source "https://mempool.space/signet/api"
+
+start-poa-server-1:
+	cd ./bin/reth && \
+	cargo run --bin reth -- poa \
+	--chain botanix_testnet \
+	--datadir ${NODE_1_DIR} \
+	--http \
+	--http.corsdomain "*" \
+	--http.port 8545 \
+	--http.addr "127.0.0.1" \
+	--http.api eth,net,trace,txpool,web3,rpc,admin \
+	-vvv \
+	--authrpc.jwtsecret "${NODE_1_DIR}/jwt.hex" \
+	--authrpc.addr "127.0.0.1" \
+	--authrpc.port 8551 \
+	--btc-server "localhost:8080" \
+	--btc-block-source "https://mempool.space/signet/api" \
+	--p2p-secret-key "${NODE_1_DIR}/discovery-secret" \
+	--port 30303
+
+start-poa-server-2:
+	cd ./bin/reth && \
+	cargo run --bin reth -- poa \
+	--chain botanix_testnet \
+	--datadir ${NODE_2_DIR} \
+	--http \
+	--http.corsdomain "*" \
+	--http.port 8546 \
+	--http.addr "127.0.0.1" \
+	--http.api eth,net,trace,txpool,web3,rpc,admin \
+	-vvv \
+	--authrpc.jwtsecret "${NODE_2_DIR}/jwt.hex" \
+	--authrpc.addr "127.0.0.1" \
+	--authrpc.port 8552 \
+	--btc-server "localhost:8080" \
+	--btc-block-source "https://mempool.space/signet/api" \
+	--p2p-secret-key "${NODE_2_DIR}/discovery-secret" \
+	--port 30304

--- a/bin/reth/src/poa/mod.rs
+++ b/bin/reth/src/poa/mod.rs
@@ -39,6 +39,7 @@ use reth_config::{
     config::{PruneConfig, StageConfig},
     Config,
 };
+use reth_consensus_common::utils;
 use reth_db::{database::Database, init_db, DatabaseEnv};
 use reth_downloaders::{
     bodies::bodies::BodiesDownloaderBuilder,
@@ -85,7 +86,6 @@ use reth_tasks::TaskExecutor;
 use reth_transaction_pool::{
     blobstore::InMemoryBlobStore, TransactionPool, TransactionValidationTaskExecutor,
 };
-use reth_consensus_common::utils;
 use secp256k1::SecretKey;
 use std::{
     net::{SocketAddr, SocketAddrV4},

--- a/crates/consensus/authority/src/epoch_manager.rs
+++ b/crates/consensus/authority/src/epoch_manager.rs
@@ -1,14 +1,15 @@
-use reth_primitives::constants::eip225::BLOCK_PERIOD;
+use futures_util::{stream::Fuse, StreamExt};
+use reth_primitives::{constants::eip225::BLOCK_PERIOD, TxHash};
 use reth_transaction_pool::{TransactionPool, ValidPoolTransaction};
-use tokio::time::{Instant, Interval};
+use tokio::{
+    sync::mpsc::Receiver,
+    time::{Instant, Interval},
+};
+use tokio_stream::{wrappers::ReceiverStream, Stream};
 use tracing::{error, info};
 
-use crate::{Storage, AuthorityConsensus};
-use std::{
-    sync::Arc,
-    task::Poll,
-    time::Duration,
-};
+use crate::{AuthorityConsensus, Storage};
+use std::{sync::Arc, task::Poll, time::Duration};
 
 #[derive(Debug)]
 /// Manages the block production epochs
@@ -42,7 +43,7 @@ impl EpochManager {
     pub(crate) async fn poll<Pool>(
         &mut self,
         pool: &Pool,
-    ) -> Poll<Vec<Arc<ValidPoolTransaction<<Pool as TransactionPool>::Transaction>>>>
+    ) -> (Poll<Vec<Arc<ValidPoolTransaction<<Pool as TransactionPool>::Transaction>>>>, bool)
     where
         Pool: TransactionPool,
     {
@@ -55,24 +56,16 @@ impl EpochManager {
         drop(storage);
 
         let is_inturn = AuthorityConsensus::is_inturn(authority_len, signer_index);
-        println!("is_inturn: {}", is_inturn);
+        info!("is_inturn: {}", is_inturn);
 
-        self.proposal_interval.tick().await;
-        if is_inturn {
-            let transactions = pool.best_transactions().collect::<Vec<_>>();
-            info!("Miner processing txs {:?}", transactions);
-            // there are pending transactions if we didn't drain the pool
-            self.has_pending_txs = !transactions.is_empty();
-
-            if transactions.is_empty() {
-                return Poll::Pending
-            }
-
-            // drain the pool
-            Poll::Ready(transactions)
+        // drain the pool
+        let transactions = pool.best_transactions().collect::<Vec<_>>();
+        info!("Miner processing txs {:?}", transactions);
+        self.has_pending_txs = !transactions.is_empty();
+        if self.has_pending_txs {
+            return (Poll::Ready(transactions), is_inturn)
         } else {
-            // TODO remove this later
-            Poll::Pending
+            return (Poll::Pending, is_inturn)
         }
 
         // NOTE: verify if network can/should be handled here or in the main task

--- a/crates/consensus/authority/src/lib.rs
+++ b/crates/consensus/authority/src/lib.rs
@@ -37,10 +37,7 @@ use reth_revm::{
     database::StateProviderDatabase, db::states::bundle_state::BundleRetention,
     processor::EVMProcessor, State,
 };
-use std::{
-    collections::HashMap,
-    sync::Arc,
-};
+use std::{collections::HashMap, sync::Arc};
 use voting::{AuthorityVoteCollection, Vote};
 
 use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
@@ -78,7 +75,11 @@ impl AuthorityConsensus {
     }
 
     /// Validates that the authority was in turn when producing the block
-    pub fn validate_inturn(block_timestamp: u64, authorities_len: u64, signer_index: u64) -> Result<(), ConsensusError> {
+    pub fn validate_inturn(
+        block_timestamp: u64,
+        authorities_len: u64,
+        signer_index: u64,
+    ) -> Result<(), ConsensusError> {
         let block_timestamp_min = block_timestamp / 60;
         if (block_timestamp_min / authorities_len) % authorities_len != signer_index {
             error!("Authority was not in turn when producing block");
@@ -367,7 +368,7 @@ impl StorageInner {
         let message =
             secp256k1::Message::from_slice(sig_hash.as_slice()).expect("Valid message to sign");
         let signature = secp.sign_ecdsa_recoverable(&message, sk);
-        
+
         let extra_data_header_with_signature = ExtraDataHeader::new(
             0u32,
             Some(signature),
@@ -491,7 +492,12 @@ mod tests {
         let block_timestamp = 10;
         let authorities_len = 3;
         let signer_index = 0;
-        assert!(AuthorityConsensus::validate_inturn(block_timestamp, authorities_len, signer_index).is_ok());
+        assert!(AuthorityConsensus::validate_inturn(
+            block_timestamp,
+            authorities_len,
+            signer_index
+        )
+        .is_ok());
     }
 
     #[test]
@@ -499,6 +505,11 @@ mod tests {
         let block_timestamp = 10;
         let authorities_len = 3;
         let signer_index = 1;
-        assert!(AuthorityConsensus::validate_inturn(block_timestamp, authorities_len, signer_index).is_err());
+        assert!(AuthorityConsensus::validate_inturn(
+            block_timestamp,
+            authorities_len,
+            signer_index
+        )
+        .is_err());
     }
 }

--- a/crates/consensus/authority/src/task.rs
+++ b/crates/consensus/authority/src/task.rs
@@ -1,10 +1,10 @@
-use crate::{epoch_manager::EpochManager, Storage, AuthorityConsensus};
+use crate::{epoch_manager::EpochManager, AuthorityConsensus, Storage};
 use reth_beacon_consensus::{BeaconEngineMessage, ForkchoiceStatus};
 use reth_botanix_lib::mint_validation::{
     parse_pegin_reth_log_topic, parse_pegout_reth_log_topic, GenesisContractEvents,
 };
 use reth_btc_wallet::block_source::{BlockSource, MempoolSpace};
-use reth_consensus_common::{utils, validation};
+use reth_consensus_common::{utils, utils::validate_poa_extra_data_header, validation};
 use reth_eth_wire::NewBlock;
 use reth_interfaces::consensus::ForkchoiceState;
 use reth_network::{message::NewBlockMessage, NetworkHandle};
@@ -20,7 +20,6 @@ use reth_revm::{database::StateProviderDatabase, processor::EVMProcessor, State}
 use reth_rpc_types::engine::PayloadStatusEnum;
 use reth_stages::PipelineEvent;
 use reth_transaction_pool::{TransactionPool, ValidPoolTransaction};
-use reth_consensus_common::utils::validate_poa_extra_data_header;
 use ruint::Uint;
 use secp256k1::{All, Secp256k1};
 use std::{collections::VecDeque, sync::Arc, task::Poll};
@@ -116,9 +115,7 @@ where
             pipe_line_events: None,
             btc_server,
             bitcoin_block_header,
-            bitcoin_block_source: MempoolSpace::new(
-                bitcoin_block_source_address.to_string(),
-            ),
+            bitcoin_block_source: MempoolSpace::new(bitcoin_block_source_address.to_string()),
             secp,
             sk,
             epoch_manager,
@@ -140,12 +137,14 @@ where
                         info!(target: "consensus::authority", ?block, "Recieved new block from peer");
 
                         // extract signer pub key
-                        let signer = utils::recovery_authority(&block.header).expect("valid signer");
-                    
+                        let signer =
+                            utils::recovery_authority(&block.header).expect("valid signer");
+
                         let storage_inner = self.epoch_manager.storage.inner.read().await;
                         let authorities = storage_inner.authorities.clone();
                         drop(storage_inner);
-                        let signer_index = authorities.iter().position(|pk| *pk == signer).expect("valid signer");
+                        let signer_index =
+                            authorities.iter().position(|pk| *pk == signer).expect("valid signer");
                         match AuthorityConsensus::validate_inturn(
                             block.header.timestamp,
                             authorities.len() as u64,
@@ -154,7 +153,7 @@ where
                             Ok(_) => {}
                             Err(err) => {
                                 error!(target: "consensus::authority", ?err, "Block import failed in turn check");
-                                continue 
+                                continue
                             }
                         }
 
@@ -172,6 +171,15 @@ where
                             Ok(payload_status) => {
                                 match payload_status.status {
                                     PayloadStatusEnum::Accepted | PayloadStatusEnum::Valid => {
+                                        // remove the tx which are now confirmed
+                                        info!("Removing txs from the pool upon recevied block");
+                                        let tx_hashes = block
+                                            .body
+                                            .iter()
+                                            .map(|tx| tx.hash().to_owned())
+                                            .collect::<Vec<_>>();
+                                        self.pool.remove_transactions(tx_hashes);
+
                                         let senders = TransactionSigned::recover_signers(
                                             &block.body,
                                             block.body.len(),
@@ -249,19 +257,24 @@ where
                 },
             }
 
-            if let Poll::Ready(transactions) = self.epoch_manager.poll(&self.pool).await {
-                info!("Adding to the list of transctions, {:?}, {:?}", transactions, self.queued);
-                // miner returned a set of transaction that we feed to
-                // the producer
-                self.queued.push_back(transactions.clone());
-                let mining_pool = self.pool.clone();
-                mining_pool.remove_transactions(
-                    transactions.iter().map(|tx| tx.hash().to_owned()).collect(),
-                );
-            }
+            let is_inturn = match self.epoch_manager.poll(&self.pool).await {
+                (Poll::Pending, is_inturn) => is_inturn,
+                (Poll::Ready(transactions), is_inturn) => {
+                    info!(
+                        "Adding to the list of transctions, {:?}, {:?}",
+                        transactions, self.queued
+                    );
+                    self.queued.push_back(transactions.clone());
+                    let mining_pool = self.pool.clone();
+                    mining_pool.remove_transactions(
+                        transactions.iter().map(|tx| tx.hash().to_owned()).collect(),
+                    );
+                    is_inturn
+                }
+            };
 
             // If insert task is not none executinon of async task is on going
-            if self.queued.is_empty() {
+            if self.queued.is_empty() || !is_inturn {
                 info!("Txs list is empty, skipping");
                 // nothing to insert
                 std::thread::sleep(std::time::Duration::from_millis(1000));
@@ -408,7 +421,7 @@ where
                 }
                 Err(e) => {
                     debug!(target: "consensus::authority", ?e, "Non-genesis contract event");
-                    continue;
+                    continue
                 }
             }
         }

--- a/crates/consensus/common/src/utils.rs
+++ b/crates/consensus/common/src/utils.rs
@@ -1,4 +1,3 @@
-
 use crate::validation;
 use reth_botanix_lib::extra_data_header::ExtraDataHeader;
 use reth_interfaces::consensus::ConsensusError;
@@ -6,8 +5,8 @@ use reth_primitives::{
     constants::STAKING_CONTRACT_ADDRESS, keccak256, Address, Bytes, Header, B256, U256,
 };
 use reth_provider::StateProvider;
-use tracing::error;
 use std::time::{SystemTime, UNIX_EPOCH};
+use tracing::error;
 
 /// Error that can occur while accessing EVM global storage
 #[derive(Debug)]
@@ -215,7 +214,6 @@ mod tests {
         assert_ne!(sighash.to_string(), EDH_DEFAULT_SIGHASH);
     }
 
-   
     // Get authority list tests
     #[test]
     fn should_recover_none_authorities() {
@@ -340,7 +338,6 @@ mod tests {
         let result = validate_poa_extra_data_header(&header, &authority_signers);
         assert!(result.is_err());
     }
-
 
     #[test]
     fn should_validate() {

--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -1,9 +1,7 @@
 //! Collection of methods for block validation.
 use reth_interfaces::{consensus::ConsensusError, RethResult};
 use reth_primitives::{
-    constants::{
-        eip4844::{DATA_GAS_PER_BLOB, MAX_DATA_GAS_PER_BLOCK},
-    },
+    constants::eip4844::{DATA_GAS_PER_BLOB, MAX_DATA_GAS_PER_BLOCK},
     eip4844::calculate_excess_blob_gas,
     BlockNumber, ChainSpec, GotExpected, Hardfork, Header, InvalidTransactionError, SealedBlock,
     SealedHeader, Transaction, TransactionSignedEcRecovered, TxEip1559, TxEip2930, TxEip4844,
@@ -495,9 +493,7 @@ pub fn validate_4844_header_standalone(header: &SealedHeader) -> Result<(), Cons
 ///
 /// From yellow paper: extraData: An arbitrary byte array containing data relevant to this block.
 /// This must be 32 bytes or fewer; formally Hx.
-pub fn validate_header_extradata(
-    header: &Header,
-) -> Result<(), ConsensusError> {
+pub fn validate_header_extradata(header: &Header) -> Result<(), ConsensusError> {
     // TODO (armins) calculate worst case max size
     // if header.extra_data.len() > MAXIMUM_EXTRA_DATA_SIZE {
     //     Err(ConsensusError::ExtraDataExceedsMax { len: header.extra_data.len() })

--- a/crates/interfaces/src/consensus.rs
+++ b/crates/interfaces/src/consensus.rs
@@ -186,6 +186,9 @@ pub enum ConsensusError {
         /// Max extra data length
         len: usize,
     },
+    /// Error when the authority is not in turn.
+    #[error("Authority not in turn")]
+    AuthorityNotInTurn,
     #[error("Difficulty after merge is not zero")]
     /// Error when the difficulty after a merge is not zero.
     TheMergeDifficultyIsNotZero,


### PR DESCRIPTION
This PR handles https://github.com/botanix-labs/botanix/issues/291.
The gossiping protocol indeed works and nodes do share txs when they arrive in the mempool. The blocking nature of the epoch manager was not allowing the fed nodes to share txs as soon as they arrive as the one out of turn never really drained the mempool or even got to it. I have reworked this a bit and also added the possibility for peers to prune their mempool after new blocks are confirmed.