### PR TITLE
300 feature ensure in turn is only producing one block per time slot

### DIFF
--- a/crates/botanix-lib/src/extra_data_header.rs
+++ b/crates/botanix-lib/src/extra_data_header.rs
@@ -476,6 +476,39 @@ mod tests {
             .unwrap()
     }
 
+    #[test]
+    fn can_recover_authority_after_serialize() {
+        let mut authority_signers = vec![];
+        let secp = Secp256k1::new();
+        let (secret_key, public_key) = secp.generate_keypair(&mut OsRng);
+        authority_signers.push(public_key);
+
+        let hello_world_hash = sha256::Hash::hash("Hello world!".as_bytes());
+        let message = Message::from(hello_world_hash);
+        let signature = secp.sign_ecdsa_recoverable(&message, &secret_key);
+
+        let header = ExtraDataHeader::new(
+            EXTRA_HEADER_VERSION,
+            Some(signature),
+            Some(authority_signers.clone()),
+            None,
+            bitcoin::hash_types::BlockHash::all_zeros(),
+        );
+
+        let serialized = header.serialize();
+
+        let deserialized_header = ExtraDataHeader::deserialize(&mut serialized.as_slice())
+            .expect("Deserialization failed");
+
+        let recovered_pk = deserialized_header
+            .authority_signature
+            .unwrap()
+            .recover(&message)
+            .unwrap();
+
+        assert_eq!(recovered_pk, public_key);
+    }
+
     // Test case for validating with an invalid signature
     #[test]
     fn test_validate_authority_signature_with_invalid_signature() {

--- a/crates/botanix-lib/src/extra_data_header.rs
+++ b/crates/botanix-lib/src/extra_data_header.rs
@@ -4,7 +4,7 @@ use bitcoin::{
     consensus::encode::{self, Decodable, Encodable},
     secp256k1,
 };
-use secp256k1::{ecdsa::RecoveryId, hashes::Hash};
+use secp256k1::{ecdsa::{RecoveryId, RecoverableSignature}, hashes::Hash};
 use thiserror::Error;
 
 const EXTRA_HEADER_VERSION: u32 = 0;
@@ -102,6 +102,11 @@ impl ExtraDataHeader {
             authority_signature,
             optional_fields,
         }
+    }
+
+    pub fn set_signature(&mut self, signature: RecoverableSignature) -> () {
+        self.authority_signature = Some(signature);
+        self.set_optional_fields_bitmask();
     }
 
     pub fn set_optional_fields_bitmask(&mut self) -> () {
@@ -608,6 +613,24 @@ mod tests {
         );
         assert_eq!(deserialized_header.authority_vote, None);
         assert_eq!(deserialized_header.authority_signature, None);
+    }
+
+    #[test]
+    fn can_set_signature() {
+        let mut edh = ExtraDataHeader::default();
+
+        assert_eq!(edh.authority_signature, None);
+        assert_eq!(edh.optional_fields, 0);
+        let secp = Secp256k1::new();
+        let (secret_key, _public_key) = secp.generate_keypair(&mut OsRng);
+
+        let hello_world_hash = sha256::Hash::hash("Hello world!".as_bytes());
+        let message = Message::from(hello_world_hash);
+        let signature = secp.sign_ecdsa_recoverable(&message, &secret_key);
+
+        edh.set_signature(signature);
+        assert_eq!(edh.authority_signature.is_some(), true);
+        assert_eq!(edh.optional_fields, 1 << HAS_SIGNATURE_POS);
     }
 
     #[test]

--- a/crates/consensus/authority/src/builder.rs
+++ b/crates/consensus/authority/src/builder.rs
@@ -105,10 +105,11 @@ where
         if signer_index.is_none() {
             return Err(AuthorityConsensusBuilderError::FailedToFindSignerIndex)
         }
+        let pk = sk.public_key(&secp);
 
         // Try to instantiate storage
         let storage =
