### PR TITLE
fixes to poa events and added events notifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,6 +535,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.40",
+]
+
+[[package]]
 name = "async-sse"
 version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,7 +596,7 @@ version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb8867f378f33f78a811a8eb9bf108ad99430d7aad43315dd9319c827ef6247"
 dependencies = [
- "http",
+ "http 0.2.11",
  "log",
  "url",
  "wildmatch",
@@ -639,7 +650,7 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http",
+ "http 0.2.11",
  "http-body",
  "hyper",
  "itoa",
@@ -665,7 +676,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
+ "http 0.2.11",
  "http-body",
  "mime",
  "rustversion",
@@ -1876,6 +1887,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b467862cc8610ca6fc9a1532d7777cee0804e678ab45410897b9396495994a0b"
+dependencies = [
+ "nix 0.27.1",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "cuckoofilter"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2816,7 +2837,7 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "hashers",
- "http",
+ "http 0.2.11",
  "instant",
  "jsonwebtoken",
  "once_cell",
@@ -2826,7 +2847,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.20.1",
  "tracing",
  "tracing-futures",
  "url",
@@ -3162,6 +3183,7 @@ checksum = "45ec6fe3675af967e67c5536c0b9d44e34e6c52f86bedc4ea49c5317b8e94d06"
 dependencies = [
  "futures-channel",
  "futures-task",
+ "tokio",
 ]
 
 [[package]]
@@ -3289,7 +3311,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "gloo-utils",
- "http",
+ "http 0.2.11",
  "js-sys",
  "pin-project",
  "serde",
@@ -3347,7 +3369,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.11",
  "indexmap 2.1.0",
  "slab",
  "tokio",
@@ -3527,13 +3549,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.11",
  "pin-project-lite",
 ]
 
@@ -3608,7 +3641,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.11",
  "http-body",
  "httparse",
  "httpdate",
@@ -3628,13 +3661,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
+ "http 0.2.11",
  "hyper",
  "log",
- "rustls",
- "rustls-native-certs",
+ "rustls 0.21.10",
+ "rustls-native-certs 0.6.3",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -3872,7 +3905,7 @@ dependencies = [
  "attohttpc",
  "bytes",
  "futures",
- "http",
+ "http 0.2.11",
  "hyper",
  "log",
  "rand 0.8.5",
@@ -4148,14 +4181,14 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "gloo-net",
- "http",
+ "http 0.2.11",
  "jsonrpsee-core",
  "pin-project",
- "rustls-native-certs",
+ "rustls-native-certs 0.6.3",
  "soketto",
  "thiserror",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tokio-util",
  "tracing",
  "url",
@@ -4228,7 +4261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82c39a00449c9ef3f50b84fc00fc4acba20ef8f559f07902244abf4c15c5ab9c"
 dependencies = [
  "futures-util",
- "http",
+ "http 0.2.11",
  "hyper",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -4275,7 +4308,7 @@ version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bca9cb3933ccae417eb6b08c3448eb1cb46e39834e5b503e395e5e5bd08546c0"
 dependencies = [
- "http",
+ "http 0.2.11",
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -4825,6 +4858,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
  "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.4.1",
  "cfg-if",
  "libc",
 ]
@@ -5537,7 +5581,7 @@ dependencies = [
  "inferno",
  "libc",
  "log",
- "nix",
+ "nix 0.26.4",
  "once_cell",
  "parking_lot 0.12.1",
  "smallvec",
@@ -5802,7 +5846,7 @@ dependencies = [
  "dns-lookup",
  "futures-core",
  "futures-util",
- "http",
+ "http 0.2.11",
  "hyper",
  "hyper-system-resolver",
  "pin-project-lite",
@@ -6195,7 +6239,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.11",
  "http-body",
  "hyper",
  "hyper-rustls",
@@ -6208,15 +6252,15 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
- "rustls-pemfile",
+ "rustls 0.21.10",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tokio-util",
  "tower-service",
  "url",
@@ -6254,12 +6298,14 @@ dependencies = [
  "const-str",
  "crossterm 0.27.0",
  "dirs-next",
+ "displaydoc",
  "eyre",
  "fdlimit",
  "futures",
  "human_bytes",
  "humantime",
  "hyper",
+ "hyper-rustls",
  "itertools 0.11.0",
  "jemalloc-ctl",
  "jemallocator",
@@ -6313,6 +6359,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shellexpand",
+ "slack-morphism",
  "tempfile",
  "thiserror",
  "tokio",
@@ -7128,7 +7175,7 @@ dependencies = [
  "client",
  "derive_more",
  "futures",
- "http",
+ "http 0.2.11",
  "http-body",
  "hyper",
  "jsonrpsee",
@@ -7603,6 +7650,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsb_derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2c53e42fccdc5f1172e099785fe78f89bc0c1e657d0c2ef591efbfac427e9a4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "rsntp"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7701,8 +7759,22 @@ checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
  "log",
  "ring 0.17.7",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41"
+dependencies = [
+ "log",
+ "ring 0.17.7",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -7712,7 +7784,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.0.0",
+ "rustls-pki-types",
  "schannel",
  "security-framework",
 ]
@@ -7727,12 +7812,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35e4980fa29e4c4b212ffb3db068a564cbf560e51d3944b7c88bd8bf5bec64f4"
+dependencies = [
+ "base64 0.21.5",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e9d979b3ce68192e42760c7810125eb6cf2ea10efae545a156063e61f314e2a"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring 0.17.7",
+ "untrusted 0.9.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef4ca26037c909dedb327b48c3327d0ba91d3dd3c4e05dad328f210ffb68e95b"
+dependencies = [
+ "ring 0.17.7",
+ "rustls-pki-types",
  "untrusted 0.9.0",
 ]
 
@@ -7752,6 +7864,26 @@ dependencies = [
  "quick-error",
  "tempfile",
  "wait-timeout",
+]
+
+[[package]]
+name = "rvs_derive"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1fa12378eb54f3d4f2db8dcdbe33af610b7e7d001961c1055858282ecef2a5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "rvstruct"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5107860ec34506b64cf3680458074eac5c2c564f7ccc140918bbcd1714fd8d5d"
+dependencies = [
+ "rvs_derive",
 ]
 
 [[package]]
@@ -8183,6 +8315,7 @@ version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
 dependencies = [
+ "cc",
  "libc",
  "signal-hook-registry",
 ]
@@ -8205,6 +8338,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "signal-hook-tokio"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213241f76fb1e37e27de3b6aa1b068a2c333233b59cca6634f634b80a27ecf1e"
+dependencies = [
+ "futures-core",
+ "libc",
+ "signal-hook",
+ "tokio",
 ]
 
 [[package]]
@@ -8268,6 +8413,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg 1.1.0",
+]
+
+[[package]]
+name = "slack-morphism"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85d5cd8a4fa04d3d46f7a79a0dcb7cd52b30ed144d402c6dc8e98ed4ec5a5993"
+dependencies = [
+ "async-recursion",
+ "async-trait",
+ "base64 0.21.5",
+ "bytes",
+ "chrono",
+ "ctrlc",
+ "futures",
+ "futures-locks",
+ "futures-util",
+ "hex",
+ "http 0.2.11",
+ "hyper",
+ "hyper-rustls",
+ "lazy_static",
+ "mime",
+ "mime_guess",
+ "rand 0.8.5",
+ "ring 0.17.7",
+ "rsb_derive",
+ "rvstruct",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "serde_with",
+ "signal-hook",
+ "signal-hook-tokio",
+ "tokio",
+ "tokio-stream",
+ "tokio-tungstenite 0.21.0",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -8340,7 +8524,7 @@ dependencies = [
  "base64 0.13.1",
  "bytes",
  "futures",
- "http",
+ "http 0.2.11",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -8877,6 +9061,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2 0.5.5",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.48.0",
 ]
 
@@ -8917,7 +9102,18 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.10",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.2",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -8941,11 +9137,27 @@ checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
 dependencies = [
  "futures-util",
  "log",
- "rustls",
+ "rustls 0.21.10",
  "tokio",
- "tokio-rustls",
- "tungstenite",
+ "tokio-rustls 0.24.1",
+ "tungstenite 0.20.1",
  "webpki-roots",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.22.2",
+ "rustls-native-certs 0.7.0",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "tungstenite 0.21.0",
 ]
 
 [[package]]
@@ -9031,7 +9243,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.11",
  "http-body",
  "hyper",
  "hyper-timeout",
@@ -9105,7 +9317,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
+ "http 0.2.11",
  "http-body",
  "http-range-header",
  "httpdate",
@@ -9388,11 +9600,32 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http",
+ "http 0.2.11",
  "httparse",
  "log",
  "rand 0.8.5",
- "rustls",
+ "rustls 0.21.10",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.0.0",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "rustls 0.22.2",
+ "rustls-pki-types",
  "sha1",
  "thiserror",
  "url",

--- a/Makefile
+++ b/Makefile
@@ -282,6 +282,7 @@ start-poa-server-1:
 	--btc-server "localhost:8080" \
 	--btc-block-source "https://mempool.space/signet/api" \
 	--p2p-secret-key "${NODE_1_DIR}/discovery-secret" \
+	--notifications-webhook-url "https://hooks.slack.com/services/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"
 	--port 30303
 
 start-poa-server-2:
@@ -301,4 +302,5 @@ start-poa-server-2:
 	--btc-server "localhost:8080" \
 	--btc-block-source "https://mempool.space/signet/api" \
 	--p2p-secret-key "${NODE_2_DIR}/discovery-secret" \
+	--notifications-webhook-url "https://hooks.slack.com/services/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"
 	--port 30304

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -90,8 +90,12 @@ tokio = { workspace = true, features = ["sync", "macros", "time", "rt-multi-thre
 futures.workspace = true
 pin-project.workspace = true
 
+# slack
+slack-morphism = { version = "1.11", features = ["hyper"] }
+
 # http/rpc
 hyper = "0.14.25"
+hyper-rustls = "0.24.0"
 
 # Botanix
 client = {path = "../btc-server/client"}
@@ -104,6 +108,9 @@ bitcoin = "0.30.0"
 
 ## Url
 url = "2.2"
+
+# displaydoc
+displaydoc = "0.2"
 
 # misc
 aquamarine.workspace = true

--- a/bin/reth/src/args/rpc_server_args.rs
+++ b/bin/reth/src/args/rpc_server_args.rs
@@ -194,6 +194,12 @@ pub struct RpcServerArgs {
     /// The metrics will be served at the given interface and port.
     #[arg(long, value_name = "BITCOIN_BLOCK_SOURCE", value_parser = parse_url, help_heading = "Btc_block_source")]
     pub btc_block_source: Url,
+
+    /// Notifications Webhook Url
+    ///
+    /// Notifications webhook to send various reports to
+    #[arg(long, value_name = "SLACK_NOTIFICATIONS_WEBHOOK_URL", value_parser = parse_url, help_heading = "Notifications Webhook url", required = false)]
+    pub slack_notifications_webhook_url: Option<Url>,
 }
 
 impl RpcServerArgs {
@@ -510,6 +516,7 @@ impl Default for RpcServerArgs {
             rpc_state_cache: RpcStateCacheArgs::default(),
             btc_server: "127.0.0.1:8080".parse().expect("valid grpc address"),
             btc_block_source: Url::parse("https://mempool.space/signet/api").expect("valid url"),
+            slack_notifications_webhook_url: None,
         }
     }
 }

--- a/bin/reth/src/poa/events.rs
+++ b/bin/reth/src/poa/events.rs
@@ -1,6 +1,6 @@
 //! Support for handling events emitted by node components.
 
-use crate::node::cl_events::ConsensusLayerHealthEvent;
+use crate::poa::cl_events::ConsensusLayerHealthEvent;
 use futures::Stream;
 use reth_beacon_consensus::BeaconConsensusEngineEvent;
 use reth_db::DatabaseEnv;
@@ -22,7 +22,9 @@ use std::{
     time::{Duration, Instant},
 };
 use tokio::time::Interval;
-use tracing::{info, warn};
+use tracing::{error, info, warn};
+
+use super::notifications::EventsNotificationClient;
 
 /// Interval of reporting node state.
 const INFO_MESSAGE_INTERVAL: Duration = Duration::from_secs(25);
@@ -39,6 +41,8 @@ struct NodeState {
     current_stage: Option<CurrentStage>,
     /// The latest block reached by either pipeline or consensus engine.
     latest_block: Option<BlockNumber>,
+    /// Events client
+    events_client: Option<EventsNotificationClient>,
 }
 
 impl NodeState {
@@ -46,8 +50,20 @@ impl NodeState {
         db: Arc<DatabaseEnv>,
         network: Option<NetworkHandle>,
         latest_block: Option<BlockNumber>,
+        events_client: Option<EventsNotificationClient>,
     ) -> Self {
-        Self { db, network, current_stage: None, latest_block }
+        Self { db, network, current_stage: None, latest_block, events_client }
+    }
+
+    fn send_notification_message_async(&self, msg: String) {
+        if let Some(client) = self.events_client.clone() {
+            let client = client.clone();
+            tokio::spawn(async move {
+                if let Err(err) = client.send_message(&msg).await {
+                    error!("Failed to send notification message: {:?}", err);
+                }
+            });
+        }
     }
 
     fn num_connected_peers(&self) -> usize {
@@ -155,17 +171,21 @@ impl NodeState {
                     ?status,
                     "Forkchoice updated"
                 );
+                self.send_notification_message_async("Forkchoice updated".to_string());
             }
             BeaconConsensusEngineEvent::CanonicalBlockAdded(block) => {
                 info!(number=block.number, hash=?block.hash, "Block added to canonical chain");
+                self.send_notification_message_async("Block added to canonical chain".to_string());
             }
             BeaconConsensusEngineEvent::CanonicalChainCommitted(head, elapsed) => {
                 self.latest_block = Some(head.number);
 
                 info!(number=head.number, hash=?head.hash, ?elapsed, "Canonical chain committed");
+                self.send_notification_message_async("Canonical chain committed".to_string());
             }
             BeaconConsensusEngineEvent::ForkBlockAdded(block) => {
                 info!(number=block.number, hash=?block.hash, "Block added to fork chain");
+                self.send_notification_message_async("Block added to fork chain".to_string());
             }
         }
     }
@@ -176,16 +196,24 @@ impl NodeState {
         if self.current_stage.is_none() {
             match event {
                 ConsensusLayerHealthEvent::NeverSeen => {
-                    warn!("Post-merge network, but never seen beacon client. Please launch one to follow the chain!")
+                    let msg = "Post-merge network, but never seen beacon client. Please launch one to follow the chain!";
+                    warn!(msg);
+                    self.send_notification_message_async(msg.to_string());
                 }
                 ConsensusLayerHealthEvent::HasNotBeenSeenForAWhile(period) => {
-                    warn!(?period, "Post-merge network, but no beacon client seen for a while. Please launch one to follow the chain!")
+                    let msg = "Post-merge network, but no beacon client seen for a while. Please launch one to follow the chain!";
+                    warn!(?period, msg);
+                    self.send_notification_message_async(msg.to_string());
                 }
                 ConsensusLayerHealthEvent::NeverReceivedUpdates => {
-                    warn!("Beacon client online, but never received consensus updates. Please ensure your beacon client is operational to follow the chain!")
+                    let msg = "Beacon client online, but never received consensus updates. Please ensure your beacon client is operational to follow the chain!";
+                    warn!(msg);
+                    self.send_notification_message_async(msg.to_string());
                 }
                 ConsensusLayerHealthEvent::HaveNotReceivedUpdatesForAWhile(period) => {
-                    warn!(?period, "Beacon client online, but no consensus updates received for a while. Please fix your beacon client to follow the chain!")
+                    let msg = "Beacon client online, but no consensus updates received for a while. Please fix your beacon client to follow the chain!";
+                    warn!(?period, msg);
+                    self.send_notification_message_async(msg.to_string());
                 }
             }
         }
@@ -275,10 +303,11 @@ pub async fn handle_events<E>(
     latest_block_number: Option<BlockNumber>,
     events: E,
     db: Arc<DatabaseEnv>,
+    events_client: Option<EventsNotificationClient>,
 ) where
     E: Stream<Item = NodeEvent> + Unpin,
 {
-    let state = NodeState::new(db, network, latest_block_number);
+    let state = NodeState::new(db, network, latest_block_number, events_client);
 
     let start = tokio::time::Instant::now() + Duration::from_secs(3);
     let mut info_interval = tokio::time::interval_at(start, INFO_MESSAGE_INTERVAL);
@@ -438,7 +467,7 @@ impl Display for Eta {
 
 #[cfg(test)]
 mod tests {
-    use crate::node::events::Eta;
+    use crate::poa::events::Eta;
     use std::time::{Duration, Instant};
 
     #[test]

--- a/bin/reth/src/poa/mod.rs
+++ b/bin/reth/src/poa/mod.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     dirs::{ChainPath, DataDirPath, MaybePlatformPath},
     init::init_genesis,
-    node::cl_events::ConsensusLayerHealthEvents,
+    poa::{cl_events::ConsensusLayerHealthEvents, notifications::EventsNotificationClient},
     prometheus_exporter,
     runner::CliContext,
     utils::get_single_header,
@@ -101,6 +101,7 @@ use reth_btc_wallet::block_source::{BlockSource, MempoolSpace};
 use rsntp::AsyncSntpClient;
 pub mod cl_events;
 pub mod events;
+pub mod notifications;
 
 /// Start the node
 #[derive(Debug, Parser)]
@@ -621,6 +622,15 @@ impl<Ext: RethCliExt> PoaNodeCommand<Ext> {
         )?;
         info!(target: "reth::cli", "Consensus engine initialized");
 
+        let event_notification_client =
+            if let Some(webhook_url) = self.rpc.slack_notifications_webhook_url.clone() {
+                let pk = secret_key.public_key(&secp256k1::Secp256k1::new());
+                let event_notification_client = EventsNotificationClient::new(pk, webhook_url)?;
+                Some(event_notification_client)
+            } else {
+                None
+            };
+
         let events = stream_select!(
             network.event_listener().map(Into::into),
             beacon_engine_handle.event_listener().map(Into::into),
@@ -637,7 +647,13 @@ impl<Ext: RethCliExt> PoaNodeCommand<Ext> {
         );
         ctx.task_executor.spawn_critical(
             "events task",
-            events::handle_events(Some(network.clone()), Some(head.number), events, db.clone()),
+            events::handle_events(
+                Some(network.clone()),
+                Some(head.number),
+                events,
+                db.clone(),
+                event_notification_client,
+            ),
         );
 
         let engine_api = EngineApi::new(
@@ -1154,28 +1170,28 @@ mod tests {
 
     #[test]
     fn parse_help_node_command() {
-        let err = NodeCommand::<()>::try_parse_from(["reth", "--help"]).unwrap_err();
+        let err = PoaNodeCommand::<()>::try_parse_from(["reth", "--help"]).unwrap_err();
         assert_eq!(err.kind(), clap::error::ErrorKind::DisplayHelp);
     }
 
     #[test]
     fn parse_common_node_command_chain_args() {
         for chain in SUPPORTED_CHAINS {
-            let args: NodeCommand = NodeCommand::<()>::parse_from(["reth", "--chain", chain]);
+            let args: PoaNodeCommand = PoaNodeCommand::<()>::parse_from(["reth", "--chain", chain]);
             assert_eq!(args.chain.chain, chain.parse().unwrap());
         }
     }
 
     #[test]
     fn parse_discovery_addr() {
-        let cmd =
-            NodeCommand::<()>::try_parse_from(["reth", "--discovery.addr", "127.0.0.1"]).unwrap();
+        let cmd = PoaNodeCommand::<()>::try_parse_from(["reth", "--discovery.addr", "127.0.0.1"])
+            .unwrap();
         assert_eq!(cmd.network.discovery.addr, Ipv4Addr::LOCALHOST);
     }
 
     #[test]
     fn parse_addr() {
-        let cmd = NodeCommand::<()>::try_parse_from([
+        let cmd = PoaNodeCommand::<()>::try_parse_from([
             "reth",
             "--discovery.addr",
             "127.0.0.1",
@@ -1189,42 +1205,49 @@ mod tests {
 
     #[test]
     fn parse_discovery_port() {
-        let cmd = NodeCommand::<()>::try_parse_from(["reth", "--discovery.port", "300"]).unwrap();
+        let cmd =
+            PoaNodeCommand::<()>::try_parse_from(["reth", "--discovery.port", "300"]).unwrap();
         assert_eq!(cmd.network.discovery.port, 300);
     }
 
     #[test]
     fn parse_port() {
-        let cmd =
-            NodeCommand::<()>::try_parse_from(["reth", "--discovery.port", "300", "--port", "99"])
-                .unwrap();
+        let cmd = PoaNodeCommand::<()>::try_parse_from([
+            "reth",
+            "--discovery.port",
+            "300",
+            "--port",
+            "99",
+        ])
+        .unwrap();
         assert_eq!(cmd.network.discovery.port, 300);
         assert_eq!(cmd.network.port, 99);
     }
 
     #[test]
     fn parse_metrics_port() {
-        let cmd = NodeCommand::<()>::try_parse_from(["reth", "--metrics", "9001"]).unwrap();
+        let cmd = PoaNodeCommand::<()>::try_parse_from(["reth", "--metrics", "9001"]).unwrap();
         assert_eq!(cmd.metrics, Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 9001)));
 
-        let cmd = NodeCommand::<()>::try_parse_from(["reth", "--metrics", ":9001"]).unwrap();
+        let cmd = PoaNodeCommand::<()>::try_parse_from(["reth", "--metrics", ":9001"]).unwrap();
         assert_eq!(cmd.metrics, Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 9001)));
 
         let cmd =
-            NodeCommand::<()>::try_parse_from(["reth", "--metrics", "localhost:9001"]).unwrap();
+            PoaNodeCommand::<()>::try_parse_from(["reth", "--metrics", "localhost:9001"]).unwrap();
         assert_eq!(cmd.metrics, Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 9001)));
     }
 
     #[test]
     fn parse_config_path() {
-        let cmd = NodeCommand::<()>::try_parse_from(["reth", "--config", "my/path/to/reth.toml"])
-            .unwrap();
+        let cmd =
+            PoaNodeCommand::<()>::try_parse_from(["reth", "--config", "my/path/to/reth.toml"])
+                .unwrap();
         // always store reth.toml in the data dir, not the chain specific data dir
         let data_dir = cmd.datadir.unwrap_or_chain_default(cmd.chain.chain);
         let config_path = cmd.config.unwrap_or(data_dir.config_path());
         assert_eq!(config_path, Path::new("my/path/to/reth.toml"));
 
-        let cmd = NodeCommand::<()>::try_parse_from(["reth"]).unwrap();
+        let cmd = PoaNodeCommand::<()>::try_parse_from(["reth"]).unwrap();
 
         // always store reth.toml in the data dir, not the chain specific data dir
         let data_dir = cmd.datadir.unwrap_or_chain_default(cmd.chain.chain);
@@ -1235,14 +1258,14 @@ mod tests {
 
     #[test]
     fn parse_db_path() {
-        let cmd = NodeCommand::<()>::try_parse_from(["reth"]).unwrap();
+        let cmd = PoaNodeCommand::<()>::try_parse_from(["reth"]).unwrap();
         let data_dir = cmd.datadir.unwrap_or_chain_default(cmd.chain.chain);
         let db_path = data_dir.db_path();
         let end = format!("reth/{}/db", SUPPORTED_CHAINS[0]);
         assert!(db_path.ends_with(end), "{:?}", cmd.config);
 
         let cmd =
-            NodeCommand::<()>::try_parse_from(["reth", "--datadir", "my/custom/path"]).unwrap();
+            PoaNodeCommand::<()>::try_parse_from(["reth", "--datadir", "my/custom/path"]).unwrap();
         let data_dir = cmd.datadir.unwrap_or_chain_default(cmd.chain.chain);
         let db_path = data_dir.db_path();
         assert_eq!(db_path, Path::new("my/custom/path/db"));
@@ -1251,7 +1274,7 @@ mod tests {
     #[test]
     #[cfg(not(feature = "optimism"))] // dev mode not yet supported in op-reth
     fn parse_dev() {
-        let cmd = NodeCommand::<()>::parse_from(["reth", "--dev"]);
+        let cmd = PoaNodeCommand::<()>::parse_from(["reth", "--dev"]);
         let chain = reth_primitives::DEV.clone();
         assert_eq!(cmd.chain.chain, chain.chain);
         assert_eq!(cmd.chain.genesis_hash, chain.genesis_hash);
@@ -1263,13 +1286,11 @@ mod tests {
 
         assert!(cmd.rpc.http);
         assert!(cmd.network.discovery.disable_discovery);
-
-        assert!(cmd.dev.dev);
     }
 
     #[test]
     fn parse_instance() {
-        let mut cmd = NodeCommand::<()>::parse_from(["reth"]);
+        let mut cmd = PoaNodeCommand::<()>::parse_from(["reth"]);
         cmd.adjust_instance_ports();
         cmd.network.port = DEFAULT_DISCOVERY_PORT + cmd.instance - 1;
         // check rpc port numbers
@@ -1279,7 +1300,7 @@ mod tests {
         // check network listening port number
         assert_eq!(cmd.network.port, 30303);
 
-        let mut cmd = NodeCommand::<()>::parse_from(["reth", "--instance", "2"]);
+        let mut cmd = PoaNodeCommand::<()>::parse_from(["reth", "--instance", "2"]);
         cmd.adjust_instance_ports();
         cmd.network.port = DEFAULT_DISCOVERY_PORT + cmd.instance - 1;
         // check rpc port numbers
@@ -1289,7 +1310,7 @@ mod tests {
         // check network listening port number
         assert_eq!(cmd.network.port, 30304);
 
-        let mut cmd = NodeCommand::<()>::parse_from(["reth", "--instance", "3"]);
+        let mut cmd = PoaNodeCommand::<()>::parse_from(["reth", "--instance", "3"]);
         cmd.adjust_instance_ports();
         cmd.network.port = DEFAULT_DISCOVERY_PORT + cmd.instance - 1;
         // check rpc port numbers

--- a/bin/reth/src/poa/notifications.rs
+++ b/bin/reth/src/poa/notifications.rs
@@ -1,0 +1,87 @@
+//! Support for handling notification events for poa
+
+use displaydoc::Display as DisplayDoc;
+use hyper::client::HttpConnector;
+use hyper_rustls::HttpsConnector;
+use slack_morphism::{
+    errors::SlackClientError,
+    prelude::{
+        SlackApiPostWebhookMessageRequest, SlackApiPostWebhookMessageResponse,
+        SlackClientHyperConnector,
+    },
+    SlackClient, SlackMessageContent,
+};
+use thiserror::Error;
+use tracing::{error, info};
+use url::Url;
+
+/// Event notification errors
+#[derive(Debug, DisplayDoc, Error)]
+pub enum Error {
+    /// Slack client error: `{0}`
+    SlackClient(#[from] SlackClientError),
+}
+
+/// Events Notification Client
+#[derive(Clone, Debug)]
+pub struct EventsNotificationClient {
+    client_id: secp256k1::PublicKey,
+    client: SlackClient<SlackClientHyperConnector<HttpsConnector<HttpConnector>>>,
+    webhook_url: Url,
+}
+
+impl EventsNotificationClient {
+    /// Client builder
+    pub fn new(client_id: secp256k1::PublicKey, webhook_url: Url) -> Result<Self, Error> {
+        let client = SlackClient::new(SlackClientHyperConnector::new());
+        Ok(Self { client_id, client, webhook_url })
+    }
+
+    /// Getter for the selected webhook url
+    #[inline]
+    pub fn get_webhook_url(&self) -> &Url {
+        &self.webhook_url
+    }
+
+    /// Client id
+    #[inline]
+    pub fn get_client_id(&self) -> &secp256k1::PublicKey {
+        &self.client_id
+    }
+
+    /// Getter for the client sender
+    #[inline]
+    pub fn get_client(
+        &self,
+    ) -> &SlackClient<SlackClientHyperConnector<HttpsConnector<HttpConnector>>> {
+        &self.client
+    }
+
+    /// Sends a notification message to the webhook url
+    pub async fn send_message(
+        &self,
+        message: &str,
+    ) -> Result<SlackApiPostWebhookMessageResponse, Error> {
+        let msg = format!("[CLIENT_ID = {}]. Text = {}", self.client_id.to_string(), message);
+        let client_result = self
+            .client
+            .post_webhook_message(
+                &self.webhook_url,
+                &SlackApiPostWebhookMessageRequest::new(SlackMessageContent::new().with_text(msg)),
+            )
+            .await
+            .map_err(|err| Error::SlackClient(err))?;
+
+        Ok(client_result)
+    }
+}
+
+/// Sends a notification using the client
+pub async fn send_notification(slack_client: Option<EventsNotificationClient>, message: &str) {
+    if let Some(slack_client) = slack_client.as_ref() {
+        match slack_client.send_message(message).await {
+            Ok(_) => info!(">>> Notification fired!"),
+            Err(err) => error!(">>> Notification client failed to send. Error = {:?}", err),
+        }
+    }
+}


### PR DESCRIPTION
This PR aims to fix some of the poa-related events and event-streamers which were incorrectly imported from node and additionally introduces a notification client which currently supports sending messages to a slack webhook that would appear in our slack in a "testnet_notifications" channel e.g. The underlying client could also be changed easily.