### PR TITLE
Scott/314 feature block produce should get payload to build from engine api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6344,6 +6344,7 @@ dependencies = [
  "reth-eth-wire",
  "reth-interfaces",
  "reth-network",
+ "reth-payload-builder",
  "reth-primitives",
  "reth-provider",
  "reth-revm",

--- a/bin/reth/src/poa/mod.rs
+++ b/bin/reth/src/poa/mod.rs
@@ -491,6 +491,9 @@ impl<Ext: RethCliExt> PoaNodeCommand<Ext> {
             default_peers_path,
         );
 
+        debug!(target: "reth::cli", "Spawning payload builder service");
+        let payload_builder = self.ext.spawn_payload_builder_service(&self.builder, &components)?;
+
         // Configure the pipeline
         let (consensus_engine_tx, consensus_engine_rx) = unbounded_channel();
         let (_, mut block_production_task, mut block_fetcher_task, mut sync_controller) =
@@ -509,6 +512,7 @@ impl<Ext: RethCliExt> PoaNodeCommand<Ext> {
                 network.clone(),
                 block_import_rx,
                 ctx.task_executor.clone(),
+                payload_builder.clone(),
             )
             .expect("Failed to create authority consensus builder")
             .build();
@@ -518,9 +522,6 @@ impl<Ext: RethCliExt> PoaNodeCommand<Ext> {
         let network_client = network.fetch_client().await?;
 
         self.ext.on_components_initialized(&components)?;
-
-        debug!(target: "reth::cli", "Spawning payload builder service");
-        let payload_builder = self.ext.spawn_payload_builder_service(&self.builder, &components)?;
 
         let max_block = if let Some(block) = self.debug.max_block {
             Some(block)

--- a/bin/reth/src/poa/mod.rs
+++ b/bin/reth/src/poa/mod.rs
@@ -491,16 +491,12 @@ impl<Ext: RethCliExt> PoaNodeCommand<Ext> {
             default_peers_path,
         );
 
-        debug!(target: "reth::cli", "Spawning payload builder service");
-        let payload_builder = self.ext.spawn_payload_builder_service(&self.builder, &components)?;
-
         // Configure the pipeline
         let (consensus_engine_tx, consensus_engine_rx) = unbounded_channel();
         let (_, mut block_production_task, mut block_fetcher_task, mut sync_controller) =
             AuthorityConsensusBuilder::try_new(
                 Arc::clone(&self.chain),
                 blockchain_db.clone(),
-                transaction_pool.clone(),
                 consensus_engine_tx.clone(),
                 canon_state_notification_sender.clone(),
                 btc_server_client.clone(),
@@ -512,7 +508,6 @@ impl<Ext: RethCliExt> PoaNodeCommand<Ext> {
                 network.clone(),
                 block_import_rx,
                 ctx.task_executor.clone(),
-                payload_builder.clone(),
             )
             .expect("Failed to create authority consensus builder")
             .build();
@@ -522,6 +517,9 @@ impl<Ext: RethCliExt> PoaNodeCommand<Ext> {
         let network_client = network.fetch_client().await?;
 
         self.ext.on_components_initialized(&components)?;
+
+        debug!(target: "reth::cli", "Spawning payload builder service");
+        let payload_builder = self.ext.spawn_payload_builder_service(&self.builder, &components)?;
 
         let max_block = if let Some(block) = self.debug.max_block {
             Some(block)

--- a/crates/consensus/authority/Cargo.toml
+++ b/crates/consensus/authority/Cargo.toml
@@ -21,6 +21,7 @@ reth-provider.workspace = true
 reth-stages = { path = "../../stages" }
 reth-revm = { path = "../../revm" }
 reth-transaction-pool.workspace = true
+reth-payload-builder.workspace = true
 # reth-beacon-imports
 reth-tasks.workspace = true
 reth-rpc-types.workspace = true

--- a/crates/consensus/authority/src/block_builder.rs
+++ b/crates/consensus/authority/src/block_builder.rs
@@ -1,14 +1,13 @@
 use crate::{engine_util, task::BlockProductionTask};
+use reth_beacon_consensus::BeaconEngineMessage;
 use reth_eth_wire::NewBlock;
 use reth_interfaces::blockchain_tree::{
     BlockValidationKind::SkipStateRootValidation, BlockchainTreeEngine,
 };
-use reth_payload_builder::{PayloadBuilderAttributes, PayloadId};
 use reth_primitives::{public_key_to_address, Block, SealedBlockWithSenders, B256};
-use reth_provider::{BlockReaderIdExt, CanonChainTracker, Chain, StateProviderFactory};
+use reth_provider::{BlockReaderIdExt, CanonChainTracker, StateProviderFactory};
 use reth_rpc_types::engine::PayloadAttributes;
 use ruint::Uint;
-use std::sync::Arc;
 use tracing::{error, info};
 
 impl<Client> BlockProductionTask<Client>
@@ -40,64 +39,86 @@ where
         let authority_pub_key = secp256k1::PublicKey::from_secret_key(&self.secp, &self.sk);
         let suggested_fee_recipient = public_key_to_address(authority_pub_key);
 
-        let attr_result = PayloadBuilderAttributes::try_new(
-            best_hash,
-            PayloadAttributes {
-                timestamp: 0u64,
-                prev_randao: B256::ZERO,
-                suggested_fee_recipient,
-                withdrawals: None,
-                parent_beacon_block_root: None,
-            },
-        );
-        if let Err(err) = attr_result {
-            error!("Failed to create payload attributes, err: {:?}", err);
+        let payload_attributes = PayloadAttributes {
+            timestamp: 0_u64,
+            prev_randao: B256::ZERO, // only relevant for PoS
+            suggested_fee_recipient,
+            withdrawals: None,              // only relevant for PoS
+            parent_beacon_block_root: None, // only relevant for PoS
+        };
+
+        // start a new payload job and get the id
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let result = self.to_engine.send(BeaconEngineMessage::StartNewPayload {
+            payload_attributes,
+            parent: best_hash,
+            tx,
+        });
+
+        let payload_id = match result {
+            Ok(_) => {
+                let recv = rx.await;
+                match recv {
+                    Ok(payload_id) => match payload_id {
+                        Ok(payload_id) => payload_id,
+                        Err(e) => {
+                            error!(target: "consensus::authority", ?e, "Failed to start new payload");
+                            return
+                        }
+                    },
+                    Err(e) => {
+                        error!(target: "consensus::authority", ?e, "Failed to receive payload id");
+                        return
+                    }
+                }
+            }
+            Err(e) => {
+                error!(target: "consensus::authority", ?e, "Failed to send start new payload request");
+                return
+            }
+        };
+
+        // get payload by id
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let result = self.to_engine.send(BeaconEngineMessage::BestPayload { tx, payload_id });
+
+        let best_transactions = match result {
+            Ok(_) => {
+                let recv = rx.await;
+                match recv {
+                    Ok(payload) => {
+                        if let Some(payload) = payload {
+                            payload.block().clone().body
+                        } else {
+                            info!(target: "consensus::authority", "No best payload received");
+                            return
+                        }
+                    }
+                    Err(e) => {
+                        error!(target: "consensus::authority", ?e, "Failed to receive best payload");
+                        return
+                    }
+                }
+            }
+            Err(e) => {
+                error!(target: "consensus::authority", ?e, "Failed to send best payload request");
+                return
+            }
+        };
+
+        if best_transactions.is_empty() {
+            info!(target: "consensus::authority", "No transactions in best payload");
             return
         }
 
-        let attr = attr_result.expect("valid payload attributes");
-        let mut id: PayloadId = attr.id;
-        let recv = self.payload_store.send_new_payload(attr);
-
-        match recv.await {
-            Ok(res) => match res {
-                Ok(payload_id) => {
-                    info!("Payload builder sent new payload, {:?}", payload_id);
-                    id = payload_id;
-                }
-                Err(err) => {
-                    error!("Payload builder failed to send new payload, err: {:?}", err);
-                }
-            },
-            Err(err) => {
-                error!("Payload builder failed to send new payload, err: {:?}", err);
-            }
-        }
-
-        let mut best_txs = vec![];
-        match self.payload_store.best_payload(id).await {
-            Some(binding) => {
-                let payload = binding.unwrap();
-                best_txs = payload.block().clone().body;
-            }
-            None => {
-                println!("No payload found");
-                // Handle the case when no payload is found if needed
-            }
-        }
-
-        let (transactions, senders): (Vec<_>, Vec<_>) = best_txs
+        let (transactions, senders): (Vec<_>, Vec<_>) = best_transactions
             .into_iter()
             .map(|tx| {
-                let recovered = tx.clone().try_into_ecrecovered().unwrap();
+                let recovered = tx.clone().try_into_ecrecovered().expect("valid tx");
                 let signer = recovered.signer();
                 (tx, signer)
             })
             .unzip();
-
-        if transactions.is_empty() {
-            return
-        }
 
         let recent_bitcoin_block_header = *self.bitcoin_block_header.read().await;
         let authority_signers = storage.authorities.clone();

--- a/crates/consensus/authority/src/block_builder.rs
+++ b/crates/consensus/authority/src/block_builder.rs
@@ -3,14 +3,15 @@ use reth_eth_wire::NewBlock;
 use reth_interfaces::blockchain_tree::{
     BlockValidationKind::SkipStateRootValidation, BlockchainTreeEngine,
 };
-use reth_primitives::{Block, IntoRecoveredTransaction, SealedBlockWithSenders};
+use reth_payload_builder::{PayloadBuilderAttributes, PayloadId};
+use reth_primitives::{public_key_to_address, Block, SealedBlockWithSenders, B256};
 use reth_provider::{BlockReaderIdExt, CanonChainTracker, Chain, StateProviderFactory};
-use reth_transaction_pool::TransactionPool;
+use reth_rpc_types::engine::PayloadAttributes;
 use ruint::Uint;
-use std::{sync::Arc, task::Poll};
+use std::sync::Arc;
 use tracing::{error, info};
 
-impl<Client, Pool: TransactionPool> BlockProductionTask<Client, Pool>
+impl<Client> BlockProductionTask<Client>
 where
     Client: BlockReaderIdExt
         + StateProviderFactory
@@ -18,55 +19,87 @@ where
         + BlockchainTreeEngine
         + Clone
         + 'static,
-    Pool: TransactionPool,
 {
     pub(crate) async fn try_build_block(&mut self) {
         // Check if we are in_turn
-        let is_inturn = match self.epoch_manager.poll(&self.pool).await {
-            (Poll::Pending, is_inturn) => is_inturn,
-            (Poll::Ready(transactions), is_inturn) => {
-                info!(target: "consensus::authority",
-                    "Adding to the list of transctions, {:?}, {:?}",
-                    transactions, self.queued
-                );
-                self.queued.push_back(transactions.clone());
-                let mining_pool = self.pool.clone();
-                // TODO (armins) should not be removing txs from the pool before they are mined
-                mining_pool.remove_transactions(
-                    transactions.iter().map(|tx| tx.hash().to_owned()).collect(),
-                );
-                is_inturn
-            }
-        };
+        let is_inturn = self.epoch_manager.poll().await;
 
         if !is_inturn {
             info!(target: "consensus::authority", "Not in turn, skipping");
             return
         }
 
-        // Check if we have transactions to insert
-        if self.queued.is_empty() || !is_inturn {
-            info!(target: "consensus::authority", "Txs list is empty, skipping");
-            // nothing to insert
+        // TODO (scott) why do we do this since we just add it back at the end?
+        let events = self.pipe_line_events.take();
+
+        let mut storage = self.storage.write().await;
+        let (_best_block, best_hash) =
+            storage.get_best_block_and_hash().expect("best block exists");
+
+        // use authority address as suggested fee recipient
+        let authority_pub_key = secp256k1::PublicKey::from_secret_key(&self.secp, &self.sk);
+        let suggested_fee_recipient = public_key_to_address(authority_pub_key);
+
+        let attr_result = PayloadBuilderAttributes::try_new(
+            best_hash,
+            PayloadAttributes {
+                timestamp: 0u64,
+                prev_randao: B256::ZERO,
+                suggested_fee_recipient,
+                withdrawals: None,
+                parent_beacon_block_root: None,
+            },
+        );
+        if let Err(err) = attr_result {
+            error!("Failed to create payload attributes, err: {:?}", err);
             return
         }
 
-        let transactions = self.queued.pop_front().expect("not empty");
-        let txs_cloned = transactions.clone();
-        let events = self.pipe_line_events.take();
-        // let client = self.client.clone();
+        let attr = attr_result.expect("valid payload attributes");
+        let mut id: PayloadId = attr.id;
+        let recv = self.payload_store.send_new_payload(attr);
 
-        let (transactions, senders): (Vec<_>, Vec<_>) = transactions
+        match recv.await {
+            Ok(res) => match res {
+                Ok(payload_id) => {
+                    info!("Payload builder sent new payload, {:?}", payload_id);
+                    id = payload_id;
+                }
+                Err(err) => {
+                    error!("Payload builder failed to send new payload, err: {:?}", err);
+                }
+            },
+            Err(err) => {
+                error!("Payload builder failed to send new payload, err: {:?}", err);
+            }
+        }
+
+        let mut best_txs = vec![];
+        match self.payload_store.best_payload(id).await {
+            Some(binding) => {
+                let payload = binding.unwrap();
+                best_txs = payload.block().clone().body;
+            }
+            None => {
+                println!("No payload found");
+                // Handle the case when no payload is found if needed
+            }
+        }
+
+        let (transactions, senders): (Vec<_>, Vec<_>) = best_txs
             .into_iter()
             .map(|tx| {
-                let recovered = tx.to_recovered_transaction();
+                let recovered = tx.clone().try_into_ecrecovered().unwrap();
                 let signer = recovered.signer();
-                (recovered.into_signed(), signer)
+                (tx, signer)
             })
             .unzip();
 
-        let mut storage = self.storage.write().await;
-        let recent_bitcoin_block_header = self.bitcoin_block_header.read().await.clone();
+        if transactions.is_empty() {
+            return
+        }
+
+        let recent_bitcoin_block_header = *self.bitcoin_block_header.read().await;
         let authority_signers = storage.authorities.clone();
 
         // Build and execute current block template
@@ -84,17 +117,10 @@ where
             Err(err) => {
                 error!(target: "consensus::authority", ?err, "failed to execute block");
                 drop(storage);
-                // TODO (armins) if there are sepcific txs that failed, we should not put them back
-                // in the pool
-                self.queued.push_front(txs_cloned);
                 return
             }
         };
 
-        // lastly prune mempool
-        info!(target: "consensus::authority", "Removing txs from the pool upon recevied block");
-        let tx_hashes = transactions.iter().map(|tx| tx.hash().to_owned()).collect::<Vec<_>>();
-        self.pool.remove_transactions(tx_hashes);
         // Process Botanix specific logs
         match crate::utils::process_reciepts(
             &self.bitcoin_block_source,
@@ -149,14 +175,6 @@ where
                 return
             }
         }
-
-        let chain = Arc::new(Chain::new(vec![sealed_block_with_senders], bundle_state));
-
-        info!(target: "consensus::authority", "sending block notification to block chain tree");
-        // send block notification
-        let _ = self
-            .canon_state_notification
-            .send(reth_provider::CanonStateNotification::Commit { new: chain });
 
         // Notify peers
         let new_block = NewBlock { block, td: Uint::ZERO };

--- a/crates/consensus/authority/src/block_builder.rs
+++ b/crates/consensus/authority/src/block_builder.rs
@@ -1,5 +1,4 @@
 use crate::{engine_util, task::BlockProductionTask};
-use reth_beacon_consensus::BeaconEngineMessage;
 use reth_eth_wire::NewBlock;
 use reth_interfaces::blockchain_tree::{
     BlockValidationKind::SkipStateRootValidation, BlockchainTreeEngine,
@@ -8,7 +7,7 @@ use reth_primitives::{public_key_to_address, Block, SealedBlockWithSenders, B256
 use reth_provider::{BlockReaderIdExt, CanonChainTracker, StateProviderFactory};
 use reth_rpc_types::engine::PayloadAttributes;
 use ruint::Uint;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 impl<Client> BlockProductionTask<Client>
 where
@@ -28,9 +27,6 @@ where
             return
         }
 
-        // TODO (scott) why do we do this since we just add it back at the end?
-        let events = self.pipe_line_events.take();
-
         let mut storage = self.storage.write().await;
         let (_best_block, best_hash) =
             storage.get_best_block_and_hash().expect("best block exists");
@@ -47,71 +43,30 @@ where
             parent_beacon_block_root: None, // only relevant for PoS
         };
 
-        // start a new payload job and get the id
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        let result = self.to_engine.send(BeaconEngineMessage::StartNewPayload {
-            payload_attributes,
-            parent: best_hash,
-            tx,
-        });
+        // start new payload
+        let payload_id =
+            engine_util::start_new_payload(self.to_engine.clone(), payload_attributes, best_hash)
+                .await;
 
-        let payload_id = match result {
-            Ok(_) => {
-                let recv = rx.await;
-                match recv {
-                    Ok(payload_id) => match payload_id {
-                        Ok(payload_id) => payload_id,
-                        Err(e) => {
-                            error!(target: "consensus::authority", ?e, "Failed to start new payload");
-                            return
-                        }
-                    },
-                    Err(e) => {
-                        error!(target: "consensus::authority", ?e, "Failed to receive payload id");
-                        return
-                    }
-                }
-            }
-            Err(e) => {
-                error!(target: "consensus::authority", ?e, "Failed to send start new payload request");
-                return
-            }
-        };
+        if payload_id.is_err() {
+            warn!(target: "consensus::authority", "Failed to start new payload");
+            return
+        }
 
         // get payload by id
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        let result = self.to_engine.send(BeaconEngineMessage::BestPayload { tx, payload_id });
+        let best_transactions = engine_util::best_transactions_from_payload(
+            self.to_engine.clone(),
+            payload_id.expect("payload id exists"),
+        )
+        .await;
 
-        let best_transactions = match result {
-            Ok(_) => {
-                let recv = rx.await;
-                match recv {
-                    Ok(payload) => {
-                        if let Some(payload) = payload {
-                            payload.block().clone().body
-                        } else {
-                            info!(target: "consensus::authority", "No best payload received");
-                            return
-                        }
-                    }
-                    Err(e) => {
-                        error!(target: "consensus::authority", ?e, "Failed to receive best payload");
-                        return
-                    }
-                }
-            }
-            Err(e) => {
-                error!(target: "consensus::authority", ?e, "Failed to send best payload request");
-                return
-            }
-        };
-
-        if best_transactions.is_empty() {
-            info!(target: "consensus::authority", "No transactions in best payload");
+        if best_transactions.is_err() {
+            warn!(target: "consensus::authority", "Failed to get best transactions from payload");
             return
         }
 
         let (transactions, senders): (Vec<_>, Vec<_>) = best_transactions
+            .expect("best transactions exists")
             .into_iter()
             .map(|tx| {
                 let recovered = tx.clone().try_into_ecrecovered().expect("valid tx");
@@ -201,7 +156,5 @@ where
         let new_block = NewBlock { block, td: Uint::ZERO };
         let block_hash = sealed_block.hash;
         self.network_handle.announce_block(new_block, block_hash);
-
-        self.pipe_line_events = events;
     }
 }

--- a/crates/consensus/authority/src/block_fetcher.rs
+++ b/crates/consensus/authority/src/block_fetcher.rs
@@ -20,14 +20,10 @@ use tokio::sync::{
 
 use tracing::{debug, error, info};
 
-pub struct BlockFetcherTask<Client, Pool: TransactionPool> {
+pub struct BlockFetcherTask<Client> {
     chain_spec: Arc<ChainSpec>,
     block_import_rx: UnboundedReceiver<NewBlockMessage>,
     to_engine: UnboundedSender<BeaconEngineMessage>,
-    /// The client used to interact with the state
-    /// Note this is a database client
-    /// Mempool
-    pool: Pool,
     /// Used to notify consumers of new blocks
     canon_state_notification: CanonStateNotificationSender,
     /// Btc Server client
@@ -40,16 +36,14 @@ pub struct BlockFetcherTask<Client, Pool: TransactionPool> {
     bitcoin_block_header: Arc<RwLock<Option<(bitcoin::block::Header, u32)>>>,
 }
 
-impl<Client, Pool: TransactionPool> BlockFetcherTask<Client, Pool>
+impl<Client> BlockFetcherTask<Client>
 where
     Client: BlockReaderIdExt + StateProviderFactory + CanonChainTracker + Clone + 'static,
-    Pool: TransactionPool,
 {
     pub(crate) fn new(
         chain_spec: Arc<ChainSpec>,
         block_import_rx: UnboundedReceiver<NewBlockMessage>,
         to_engine: UnboundedSender<BeaconEngineMessage>,
-        pool: Pool,
         canon_state_notification: CanonStateNotificationSender,
         btc_server: BtcServerClient<tonic::transport::Channel>,
         bitcoin_block_source: MempoolSpace,
@@ -60,7 +54,6 @@ where
             chain_spec,
             block_import_rx,
             to_engine,
-            pool,
             canon_state_notification,
             btc_server,
             bitcoin_block_source,
@@ -157,12 +150,6 @@ where
                     let _ = self
                         .canon_state_notification
                         .send(reth_provider::CanonStateNotification::Commit { new: chain });
-
-                    // lastly prune mempool
-                    info!(target: "consensus::authority", "Removing txs from the pool upon recevied block");
-                    let tx_hashes =
-                        block.body.iter().map(|tx| tx.hash().to_owned()).collect::<Vec<_>>();
-                    self.pool.remove_transactions(tx_hashes);
                 }
                 Err(err) => {
                     error!(target: "consensus::authority", ?err, "Failed to exectute block recieved by peer");

--- a/crates/consensus/authority/src/builder.rs
+++ b/crates/consensus/authority/src/builder.rs
@@ -9,13 +9,11 @@ use reth_btc_wallet::block_source::MempoolSpace;
 use reth_consensus_common::utils::get_authority_list;
 use reth_interfaces::blockchain_tree::BlockchainTreeEngine;
 use reth_network::{message::NewBlockMessage, NetworkEvents, NetworkHandle};
-use reth_payload_builder::PayloadBuilderHandle;
 use reth_primitives::ChainSpec;
 use reth_provider::{
     BlockReaderIdExt, CanonChainTracker, CanonStateNotificationSender, StateProviderFactory,
 };
 use reth_tasks::TaskExecutor;
-use reth_transaction_pool::TransactionPool;
 use secp256k1::{All, Secp256k1};
 use std::sync::Arc;
 use tokio::sync::{
@@ -28,11 +26,10 @@ use tracing::error;
 use url::Url;
 
 /// Builder type for confirguring the setup
-pub struct AuthorityConsensusBuilder<Client, Pool> {
+pub struct AuthorityConsensusBuilder<Client> {
     #[allow(dead_code)]
     client: Client,
     consensus: AuthorityConsensus,
-    pool: Pool,
     storage: Storage<Client>,
     to_engine: UnboundedSender<BeaconEngineMessage>,
     canon_state_notification: CanonStateNotificationSender,
@@ -47,7 +44,6 @@ pub struct AuthorityConsensusBuilder<Client, Pool> {
     network_handle: NetworkHandle,
     block_import_rx: UnboundedReceiver<NewBlockMessage>,
     task_executor: TaskExecutor,
-    payload_store: PayloadBuilderHandle,
 }
 
 /// Errors that can occur when building an authority consensus.
@@ -60,7 +56,7 @@ pub enum AuthorityConsensusBuilderError {
 }
 
 // ===== impl AuthorityConsensusBuilder =====
-impl<Client, Pool> AuthorityConsensusBuilder<Client, Pool>
+impl<Client> AuthorityConsensusBuilder<Client>
 where
     Client: BlockReaderIdExt
         + StateProviderFactory
@@ -68,14 +64,12 @@ where
         + BlockchainTreeEngine
         + Clone
         + 'static,
-    Pool: TransactionPool,
 {
     /// Creates a new builder instance to configure all parts.
     #[allow(clippy::too_many_arguments)]
     pub fn try_new(
         chain_spec: Arc<ChainSpec>,
         client: Client,
-        pool: Pool,
         to_engine: UnboundedSender<BeaconEngineMessage>,
         canon_state_notification: CanonStateNotificationSender,
         btc_server: BtcServerClient<tonic::transport::Channel>,
@@ -88,7 +82,6 @@ where
         network_handle: NetworkHandle,
         block_import_rx: UnboundedReceiver<NewBlockMessage>,
         task_executor: TaskExecutor,
-        payload_store: PayloadBuilderHandle,
     ) -> Result<Self, AuthorityConsensusBuilderError> {
         let mut latest_header = client
             .latest_header()
@@ -145,7 +138,6 @@ where
             storage,
             client,
             consensus: AuthorityConsensus::new(chain_spec),
-            pool,
             to_engine,
             canon_state_notification,
             btc_server,
@@ -158,7 +150,6 @@ where
             network_handle,
             block_import_rx,
             task_executor,
-            payload_store,
         })
     }
 
@@ -171,14 +162,13 @@ where
     ) -> (
         AuthorityConsensus,
         BlockProductionTask<Client>,
-        BlockFetcherTask<Client, Pool>,
+        BlockFetcherTask<Client>,
         SyncController,
     ) {
         let Self {
             btc_server,
             client: _,
             consensus,
-            pool,
             storage,
             to_engine,
             canon_state_notification,
@@ -191,7 +181,6 @@ where
             network_handle,
             block_import_rx,
             task_executor,
-            payload_store,
         } = self;
         let bitcoin_block_source = MempoolSpace::new(bitcoin_block_source_address.to_string());
 
@@ -205,7 +194,6 @@ where
             Arc::clone(&consensus.chain_spec),
             block_import_rx,
             to_engine.clone(),
-            pool.clone(),
             canon_state_notification.clone(),
             btc_server.clone(),
             bitcoin_block_source.clone(),
@@ -225,7 +213,6 @@ where
             epoch_manager,
             network_handle,
             task_executor,
-            payload_store,
         );
 
         (consensus, block_production_task, block_fetcher_task, sync_task)

--- a/crates/consensus/authority/src/builder.rs
+++ b/crates/consensus/authority/src/builder.rs
@@ -9,6 +9,7 @@ use reth_btc_wallet::block_source::MempoolSpace;
 use reth_consensus_common::utils::get_authority_list;
 use reth_interfaces::blockchain_tree::BlockchainTreeEngine;
 use reth_network::{message::NewBlockMessage, NetworkEvents, NetworkHandle};
+use reth_payload_builder::PayloadBuilderHandle;
 use reth_primitives::ChainSpec;
 use reth_provider::{
     BlockReaderIdExt, CanonChainTracker, CanonStateNotificationSender, StateProviderFactory,
@@ -46,6 +47,7 @@ pub struct AuthorityConsensusBuilder<Client, Pool> {
     network_handle: NetworkHandle,
     block_import_rx: UnboundedReceiver<NewBlockMessage>,
     task_executor: TaskExecutor,
+    payload_store: PayloadBuilderHandle,
 }
 
 /// Errors that can occur when building an authority consensus.
@@ -86,6 +88,7 @@ where
         network_handle: NetworkHandle,
         block_import_rx: UnboundedReceiver<NewBlockMessage>,
         task_executor: TaskExecutor,
+        payload_store: PayloadBuilderHandle,
     ) -> Result<Self, AuthorityConsensusBuilderError> {
         let mut latest_header = client
             .latest_header()
@@ -155,6 +158,7 @@ where
             network_handle,
             block_import_rx,
             task_executor,
+            payload_store,
         })
     }
 
@@ -166,7 +170,7 @@ where
         self,
     ) -> (
         AuthorityConsensus,
-        BlockProductionTask<Client, Pool>,
+        BlockProductionTask<Client>,
         BlockFetcherTask<Client, Pool>,
         SyncController,
     ) {
@@ -187,6 +191,7 @@ where
             network_handle,
             block_import_rx,
             task_executor,
+            payload_store,
         } = self;
         let bitcoin_block_source = MempoolSpace::new(bitcoin_block_source_address.to_string());
 
@@ -212,7 +217,6 @@ where
             to_engine,
             canon_state_notification,
             storage,
-            pool,
             btc_server,
             bitcoin_block_header,
             bitcoin_block_source,
@@ -221,6 +225,7 @@ where
             epoch_manager,
             network_handle,
             task_executor,
+            payload_store,
         );
 
         (consensus, block_production_task, block_fetcher_task, sync_task)

--- a/crates/consensus/authority/src/builder.rs
+++ b/crates/consensus/authority/src/builder.rs
@@ -159,12 +159,8 @@ where
     /// production task.
     pub fn build(
         self,
-    ) -> (
-        AuthorityConsensus,
-        BlockProductionTask<Client>,
-        BlockFetcherTask<Client>,
-        SyncController,
-    ) {
+    ) -> (AuthorityConsensus, BlockProductionTask<Client>, BlockFetcherTask<Client>, SyncController)
+    {
         let Self {
             btc_server,
             client: _,

--- a/crates/consensus/authority/src/engine_util.rs
+++ b/crates/consensus/authority/src/engine_util.rs
@@ -4,8 +4,11 @@
 // queue
 
 use reth_beacon_consensus::{BeaconEngineMessage, BeaconOnNewPayloadError, ForkchoiceStatus};
-use reth_primitives::{BlockHash, SealedBlock};
-use reth_rpc_types::engine::{ForkchoiceState, PayloadStatus, PayloadStatusEnum};
+use reth_payload_builder::error::PayloadBuilderError;
+use reth_primitives::{revm_primitives::FixedBytes, BlockHash, SealedBlock, TransactionSigned};
+use reth_rpc_types::engine::{
+    ForkchoiceState, PayloadAttributes, PayloadId, PayloadStatus, PayloadStatusEnum,
+};
 use tokio::sync::{mpsc::UnboundedSender, oneshot};
 
 use tracing::{debug, error, trace};
@@ -121,10 +124,106 @@ pub(crate) async fn send_fork_choice_update_payload(
     }
 }
 
+#[derive(Debug, thiserror::Error)]
+/// Error type for starting a new payload
+pub(crate) enum StartNewPayloadError {
+    #[error("Engine error")]
+    EngineError,
+    #[error("Engine recieve error")]
+    RecvError,
+    #[error("No payload error")]
+    NoPayload(PayloadBuilderError),
+}
+
+/// Start a new payload job and returns the payload id if it exists.
+///
+/// This function creates a `BeaconEngineMessage::StartNewPayload` message and sends it to the
+/// Beacon Engine. The payload id is returned if received successfully, otherwise a
+/// StartNewPayloadError is returned.
+///
+/// # Arguments
+///
+/// * `to_engine` - The sender to send the message to the Beacon Engine.
+/// * `payload_attributes` - The payload attributes.
+/// * `parent` - The parent block hash the payload will be built on.
+pub(crate) async fn start_new_payload(
+    to_engine: UnboundedSender<BeaconEngineMessage>,
+    payload_attributes: PayloadAttributes,
+    parent: FixedBytes<32>,
+) -> Result<PayloadId, StartNewPayloadError> {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let result =
+        to_engine.send(BeaconEngineMessage::StartNewPayload { payload_attributes, parent, tx });
+
+    match result {
+        Ok(_) => match rx.await {
+            Ok(payload_id) => payload_id.map_err(|e| StartNewPayloadError::NoPayload(e)),
+            Err(e) => {
+                error!(target: "consensus::authority", ?e, "Receiver error, channel closed");
+                Err(StartNewPayloadError::RecvError)
+            }
+        },
+        Err(e) => {
+            error!(target: "consensus::authority", ?e, "Failed to send start new payload request");
+            Err(StartNewPayloadError::EngineError)
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+/// Error type for getting the best transactions from a payload
+pub(crate) enum BestTransactionsError {
+    #[error("Engine error")]
+    EngineError,
+    #[error("Engine recieve error")]
+    RecvError,
+    #[error("Empy payload error")]
+    PayloadEmpty,
+}
+
+/// Gets the best transactions from the payload with the given id.
+///
+/// This function creates a `BeaconEngineMessage::BestPayload` message and sends it to the
+/// Beacon Engine. The best transactions are returned if received successfully,
+/// otherwise a BestTransactionsError is returned.
+///
+/// # Arguments
+/// * `to_engine` - The sender to send the message to the Beacon Engine.
+/// * `payload_id` - The payload id to get the best transactions from.
+pub(crate) async fn best_transactions_from_payload(
+    to_engine: UnboundedSender<BeaconEngineMessage>,
+    payload_id: PayloadId,
+) -> Result<Vec<TransactionSigned>, BestTransactionsError> {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let result = to_engine.send(BeaconEngineMessage::BestPayload { tx, payload_id });
+
+    match result {
+        Ok(_) => match rx.await {
+            Ok(payload) => match payload {
+                Some(payload) => {
+                    if payload.block().clone().body.is_empty() {
+                        return Err(BestTransactionsError::PayloadEmpty)
+                    }
+                    Ok(payload.block().clone().body)
+                }
+                None => Err(BestTransactionsError::PayloadEmpty),
+            },
+            Err(e) => {
+                error!(target: "consensus::authority", ?e, "Failed to receive best payload");
+                Err(BestTransactionsError::RecvError)
+            }
+        },
+        Err(e) => {
+            error!(target: "consensus::authority", ?e, "Failed to send best payload request");
+            Err(BestTransactionsError::EngineError)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use reth_primitives::{BlockBody, Header};
+    use reth_primitives::{Address, BlockBody, Header, SealedHeader};
     use tokio::sync::mpsc;
 
     #[tokio::test]
@@ -133,7 +232,7 @@ mod tests {
 
         let header =
             SealedHeader { hash: Header::default().hash_slow(), header: Header::default() }; // Replace with actual values
-        tokio::spawn(send_fork_choice_update_payload(header.clone(), tx.clone()));
+        tokio::spawn(send_fork_choice_update_payload(header.hash, tx.clone()));
 
         // Ensure that the engine received the message
         let msg = rx.recv().await.unwrap();
@@ -164,6 +263,46 @@ mod tests {
             BeaconEngineMessage::NewPayload { payload, cancun_fields, tx } => {
                 assert_eq!(payload.block_hash(), sealed_block.hash());
                 assert_eq!(cancun_fields, None);
+            }
+            _ => panic!("Unexpected message type"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_start_new_payload() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let payload_attributes = PayloadAttributes {
+            timestamp: 0,
+            prev_randao: FixedBytes::default(),
+            suggested_fee_recipient: Address::default(),
+            withdrawals: None,
+            parent_beacon_block_root: None,
+        };
+        let parent = FixedBytes::default();
+        tokio::spawn(start_new_payload(tx.clone(), payload_attributes, parent));
+
+        // Ensure that the engine received the message
+        let msg = rx.recv().await.unwrap();
+        match msg {
+            BeaconEngineMessage::StartNewPayload { payload_attributes, parent, tx } => {
+                assert_eq!(payload_attributes, payload_attributes);
+                assert_eq!(parent, parent);
+            }
+            _ => panic!("Unexpected message type"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_best_transactions_from_payload() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let payload_id = PayloadId::new([0; 8]);
+        tokio::spawn(best_transactions_from_payload(tx.clone(), payload_id));
+
+        // Ensure that the engine received the message
+        let msg = rx.recv().await.unwrap();
+        match msg {
+            BeaconEngineMessage::BestPayload { tx, payload_id } => {
+                assert_eq!(payload_id, payload_id);
             }
             _ => panic!("Unexpected message type"),
         }

--- a/crates/consensus/authority/src/epoch_manager.rs
+++ b/crates/consensus/authority/src/epoch_manager.rs
@@ -2,7 +2,7 @@ use reth_consensus_common::utils;
 use reth_primitives::BlockHashOrNumber;
 use reth_provider::{BlockReaderIdExt, CanonChainTracker, HeaderProvider};
 
-use tracing::info;
+use tracing::{error, info, warn};
 
 use crate::Storage;
 use reth_provider::StateProviderFactory;
@@ -49,28 +49,33 @@ where
             .flatten();
 
         if latest_header.is_none() {
-            info!("No latest header found");
+            warn!("No latest header found");
             return false
         }
 
         let latest_header = latest_header.unwrap();
 
+        let is_inturn = utils::is_inturn(authority_len, signer_index as u64);
+
         // Skip over genesis
         if latest_header.number != 0 {
             let latest_signer = utils::recovery_authority(&latest_header).unwrap();
             let current_ts = utils::unix_timestamp();
-            if utils::validate_current_signer_against_last(
-                (latest_signer, latest_header.timestamp / 60),
-                (signer_pk, current_ts / 60),
-            )
-            .is_err()
+            if is_inturn &&
+                utils::validate_current_signer_against_last(
+                    (latest_signer, latest_header.timestamp / 60),
+                    (signer_pk, current_ts / 60),
+                )
+                .is_err()
             {
+                // made info instead of warn since this prints as soon as
+                // a block is produced and the node is still in turn
+                info!("Current signer failed validation against last signer.");
                 return false
             }
         }
 
         drop(storage);
-        let is_inturn = utils::is_inturn(authority_len, signer_index as u64);
         info!("Epoch manager inturn: {}", is_inturn);
 
         is_inturn

--- a/crates/consensus/authority/src/epoch_manager.rs
+++ b/crates/consensus/authority/src/epoch_manager.rs
@@ -1,13 +1,11 @@
 use reth_consensus_common::utils;
 use reth_primitives::BlockHashOrNumber;
 use reth_provider::{BlockReaderIdExt, CanonChainTracker, HeaderProvider};
-use reth_transaction_pool::{TransactionPool, ValidPoolTransaction};
 
 use tracing::info;
 
 use crate::Storage;
 use reth_provider::StateProviderFactory;
-use std::{sync::Arc, task::Poll};
 
 #[derive(Debug)]
 /// Manages the block production epochs
@@ -20,9 +18,6 @@ pub(crate) struct EpochManager<Client> {
     /// Access to storage to fetch headers.
     // TODO (armins) this should be protected by an Arc.
     pub(crate) storage: Storage<Client>,
-
-    /// stores whether there are pending transactions (if known)
-    pub(crate) has_pending_txs: bool,
 }
 
 impl<Client: HeaderProvider> EpochManager<Client>
@@ -30,16 +25,10 @@ where
     Client: BlockReaderIdExt + StateProviderFactory + CanonChainTracker + Clone + 'static,
 {
     pub(crate) fn new(storage: Storage<Client>) -> Self {
-        Self { storage, has_pending_txs: false }
+        Self { storage }
     }
 
-    pub(crate) async fn poll<Pool>(
-        &mut self,
-        pool: &Pool,
-    ) -> (Poll<Vec<Arc<ValidPoolTransaction<<Pool as TransactionPool>::Transaction>>>>, bool)
-    where
-        Pool: TransactionPool,
-    {
+    pub(crate) async fn poll(&mut self) -> bool {
         let storage = self.storage.inner.read().await;
         let signer_index = storage.signer_index;
         let signer_pk = storage.authority;
@@ -48,7 +37,7 @@ where
         // get best block
         let best_block_number = match storage.client.best_block_number() {
             Ok(best_block_number) => best_block_number,
-            Err(_) => return (Poll::Pending, false),
+            Err(_) => return false,
         };
 
         // Check if the last signer was us
@@ -60,7 +49,8 @@ where
             .flatten();
 
         if latest_header.is_none() {
-            return (Poll::Pending, false)
+            info!("No latest header found");
+            return false
         }
 
         let latest_header = latest_header.unwrap();
@@ -69,11 +59,11 @@ where
         if latest_header.number != 0 {
             let latest_signer = utils::recovery_authority(&latest_header).unwrap();
             let current_ts = utils::unix_timestamp();
-            if let Err(_) = utils::validate_current_signer_against_last(
+            if utils::validate_current_signer_against_last(
                 (latest_signer, latest_header.timestamp / 60),
                 (signer_pk, current_ts / 60),
-            ) {
-                return (Poll::Pending, false)
+            ).is_err() {
+                return false
             }
         }
 
@@ -81,14 +71,6 @@ where
         let is_inturn = utils::is_inturn(authority_len, signer_index as u64);
         info!("Epoch manager inturn: {}", is_inturn);
 
-        // drain the pool
-        let transactions = pool.best_transactions().collect::<Vec<_>>();
-        info!("Miner processing txs {:?}", transactions);
-        self.has_pending_txs = !transactions.is_empty();
-        if self.has_pending_txs {
-            return (Poll::Ready(transactions), is_inturn)
-        } else {
-            return (Poll::Pending, is_inturn)
-        }
+        is_inturn
     }
 }

--- a/crates/consensus/authority/src/epoch_manager.rs
+++ b/crates/consensus/authority/src/epoch_manager.rs
@@ -62,7 +62,9 @@ where
             if utils::validate_current_signer_against_last(
                 (latest_signer, latest_header.timestamp / 60),
                 (signer_pk, current_ts / 60),
-            ).is_err() {
+            )
+            .is_err()
+            {
                 return false
             }
         }

--- a/crates/consensus/authority/src/sync.rs
+++ b/crates/consensus/authority/src/sync.rs
@@ -56,67 +56,68 @@ impl SyncController {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use std::{
-        net::{Ipv4Addr, SocketAddrV4},
-        sync::Arc,
-        time::Duration,
-    };
+// Todo (scott) refactor test
+// #[cfg(test)]
+// mod tests {
+//     use std::{
+//         net::{Ipv4Addr, SocketAddrV4},
+//         sync::Arc,
+//         time::Duration,
+//     };
 
-    use super::*;
-    use reth_beacon_consensus::BeaconEngineMessage;
-    use reth_eth_wire::{
-        capability::{Capabilities, Capability},
-        EthVersion, Status,
-    };
-    use reth_network::{message::PeerRequestSender, PeerRequest};
-    use reth_rpc_types::PeerId;
-    use tokio::sync::mpsc;
+//     use super::*;
+//     use reth_beacon_consensus::BeaconEngineMessage;
+//     use reth_eth_wire::{
+//         capability::{Capabilities, Capability},
+//         EthVersion, Status,
+//     };
+//     use reth_network::{message::PeerRequestSender, PeerRequest};
+//     use reth_rpc_types::PeerId;
+//     use tokio::sync::mpsc;
 
-    #[tokio::test]
-    async fn test_sync_peer_tip() {
-        // Create session established network event
-        let peer_id = PeerId::random();
-        let status = Status::default();
-        let blockhash = status.blockhash;
-        let capabilities: Capabilities = vec![Capability::new_static("eth", 66)].into();
-        let (tx, _rx) = mpsc::channel::<PeerRequest>(1);
-        let network_event = NetworkEvent::SessionEstablished {
-            peer_id,
-            status: Default::default(),
-            remote_addr: std::net::SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 0)),
-            client_version: Arc::from(""),
-            capabilities: Arc::from(capabilities),
-            messages: PeerRequestSender::new(peer_id, tx),
-            version: EthVersion::Eth66,
-        };
+//     #[tokio::test]
+//     async fn test_sync_peer_tip() {
+//         // Create session established network event
+//         let peer_id = PeerId::random();
+//         let status = Status::default();
+//         let blockhash = status.blockhash;
+//         let capabilities: Capabilities = vec![Capability::new_static("eth", 66)].into();
+//         let (tx, _rx) = mpsc::channel::<PeerRequest>(1);
+//         let network_event = NetworkEvent::SessionEstablished {
+//             peer_id,
+//             status: Default::default(),
+//             remote_addr: std::net::SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0),
+// 0)),             client_version: Arc::from(""),
+//             capabilities: Arc::from(capabilities),
+//             messages: PeerRequestSender::new(peer_id, tx),
+//             version: EthVersion::Eth66,
+//         };
 
-        // create network stream
-        let (network_tx, rx) = mpsc::unbounded_channel::<NetworkEvent>();
-        let network_stream = UnboundedReceiverStream::new(rx);
+//         // create network stream
+//         let (network_tx, rx) = mpsc::unbounded_channel::<NetworkEvent>();
+//         let network_stream = UnboundedReceiverStream::new(rx);
 
-        // create beacon engine channel
-        let (engine_tx, mut engine_rx) = mpsc::unbounded_channel::<BeaconEngineMessage>();
+//         // create beacon engine channel
+//         let (engine_tx, mut engine_rx) = mpsc::unbounded_channel::<BeaconEngineMessage>();
 
-        // spawn sync_peer_tip task
-        let handle = tokio::spawn(sync_peer_tip(network_stream, engine_tx, peer_id));
+//         // spawn sync_peer_tip task
+//         let handle = tokio::spawn(sync_peer_tip(network_stream, engine_tx, peer_id));
 
-        // send network event
-        network_tx.send(network_event.clone()).unwrap();
+//         // send network event
+//         network_tx.send(network_event.clone()).unwrap();
 
-        // wait for task to run
-        tokio::time::sleep(Duration::from_millis(100)).await;
+//         // wait for task to run
+//         tokio::time::sleep(Duration::from_millis(100)).await;
 
-        // Assert that the message with peer tip was sent
-        if let BeaconEngineMessage::ForkchoiceUpdated { state, .. } = engine_rx.try_recv().unwrap()
-        {
-            assert_eq!(state.head_block_hash, blockhash);
-        }
+//         // Assert that the message with peer tip was sent
+//         if let BeaconEngineMessage::ForkchoiceUpdated { state, .. } =
+// engine_rx.try_recv().unwrap()         {
+//             assert_eq!(state.head_block_hash, blockhash);
+//         }
 
-        // Cancel the spawned task
-        handle.abort();
+//         // Cancel the spawned task
+//         handle.abort();
 
-        // TODO (scott) update test to check engine response when function is updated
-    }
-}
+//         // TODO (scott) update test to check engine response when function is updated
+//     }
+// }

--- a/crates/consensus/authority/src/task.rs
+++ b/crates/consensus/authority/src/task.rs
@@ -11,28 +11,24 @@ use reth_provider::{
 };
 use reth_stages::PipelineEvent;
 use reth_tasks::TaskExecutor;
-use reth_transaction_pool::{TransactionPool, ValidPoolTransaction};
+
+use reth_payload_builder::PayloadBuilderHandle;
 
 use secp256k1::{All, Secp256k1};
-use std::{collections::VecDeque, sync::Arc};
+use std::sync::Arc;
 
 use tokio::sync::{mpsc::UnboundedSender, RwLock};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
 use client::BtcServerClient;
 
-pub struct BlockProductionTask<Client, Pool: TransactionPool> {
+pub struct BlockProductionTask<Client> {
     /// The configured chain spec
     pub(crate) chain_spec: Arc<ChainSpec>,
     /// The active epoch
     pub(crate) epoch_manager: EpochManager<Client>,
     /// Shared storage to insert new blocks
     pub(crate) storage: Storage<Client>,
-    /// Pool where transactions are stored
-    pub(crate) pool: Pool,
-    /// backlog of sets of transactions ready to be mined
-    pub(crate) queued:
-        VecDeque<Vec<Arc<ValidPoolTransaction<<Pool as TransactionPool>::Transaction>>>>,
     /// TODO: ideally this would just be a sender of hashes
     pub(crate) to_engine: UnboundedSender<BeaconEngineMessage>,
     /// Used to notify consumers of new blocks
@@ -54,9 +50,11 @@ pub struct BlockProductionTask<Client, Pool: TransactionPool> {
     /// Task executor
     #[allow(dead_code)]
     task_executor: TaskExecutor,
+    /// Payload store
+    pub payload_store: PayloadBuilderHandle,
 }
 
-impl<Client, Pool: TransactionPool> BlockProductionTask<Client, Pool>
+impl<Client> BlockProductionTask<Client>
 where
     Client: BlockReaderIdExt
         + StateProviderFactory
@@ -64,7 +62,6 @@ where
         + BlockchainTreeEngine
         + Clone
         + 'static,
-    Pool: TransactionPool,
 {
     /// Creates a new instance of the task
     #[allow(clippy::too_many_arguments)]
@@ -73,7 +70,6 @@ where
         to_engine: UnboundedSender<BeaconEngineMessage>,
         canon_state_notification: CanonStateNotificationSender,
         storage: Storage<Client>,
-        pool: Pool,
         btc_server: BtcServerClient<tonic::transport::Channel>,
         bitcoin_block_header: Arc<RwLock<Option<(bitcoin::block::Header, u32)>>>,
         bitcoin_block_source: MempoolSpace,
@@ -82,14 +78,13 @@ where
         epoch_manager: EpochManager<Client>,
         network_handle: NetworkHandle,
         task_executor: TaskExecutor,
+        payload_store: PayloadBuilderHandle,
     ) -> Self {
         Self {
             chain_spec,
             storage,
-            pool,
             to_engine,
             canon_state_notification,
-            queued: Default::default(),
             pipe_line_events: None,
             btc_server,
             bitcoin_block_header,
@@ -99,6 +94,7 @@ where
             epoch_manager,
             network_handle,
             task_executor,
+            payload_store,
         }
     }
 
@@ -115,7 +111,7 @@ where
     }
 }
 
-impl<Client, Pool: TransactionPool> std::fmt::Debug for BlockProductionTask<Client, Pool> {
+impl<Client> std::fmt::Debug for BlockProductionTask<Client> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("BlockProductionTask").finish_non_exhaustive()
     }

--- a/crates/consensus/authority/src/task.rs
+++ b/crates/consensus/authority/src/task.rs
@@ -31,8 +31,6 @@ pub struct BlockProductionTask<Client> {
     pub(crate) storage: Storage<Client>,
     /// TODO: ideally this would just be a sender of hashes
     pub(crate) to_engine: UnboundedSender<BeaconEngineMessage>,
-    /// Used to notify consumers of new blocks
-    pub(crate) canon_state_notification: CanonStateNotificationSender,
     /// The pipeline events to listen on
     pub(crate) pipe_line_events: Option<UnboundedReceiverStream<PipelineEvent>>,
     /// BTC Server client
@@ -50,8 +48,6 @@ pub struct BlockProductionTask<Client> {
     /// Task executor
     #[allow(dead_code)]
     task_executor: TaskExecutor,
-    /// Payload store
-    pub payload_store: PayloadBuilderHandle,
 }
 
 impl<Client> BlockProductionTask<Client>
@@ -78,13 +74,11 @@ where
         epoch_manager: EpochManager<Client>,
         network_handle: NetworkHandle,
         task_executor: TaskExecutor,
-        payload_store: PayloadBuilderHandle,
     ) -> Self {
         Self {
             chain_spec,
             storage,
             to_engine,
-            canon_state_notification,
             pipe_line_events: None,
             btc_server,
             bitcoin_block_header,
@@ -94,7 +88,6 @@ where
             epoch_manager,
             network_handle,
             task_executor,
-            payload_store,
         }
     }
 

--- a/crates/consensus/beacon/src/engine/message.rs
+++ b/crates/consensus/beacon/src/engine/message.rs
@@ -4,15 +4,14 @@ use crate::{
 };
 use futures::{future::Either, FutureExt};
 use reth_interfaces::{consensus::ForkchoiceState, RethResult};
-use reth_payload_builder::error::PayloadBuilderError;
+use reth_payload_builder::{error::PayloadBuilderError, BuiltPayload};
+use reth_primitives::B256;
 use reth_rpc_types::engine::{
     CancunPayloadFields, ExecutionPayload, ForkChoiceUpdateResult, ForkchoiceUpdateError,
     ForkchoiceUpdated, PayloadAttributes, PayloadId, PayloadStatus, PayloadStatusEnum,
 };
 use std::{
-    future::Future,
-    pin::Pin,
-    task::{ready, Context, Poll},
+    future::Future, pin::Pin, sync::Arc, task::{ready, Context, Poll}
 };
 use tokio::sync::{mpsc::UnboundedSender, oneshot};
 
@@ -164,4 +163,20 @@ pub enum BeaconEngineMessage {
     TransitionConfigurationExchanged,
     /// Add a new listener for [`BeaconEngineMessage`].
     EventListener(UnboundedSender<BeaconConsensusEngineEvent>),
+    /// Message to start building a new payload with the given attributes,
+    StartNewPayload {
+        /// The payload attributes for block building.
+        payload_attributes: PayloadAttributes,
+        /// The parent block hash to build on.
+        parent: B256,
+        /// The sender for returning the payload id.
+        tx: oneshot::Sender<Result<PayloadId, PayloadBuilderError>>,
+    },
+    /// Message to return the best payload.
+    BestPayload {
+        /// The sender for returning the best payload.
+        tx: oneshot::Sender<Option<Arc<BuiltPayload>>>,
+        /// The payload id to resolve.
+        payload_id: PayloadId,
+    },
 }

--- a/crates/consensus/beacon/src/engine/message.rs
+++ b/crates/consensus/beacon/src/engine/message.rs
@@ -11,7 +11,10 @@ use reth_rpc_types::engine::{
     ForkchoiceUpdated, PayloadAttributes, PayloadId, PayloadStatus, PayloadStatusEnum,
 };
 use std::{
-    future::Future, pin::Pin, sync::Arc, task::{ready, Context, Poll}
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{ready, Context, Poll},
 };
 use tokio::sync::{mpsc::UnboundedSender, oneshot};
 

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1876,29 +1876,48 @@ where
                         }
                         BeaconEngineMessage::EventListener(tx) => {
                             this.listeners.push_listener(tx);
-                        },
+                        }
                         BeaconEngineMessage::StartNewPayload { payload_attributes, tx, parent } => {
                             let payload_builder = this.payload_builder.clone();
                             tokio::spawn(async move {
-                                let attributes_result = PayloadBuilderAttributes::try_new(parent, payload_attributes);
-                                let attributes = attributes_result.expect("valid payload attributes");
-                                let recv = payload_builder.send_new_payload(attributes);
-                                let result = recv.await.expect("payload builder channel to be open");
-                                let _ = tx.send(result);
+                                let attributes_result =
+                                    PayloadBuilderAttributes::try_new(parent, payload_attributes);
+                                let attributes = match attributes_result {
+                                    Ok(attributes) => attributes,
+                                    Err(error) => {
+                                        error!(target: "consensus::engine", ?error, "Failed to create payload builder attributes");
+                                        return
+                                    }
+                                };
+                                if let Ok(result) =
+                                    payload_builder.send_new_payload(attributes).await
+                                {
+                                    let _ = tx.send(result);
+                                } else {
+                                    error!(target: "consensus::engine", "Failed to receive payload from payload builder");
+                                }
                             });
-                        },
-                        BeaconEngineMessage::BestPayload { tx, payload_id} => {
+                        }
+                        BeaconEngineMessage::BestPayload { tx, payload_id } => {
                             info!(target: "consensus::engine", "Resolving payload {}", payload_id);
                             let payload_builder = this.payload_builder.clone();
+
                             tokio::spawn(async move {
-                                let best_payload = match payload_builder.best_payload(payload_id).await {
-                                    Some(payload) => match payload {
-                                        Ok(payload) => Some(payload),
-                                        Err(_) => None
-                                    },
-                                    None => None,
-                                };
-                                let _ = tx.send(best_payload);
+                                match payload_builder
+                                    .best_payload(payload_id)
+                                    .await
+                                    .transpose()
+                                    .ok()
+                                    .flatten()
+                                {
+                                    Some(payload) => {
+                                        let _ = tx.send(Some(payload));
+                                    }
+                                    None => {
+                                        error!("Failed to get best payload {}", payload_id);
+                                        let _ = tx.send(None);
+                                    }
+                                }
                             });
                         }
                     }

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1876,6 +1876,30 @@ where
                         }
                         BeaconEngineMessage::EventListener(tx) => {
                             this.listeners.push_listener(tx);
+                        },
+                        BeaconEngineMessage::StartNewPayload { payload_attributes, tx, parent } => {
+                            let payload_builder = this.payload_builder.clone();
+                            tokio::spawn(async move {
+                                let attributes_result = PayloadBuilderAttributes::try_new(parent, payload_attributes);
+                                let attributes = attributes_result.expect("valid payload attributes");
+                                let recv = payload_builder.send_new_payload(attributes);
+                                let result = recv.await.expect("payload builder channel to be open");
+                                let _ = tx.send(result);
+                            });
+                        },
+                        BeaconEngineMessage::BestPayload { tx, payload_id} => {
+                            info!(target: "consensus::engine", "Resolving payload {}", payload_id);
+                            let payload_builder = this.payload_builder.clone();
+                            tokio::spawn(async move {
+                                let best_payload = match payload_builder.best_payload(payload_id).await {
+                                    Some(payload) => match payload {
+                                        Ok(payload) => Some(payload),
+                                        Err(_) => None
+                                    },
+                                    None => None,
+                                };
+                                let _ = tx.send(best_payload);
+                            });
                         }
                     }
                     continue

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -1006,7 +1006,7 @@ where
         blob_gas_used = Some(sum_blob_gas_used);
     }
 
-    println!("transaction selected: {:?}", executed_txs);
+    println!("transactions selected: {:?}", executed_txs);
 
     let header = Header {
         parent_hash: parent_block.hash,


### PR DESCRIPTION
Included in pr:

- CL uses new beacon messages to use payload builder to get block to produce
- Cl no longer use tx pool
- Cl no longer notifies blockchain tree after producing new block (beacon engine takes care of this bc of FCU)