### PR TITLE
poa tx payload builder fixes & epoch manager fixes

### DIFF
--- a/crates/consensus/authority/src/block_builder.rs
+++ b/crates/consensus/authority/src/block_builder.rs
@@ -1,4 +1,5 @@
 use crate::{engine_util, task::BlockProductionTask};
+use reth_consensus_common::utils;
 use reth_eth_wire::NewBlock;
 use reth_interfaces::blockchain_tree::{
     BlockValidationKind::SkipStateRootValidation, BlockchainTreeEngine,
@@ -42,7 +43,7 @@ where
         let suggested_fee_recipient = public_key_to_address(authority_pub_key);
 
         let payload_attributes = PayloadAttributes {
-            timestamp: 0_u64,
+            timestamp: utils::unix_timestamp(),
             prev_randao: B256::ZERO, // only relevant for PoS
             suggested_fee_recipient,
             withdrawals: None,              // only relevant for PoS

--- a/crates/consensus/authority/src/engine_util.rs
+++ b/crates/consensus/authority/src/engine_util.rs
@@ -182,6 +182,9 @@ pub(crate) async fn best_transactions_from_payload<Engine: reth_node_api::Engine
         .transpose()
         .map_err(BestTransactionsError::EngineError)?
         .ok_or_else(|| BestTransactionsError::PayloadEmpty)?;
+    if best_txs.block().body.is_empty() {
+        return Err(BestTransactionsError::PayloadEmpty);
+    }
     Ok(best_txs)
 }
 

--- a/crates/consensus/authority/src/epoch_manager.rs
+++ b/crates/consensus/authority/src/epoch_manager.rs
@@ -37,7 +37,10 @@ where
         // get best block
         let best_block_number = match storage.client.best_block_number() {
             Ok(best_block_number) => best_block_number,
-            Err(_) => return false,
+            Err(_) => {
+                drop(storage);
+                return false
+            }
         };
 
         // Check if the last signer was us
@@ -49,6 +52,7 @@ where
             .flatten();
 
         if latest_header.is_none() {
+            drop(storage);
             warn!("No latest header found");
             return false
         }
@@ -61,15 +65,14 @@ where
         if latest_header.number != 0 {
             let latest_signer = utils::recovery_authority(&latest_header).unwrap();
             let current_ts = utils::unix_timestamp();
-            if is_inturn &&
-                utils::validate_current_signer_against_last(
-                    (latest_signer, latest_header.timestamp / 60),
-                    (signer_pk, current_ts / 60),
-                )
-                .is_err()
-            {
+            let current_last_signer_validation = utils::validate_current_signer_against_last(
+                (latest_signer, latest_header.timestamp as f64 / 60.0),
+                (signer_pk, current_ts as f64 / 60.0),
+            );
+            if is_inturn && current_last_signer_validation.is_err() {
                 // made info instead of warn since this prints as soon as
                 // a block is produced and the node is still in turn
+                drop(storage);
                 info!("Current signer failed validation against last signer.");
                 return false
             }

--- a/crates/consensus/common/src/utils.rs
+++ b/crates/consensus/common/src/utils.rs
@@ -216,8 +216,8 @@ pub fn validate_against_parent(
     let current_signer = recovery_authority(&current)
         .map_err(|e| ValidateAgainstParentError::FailedToDerserializeExtraData(e))?;
     // Check if the parent block was mined in a different turn
-    let parent_ts = parent.timestamp / 60;
-    let current_ts = current.timestamp / 60;
+    let parent_ts = parent.timestamp as f64 / 60.0;
+    let current_ts = current.timestamp as f64 / 60.0;
 
     validate_current_signer_against_last((parent_signer, parent_ts), (current_signer, current_ts))?;
 
@@ -227,13 +227,13 @@ pub fn validate_against_parent(
 /// Validate current signer and its last block timestamp against the last signer and its last block
 /// timestamp Used to prevent a signer from signing multiple blocks in the same turn
 pub fn validate_current_signer_against_last(
-    last: (secp256k1::PublicKey, u64),
-    current: (secp256k1::PublicKey, u64),
+    last: (secp256k1::PublicKey, f64),
+    current: (secp256k1::PublicKey, f64),
 ) -> Result<(), ValidateAgainstParentError> {
     // Last block should be greater that 1 minute in the worst cast
     // Even in the case of > 2 federation members the worst case time between blocks for the same
     // Signer should be 1 minute. Assuming 1 minute block times
-    if last.0 == current.0 && current.1 - last.1 < 1 {
+    if last.0 == current.0 && current.1 - last.1 < 1.0 {
         return Err(ValidateAgainstParentError::SignerLimitExceeded);
     }
 

--- a/crates/primitives/src/constants/mod.rs
+++ b/crates/primitives/src/constants/mod.rs
@@ -17,7 +17,7 @@ pub const RETH_CLIENT_VERSION: &str = concat!("reth/v", env!("CARGO_PKG_VERSION"
 pub const SELECTOR_LEN: usize = 4;
 
 /// Maximum extra data size in a block after genesis
-pub const MAXIMUM_EXTRA_DATA_SIZE: usize = 128;
+pub const MAXIMUM_EXTRA_DATA_SIZE: usize = 256;
 
 /// Fixed number of extra-data suffix bytes reserved for signer seal.
 pub const MAXIMUM_EXTRA_SEAL_SIZE: usize = 65;


### PR DESCRIPTION
This MR addresses a few points:

- it adds a higher limit to the extra payload in the header
- it fixes the issue of empty best txs as to avoid empty blocks produced by the same fed member
- it provides better numerical comparisons in the first last validator check
- fixes the temp dropping of the storage lock inside the epoch manager in case of early returns.