### PR TITLE
refactor: process pegouts at end of epoch

### DIFF
--- a/crates/consensus/authority/src/block_builder.rs
+++ b/crates/consensus/authority/src/block_builder.rs
@@ -1,8 +1,9 @@
 use crate::{
     engine_util::{self, BestTransactionsError},
     task::BlockProductionTask,
-    utils::is_epoch_end,
+    utils::{is_epoch_end, send_pegouts},
 };
+use client::MakeTxRequest;
 use reth_consensus_common::utils;
 use reth_eth_wire::NewBlock;
 use reth_interfaces::blockchain_tree::{
@@ -41,26 +42,6 @@ where
 
         let mut storage = self.storage.write().await;
         let (best_block, best_hash) = storage.get_best_block_and_hash().expect("best block exists");
-
-        // if epoch end block, process pegouts
-        let current_block = best_block + 1;
-        let pegouts = if is_epoch_end(current_block) {
-            match self.epoch_manager.epoch_pegouts(current_block).await {
-                Ok(pegouts) => pegouts,
-                Err(e) => {
-                    panic!("Failed to get pegouts {}", e)
-                }
-            }
-        } else {
-            vec![]
-        };
-
-        if pegouts.is_empty() {
-            info!(target: "consensus::authority", "No pegouts found");
-        } else {
-            info!(target: "consensus::authority", "Processing pegouts: {:?}", pegouts);
-            // TODO(scott)
-        }
 
         // use authority address as suggested fee recipient
         let authority_pub_key = secp256k1::PublicKey::from_secret_key(&self.secp, &self.sk);
@@ -159,15 +140,11 @@ where
         };
 
         // Process Botanix specific logs