-            Storage::try_new(&mut headers, authorities, signer_index.expect("valid index"))
+            Storage::try_new(&mut headers, authorities, signer_index.expect("valid index"), pk)
                 .map_err(|e| {
                     error!("Failed to instantiate storage: {:?}", e);
                     AuthorityConsensusBuilderError::InvalidStorage

--- a/crates/consensus/authority/src/epoch_manager.rs
+++ b/crates/consensus/authority/src/epoch_manager.rs
@@ -47,30 +47,25 @@ impl EpochManager {
     {
         let storage = self.storage.inner.read().await;
         let signer_index = storage.signer_index;
-        println!("signer_index: {}", signer_index);
-
+        let signer_pk = storage.authority;
         let authority_len = storage.authorities.len() as u64;
-        let signer_index = storage.signer_index as u64;
 
         // Check if the last signer was us
         // If so nothing to do anymore until the next timeslot
         let latest_header = storage.headers.get(&storage.best_block).expect("best block");
+        // Skip over genesis
         if latest_header.number != 0 {
             let latest_signer = utils::recovery_authority(&latest_header).unwrap();
-            let latest_signer_index =
-                storage.authorities.iter().position(|pk| pk == &latest_signer).unwrap() as u64;
-            println!("signer_index: {},  latest_signer_index: {}", signer_index, latest_signer_index);
-            if latest_signer_index == signer_index {
-                debug!(
-                    "latest signer index {} != signer index {}",
-                    latest_signer_index, signer_index
-                );
+            let current_ts = utils::unix_timestamp();
+            if let Err(_) = utils::validate_current_signer_against_last(
+                (latest_signer, latest_header.timestamp / 60),
+                (signer_pk, current_ts / 60),
+            ) {
                 return Poll::Pending
             }
         }
 
         drop(storage);
-
         let is_inturn = AuthorityConsensus::is_inturn(authority_len, signer_index);
         info!("is_inturn: {}", is_inturn);
 

--- a/crates/consensus/authority/src/epoch_manager.rs
+++ b/crates/consensus/authority/src/epoch_manager.rs
@@ -13,8 +13,6 @@ use std::{sync::Arc, task::Poll, time::Duration};
 
 #[derive(Debug)]
 /// Manages the block production epochs
-/// Signing time is the parent timestamp + BLOCK_PERIOD
-/// If the signer is inturn then we broadcast the block
 ///
 /// Blocks will be rejected by consensus if
 /// 1. The signer is not in the federation
@@ -53,6 +51,24 @@ impl EpochManager {
 
         let authority_len = storage.authorities.len() as u64;
         let signer_index = storage.signer_index as u64;
+
+        // Check if the last signer was us
+        // If so nothing to do anymore until the next timeslot
+        let latest_header = storage.headers.get(&storage.best_block).expect("best block");
+        if latest_header.number != 0 {
+            let latest_signer = utils::recovery_authority(&latest_header).unwrap();
+            let latest_signer_index =
+                storage.authorities.iter().position(|pk| pk == &latest_signer).unwrap() as u64;
+            println!("signer_index: {},  latest_signer_index: {}", signer_index, latest_signer_index);
+            if latest_signer_index == signer_index {
+                debug!(
+                    "latest signer index {} != signer index {}",
+                    latest_signer_index, signer_index
+                );
+                return Poll::Pending
+            }
+        }
+
         drop(storage);
 
         let is_inturn = AuthorityConsensus::is_inturn(authority_len, signer_index);
@@ -67,10 +83,5 @@ impl EpochManager {
         } else {
             return (Poll::Pending, is_inturn)
         }
-
-        // NOTE: verify if network can/should be handled here or in the main task
-        // TODO: check network handle for gossiped block
-        // TODO: set gossiped block header in storage or...
-        // TODO: if `None` do the following
     }
 }

--- a/crates/consensus/authority/src/epoch_manager.rs
+++ b/crates/consensus/authority/src/epoch_manager.rs
@@ -66,7 +66,7 @@ impl EpochManager {
         }
 
         drop(storage);
-        let is_inturn = AuthorityConsensus::is_inturn(authority_len, signer_index);
+        let is_inturn = AuthorityConsensus::is_inturn(authority_len, signer_index as u64);
         info!("is_inturn: {}", is_inturn);
 
         // drain the pool

--- a/crates/consensus/authority/src/epoch_manager.rs
+++ b/crates/consensus/authority/src/epoch_manager.rs
@@ -1,4 +1,5 @@
 use futures_util::{stream::Fuse, StreamExt};
+use reth_consensus_common::utils;
 use reth_primitives::{constants::eip225::BLOCK_PERIOD, TxHash};
 use reth_transaction_pool::{TransactionPool, ValidPoolTransaction};
 use tokio::{
@@ -61,13 +62,13 @@ impl EpochManager {
                 (latest_signer, latest_header.timestamp / 60),
                 (signer_pk, current_ts / 60),
             ) {
-                return Poll::Pending
+                return (Poll::Pending, false)
             }
         }
 
         drop(storage);
         let is_inturn = AuthorityConsensus::is_inturn(authority_len, signer_index as u64);
-        info!("is_inturn: {}", is_inturn);
+        info!("Epoch manager inturn: {}", is_inturn);
 
         // drain the pool
         let transactions = pool.best_transactions().collect::<Vec<_>>();

--- a/crates/consensus/authority/src/lib.rs
+++ b/crates/consensus/authority/src/lib.rs
@@ -101,6 +101,7 @@ impl Consensus for AuthorityConsensus {
         header: &SealedHeader,
         parent: &SealedHeader,
     ) -> Result<(), ConsensusError> {
+        utils::validate_against_parent(parent.header.clone(), header.header.clone())?;
         validation::validate_header_regarding_parent(parent, header, &self.chain_spec)?;
         Ok(())
     }

--- a/crates/consensus/authority/src/lib.rs
+++ b/crates/consensus/authority/src/lib.rs
@@ -121,7 +121,7 @@ impl Consensus for AuthorityConsensus {
 }
 
 /// In memory storage
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub(crate) struct Storage {
     pub(crate) inner: Arc<RwLock<StorageInner>>,
 }
@@ -138,6 +138,7 @@ impl Storage {
         headers: &mut Vec<SealedHeader>,
         authorities: Vec<secp256k1::PublicKey>,
         signer_index: usize,
+        pk: secp256k1::PublicKey,
     ) -> Result<Self, StorageCreationError> {
         if headers.len() == 0 {
             return Err(StorageCreationError::EmptyHeaders)
@@ -154,7 +155,11 @@ impl Storage {
             best_block: header.number,
             authorities,
             signer_index,
-            ..Default::default()
+            authority: pk,
+            headers: HashMap::new(),
+            hash_to_number: HashMap::new(),
+            bodies: HashMap::new(),
+            authority_votes: AuthorityVoteCollection::default(),
         };
         storage.headers.insert(header.number, header);
         storage.bodies.insert(best_hash, BlockBody::default());
@@ -175,7 +180,7 @@ impl Storage {
 
 /// In-memory storage for the chain the authority seal engine is building.
 /// Headers from the most current epoch to the tip
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub(crate) struct StorageInner {
     /// Headers buffered for download.
     pub(crate) headers: HashMap<BlockNumber, Header>,
@@ -196,6 +201,8 @@ pub(crate) struct StorageInner {
     /// keep track of my place among the singer
     /// This will change as new signers are removed
     pub(crate) signer_index: usize,
+    /// Authority Signer public key
+    pub(crate) authority: secp256k1::PublicKey,
 }
 
 // === impl StorageInner ===
@@ -227,7 +234,7 @@ impl StorageInner {
         self.best_block = header.number;
         self.total_difficulty += header.difficulty;
 
-        trace!(target: "consensus::authority", num=self.best_block, hash=?self.best_hash, "inserting new block");
+        info!(target: "consensus::authority", num=self.best_block, hash=?self.best_hash, "inserting new block");
         self.headers.insert(header.number, header);
         self.bodies.insert(self.best_hash, body);
         self.hash_to_number.insert(self.best_hash, self.best_block);
@@ -359,10 +366,10 @@ impl StorageInner {
         header.state_root = state_root;
 
         // Serialize the header without signature
-        let extra_header_content_no_signature = ExtraDataHeader::new(
+        let mut extra_header_content_no_signature = ExtraDataHeader::new(
             0u32,
             None,
-            Some(authorities.clone()),
+            if header.is_poa_epoch() { Some(authorities.clone()) } else { None },
             vote_for,
             recent_block_hash,
         );
@@ -376,16 +383,9 @@ impl StorageInner {
             secp256k1::Message::from_slice(sig_hash.as_slice()).expect("Valid message to sign");
         let signature = secp.sign_ecdsa_recoverable(&message, sk);
 
-        let extra_data_header_with_signature = ExtraDataHeader::new(
-            0u32,
-            Some(signature),
-            // Only include authority signer if we are creating a poa epoch block
-            if header.is_poa_epoch() { Some(authorities.clone()) } else { None },
-            vote_for,
-            recent_block_hash,
-        );
-        header.extra_data = Bytes::from(extra_data_header_with_signature.serialize());
+        extra_header_content_no_signature.set_signature(signature.clone());
 
+        header.extra_data = Bytes::from(extra_header_content_no_signature.serialize());
         Ok(header)
     }
 

--- a/crates/consensus/authority/src/task.rs
+++ b/crates/consensus/authority/src/task.rs
@@ -10,7 +10,7 @@ use reth_consensus_common::{
     validation,
 };
 use reth_eth_wire::NewBlock;
-use reth_interfaces::consensus::ForkchoiceState;
+use reth_interfaces::consensus::{ConsensusError, ForkchoiceState};
 use reth_network::{message::NewBlockMessage, NetworkHandle};
 use reth_primitives::{
     hex, Block, BlockBody, ChainSpec, IntoRecoveredTransaction, Log, SealedBlockWithSenders,
@@ -50,6 +50,16 @@ enum ProcessBotanixLogError {
     FailedToMakePegoutTx(tonic::Status),
 }
 
+/// Errors
+#[derive(Debug, thiserror::Error)]
+enum PersistNewBlockError {
+    #[error("Failed to validate PoA header")]
+    FailedToValidatePoaHeader(ConsensusError),
+    #[error("Failed ForkchoiceUpdateV2")]
+    FailedForkchoiceUpdateV2(),
+    #[error("Failed to communicate with engine API")]
+    FailedToCommunicateWithEngine(),
+}
 pub struct BlockProductionTask<Client, Pool: TransactionPool> {
     /// The configured chain spec
     chain_spec: Arc<ChainSpec>,
@@ -140,7 +150,7 @@ where
                     }
                     TryRecvError::Disconnected => {
                         error!(target: "consensus::authority", "Block import channel disconnected");
-                        return ()
+                        continue
                     }
                 },
             };
@@ -250,8 +260,15 @@ where
                             }
                         }
 
-                        self.persist_new_block(sealed_block_with_senders.clone(), bundle_state)
-                            .await;
+                        match self
+                            .persist_new_block(sealed_block_with_senders.clone(), bundle_state)
+                            .await
+                        {
+                            Ok(_) => {}
+                            Err(err) => {
+                                error!(target: "consensus::authority", ?err, "Failed to persist new block");
+                            }
+                        }
                     }
                     Err(err) => {
                         error!(target: "consensus::authority", ?err, "Failed to exectute block recieved by peer");
@@ -345,7 +362,14 @@ where
             let sealed_block = block.clone().seal_slow();
             let sealed_block_with_senders =
                 SealedBlockWithSenders::new(sealed_block, senders).expect("senders are valid");
-            self.persist_new_block(sealed_block_with_senders.clone(), bundle_state).await;
+            match self.persist_new_block(sealed_block_with_senders.clone(), bundle_state).await {
+                Ok(_) => {}
+                Err(err) => {
+                    error!(target: "consensus::authority", ?err, "Failed to persist new block");
+                    // TODO(armins) failed txs should get retried
+                    continue
+                }
+            }
             // Notify peers
             let new_block = NewBlock { block, td: Uint::ZERO };
             let block_hash = sealed_block_with_senders.hash();
@@ -454,12 +478,14 @@ where
         &mut self,
         sealed_block: SealedBlockWithSenders,
         bundled_state: BundleStateWithReceipts,
-    ) -> () {
+    ) -> Result<(), PersistNewBlockError> {
         let new_header = sealed_block.header.clone();
         // perform PoA validation
-        let authority_signers = self.storage.read().await.authorities.clone();
-        // TODO (armins) remove this unwrap
-        validate_poa_extra_data_header(&new_header, &authority_signers).unwrap();
+        let storage = self.storage.read().await;
+        let authority_signers = storage.authorities.clone();
+        drop(storage);
+        validate_poa_extra_data_header(&new_header, &authority_signers)
+            .map_err(|e| PersistNewBlockError::FailedToValidatePoaHeader(e))?;
 
         let state = ForkchoiceState {
             head_block_hash: new_header.hash,
@@ -485,7 +511,7 @@ where
                         ForkchoiceStatus::Valid => break,
                         ForkchoiceStatus::Invalid => {
                             error!(target: "consensus::authority", ?fcu_response, "Forkchoice update returned invalid response");
-                            return ()
+                            return Err(PersistNewBlockError::FailedForkchoiceUpdateV2());
                         }
                         ForkchoiceStatus::Syncing => {
                             debug!(target: "consensus::authority", ?fcu_response, "Forkchoice update returned SYNCING, waiting for VALID");
@@ -496,7 +522,7 @@ where
                 }
                 Err(err) => {
                     error!(target: "consensus::authority", ?err, "Authority fork choice update failed");
-                    return ()
+                    return Err(PersistNewBlockError::FailedToCommunicateWithEngine());
                 }
             }
         }
@@ -524,6 +550,8 @@ where
         // Lastly remove confirmed txs from the mempool
         mining_pool
             .remove_transactions(body.transactions.iter().map(|tx| tx.hash().to_owned()).collect());
+
+        Ok(())
     }
 
     /// Sets the pipeline events to listen on.

--- a/crates/consensus/authority/src/task.rs
+++ b/crates/consensus/authority/src/task.rs
@@ -520,11 +520,6 @@ where
             ommers: vec![],
             withdrawals: None,
         };
-        self.storage
-            .write()
-            .await
-            .insert_new_block(sealed_block.header.header.clone(), body.clone());
-
         let mining_pool = self.pool.clone();
         // Lastly remove confirmed txs from the mempool
         mining_pool

--- a/crates/consensus/common/src/utils.rs
+++ b/crates/consensus/common/src/utils.rs
@@ -187,6 +187,7 @@ impl From<ValidateAgainstParentError> for ConsensusError {
     }
 }
 
+/// Validate current PoA header against parent header
 pub fn validate_against_parent(
     parent: Header,
     current: Header,
@@ -209,17 +210,16 @@ pub fn validate_against_parent(
     Ok(())
 }
 
+/// Validate current signer and its last block timestamp against the last signer and its last block timestamp
+/// Used to prevent a signer from signing multiple blocks in the same turn
 pub fn validate_current_signer_against_last(
     last: (secp256k1::PublicKey, u64),
     current: (secp256k1::PublicKey, u64),
 ) -> Result<(), ValidateAgainstParentError> {
-    if last.0 == current.0 {
-        return Err(ValidateAgainstParentError::SignerLimitExceeded)
-    }
     // Last block should be greater that 1 minute in the worst cast
     // Even in the case of > 2 federation members the worst case time between blocks for the same
     // Signer should be 1 minute. Assuming 1 minute block times
-    if current.1 - last.1 < 1 {
+    if last.0 == current.0 && current.1 - last.1 < 1 {
         return Err(ValidateAgainstParentError::SignerLimitExceeded)
     }
 

--- a/crates/consensus/common/src/utils.rs
+++ b/crates/consensus/common/src/utils.rs
@@ -168,7 +168,7 @@ pub fn validate_poa_extra_data_header(
 
 /// Validate against parent header errors
 #[derive(Debug)]
-pub enum ValidateAgainstParrentError {
+pub enum ValidateAgainstParentError {
     /// Signer limit exceeded
     /// Could occur when signer is signings many blocks in the same turn
     SignerLimitExceeded,
@@ -176,11 +176,11 @@ pub enum ValidateAgainstParrentError {
     FailedToDerserializeExtraData(RecoverAuthorityError),
 }
 
-impl From<ValidateAgainstParrentError> for ConsensusError {
-    fn from(e: ValidateAgainstParrentError) -> Self {
+impl From<ValidateAgainstParentError> for ConsensusError {
+    fn from(e: ValidateAgainstParentError) -> Self {
         match e {
-            ValidateAgainstParrentError::SignerLimitExceeded => ConsensusError::SignerLimitExceeded,
-            ValidateAgainstParrentError::FailedToDerserializeExtraData(_) => {
+            ValidateAgainstParentError::SignerLimitExceeded => ConsensusError::SignerLimitExceeded,
+            ValidateAgainstParentError::FailedToDerserializeExtraData(_) => {
                 ConsensusError::ExtraDataInvalid
             }
         }
@@ -190,29 +190,37 @@ impl From<ValidateAgainstParrentError> for ConsensusError {
 pub fn validate_against_parent(
     parent: Header,
     current: Header,
-) -> Result<(), ValidateAgainstParrentError> {
+) -> Result<(), ValidateAgainstParentError> {
     // Gensis block does not have a federation signature, skip
     if parent.number == 0 {
         return Ok(())
     }
-    let parent_signer = recovery_authority(&parent)
-        .map_err(|e| ValidateAgainstParrentError::FailedToDerserializeExtraData(e))?;
+    let parent_signer = recovery_authority(&parent).map_err(|e: RecoverAuthorityError| {
+        ValidateAgainstParentError::FailedToDerserializeExtraData(e)
+    })?;
     let current_signer = recovery_authority(&current)
-        .map_err(|e| ValidateAgainstParrentError::FailedToDerserializeExtraData(e))?;
-    let is_same_signer = parent_signer == current_signer;
+        .map_err(|e| ValidateAgainstParentError::FailedToDerserializeExtraData(e))?;
     // Check if the parent block was mined in a different turn
     let parent_ts = parent.timestamp / 60;
     let current_ts = current.timestamp / 60;
 
-    if !is_same_signer {
-        return Ok(());
-    }
+    validate_current_signer_against_last((parent_signer, parent_ts), (current_signer, current_ts))?;
 
+    Ok(())
+}
+
+pub fn validate_current_signer_against_last(
+    last: (secp256k1::PublicKey, u64),
+    current: (secp256k1::PublicKey, u64),
+) -> Result<(), ValidateAgainstParentError> {
+    if last.0 == current.0 {
+        return Err(ValidateAgainstParentError::SignerLimitExceeded)
+    }
     // Last block should be greater that 1 minute in the worst cast
     // Even in the case of > 2 federation members the worst case time between blocks for the same
     // Signer should be 1 minute. Assuming 1 minute block times
-    if current_ts - parent_ts < 1 {
-        return Err(ValidateAgainstParrentError::SignerLimitExceeded)
+    if current.1 - last.1 < 1 {
+        return Err(ValidateAgainstParentError::SignerLimitExceeded)
     }
 
     Ok(())
@@ -258,9 +266,7 @@ mod tests {
                 secp256k1::Secp256k1::sign_ecdsa_recoverable(&secp, &message, &sk1)
             }
         };
-
-        edh.authority_signature = Some(signature);
-        edh.set_optional_fields_bitmask();
+        edh.set_signature(signature);
 
         header.extra_data = Bytes::from(edh.serialize());
     }
@@ -279,7 +285,7 @@ mod tests {
         // regarless of the signature, the sighash should be the same
         // This is because we remove the signature from the extra data header before signing
         let mut edh = ExtraDataHeader::default();
-        edh.authority_signature = Some(
+        edh.set_signature(
             secp256k1::ecdsa::RecoverableSignature::from_compact(
                 &[0u8; 64],
                 RecoveryId::from_i32(1i32).unwrap(),
@@ -395,8 +401,7 @@ mod tests {
         let message = secp256k1::Message::from_slice(&sighash.as_slice()).unwrap();
         let signature = secp256k1::Secp256k1::sign_ecdsa_recoverable(&secp, &message, &non_fed);
 
-        edh.authority_signature = Some(signature);
-        edh.set_optional_fields_bitmask();
+        edh.set_signature(signature);
 
         header.extra_data = Bytes::from(edh.serialize());
         let authority_signers = vec![];

--- a/crates/consensus/common/src/utils.rs
+++ b/crates/consensus/common/src/utils.rs
@@ -165,6 +165,59 @@ pub fn validate_poa_extra_data_header(
 
     Ok(())
 }
+
+/// Validate against parent header errors
+#[derive(Debug)]
+pub enum ValidateAgainstParrentError {
+    /// Signer limit exceeded
+    /// Could occur when signer is signings many blocks in the same turn
+    SignerLimitExceeded,
+    /// Failed to deserialize the extra data
+    FailedToDerserializeExtraData(RecoverAuthorityError),
+}
+
+impl From<ValidateAgainstParrentError> for ConsensusError {
+    fn from(e: ValidateAgainstParrentError) -> Self {
+        match e {
+            ValidateAgainstParrentError::SignerLimitExceeded => ConsensusError::SignerLimitExceeded,
+            ValidateAgainstParrentError::FailedToDerserializeExtraData(_) => {
+                ConsensusError::ExtraDataInvalid
+            }
+        }
+    }
+}
+
+pub fn validate_against_parent(
+    parent: Header,
+    current: Header,
+) -> Result<(), ValidateAgainstParrentError> {
+    // Gensis block does not have a federation signature, skip
+    if parent.number == 0 {
+        return Ok(())
+    }
+    let parent_signer = recovery_authority(&parent)
+        .map_err(|e| ValidateAgainstParrentError::FailedToDerserializeExtraData(e))?;
+    let current_signer = recovery_authority(&current)
+        .map_err(|e| ValidateAgainstParrentError::FailedToDerserializeExtraData(e))?;
+    let is_same_signer = parent_signer == current_signer;
+    // Check if the parent block was mined in a different turn
+    let parent_ts = parent.timestamp / 60;
+    let current_ts = current.timestamp / 60;
+
+    if !is_same_signer {
+        return Ok(());
+    }
+
+    // Last block should be greater that 1 minute in the worst cast
+    // Even in the case of > 2 federation members the worst case time between blocks for the same
+    // Signer should be 1 minute. Assuming 1 minute block times
+    if current_ts - parent_ts < 1 {
+        return Err(ValidateAgainstParrentError::SignerLimitExceeded)
+    }
+
+    Ok(())
+}
+
 mod tests {
     use std::str::FromStr;
 
@@ -173,6 +226,44 @@ mod tests {
 
     const EDH_DEFAULT_SIGHASH: &str =
         "0x0a088807360d347e57b95b64d765266f9551acc33ecfcdb2d49003a66acbf192";
+
+    const SK1: &str = "1aabc5cc52b62b570dc69001f1ab49cd1a7056bf6312fe058f094135f2c9b019";
+    const SK2: &str = "1bc1f5cc52b62b570dc69001f1ab49cd1a7056bf6312fe058f094135f2c9b019";
+
+    fn generate_secret_key(hex_string: &str) -> secp256k1::SecretKey {
+        secp256k1::SecretKey::from_str(hex_string).expect("Invalid hex string for SecretKey")
+    }
+
+    fn sign_block_helper(header: &mut Header, signer_sk: Option<&str>) -> () {
+        let mut edh = ExtraDataHeader::default();
+        let sk1 = generate_secret_key(SK1);
+        let sk2 = generate_secret_key(SK2);
+
+        edh.authority_signers = Some(vec![
+            secp256k1::PublicKey::from_secret_key(&secp256k1::Secp256k1::new(), &sk1),
+            secp256k1::PublicKey::from_secret_key(&secp256k1::Secp256k1::new(), &sk2),
+        ]);
+
+        let secp = secp256k1::Secp256k1::new();
+        header.number = 1;
+
+        let sighash = create_authority_sighash(&mut header.clone(), &edh);
+        let message = secp256k1::Message::from_slice(&sighash.as_slice()).unwrap();
+        let signature = {
+            if let Some(sk_str) = signer_sk {
+                let sk = generate_secret_key(sk_str);
+                secp256k1::Secp256k1::sign_ecdsa_recoverable(&secp, &message, &sk)
+            } else {
+                // By default sign with the first authority
+                secp256k1::Secp256k1::sign_ecdsa_recoverable(&secp, &message, &sk1)
+            }
+        };
+
+        edh.authority_signature = Some(signature);
+        edh.set_optional_fields_bitmask();
+
+        header.extra_data = Bytes::from(edh.serialize());
+    }
     /* Tests for create authority sighash utility */
     #[test]
     fn create_default_edh_sighhash() {
@@ -240,26 +331,9 @@ mod tests {
 
     #[test]
     fn should_recovery_authorities() {
-        let mut edh = ExtraDataHeader::default();
-        edh.authority_signers = Some(vec![
-            secp256k1::PublicKey::from_secret_key(
-                &secp256k1::Secp256k1::new(),
-                &secp256k1::SecretKey::from_str(
-                    "1aabc5cc52b62b570dc69001f1ab49cd1a7056bf6312fe058f094135f2c9b019",
-                )
-                .unwrap(),
-            ),
-            secp256k1::PublicKey::from_secret_key(
-                &secp256k1::Secp256k1::new(),
-                &secp256k1::SecretKey::from_str(
-                    "1bc1f5cc52b62b570dc69001f1ab49cd1a7056bf6312fe058f094135f2c9b019",
-                )
-                .unwrap(),
-            ),
-        ]);
-        edh.set_optional_fields_bitmask();
         let mut header = Header::default();
-        header.extra_data = Bytes::from(edh.serialize());
+        sign_block_helper(&mut header, None);
+        let edh = ExtraDataHeader::deserialize(&mut header.extra_data.to_vec().as_slice()).unwrap();
         let signer_list = get_authority_list(&header).unwrap();
 
         assert_eq!(signer_list, edh.authority_signers);
@@ -277,34 +351,12 @@ mod tests {
     // Tests for recover authority pk
     #[test]
     fn should_recover_authority() {
-        let mut edh = ExtraDataHeader::default();
-        let sk1 = secp256k1::SecretKey::from_str(
-            "1aabc5cc52b62b570dc69001f1ab49cd1a7056bf6312fe058f094135f2c9b019",
-        )
-        .unwrap();
-        let sk2 = secp256k1::SecretKey::from_str(
-            "1bc1f5cc52b62b570dc69001f1ab49cd1a7056bf6312fe058f094135f2c9b019",
-        )
-        .unwrap();
-
-        edh.authority_signers = Some(vec![
-            secp256k1::PublicKey::from_secret_key(&secp256k1::Secp256k1::new(), &sk1),
-            secp256k1::PublicKey::from_secret_key(&secp256k1::Secp256k1::new(), &sk2),
-        ]);
-
         let mut header = Header::default();
+        sign_block_helper(&mut header, None);
+        let edh = ExtraDataHeader::deserialize(&mut header.extra_data.to_vec().as_slice()).unwrap();
 
-        let sighash = create_authority_sighash(&mut header, &edh);
-        let secp = secp256k1::Secp256k1::new();
-        let message = secp256k1::Message::from_slice(&sighash.as_slice()).unwrap();
-        let signature = secp256k1::Secp256k1::sign_ecdsa_recoverable(&secp, &message, &sk1);
-
-        edh.authority_signature = Some(signature);
-        edh.set_optional_fields_bitmask();
-
-        header.extra_data = Bytes::from(edh.serialize());
         let recovered = recovery_authority(&header).unwrap();
-
+        // utility function above only signs with the first authority
         assert_eq!(recovered, edh.authority_signers.unwrap()[0]);
     }
 
@@ -353,35 +405,11 @@ mod tests {
     }
 
     #[test]
-    fn should_validate() {
+    fn should_validate_poa_header() {
         // In this case we are signing with a non federation different key
-        let mut edh = ExtraDataHeader::default();
-        let sk1 = secp256k1::SecretKey::from_str(
-            "1aabc5cc52b62b570dc69001f1ab49cd1a7056bf6312fe058f094135f2c9b019",
-        )
-        .unwrap();
-        let sk2 = secp256k1::SecretKey::from_str(
-            "1bc1f5cc52b62b570dc69001f1ab49cd1a7056bf6312fe058f094135f2c9b019",
-        )
-        .unwrap();
-
-        edh.authority_signers = Some(vec![
-            secp256k1::PublicKey::from_secret_key(&secp256k1::Secp256k1::new(), &sk1),
-            secp256k1::PublicKey::from_secret_key(&secp256k1::Secp256k1::new(), &sk2),
-        ]);
-
-        let secp = secp256k1::Secp256k1::new();
         let mut header = Header::default();
-        header.number = 1;
-
-        let sighash = create_authority_sighash(&mut header, &edh);
-        let message = secp256k1::Message::from_slice(&sighash.as_slice()).unwrap();
-        let signature = secp256k1::Secp256k1::sign_ecdsa_recoverable(&secp, &message, &sk1);
-
-        edh.authority_signature = Some(signature);
-        edh.set_optional_fields_bitmask();
-
-        header.extra_data = Bytes::from(edh.serialize());
+        sign_block_helper(&mut header, None);
+        let edh = ExtraDataHeader::deserialize(&mut header.extra_data.to_vec().as_slice()).unwrap();
         let authority_signers = edh.authority_signers.unwrap();
         let result = validate_poa_extra_data_header(&header, &authority_signers);
         assert!(result.is_ok());
@@ -428,5 +456,61 @@ mod tests {
         let beneficiary_address = public_key_to_address(auth_signer2);
         header.beneficiary = beneficiary_address;
         assert!(validate_poa_block_beneficiary(&header, &authority_signers).is_ok());
+
+    }
+
+    #[test]
+    fn validate_against_parent_skip_gensis() {
+        let mut parent = Header::default();
+        parent.number = 0;
+        let current = Header::default();
+        let result = validate_against_parent(parent, current);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn should_fail_with_same_signer() {
+        let mut parent = Header::default();
+        let mut current = Header::default();
+
+        parent.number = 1;
+        current.number = 2;
+
+        sign_block_helper(&mut parent, None);
+        sign_block_helper(&mut current, None);
+
+        let result = validate_against_parent(parent, current);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn should_pass_after_sufficient_time() {
+        let mut parent = Header::default();
+        let mut current = Header::default();
+
+        parent.number = 1;
+        parent.timestamp = 1704834442 as u64;
+        current.number = 2;
+        current.timestamp = 1704834442 as u64 + 60;
+
+        sign_block_helper(&mut parent, None);
+        sign_block_helper(&mut current, None);
+
+        let result = validate_against_parent(parent, current);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn should_pass_with_different_signer() {
+        let mut parent = Header::default();
+        let mut current = Header::default();
+        parent.number = 1;
+        current.number = 2;
+
+        sign_block_helper(&mut parent, None);
+        sign_block_helper(&mut current, Some(SK2));
+
+        let result = validate_against_parent(parent, current);
+        assert!(result.is_ok());
     }
 }

--- a/crates/interfaces/src/consensus.rs
+++ b/crates/interfaces/src/consensus.rs
@@ -293,4 +293,10 @@ pub enum ConsensusError {
     /// PoA specific: failed to recover authority from block signature
     #[error("Failed to recover authority")]
     FailedToRecoverAuthority,
+    /// PoA specific: same signer as previous block
+    #[error("Same signer as previous block")]
+    SignerLimitExceeded,
+    /// PoA specific: authority signer not in turn
+    #[error("Authority signer not in turn")]
+    AuthorityNotInTurn, 
 }

--- a/crates/interfaces/src/consensus.rs
+++ b/crates/interfaces/src/consensus.rs
@@ -186,10 +186,6 @@ pub enum ConsensusError {
         /// Max extra data length
         len: usize,
     },
-    /// Error when the authority is not in turn.
-    #[error("Authority not in turn")]
-    AuthorityNotInTurn,
-
     /// Error when the assigned block beneficiary is not within the authorized authorities.
     #[error("Block beneficiary is not within the authorities list")]
     BlockBeneficiaryIsNotAuthority,
@@ -298,5 +294,5 @@ pub enum ConsensusError {
     SignerLimitExceeded,
     /// PoA specific: authority signer not in turn
     #[error("Authority signer not in turn")]
-    AuthorityNotInTurn, 
+    AuthorityNotInTurn,
 }


### PR DESCRIPTION
This PR achieves a couple of different things:
* empose signer limit for in turn fed member
* Removed duplicate block assertions -> causing recover authority to fail
* Adds auth pk to storage inner on new()
* And removes some unwrap() from persist_new_block()

The authority task is getting a bit hairy. Mainly b/c this task does 2 main things
1. Handle block import
2. Handle create new block

And within these tasks there are duplicate code and functions that should in an async util. Such as calling the engine API
 I think its fine to have the two things in the same tasks but this code could use refactor and cleaning up 
