### PR TITLE
feature: base fee burn should go to block producer

### DIFF
--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -374,8 +374,9 @@ impl Transaction {
         let fee = max_fee_per_gas - base_fee;
 
         // Compare the fee with max_priority_fee_per_gas (or gas price for non-EIP1559 transactions)
+        // NOTE: Add the priority_fee to the base fee as we have to avoid lost BTC on Botanix
         if let Some(priority_fee) = self.max_priority_fee_per_gas() {
-            Some(fee.min(priority_fee))
+            Some(fee.min(priority_fee) + base_fee)
         } else {
             Some(fee)
         }


### PR DESCRIPTION
This PR makes it possible for the base fee not to be burned as it currently happens under Eth 1559, but to rather be added to the prio fee so we can avoid lost BTC on Botanix.