-        match crate::utils::process_receipts(
-            &self.bitcoind_client,
-            &mut self.btc_server.clone(),
-            &bundle_state,
-            false,
-        )
-        .await
-        {
-            Ok(_) => {}
+        let mut current_block_pegouts: Vec<MakeTxRequest> = Vec::new();
+        match crate::utils::process_receipts(&mut self.btc_server.clone(), &bundle_state).await {
+            Ok(pegouts) => if !pegouts.is_empty() {
+                current_block_pegouts.extend(pegouts);
+            },
             Err(e) => {
                 error!(target: "consensus::authority", ?e, "Failed to process botanix log");
                 return;
@@ -200,7 +177,6 @@ where
         storage.client.set_canonical_head(sealed_block.header.clone());
         storage.client.set_safe(sealed_block.header.clone());
         storage.client.set_finalized(sealed_block.header.clone());
-        drop(storage);
 
         match engine_util::send_fork_choice_update_payload(
             new_header.hash(),
@@ -221,9 +197,26 @@ where
         let block_hash = new_block.clone().block.hash_slow();
         self.network_handle.announce_block(new_block, block_hash);
 
-        // TODO (scott) Process pegouts
-        // access pegouts from cache (need to add) or if cache empty
-        // bc busted when node went offline,
-        // use utils method to get all pegouts from epoch
+        // If end of epoch, process pegouts
+        if is_epoch_end(sealed_block.header.number) {
+            // get pegouts up to best block
+            let mut pegouts: Vec<MakeTxRequest> = Vec::new();
+            match self.epoch_manager.epoch_pegouts(best_block).await {
+                Ok(epoch_pegouts) => pegouts.extend(epoch_pegouts),
+                Err(e) => {
+                    error!(target: "consensus::authority", ?e, "Failed to fetch pegouts");
+                    drop(storage);
+                    return;
+                }
+            };
+
+            // add current block pegouts
+            pegouts.extend(current_block_pegouts);
+
+            info!(target: "consensus::authority", "Sending pegouts: {:?}", pegouts);
+            if let Err(e) = send_pegouts(&self.bitcoind_client, &mut self.btc_server, pegouts).await {
+                error!(target: "consensus::authority", ?e, "Failed to send pegouts");
+            }
+        }
     }
 }

--- a/crates/consensus/authority/src/block_fetcher.rs
+++ b/crates/consensus/authority/src/block_fetcher.rs
@@ -127,10 +127,8 @@ where
                             .expect("senders are valid");
                     // Process Botanix specific logs
                     match crate::utils::process_receipts(
-                        &self.bitcoind_client,
                         &mut self.btc_server.clone(),
                         &bundle_state,
-                        false,
                     )
                     .await
                     {

--- a/crates/consensus/authority/src/epoch_manager.rs
+++ b/crates/consensus/authority/src/epoch_manager.rs
@@ -7,7 +7,7 @@ use reth_provider::{BlockReaderIdExt, CanonChainTracker, HeaderProvider};
 use tracing::{error, info, warn};
 
 use crate::{
-    utils::{bloom_contains_pegout, make_tx_request_for_pegout_in_receipt},
+    utils::{bloom_contains_pegout, find_epoch_start, make_tx_request_for_pegout_in_receipt},
     Storage,
 };
 use reth_provider::StateProviderFactory;
@@ -43,19 +43,19 @@ where
     ///
     /// # Arguments
     ///
-    /// * `end_block` - The end block of the epoch
+    /// * `current_block` - The current block number
     ///
     /// # Returns
     ///
     /// A vector of `MakeTxRequest` representing the pegouts in the epoch
     pub(crate) async fn epoch_pegouts(
         &self,
-        end_block: u64,
+        best_block: u64,
     ) -> Result<Vec<MakeTxRequest>, EpochManagerError> {
-        let start_block = (end_block - EPOCH_LENGTH) + 1;
+        let start_block = find_epoch_start(EPOCH_LENGTH, best_block);
         let storage = self.storage.inner.read().await;
         let pegouts: Vec<MakeTxRequest> = vec![];
-        for block in start_block..=end_block {
+        for block in start_block..=best_block {
             match storage.client.block_by_number(block) {
                 Ok(Some(block)) if bloom_contains_pegout(block.header.logs_bloom) => {
                     match storage

--- a/crates/consensus/authority/src/utils.rs
+++ b/crates/consensus/authority/src/utils.rs
@@ -5,7 +5,6 @@ use reth_botanix_lib::mint_validation::{
     MINT_CONTRACT_ADDRESS, MINT_TOPIC,
 };
 use reth_btc_wallet::bitcoind::BitcoindClient;
-
 use reth_primitives::{constants::eip225::EPOCH_LENGTH, hex, Bloom, BloomInput, Log, Receipt};
 use reth_provider::BundleStateWithReceipts;
 
@@ -20,7 +19,7 @@ pub(crate) enum ProcessBotanixLogError {
     #[error("Failed to broadcast pegout tx")]
     FailedToBroadcastPegout,
     #[error("Failed to make pegout tx")]
-    FailedToMakePegoutTx(tonic::Status),
+    FailedToMakePegoutTx,
 }
 
 /// Search a receipt for a pegout and return a MakeTxRequest for the pegout
@@ -68,23 +67,22 @@ pub(crate) async fn make_tx_request_for_pegout_in_receipt(
 /// This function iterates over the receipts in the bundle and for each receipt, it checks if it is
 /// a prunning block or if it is successful. If the receipt is successful, it processes each log in
 /// the receipt and calls the `process_botanix_log` function. Finally, it logs the receipt
-/// information.
+/// information and returns a list of pegins if they exist.
 ///
 /// # Arguments
 ///
+/// * `btc_server` - The btc server client to send the pegins and pegouts to.
 /// * `bundle_state` - The bundle state with receipts to process.
-/// * `should_broadcast_pegout` - A boolean indicating whether to broadcast pegout or not.
 ///
 /// # Returns
 ///
-/// Returns `Ok(())` if the processing is successful, otherwise returns an error of type
+/// Returns `Ok(Vec<MakeTxRequest>)` if the processing is successful, otherwise returns an error of type
 /// `ProcessBotanixLogError`.
 pub(crate) async fn process_receipts(
-    bitcoind_client: &BitcoindClient,
     btc_server: &mut BtcServerClient<tonic::transport::Channel>,
     bundle_state: &BundleStateWithReceipts,
-    should_broadcast_pegout: bool,
-) -> Result<(), ProcessBotanixLogError> {
+) -> Result<Vec<MakeTxRequest>, ProcessBotanixLogError> {
+    let mut pegouts: Vec<MakeTxRequest> = Vec::new();
     let receipts_bundle = bundle_state.receipts().iter();
     for (index, receipts) in receipts_bundle.enumerate() {
         for receipt in receipts {
@@ -97,14 +95,22 @@ pub(crate) async fn process_receipts(
                     continue;
                 }
                 for log in &receipt.logs {
-                    process_botanix_log(bitcoind_client, btc_server, log, should_broadcast_pegout)
-                        .await?;
+                    match process_botanix_log(btc_server, log).await {
+                        Ok(Some(pegout)) => {
+                            pegouts.push(pegout);
+                        }
+                        Ok(None) => continue,
+                        Err(e) => {
+                            error!(target: "consensus::authority", ?e, "Failed to process botanix log");
+                            return Err(e);
+                        }
+                    }
                 }
             }
             info!(target: "consensus::authority", "Receipt {:?}", receipt);
         }
     }
-    Ok(())
+    Ok(pegouts)
 }
 
 /// Search a log for a pegout and return a MakeTxRequest for the pegout
@@ -121,6 +127,7 @@ async fn make_tx_request_for_pegout(log: Log) -> Option<MakeTxRequest> {
         match GenesisContractEvents::try_from(*topic) {
             Ok(GenesisContractEvents::MintingEvent) => continue,
             Ok(GenesisContractEvents::BurnEvent) => {
+                // TODO (scott): fetch fee - this will make function async
                 let fee_rate = 30u32;
                 let pegout = parse_pegout_reth_log_topic(&log).expect("valid pegout request");
                 return Some(MakeTxRequest {
@@ -138,32 +145,52 @@ async fn make_tx_request_for_pegout(log: Log) -> Option<MakeTxRequest> {
     None
 }
 
+pub(crate) async fn send_pegouts(
+    bitcoin_block_source: &BitcoindClient,
+    btc_server: &mut BtcServerClient<tonic::transport::Channel>,
+    pegouts: Vec<MakeTxRequest>,
+) -> Result<(), ProcessBotanixLogError> {
+    for pegout in pegouts {
+        // TODO (scott): call bitcoind's testmempoolaccept to check if tx is valid before proceeding
+        match btc_server.make_tx(pegout).await {
+            Ok(response) => {
+                let raw_tx = response.into_inner().tx;
+                info!(target: "consensus::authority", "broadcasting withdrawal tx");
+
+                bitcoin_block_source
+                    .broadcast_tx(&hex::encode(raw_tx))
+                    .await
+                    .map_err(|_| ProcessBotanixLogError::FailedToBroadcastPegout)?;
+            }
+            Err(e) => {
+                error!(target: "consensus::authority", ?e, "Failed to make pegout tx");
+                continue;
+            }
+        }
+    }
+
+    Ok(())
+}
+
 /// Processes a single botanix log and performs actions based on the log's topics.
 ///
 /// This function checks the topics of the log and performs different actions based on the topic.
 /// If the topic is `GenesisContractEvents::MintingEvent`, it parses and sends the minting event to
-/// the `btc_server`. If the topic is `GenesisContractEvents::BurnEvent` and
-/// `should_broadcast_pegout` is true, it parses and sends the withdrawal event to the `btc_server`.
+/// the `btc_server`. If the topic is `GenesisContractEvents::BurnEvent`, it validates the pegout and returns it.
 ///
 /// # Arguments
 ///
+/// * `btc_server` - The btc server client to send the pegins and pegouts to.
 /// * `log` - The log to process.
-/// * `should_broadcast_pegout` - A boolean indicating whether to broadcast pegout or not.
 ///
 /// # Returns
 ///
-/// Returns `Ok(())` if the processing is successful, otherwise returns an error of type
-/// `ProcessBotanixLogError`.
-
-// TODO (scott) remove `should_broadcast_pegout` since this only happens for epoch block
-// check if pegout and store in cache
-// create util method to send pegouts
+/// Returns `Ok(Option<MakeTxRequest>)` if the processing is successful, otherwise returns an error of type `ProcessBotanixLogError`.
 async fn process_botanix_log(
-    bitcoind_client: &BitcoindClient,
     btc_server: &mut BtcServerClient<tonic::transport::Channel>,
     log: &Log,
-    should_broadcast_pegout: bool,
-) -> Result<(), ProcessBotanixLogError> {
+) -> Result<Option<MakeTxRequest>, ProcessBotanixLogError> {
+    let mut pegout: Option<MakeTxRequest> = None;
     for topic in &log.topics {
         match GenesisContractEvents::try_from(*topic) {
             Ok(GenesisContractEvents::MintingEvent) => {
@@ -187,31 +214,24 @@ async fn process_botanix_log(
                 }
             }
             Ok(GenesisContractEvents::BurnEvent) => {
-                if !should_broadcast_pegout {
-                    continue;
-                }
-                // TODO (armins): obv
+                // TODO(scott): make dynamic
                 let fee_rate = 30u32;
-                info!(target: "consensus::authority", "Parsing and sending withdrawal event to btc_server");
-                let pegout = parse_pegout_reth_log_topic(log).expect("valid pegout request");
-                let request = MakeTxRequest {
-                    address: pegout.destination.to_string(),
-                    value: pegout.amount.to_sat(),
-                    fee_rate,
-                };
 
-                let response = btc_server
-                    .make_tx(request)
-                    .await
-                    .map_err(ProcessBotanixLogError::FailedToMakePegoutTx)?;
-
-                let raw_tx = response.into_inner().tx;
-                info!(target: "consensus::authority", "broadcasting withdrawal tx");
-
-                bitcoind_client
-                    .broadcast_tx(&hex::encode(raw_tx))
-                    .await
-                    .map_err(|_| ProcessBotanixLogError::FailedToBroadcastPegout)?;
+                // validate pegout
+                info!(target: "consensus::authority", "Validating pegout");
+                match parse_pegout_reth_log_topic(&log) {
+                    Ok(parsed_pegout) => {
+                        pegout = Some(MakeTxRequest {
+                            address: parsed_pegout.destination.to_string(),
+                            value: parsed_pegout.amount.to_sat(),
+                            fee_rate,
+                        });
+                    }
+                    Err(e) => {
+                        error!(target: "consensus::authority", ?e, "Failed to parse pegout");
+                        return Err(ProcessBotanixLogError::FailedToMakePegoutTx);
+                    }
+                }
             }
             Err(e) => {
                 debug!(target: "consensus::authority", ?e, "Non-genesis contract event");
@@ -219,7 +239,7 @@ async fn process_botanix_log(
             }
         }
     }
-    Ok(())
+    Ok(pegout)
 }
 
 fn bloom_contains_minting_contract_address(bloom: Bloom) -> bool {
@@ -227,13 +247,13 @@ fn bloom_contains_minting_contract_address(bloom: Bloom) -> bool {
 }
 
 pub(crate) fn bloom_contains_pegout(bloom: Bloom) -> bool {
-    bloom_contains_minting_contract_address(bloom) &&
-        bloom.contains_input(BloomInput::Raw(BURN_TOPIC.as_ref()))
+    bloom_contains_minting_contract_address(bloom)
+        && bloom.contains_input(BloomInput::Raw(BURN_TOPIC.as_ref()))
 }
 
 pub(crate) fn bloom_contains_pegin(bloom: Bloom) -> bool {
-    bloom_contains_minting_contract_address(bloom) &&
-        bloom.contains_input(BloomInput::Raw(MINT_TOPIC.as_ref()))
+    bloom_contains_minting_contract_address(bloom)
+        && bloom.contains_input(BloomInput::Raw(MINT_TOPIC.as_ref()))
 }
 
 /// Returns true if the given block number is the end of an epoch
@@ -250,10 +270,29 @@ pub(crate) fn is_epoch_end(current_block_number: u64) -> bool {
     (current_block_number + 1) % EPOCH_LENGTH == 0
 }
 
+/// Finds the starting block number for the current epoch based on the current block number
+///
+/// # Arguments
+///
+/// * `epoch_length` - The length of an epoch
+/// * `current_block_number` - The current block number
+///
+/// # Returns
+///
+/// Returns the starting block number for the current epoch.
+pub(crate) fn find_epoch_start(epoch_length: u64, current_block_number: u64) -> u64 {
+    let mut start_block_number = current_block_number;
+    while start_block_number % epoch_length != 0 {
+        start_block_number -= 1;
+    }
+    start_block_number
+}
+
 #[cfg(test)]
 mod test {
     use std::str::FromStr;
 
+    use rand::Rng;
     use reth_primitives::{address, b256, bloom, bytes, Header, B256, U256};
 
     use super::*;
@@ -368,5 +407,20 @@ mod test {
         assert!(!is_epoch_end(start_block_2));
         assert!(is_epoch_end(end_block_2));
         assert!(!is_epoch_end(start_block_3));
+    }
+
+    #[test]
+    fn test_find_epoch_start() {
+        let mut rng = rand::thread_rng();
+
+        let current_block_1 = 0;
+        let current_block_2 = current_block_1 + rng.gen_range(1..EPOCH_LENGTH);
+        let current_block_3 = current_block_1 + EPOCH_LENGTH;
+        let current_block_4 = current_block_3 + rng.gen_range(1..EPOCH_LENGTH);
+
+        assert_eq!(find_epoch_start(EPOCH_LENGTH, current_block_1), current_block_1);
+        assert_eq!(find_epoch_start(EPOCH_LENGTH, current_block_2), current_block_1);
+        assert_eq!(find_epoch_start(EPOCH_LENGTH, current_block_3), current_block_3);
+        assert_eq!(find_epoch_start(EPOCH_LENGTH, current_block_4), current_block_3);
     }
 }


### PR DESCRIPTION
this replaces pr: https://github.com/botanix-labs/Macbeth/pull/109

@0xBEEFCAF3 this pr does not store pegouts in the cache per our discussion