### PR TITLE
refactor(btc_server): move most psbt validation to `validate_psbt()`

### DIFF
--- a/bin/btc-server/client/src/btc_server.rs
+++ b/bin/btc-server/client/src/btc_server.rs
@@ -209,7 +209,8 @@ pub struct GetUtxoMerkleRootResponse {
 /// Generated client implementations.
 pub mod btc_server_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::{http::Uri, *};
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct BtcServerClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -253,8 +254,9 @@ pub mod btc_server_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
         {
             BtcServerClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -293,32 +295,44 @@ pub mod btc_server_client {
             &mut self,
             request: impl tonic::IntoRequest<super::NotifyPeginRequest>,
         ) -> std::result::Result<tonic::Response<super::Empty>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/btc_server.BtcServer/NotifyPegin");
+            let path = http::uri::PathAndQuery::from_static(
+                "/btc_server.BtcServer/NotifyPegin",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("btc_server.BtcServer", "NotifyPegin"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("btc_server.BtcServer", "NotifyPegin"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_gateway_address(
             &mut self,
             request: impl tonic::IntoRequest<super::GetGatewayAddressRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetGatewayAddressResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetGatewayAddressResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/btc_server.BtcServer/GetGatewayAddress");
+            let path = http::uri::PathAndQuery::from_static(
+                "/btc_server.BtcServer/GetGatewayAddress",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("btc_server.BtcServer", "GetGatewayAddress"));
@@ -327,33 +341,45 @@ pub mod btc_server_client {
         pub async fn get_public_key(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
-        ) -> std::result::Result<tonic::Response<super::GetPublicKeyResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetPublicKeyResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/btc_server.BtcServer/GetPublicKey");
+            let path = http::uri::PathAndQuery::from_static(
+                "/btc_server.BtcServer/GetPublicKey",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("btc_server.BtcServer", "GetPublicKey"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("btc_server.BtcServer", "GetPublicKey"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_round1_dkg_package(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> std::result::Result<tonic::Response<super::DkgPayload>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/btc_server.BtcServer/GetRound1DkgPackage");
+            let path = http::uri::PathAndQuery::from_static(
+                "/btc_server.BtcServer/GetRound1DkgPackage",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("btc_server.BtcServer", "GetRound1DkgPackage"));
@@ -363,15 +389,19 @@ pub mod btc_server_client {
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> std::result::Result<tonic::Response<super::DkgPayload>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/btc_server.BtcServer/GetRound1DkgPackages");
+            let path = http::uri::PathAndQuery::from_static(
+                "/btc_server.BtcServer/GetRound1DkgPackages",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("btc_server.BtcServer", "GetRound1DkgPackages"));
@@ -381,15 +411,19 @@ pub mod btc_server_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DkgPayload>,
         ) -> std::result::Result<tonic::Response<super::Empty>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/btc_server.BtcServer/NewRound1DkgPackage");
+            let path = http::uri::PathAndQuery::from_static(
+                "/btc_server.BtcServer/NewRound1DkgPackage",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("btc_server.BtcServer", "NewRound1DkgPackage"));
@@ -399,15 +433,19 @@ pub mod btc_server_client {
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> std::result::Result<tonic::Response<super::DkgPayload>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/btc_server.BtcServer/GetRound2DkgPackage");
+            let path = http::uri::PathAndQuery::from_static(
+                "/btc_server.BtcServer/GetRound2DkgPackage",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("btc_server.BtcServer", "GetRound2DkgPackage"));
@@ -417,15 +455,19 @@ pub mod btc_server_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DkgPayload>,
         ) -> std::result::Result<tonic::Response<super::Empty>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/btc_server.BtcServer/NewRound2DkgPackage");
+            let path = http::uri::PathAndQuery::from_static(
+                "/btc_server.BtcServer/NewRound2DkgPackage",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("btc_server.BtcServer", "NewRound2DkgPackage"));
@@ -434,58 +476,80 @@ pub mod btc_server_client {
         pub async fn get_round1_signing_package(
             &mut self,
             request: impl tonic::IntoRequest<super::Round1SigningPackageRequest>,
-        ) -> std::result::Result<tonic::Response<super::Round1SigningPackage>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::Round1SigningPackage>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/btc_server.BtcServer/GetRound1SigningPackage",
             );
             let mut req = request.into_request();
             req.extensions_mut()
-                .insert(GrpcMethod::new("btc_server.BtcServer", "GetRound1SigningPackage"));
+                .insert(
+                    GrpcMethod::new("btc_server.BtcServer", "GetRound1SigningPackage"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_round2_signing_package(
             &mut self,
             request: impl tonic::IntoRequest<super::SignPayload>,
-        ) -> std::result::Result<tonic::Response<super::Round2SigningPackage>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::Round2SigningPackage>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/btc_server.BtcServer/GetRound2SigningPackage",
             );
             let mut req = request.into_request();
             req.extensions_mut()
-                .insert(GrpcMethod::new("btc_server.BtcServer", "GetRound2SigningPackage"));
+                .insert(
+                    GrpcMethod::new("btc_server.BtcServer", "GetRound2SigningPackage"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn signer_finalize(
             &mut self,
             request: impl tonic::IntoRequest<super::FinalizeSignerRequest>,
-        ) -> std::result::Result<tonic::Response<super::FinalizeSigningResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::FinalizeSigningResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/btc_server.BtcServer/SignerFinalize");
+            let path = http::uri::PathAndQuery::from_static(
+                "/btc_server.BtcServer/SignerFinalize",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("btc_server.BtcServer", "SignerFinalize"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("btc_server.BtcServer", "SignerFinalize"));
             self.inner.unary(req, path, codec).await
         }
         /// only meant to be used by the cordinator
@@ -493,19 +557,24 @@ pub mod btc_server_client {
             &mut self,
             request: impl tonic::IntoRequest<super::Round1SigningPackage>,
         ) -> std::result::Result<tonic::Response<super::Empty>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/btc_server.BtcServer/NewRound1SigningPackage",
             );
             let mut req = request.into_request();
             req.extensions_mut()
-                .insert(GrpcMethod::new("btc_server.BtcServer", "NewRound1SigningPackage"));
+                .insert(
+                    GrpcMethod::new("btc_server.BtcServer", "NewRound1SigningPackage"),
+                );
             self.inner.unary(req, path, codec).await
         }
         /// Meant to be used at anytime to perform utxo selection and create a tx
@@ -513,16 +582,22 @@ pub mod btc_server_client {
             &mut self,
             request: impl tonic::IntoRequest<super::MakeTxRequest>,
         ) -> std::result::Result<tonic::Response<super::SignPayload>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/btc_server.BtcServer/GetPsbt");
+            let path = http::uri::PathAndQuery::from_static(
+                "/btc_server.BtcServer/GetPsbt",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("btc_server.BtcServer", "GetPsbt"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("btc_server.BtcServer", "GetPsbt"));
             self.inner.unary(req, path, codec).await
         }
         /// Meant to be used to transition the signing round to round 2 after round 1
@@ -531,15 +606,19 @@ pub mod btc_server_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ToSignRequest>,
         ) -> std::result::Result<tonic::Response<super::SignPayload>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/btc_server.BtcServer/GetToSignPackage");
+            let path = http::uri::PathAndQuery::from_static(
+                "/btc_server.BtcServer/GetToSignPackage",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("btc_server.BtcServer", "GetToSignPackage"));
@@ -549,87 +628,121 @@ pub mod btc_server_client {
             &mut self,
             request: impl tonic::IntoRequest<super::Round2SigningPackage>,
         ) -> std::result::Result<tonic::Response<super::Empty>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/btc_server.BtcServer/NewRound2SigningPackage",
             );
             let mut req = request.into_request();
             req.extensions_mut()
-                .insert(GrpcMethod::new("btc_server.BtcServer", "NewRound2SigningPackage"));
+                .insert(
+                    GrpcMethod::new("btc_server.BtcServer", "NewRound2SigningPackage"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn finalize_signing(
             &mut self,
             request: impl tonic::IntoRequest<super::FinalizeSigningRequest>,
-        ) -> std::result::Result<tonic::Response<super::FinalizeSigningResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::FinalizeSigningResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/btc_server.BtcServer/FinalizeSigning");
+            let path = http::uri::PathAndQuery::from_static(
+                "/btc_server.BtcServer/FinalizeSigning",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("btc_server.BtcServer", "FinalizeSigning"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("btc_server.BtcServer", "FinalizeSigning"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_all_utxos(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
-        ) -> std::result::Result<tonic::Response<super::GetAllUtxosResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetAllUtxosResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/btc_server.BtcServer/GetAllUtxos");
+            let path = http::uri::PathAndQuery::from_static(
+                "/btc_server.BtcServer/GetAllUtxos",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("btc_server.BtcServer", "GetAllUtxos"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("btc_server.BtcServer", "GetAllUtxos"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn remove_utxo(
             &mut self,
             request: impl tonic::IntoRequest<super::RemoveUtxoRequest>,
-        ) -> std::result::Result<tonic::Response<super::RemoveUtxoResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::RemoveUtxoResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/btc_server.BtcServer/RemoveUtxo");
+            let path = http::uri::PathAndQuery::from_static(
+                "/btc_server.BtcServer/RemoveUtxo",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("btc_server.BtcServer", "RemoveUtxo"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("btc_server.BtcServer", "RemoveUtxo"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_utxo_merkle_root(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
-        ) -> std::result::Result<tonic::Response<super::GetUtxoMerkleRootResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetUtxoMerkleRootResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/btc_server.BtcServer/GetUTXOMerkleRoot");
+            let path = http::uri::PathAndQuery::from_static(
+                "/btc_server.BtcServer/GetUTXOMerkleRoot",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("btc_server.BtcServer", "GetUTXOMerkleRoot"));

--- a/bin/btc-server/src/cordinator.rs
+++ b/bin/btc-server/src/cordinator.rs
@@ -23,7 +23,6 @@ use secp256k1::PublicKey;
 use reth_btc_wallet::psbt::{PsbtExt, PsbtInputExt};
 use reth_btc_wallet::transaction::CalculateSighashError;
 use reth_btc_wallet::TAPROOT_KEYSPEND_SATISFACTION_WEIGHT;
-use sled::Db;
 
 use crate::util::{self, OutPointExt, VerifyingKeyExt};
 use crate::{merkle, App, Error};
@@ -105,7 +104,6 @@ impl App {
         psbt: &Psbt,
     ) -> Result<(), CoordinatorError> {
         self.db.get_key_package()?.ok_or(CoordinatorError::MissingKeyPackage)?;
-
         validate_psbt(psbt, ROUND1, self.min_signers, &self.db)?;
 
         // TODO Need to check if this frost id actually provided a nonce
@@ -118,6 +116,7 @@ impl App {
         // Note: There doesn't need to be a check for a quorum of round1 signing packages
         // The more the better in the case one is unresponsive
         // the frost lib will check if we have enough when we create the signing package
+        self.db.update_psbt(signing_session_id, psbt)?;
         self.db.flush()?;
         debug!("Stored round1 signing from peer: {:?}", frost_id);
 
@@ -131,10 +130,6 @@ impl App {
         psbt: &Psbt,
     ) -> Result<(), CoordinatorError> {
         self.db.get_key_package()?.ok_or(CoordinatorError::MissingKeyPackage)?;
-        // Can't add our selves
-        if frost_id == self.identifier {
-            return Err(CoordinatorError::InvalidFrostPeerId);
-        }
         // validate PSBT
         validate_psbt(psbt, ROUND2, self.min_signers, &self.db)?;
 
@@ -285,6 +280,7 @@ impl App {
         if let Some(psbt) = self.db.get_psbt(&signing_session_id)? {
             for input in &psbt.inputs {
                 let sc = input.all_signing_commitments();
+                info!("sc.len() = {}", sc.len());
                 if sc.len() < self.min_signers as usize {
                     return Err(CoordinatorError::NotEnoughSigners);
                 }

--- a/bin/btc-server/src/cordinator.rs
+++ b/bin/btc-server/src/cordinator.rs
@@ -106,11 +106,17 @@ impl App {
         self.db.get_key_package()?.ok_or(CoordinatorError::MissingKeyPackage)?;
         validate_psbt(psbt, ROUND1, self.min_signers, &self.db)?;
 
-        // TODO Need to check if this frost id actually provided a nonce
-        // let scs = psbt.
-        // if !scs.iter().any(|sc| sc.contains_key(&frost_id)) {
-        //     return Err(CoordinatorError::CouldNotFindParticipantInformation());
-        // }
+        info!("psbt() = {}", psbt);
+
+        for input in &psbt.inputs {
+            let sc = input.signing_commitments(frost_id);
+            info!("sc.keys() = {:?}", sc);
+            info!("frost id: {:?}", frost_id);
+
+            if sc.is_none() {
+                return Err(CoordinatorError::CouldNotFindParticipantInformation());
+            }
+        }
 
         // TODO Need to check this psbt affect the other inputs and outputs
         // Note: There doesn't need to be a check for a quorum of round1 signing packages

--- a/bin/btc-server/src/cordinator.rs
+++ b/bin/btc-server/src/cordinator.rs
@@ -1,7 +1,17 @@
+use crate::database::Utxo;
+
+use crate::database::Error as DbError;
+use crate::util::validate_psbt;
+use crate::util::ValidatePSBTError;
+use crate::util::VerifyingKeyExtError;
+use crate::util::NO_FLAGS;
+use crate::util::ROUND1;
+use crate::util::ROUND1_TRANSITION;
+use crate::util::ROUND2;
+use crate::SECP;
 use std::collections::HashMap;
 
 use bdk::{
-    descriptor::error,
     miniscript::psbt::Error as PsbtError,
     wallet::coin_selection::{CoinSelectionAlgorithm, Error as BdkCoinselectionError},
 };
@@ -10,13 +20,13 @@ use bitcoincore_rpc::RpcApi;
 use frost_secp256k1_tr as frost;
 use secp256k1::PublicKey;
 
-use reth_btc_wallet::TAPROOT_KEYSPEND_SATISFACTION_WEIGHT;
 use reth_btc_wallet::psbt::{PsbtExt, PsbtInputExt};
 use reth_btc_wallet::transaction::CalculateSighashError;
+use reth_btc_wallet::TAPROOT_KEYSPEND_SATISFACTION_WEIGHT;
+use sled::Db;
 
-use crate::database::{self, Utxo};
-use crate::util::{self, OutPointExt, VerifyingKeyExt, VerifyingKeyExtError};
-use crate::{merkle, SECP, App, Error};
+use crate::util::{self, OutPointExt, VerifyingKeyExt};
+use crate::{merkle, App, Error};
 
 #[derive(Debug, Error)]
 pub enum CoordinatorError {
@@ -39,19 +49,23 @@ pub enum CoordinatorError {
     #[error("internal FROST error: {0}")]
     FrostError(#[from] frost::Error),
     #[error("internal DB error")]
-    Db(#[from] database::Error),
+    Db(#[from] DbError),
     #[error("PSBT finalization failed : {0:?}")]
     PbstFinalizationFailed(Vec<PsbtError>),
     #[error("Invalid resulting transaction")]
     InvaildResultingTx,
     #[error("Failed parse out to sign package: {0}")]
     PsbtToSigningPackageConversionError(
-        #[from] reth_btc_wallet::psbt::PsbtToSigningPackageConversionError
+        #[from] reth_btc_wallet::psbt::PsbtToSigningPackageConversionError,
     ),
     #[error("Could not find psbt")]
     CouldNotFindPsbt,
     #[error("Failed to broadcast tx: {0}")]
     FailedToBroadcastTx(bitcoincore_rpc::Error),
+    #[error("Could not find participant information")]
+    CouldNotFindParticipantInformation(),
+    #[error("Failed to validate psbt: {0}")]
+    FailedToValidatePsbt(#[from] ValidatePSBTError),
 }
 
 impl App {
@@ -77,7 +91,7 @@ impl App {
             let merkle_root = merkle_tree.root().expect("Merkle tree should have a root");
             self.db
                 .store_utxo_merkle_root(&merkle_root)
-                .map_err(|e| CoordinatorError::Db(database::Error::from(e)))?;
+                .map_err(|e| CoordinatorError::Db(DbError::from(e)))?;
         } else {
             warn!("Duplicate utxo {}", utxo.outpoint);
         }
@@ -91,12 +105,19 @@ impl App {
         psbt: &Psbt,
     ) -> Result<(), CoordinatorError> {
         self.db.get_key_package()?.ok_or(CoordinatorError::MissingKeyPackage)?;
-        // TODO (armins) need to verify here that the psbt is in a valid round 1 state
 
+        validate_psbt(psbt, ROUND1, self.min_signers, &self.db)?;
+
+        // TODO Need to check if this frost id actually provided a nonce
+        // let scs = psbt.
+        // if !scs.iter().any(|sc| sc.contains_key(&frost_id)) {
+        //     return Err(CoordinatorError::CouldNotFindParticipantInformation());
+        // }
+
+        // TODO Need to check this psbt affect the other inputs and outputs
         // Note: There doesn't need to be a check for a quorum of round1 signing packages
         // The more the better in the case one is unresponsive
         // the frost lib will check if we have enough when we create the signing package
-        self.db.update_psbt(signing_session_id, psbt)?;
         self.db.flush()?;
         debug!("Stored round1 signing from peer: {:?}", frost_id);
 
@@ -110,8 +131,12 @@ impl App {
         psbt: &Psbt,
     ) -> Result<(), CoordinatorError> {
         self.db.get_key_package()?.ok_or(CoordinatorError::MissingKeyPackage)?;
-        // TODO (armins) need to verify here that the psbt is in a valid round 2 state
-        // TODO Checks if we have enough partial signatures
+        // Can't add our selves
+        if frost_id == self.identifier {
+            return Err(CoordinatorError::InvalidFrostPeerId);
+        }
+        // validate PSBT
+        validate_psbt(psbt, ROUND2, self.min_signers, &self.db)?;
 
         self.db.update_psbt(signing_session_id, psbt)?;
         self.db.flush()?;
@@ -165,7 +190,7 @@ impl App {
         let _tx_lock = self.tx_lock.lock();
 
         // collect all database utxos in a hashmap
-        let utxos = self.db.iter_utxos().fold::<Result<_, database::Error>, _>(
+        let utxos = self.db.iter_utxos().fold::<Result<_, DbError>, _>(
             Ok(HashMap::new()),
             |mut ret, r| {
                 if let Ok(ref mut map) = ret {
@@ -237,6 +262,10 @@ impl App {
             change.clone(),
         );
 
+        // Sanity check that we created a valid PSBT
+        // This should not fail
+        validate_psbt(&psbt, NO_FLAGS, self.min_signers, &self.db)?;
+
         Ok(psbt)
     }
 
@@ -262,6 +291,7 @@ impl App {
             }
 
             // TODO (armins) verify that the psbt is in a valid state for end of round 1
+            validate_psbt(&psbt, ROUND1_TRANSITION, self.min_signers, &self.db)?;
             return Ok(psbt);
         }
 

--- a/bin/btc-server/src/main.rs
+++ b/bin/btc-server/src/main.rs
@@ -332,22 +332,22 @@ mod test {
     use std::collections::BTreeMap;
     use std::str::FromStr;
 
-    use bitcoin::psbt::Psbt;
-    use bitcoin::{Amount, FeeRate, OutPoint};
     use bitcoin::blockdata::{script::Script, transaction::TxOut};
-    use bitcoincore_rpc::json::{EstimateMode, EstimateSmartFeeResult};
-    use rand::{thread_rng, Rng};
-    use tonic::Request;
+    use bitcoin::psbt::Psbt;
     use bitcoin::{
         absolute::LockTime, hashes::Hash, Address, ScriptBuf, Sequence, Transaction, TxIn, Txid,
     };
+    use bitcoin::{Amount, FeeRate, OutPoint};
+    use bitcoincore_rpc::json::{EstimateMode, EstimateSmartFeeResult};
     use frost_secp256k1_tr as frost;
     use rand::RngCore;
+    use rand::{thread_rng, Rng};
+    use tonic::Request;
 
     use reth_btc_wallet::psbt::PsbtInputExt;
 
-    use crate::rpc::{self, BtcServer};
     use crate::database::Utxo;
+    use crate::rpc::{self, BtcServer};
 
     const FEERATE: FeeRate = FeeRate::from_sat_per_kwu(5 * 250);
 
@@ -493,14 +493,8 @@ mod test {
 
         let mut psbt = Psbt::from_unsigned_tx(tx).expect("valid psbt");
         for i in 0..num_inputs {
-<<<<<<< HEAD
-            psbt.inputs[i].witness_utxo = Some(TxOut {
-                value: value_per_input,
-                script_pubkey: ScriptBuf::new(),
-            });
-=======
-            psbt.inputs[i].witness_utxo = Some(TxOut { value: 1000, script_pubkey: ScriptBuf::new() });
->>>>>>> 46b78a5ec (test(btc_server): tests for `validate_psbt()`)
+            psbt.inputs[i].witness_utxo =
+                Some(TxOut { value: value_per_input, script_pubkey: ScriptBuf::new() });
         }
         psbt
     }
@@ -785,7 +779,7 @@ mod test {
         let app = setup();
         let signing_session_id = [0u8; 32];
         let mut psbt = create_psbt(1);
-        let tx = psbt.clone().extract_tx();
+        let tx = psbt.clone().unsigned_tx;
         // Add the utxo
         let utxo = Utxo::new(tx.input[0].previous_output, tx.output[0].clone(), None);
         app.add_pegin(&utxo).expect("valid pegin utxo");
@@ -797,21 +791,28 @@ mod test {
         assert_eq!(nonce_commits.err().unwrap().to_string(), "missing key package");
     }
 
-    #[tokio::test]
-    async fn should_fail_when_requesting_too_many_nonces() {
-        let app = setup();
-        let signing_session_id = [0u8; 32];
-        let mut psbt = create_psbt(100);
-        let mock_bitcoind = MockBitcoind::new();
+    // TODO re-enable this test once we have a limit on max number of inputs
+    // #[tokio::test]
+    // async fn should_fail_when_requesting_too_many_nonces() {
+    //     let app = setup();
+    //     let signing_session_id = [0u8; 32];
+    //     let (shares, pk_package) = trusted_dealer_setup(app.min_signers, app.max_signers);
+    //     let key_package = frost::keys::KeyPackage::try_from(shares[&app.identifier].clone())
+    //         .expect("valid key package");
+    //     app.db.set_pubkey_package(pk_package).expect("set public key package");
+    //     app.db.set_key_package(key_package).expect("set key package");
 
-        let nonce_commits =
-            app.get_round1_signing_package(&mut psbt, &signing_session_id, &mock_bitcoind).await;
-        assert!(nonce_commits.is_err());
-        assert_eq!(
-            nonce_commits.err().unwrap().to_string(),
-            "invalid number of signing nonces requested"
-        );
-    }
+    //     let mut psbt = create_psbt(100);
+    //     let mock_bitcoind = MockBitcoind::new();
+
+    //     let nonce_commits =
+    //         app.get_round1_signing_package(&mut psbt, &signing_session_id, &mock_bitcoind).await;
+    //     assert!(nonce_commits.is_err());
+    //     assert_eq!(
+    //         nonce_commits.err().unwrap().to_string(),
+    //         "invalid number of signing nonces requested"
+    //     );
+    // }
 
     #[tokio::test]
     async fn should_get_round1_nonce_commitments() {
@@ -827,8 +828,11 @@ mod test {
         let mut psbt = create_psbt(1);
         let tx = psbt.clone().extract_tx();
         // Add the utxo
-        let utxo = Utxo::new(tx.input[0].previous_output, tx.output[0].clone(), None);
-
+        let utxo = Utxo::new(
+            tx.input[0].previous_output,
+            psbt.inputs[0].witness_utxo.clone().expect("some"),
+            None,
+        );
         app.add_pegin(&utxo).expect("valid pegin utxo");
         app.get_round1_signing_package(&mut psbt, &signing_session_id, &mock_bitcoind)
             .await
@@ -848,7 +852,11 @@ mod test {
 
         let mut psbt = create_psbt(1);
         let tx = psbt.clone().extract_tx();
-        let utxo = Utxo::new(tx.input[0].previous_output, tx.output[0].clone(), None);
+        let utxo = Utxo::new(
+            tx.input[0].previous_output,
+            psbt.inputs[0].witness_utxo.clone().expect("some"),
+            None,
+        );
         app.add_pegin(&utxo).expect("valid pegin utxo");
         app.get_round1_signing_package(&mut psbt, &signing_session_id, &mock_bitcoind)
             .await
@@ -873,62 +881,6 @@ mod test {
     //     assert!(res.is_err());
     //     assert_eq!(res.err().unwrap().to_string(), "missing key package");
     // }
-
-    // #[test]
-    // fn tx_input_sanity_check() {
-    //     // Setup
-    //     let signing_session_id = [0u8; 32];
-    //     let app = setup();
-    //     let (shares, pk_package) = trusted_dealer_setup(app.min_signers, app.max_signers);
-    //     let key_package = frost::keys::KeyPackage::try_from(shares[&app.identifier].clone())
-    //         .expect("valid key package");
-
-    //     app.db.set_pubkey_package(pk_package).expect("set public key package");
-    //     app.db.set_key_package(key_package.clone()).expect("set key package");
-
-    //     let tx =
-    //         Transaction { version: 2, lock_time: LockTime::ZERO, input: vec![], output: vec![] };
-    //     let mut psbt = Psbt::from_unsigned_tx(tx).expect("valid tx");
-    //     let mut signing_package: Vec<frost::SigningPackage> = vec![];
-    //     let res = app.get_round2_signing_package(&psbt);
-    //     assert!(res.is_err());
-    //     assert_eq!(
-    //         res.err().unwrap().to_string(),
-    //         "invalid signing package: number of inputs cannot be zero"
-    //     );
-
-    //     let nonce_commits = app
-    //         .get_round1_signing_package(&mut psbt, &signing_session_id)
-    //         .expect("valid nonce commits request");
-
-    //     let mut sc = BTreeMap::new();
-    //     sc.insert(frost::Identifier::try_from(1u16).expect("valid id"),
-    // nonce_commits[0].clone());
-
-    //     // Input size mismatch with the number of signing packages
-    //     let tx = create_tx(1);
-    //     let mut psbt = Psbt::from_unsigned_tx(tx.clone()).expect("valid tx");
-    //     // we need to insert the signing commitments
-    //     let tx_out = TxOut { value: 1000, script_pubkey: ScriptBuf::new() };
-    //     psbt.inputs[0].witness_utxo = Some(tx_out.clone());
-    //     psbt.inputs[0]
-    //         .unknown
-    //         .insert(SIGNING_COMMITMENTS.clone(), serde_json::to_vec(&sc).unwrap());
-
-    //     let res = app.get_round2_signing_package(&psbt);
-    //     assert!(res.is_err());
-    //     assert_eq!(res.err().unwrap().to_string(), "invalid signing package: UTXO not found in
-    // DB");
-
-    //     // Add the pegin utxo and re-run test
-    //     let utxo =
-    //         Utxo { outpoint: OutPoint::new(tx.txid(), 0), eth_address: None, output: tx_out };
-
-    //     app.add_pegin(&utxo);
-    //     let res = app.get_round2_signing_package(&psbt);
-    //     assert!(res.is_err());
-    //     assert_eq!(res.err().unwrap().to_string(), "invalid signing package: UTXO not found in
-    // DB"); }
 
     // #[test]
     // fn should_not_sign_if_signer_is_not_in_signing_set() {

--- a/bin/btc-server/src/main.rs
+++ b/bin/btc-server/src/main.rs
@@ -397,7 +397,6 @@ mod test {
     pub fn setup() -> App {
         let tmpdir = tempfile::tempdir().unwrap();
         let dbdir = tmpdir.path().to_path_buf().join("db.db");
-        println!("Starting app with db in '{}'", dbdir.display());
 
         let app = App {
             db: database::Db::open(&dbdir).unwrap(),
@@ -475,7 +474,7 @@ mod test {
         // Hardcoded one output
         let mut outputs = vec![];
         outputs.push(TxOut {
-            value: 0,
+            value: 1000,
             script_pubkey: Address::from_str("mrpkDJFJdNGA22FaxCWw6T9oXogXfHU1rh")
                 .expect("valid address")
                 .assume_checked()
@@ -494,10 +493,14 @@ mod test {
 
         let mut psbt = Psbt::from_unsigned_tx(tx).expect("valid psbt");
         for i in 0..num_inputs {
+<<<<<<< HEAD
             psbt.inputs[i].witness_utxo = Some(TxOut {
                 value: value_per_input,
                 script_pubkey: ScriptBuf::new(),
             });
+=======
+            psbt.inputs[i].witness_utxo = Some(TxOut { value: 1000, script_pubkey: ScriptBuf::new() });
+>>>>>>> 46b78a5ec (test(btc_server): tests for `validate_psbt()`)
         }
         psbt
     }

--- a/bin/btc-server/src/main.rs
+++ b/bin/btc-server/src/main.rs
@@ -869,6 +869,52 @@ mod test {
         assert_ne!(sc1, sc2);
     }
 
+    #[tokio::test]
+    async fn should_add_signing_package_round1() {
+        let mut app_signer = setup();
+        let mut app_coordinator = setup();
+        let signing_session_id = [0u8; 32];
+        let (shares, pk_package) =
+            trusted_dealer_setup(app_signer.min_signers, app_signer.max_signers);
+        let key_package = frost::keys::KeyPackage::try_from(shares[&app_signer.identifier].clone())
+            .expect("valid key package");
+        let mock_bitcoind = MockBitcoind::new();
+
+        // Add the key packages
+        app_signer.db.set_pubkey_package(pk_package.clone()).expect("set public key package");
+        app_signer.db.set_key_package(key_package.clone()).expect("set key package");
+
+        app_coordinator.db.set_pubkey_package(pk_package).expect("set public key package");
+        app_coordinator.db.set_key_package(key_package).expect("set key package");
+
+        let mut psbt = create_psbt(1);
+        let tx = psbt.clone().extract_tx();
+        // Add the utxo
+        let utxo = Utxo::new(
+            tx.input[0].previous_output,
+            psbt.inputs[0].witness_utxo.clone().expect("some"),
+            None,
+        );
+        app_signer.add_pegin(&utxo).expect("valid pegin utxo");
+        app_coordinator.add_pegin(&utxo).expect("valid pegin utxo");
+
+        // Should fail if there are no signing commits in the psbt
+        let res =
+            app_coordinator.add_round1_signing(&signing_session_id, app_signer.identifier, &psbt);
+        assert!(res.is_err());
+        assert_eq!(res.err().unwrap().to_string(), "Could not find participant information");
+
+        app_signer
+            .get_round1_signing_package(&mut psbt, &signing_session_id, &mock_bitcoind)
+            .await
+            .expect("valid nonce commits request");
+        psbt.inputs[0].signing_commitments(app_signer.identifier).expect("valid sc1");
+
+        app_coordinator
+            .add_round1_signing(&signing_session_id, app_signer.identifier, &psbt)
+            .expect("should add signing round 1");
+    }
+
     // TODO (armins) fix these tests!!
     // #[test]
     // fn should_not_sign_without_dkg() {

--- a/bin/btc-server/src/rpc/btc_server.rs
+++ b/bin/btc-server/src/rpc/btc_server.rs
@@ -210,8 +210,7 @@ pub struct GetUtxoMerkleRootResponse {
 pub mod btc_server_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    /// Generated trait containing gRPC methods that should be implemented for use with
-    /// BtcServerServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with BtcServerServer.
     #[async_trait]
     pub trait BtcServer: Send + Sync + 'static {
         async fn notify_pegin(
@@ -221,11 +220,17 @@ pub mod btc_server_server {
         async fn get_gateway_address(
             &self,
             request: tonic::Request<super::GetGatewayAddressRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetGatewayAddressResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetGatewayAddressResponse>,
+            tonic::Status,
+        >;
         async fn get_public_key(
             &self,
             request: tonic::Request<super::Empty>,
-        ) -> std::result::Result<tonic::Response<super::GetPublicKeyResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetPublicKeyResponse>,
+            tonic::Status,
+        >;
         async fn get_round1_dkg_package(
             &self,
             request: tonic::Request<super::Empty>,
@@ -249,15 +254,24 @@ pub mod btc_server_server {
         async fn get_round1_signing_package(
             &self,
             request: tonic::Request<super::Round1SigningPackageRequest>,
-        ) -> std::result::Result<tonic::Response<super::Round1SigningPackage>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::Round1SigningPackage>,
+            tonic::Status,
+        >;
         async fn get_round2_signing_package(
             &self,
             request: tonic::Request<super::SignPayload>,
-        ) -> std::result::Result<tonic::Response<super::Round2SigningPackage>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::Round2SigningPackage>,
+            tonic::Status,
+        >;
         async fn signer_finalize(
             &self,
             request: tonic::Request<super::FinalizeSignerRequest>,
-        ) -> std::result::Result<tonic::Response<super::FinalizeSigningResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::FinalizeSigningResponse>,
+            tonic::Status,
+        >;
         /// only meant to be used by the cordinator
         async fn new_round1_signing_package(
             &self,
@@ -281,19 +295,31 @@ pub mod btc_server_server {
         async fn finalize_signing(
             &self,
             request: tonic::Request<super::FinalizeSigningRequest>,
-        ) -> std::result::Result<tonic::Response<super::FinalizeSigningResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::FinalizeSigningResponse>,
+            tonic::Status,
+        >;
         async fn get_all_utxos(
             &self,
             request: tonic::Request<super::Empty>,
-        ) -> std::result::Result<tonic::Response<super::GetAllUtxosResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetAllUtxosResponse>,
+            tonic::Status,
+        >;
         async fn remove_utxo(
             &self,
             request: tonic::Request<super::RemoveUtxoRequest>,
-        ) -> std::result::Result<tonic::Response<super::RemoveUtxoResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::RemoveUtxoResponse>,
+            tonic::Status,
+        >;
         async fn get_utxo_merkle_root(
             &self,
             request: tonic::Request<super::Empty>,
-        ) -> std::result::Result<tonic::Response<super::GetUtxoMerkleRootResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetUtxoMerkleRootResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct BtcServerServer<T: BtcServer> {
@@ -318,7 +344,10 @@ pub mod btc_server_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -374,9 +403,15 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/NotifyPegin" => {
                     #[allow(non_camel_case_types)]
                     struct NotifyPeginSvc<T: BtcServer>(pub Arc<T>);
-                    impl<T: BtcServer> tonic::server::UnaryService<super::NotifyPeginRequest> for NotifyPeginSvc<T> {
+                    impl<
+                        T: BtcServer,
+                    > tonic::server::UnaryService<super::NotifyPeginRequest>
+                    for NotifyPeginSvc<T> {
                         type Response = super::Empty;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::NotifyPeginRequest>,
@@ -414,11 +449,15 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/GetGatewayAddress" => {
                     #[allow(non_camel_case_types)]
                     struct GetGatewayAddressSvc<T: BtcServer>(pub Arc<T>);
-                    impl<T: BtcServer> tonic::server::UnaryService<super::GetGatewayAddressRequest>
-                        for GetGatewayAddressSvc<T>
-                    {
+                    impl<
+                        T: BtcServer,
+                    > tonic::server::UnaryService<super::GetGatewayAddressRequest>
+                    for GetGatewayAddressSvc<T> {
                         type Response = super::GetGatewayAddressResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetGatewayAddressRequest>,
@@ -456,10 +495,17 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/GetPublicKey" => {
                     #[allow(non_camel_case_types)]
                     struct GetPublicKeySvc<T: BtcServer>(pub Arc<T>);
-                    impl<T: BtcServer> tonic::server::UnaryService<super::Empty> for GetPublicKeySvc<T> {
+                    impl<T: BtcServer> tonic::server::UnaryService<super::Empty>
+                    for GetPublicKeySvc<T> {
                         type Response = super::GetPublicKeyResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
-                        fn call(&mut self, request: tonic::Request<super::Empty>) -> Self::Future {
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::Empty>,
+                        ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 <T as BtcServer>::get_public_key(&inner, request).await
@@ -493,13 +539,21 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/GetRound1DkgPackage" => {
                     #[allow(non_camel_case_types)]
                     struct GetRound1DkgPackageSvc<T: BtcServer>(pub Arc<T>);
-                    impl<T: BtcServer> tonic::server::UnaryService<super::Empty> for GetRound1DkgPackageSvc<T> {
+                    impl<T: BtcServer> tonic::server::UnaryService<super::Empty>
+                    for GetRound1DkgPackageSvc<T> {
                         type Response = super::DkgPayload;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
-                        fn call(&mut self, request: tonic::Request<super::Empty>) -> Self::Future {
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::Empty>,
+                        ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as BtcServer>::get_round1_dkg_package(&inner, request).await
+                                <T as BtcServer>::get_round1_dkg_package(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -530,13 +584,21 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/GetRound1DkgPackages" => {
                     #[allow(non_camel_case_types)]
                     struct GetRound1DkgPackagesSvc<T: BtcServer>(pub Arc<T>);
-                    impl<T: BtcServer> tonic::server::UnaryService<super::Empty> for GetRound1DkgPackagesSvc<T> {
+                    impl<T: BtcServer> tonic::server::UnaryService<super::Empty>
+                    for GetRound1DkgPackagesSvc<T> {
                         type Response = super::DkgPayload;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
-                        fn call(&mut self, request: tonic::Request<super::Empty>) -> Self::Future {
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::Empty>,
+                        ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as BtcServer>::get_round1_dkg_packages(&inner, request).await
+                                <T as BtcServer>::get_round1_dkg_packages(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -567,16 +629,21 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/NewRound1DkgPackage" => {
                     #[allow(non_camel_case_types)]
                     struct NewRound1DkgPackageSvc<T: BtcServer>(pub Arc<T>);
-                    impl<T: BtcServer> tonic::server::UnaryService<super::DkgPayload> for NewRound1DkgPackageSvc<T> {
+                    impl<T: BtcServer> tonic::server::UnaryService<super::DkgPayload>
+                    for NewRound1DkgPackageSvc<T> {
                         type Response = super::Empty;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::DkgPayload>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as BtcServer>::new_round1_dkg_package(&inner, request).await
+                                <T as BtcServer>::new_round1_dkg_package(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -607,13 +674,21 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/GetRound2DkgPackage" => {
                     #[allow(non_camel_case_types)]
                     struct GetRound2DkgPackageSvc<T: BtcServer>(pub Arc<T>);
-                    impl<T: BtcServer> tonic::server::UnaryService<super::Empty> for GetRound2DkgPackageSvc<T> {
+                    impl<T: BtcServer> tonic::server::UnaryService<super::Empty>
+                    for GetRound2DkgPackageSvc<T> {
                         type Response = super::DkgPayload;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
-                        fn call(&mut self, request: tonic::Request<super::Empty>) -> Self::Future {
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::Empty>,
+                        ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as BtcServer>::get_round2_dkg_package(&inner, request).await
+                                <T as BtcServer>::get_round2_dkg_package(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -644,16 +719,21 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/NewRound2DkgPackage" => {
                     #[allow(non_camel_case_types)]
                     struct NewRound2DkgPackageSvc<T: BtcServer>(pub Arc<T>);
-                    impl<T: BtcServer> tonic::server::UnaryService<super::DkgPayload> for NewRound2DkgPackageSvc<T> {
+                    impl<T: BtcServer> tonic::server::UnaryService<super::DkgPayload>
+                    for NewRound2DkgPackageSvc<T> {
                         type Response = super::Empty;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::DkgPayload>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as BtcServer>::new_round2_dkg_package(&inner, request).await
+                                <T as BtcServer>::new_round2_dkg_package(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -684,19 +764,26 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/GetRound1SigningPackage" => {
                     #[allow(non_camel_case_types)]
                     struct GetRound1SigningPackageSvc<T: BtcServer>(pub Arc<T>);
-                    impl<T: BtcServer>
-                        tonic::server::UnaryService<super::Round1SigningPackageRequest>
-                        for GetRound1SigningPackageSvc<T>
-                    {
+                    impl<
+                        T: BtcServer,
+                    > tonic::server::UnaryService<super::Round1SigningPackageRequest>
+                    for GetRound1SigningPackageSvc<T> {
                         type Response = super::Round1SigningPackage;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::Round1SigningPackageRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as BtcServer>::get_round1_signing_package(&inner, request).await
+                                <T as BtcServer>::get_round1_signing_package(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -728,17 +815,23 @@ pub mod btc_server_server {
                     #[allow(non_camel_case_types)]
                     struct GetRound2SigningPackageSvc<T: BtcServer>(pub Arc<T>);
                     impl<T: BtcServer> tonic::server::UnaryService<super::SignPayload>
-                        for GetRound2SigningPackageSvc<T>
-                    {
+                    for GetRound2SigningPackageSvc<T> {
                         type Response = super::Round2SigningPackage;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SignPayload>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as BtcServer>::get_round2_signing_package(&inner, request).await
+                                <T as BtcServer>::get_round2_signing_package(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -769,11 +862,15 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/SignerFinalize" => {
                     #[allow(non_camel_case_types)]
                     struct SignerFinalizeSvc<T: BtcServer>(pub Arc<T>);
-                    impl<T: BtcServer> tonic::server::UnaryService<super::FinalizeSignerRequest>
-                        for SignerFinalizeSvc<T>
-                    {
+                    impl<
+                        T: BtcServer,
+                    > tonic::server::UnaryService<super::FinalizeSignerRequest>
+                    for SignerFinalizeSvc<T> {
                         type Response = super::FinalizeSigningResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::FinalizeSignerRequest>,
@@ -811,18 +908,26 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/NewRound1SigningPackage" => {
                     #[allow(non_camel_case_types)]
                     struct NewRound1SigningPackageSvc<T: BtcServer>(pub Arc<T>);
-                    impl<T: BtcServer> tonic::server::UnaryService<super::Round1SigningPackage>
-                        for NewRound1SigningPackageSvc<T>
-                    {
+                    impl<
+                        T: BtcServer,
+                    > tonic::server::UnaryService<super::Round1SigningPackage>
+                    for NewRound1SigningPackageSvc<T> {
                         type Response = super::Empty;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::Round1SigningPackage>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as BtcServer>::new_round1_signing_package(&inner, request).await
+                                <T as BtcServer>::new_round1_signing_package(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -853,16 +958,21 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/GetPsbt" => {
                     #[allow(non_camel_case_types)]
                     struct GetPsbtSvc<T: BtcServer>(pub Arc<T>);
-                    impl<T: BtcServer> tonic::server::UnaryService<super::MakeTxRequest> for GetPsbtSvc<T> {
+                    impl<T: BtcServer> tonic::server::UnaryService<super::MakeTxRequest>
+                    for GetPsbtSvc<T> {
                         type Response = super::SignPayload;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::MakeTxRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as BtcServer>::get_psbt(&inner, request).await };
+                            let fut = async move {
+                                <T as BtcServer>::get_psbt(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -892,9 +1002,13 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/GetToSignPackage" => {
                     #[allow(non_camel_case_types)]
                     struct GetToSignPackageSvc<T: BtcServer>(pub Arc<T>);
-                    impl<T: BtcServer> tonic::server::UnaryService<super::ToSignRequest> for GetToSignPackageSvc<T> {
+                    impl<T: BtcServer> tonic::server::UnaryService<super::ToSignRequest>
+                    for GetToSignPackageSvc<T> {
                         type Response = super::SignPayload;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ToSignRequest>,
@@ -932,18 +1046,26 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/NewRound2SigningPackage" => {
                     #[allow(non_camel_case_types)]
                     struct NewRound2SigningPackageSvc<T: BtcServer>(pub Arc<T>);
-                    impl<T: BtcServer> tonic::server::UnaryService<super::Round2SigningPackage>
-                        for NewRound2SigningPackageSvc<T>
-                    {
+                    impl<
+                        T: BtcServer,
+                    > tonic::server::UnaryService<super::Round2SigningPackage>
+                    for NewRound2SigningPackageSvc<T> {
                         type Response = super::Empty;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::Round2SigningPackage>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as BtcServer>::new_round2_signing_package(&inner, request).await
+                                <T as BtcServer>::new_round2_signing_package(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -974,11 +1096,15 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/FinalizeSigning" => {
                     #[allow(non_camel_case_types)]
                     struct FinalizeSigningSvc<T: BtcServer>(pub Arc<T>);
-                    impl<T: BtcServer> tonic::server::UnaryService<super::FinalizeSigningRequest>
-                        for FinalizeSigningSvc<T>
-                    {
+                    impl<
+                        T: BtcServer,
+                    > tonic::server::UnaryService<super::FinalizeSigningRequest>
+                    for FinalizeSigningSvc<T> {
                         type Response = super::FinalizeSigningResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::FinalizeSigningRequest>,
@@ -1016,10 +1142,17 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/GetAllUtxos" => {
                     #[allow(non_camel_case_types)]
                     struct GetAllUtxosSvc<T: BtcServer>(pub Arc<T>);
-                    impl<T: BtcServer> tonic::server::UnaryService<super::Empty> for GetAllUtxosSvc<T> {
+                    impl<T: BtcServer> tonic::server::UnaryService<super::Empty>
+                    for GetAllUtxosSvc<T> {
                         type Response = super::GetAllUtxosResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
-                        fn call(&mut self, request: tonic::Request<super::Empty>) -> Self::Future {
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::Empty>,
+                        ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 <T as BtcServer>::get_all_utxos(&inner, request).await
@@ -1053,16 +1186,23 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/RemoveUtxo" => {
                     #[allow(non_camel_case_types)]
                     struct RemoveUtxoSvc<T: BtcServer>(pub Arc<T>);
-                    impl<T: BtcServer> tonic::server::UnaryService<super::RemoveUtxoRequest> for RemoveUtxoSvc<T> {
+                    impl<
+                        T: BtcServer,
+                    > tonic::server::UnaryService<super::RemoveUtxoRequest>
+                    for RemoveUtxoSvc<T> {
                         type Response = super::RemoveUtxoResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::RemoveUtxoRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as BtcServer>::remove_utxo(&inner, request).await };
+                            let fut = async move {
+                                <T as BtcServer>::remove_utxo(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1092,13 +1232,21 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/GetUTXOMerkleRoot" => {
                     #[allow(non_camel_case_types)]
                     struct GetUTXOMerkleRootSvc<T: BtcServer>(pub Arc<T>);
-                    impl<T: BtcServer> tonic::server::UnaryService<super::Empty> for GetUTXOMerkleRootSvc<T> {
+                    impl<T: BtcServer> tonic::server::UnaryService<super::Empty>
+                    for GetUTXOMerkleRootSvc<T> {
                         type Response = super::GetUtxoMerkleRootResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
-                        fn call(&mut self, request: tonic::Request<super::Empty>) -> Self::Future {
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::Empty>,
+                        ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as BtcServer>::get_utxo_merkle_root(&inner, request).await
+                                <T as BtcServer>::get_utxo_merkle_root(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1126,14 +1274,18 @@ pub mod btc_server_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    Ok(http::Response::builder()
-                        .status(200)
-                        .header("grpc-status", "12")
-                        .header("content-type", "application/grpc")
-                        .body(empty_body())
-                        .unwrap())
-                }),
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
             }
         }
     }

--- a/bin/btc-server/src/signer.rs
+++ b/bin/btc-server/src/signer.rs
@@ -111,6 +111,7 @@ impl App {
         _signing_session_id: &[u8; 32],
         bitcoind_client: &impl bitcoincore_rpc::RpcApi,
     ) -> Result<(), SigningRound1Error> {
+        self.db.get_key_package()?.ok_or(SigningRound1Error::MissingKeyPackage)?;
         // Check if have already provided nonces for the current session
         let mut nonces_lock = self.frost_round1_nonces.lock().await;
         if nonces_lock.is_some() {

--- a/bin/btc-server/src/signer.rs
+++ b/bin/btc-server/src/signer.rs
@@ -1,6 +1,6 @@
 use crate::{
     database::{self, Error as DbError},
-    util::{self, VerifyingKeyExt},
+    util::{self, validate_psbt, VerifyingKeyExt, ROUND1, ROUND1_TRANSITION},
     App, Error, SECP,
 };
 use bdk::miniscript::psbt::Error as PsbtError;
@@ -11,8 +11,8 @@ use bitcoincore_rpc::json::EstimateMode;
 use frost_secp256k1_tr as frost;
 use rand::thread_rng;
 
-use reth_btc_wallet::transaction::CalculateSighashError;
 use reth_btc_wallet::psbt::{PsbtExt, PsbtInputExt};
+use reth_btc_wallet::transaction::CalculateSighashError;
 
 #[derive(Debug)]
 pub enum SigningError {
@@ -45,12 +45,14 @@ pub enum SigningRound1Error {
     Db(#[from] database::Error),
     #[error("failed to add signing commits to psbt")]
     FailedToAddSigningCommitsToPsbt(
-        #[from] reth_btc_wallet::psbt::PsbtToSigningPackageConversionError
+        #[from] reth_btc_wallet::psbt::PsbtToSigningPackageConversionError,
     ),
     #[error("failed to get smart estimate fee rate")]
     FailedToGetEstimateSmartFeeRate,
     #[error("fee rate difference is too great")]
     FeeRateDifferenceTooGreat,
+    #[error("failed to validate psbt: {0}")]
+    FailedToValidatePsbt(#[from] crate::util::ValidatePSBTError),
 }
 
 #[derive(Debug, Error)]
@@ -71,10 +73,11 @@ pub enum SigningRound2Error {
     FailedToCalculateSighash(#[from] CalculateSighashError),
     #[error("Failed parse out to sign package: {0}")]
     PsbtToSigningPackageConversionError(
-        #[from] reth_btc_wallet::psbt::PsbtToSigningPackageConversionError
+        #[from] reth_btc_wallet::psbt::PsbtToSigningPackageConversionError,
     ),
+    #[error("failed to validate psbt: {0}")]
+    FailedToValidatePsbt(#[from] crate::util::ValidatePSBTError),
 }
-
 impl From<SigningRound1Error> for SigningError {
     fn from(e: SigningRound1Error) -> Self {
         SigningError::Round1(e)
@@ -108,10 +111,6 @@ impl App {
         _signing_session_id: &[u8; 32],
         bitcoind_client: &impl bitcoincore_rpc::RpcApi,
     ) -> Result<(), SigningRound1Error> {
-        let num_inputs = psbt.inputs.len();
-        if num_inputs == 0 || num_inputs > 15 {
-            return Err(SigningRound1Error::InvalidNumberOfNoncesRequested);
-        }
         // Check if have already provided nonces for the current session
         let mut nonces_lock = self.frost_round1_nonces.lock().await;
         if nonces_lock.is_some() {
@@ -152,6 +151,9 @@ impl App {
                 return Err(SigningRound1Error::InvalidSigningPackage("UTXO not found in DB"));
             }
         }
+        // Validate PSBT
+        validate_psbt(psbt, ROUND1, self.min_signers, &self.db)?;
+        let num_inputs = psbt.inputs.len();
 
         let key_package =
             self.db.get_key_package()?.ok_or(SigningRound1Error::MissingKeyPackage)?;
@@ -186,6 +188,10 @@ impl App {
         // to provide new ones
         let key_package =
             self.db.get_key_package()?.ok_or(SigningRound2Error::MissingKeyPackage)?;
+
+        // Validate PSBT
+        validate_psbt(psbt, ROUND1_TRANSITION, self.min_signers, &self.db)?;
+
         let tx = psbt.clone().extract_tx();
         let num_inputs = tx.input.len();
         let mut signing_packages = psbt.signing_packages()?;

--- a/bin/btc-server/src/util.rs
+++ b/bin/btc-server/src/util.rs
@@ -1,15 +1,26 @@
-
 use std::fmt;
 
-use bitcoin::{
-    consensus::encode as btcencode,
-    hashes::Hash,
-    psbt::Psbt,
-    OutPoint,
+use crate::{
+    database::{Db, Utxo},
+    Error, SECP,
 };
+use bitcoin::{consensus::encode as btcencode, hashes::Hash, psbt::Psbt, Amount, OutPoint};
 use frost_secp256k1_tr as frost;
+use lazy_static::lazy_static;
+use reth_btc_wallet::psbt::{PsbtExt, PsbtInputExt};
 
-use crate::{database::Utxo, Error, SECP};
+lazy_static! {
+    // TODO get a fee max amount
+    static ref MAX_AMOUNT: bitcoin::Amount = bitcoin::Amount::from_sat(21_000_000 * 100_000_000);
+}
+
+// Psbt validation flags
+pub const NO_FLAGS: u8 = 0u8;
+pub const ROUND1: u8 = 1u8;
+pub const ROUND1_TRANSITION: u8 = 1u8 << 1 | ROUND1;
+pub const ROUND2: u8 = 1u8 << 2 | ROUND1_TRANSITION;
+pub const ROUND2_TRANSITION: u8 = 1u8 << 3 | ROUND1_TRANSITION;
+pub const PSBT_FINAL: u8 = 1u8 << 4 | ROUND2_TRANSITION;
 
 /// Extension trait for OutPoint.
 pub trait OutPointExt: Into<OutPoint> {
@@ -176,17 +187,165 @@ pub fn add_remove_utxo_from_psbt(
     (change_outputs, selected_inputs)
 }
 
-
 pub fn convert_bdk_feerate_to_bitcoin(fee_rate: bdk::FeeRate) -> bitcoin::FeeRate {
     bitcoin::FeeRate::from_sat_per_kwu((fee_rate.sat_per_kwu()) as u64)
+}
+
+#[derive(Debug, Error)]
+pub enum ValidatePSBTError {
+    #[error("inputs cannot be 0")]
+    NoInputs,
+    #[error("outputs cannot be 0")]
+    NoOutputs,
+    #[error("cannot calculate fee")]
+    FeeCalculationError(bitcoin::psbt::Error),
+    #[error("failed fee sanity check")]
+    FeeSanityCheck(&'static str),
+    #[error("missing witness utxo")]
+    MissingWitnessUtxo,
+    #[error("cannot find UTXO in db")]
+    UtxoNotFound,
+    #[error("invalid number of signing commitments")]
+    InvalidNumberOfSigningCommitments,
+    #[error("invalid number of partial signatures")]
+    InvalidNumberOfPartialSignatures,
+    #[error("frost id mismatch")]
+    FrostIdMismatch,
+    #[error("eth tweak mismatch")]
+    EthTweakMismatch,
+    #[error("txout mismatch")]
+    TxOutMismatch,
+}
+
+/// Validates PSBT structure and content at a given state in the signing session
+///
+/// # Arguments
+///
+/// * `psbt` - The PSBT to be validated.
+/// * `flags` - Flags indicating the validation criteria and actions to be performed.
+/// * `min_signers` - The minimum number of signers required for certain validations.
+/// * `db` - Database reference used for UTXO lookups.
+///
+/// `NO_FLAGS`: Performs basic sanity checks only.
+/// `ROUND1`: Validates witnes_UTXO and UTXO existence in the database. Also checks the validity of the input material.
+/// `ROUND1_TRANSITION`: Validates signing commitments in round 1, ensuring the required signers.
+/// `ROUND2`: Checks if there are enough round 2 partial signatures. Ensuring we never add more than a quorum of signers
+/// `ROUND2_TRANSITION`: Validates partial signatures during the transition to round 2, ensuring signers match and Frost IDs align.
+///
+pub fn validate_psbt(
+    psbt: &Psbt,
+    flags: u8,
+    min_signers: u16,
+    db: &Db,
+) -> Result<(), ValidatePSBTError> {
+    // Sanity check for # of inputs and outputs
+    if psbt.inputs.len() == 0 {
+        return Err(ValidatePSBTError::NoInputs);
+    }
+    if psbt.outputs.len() == 0 {
+        return Err(ValidatePSBTError::NoOutputs);
+    }
+    // Sanity fee checks
+    let fee = psbt.fee().map_err(|e| ValidatePSBTError::FeeCalculationError(e))?;
+    if fee < Amount::ZERO {
+        return Err(ValidatePSBTError::FeeSanityCheck("Fee cannot be negative"));
+    }
+    if fee > MAX_AMOUNT.clone() {
+        return Err(ValidatePSBTError::FeeSanityCheck("Fee cannot be greater than max amount"));
+    }
+
+    // If we are just validating sanity checks we can stop here
+    if flags == NO_FLAGS {
+        return Ok(());
+    }
+
+    // validate signing commitments in round 1
+    if flags & ROUND1_TRANSITION == ROUND1_TRANSITION {
+        let scs = psbt.inputs.iter().map(|i| i.all_signing_commitments()).collect::<Vec<_>>();
+        if scs.len() != psbt.inputs.len() {
+            return Err(ValidatePSBTError::InvalidNumberOfSigningCommitments);
+        }
+        // Each map should have atleast min_signers number of signing commitments
+        for sc in scs {
+            if sc.len() < min_signers as usize {
+                return Err(ValidatePSBTError::InvalidNumberOfSigningCommitments);
+            }
+        }
+    }
+
+    // Check if we have enough round 2 partial sigs
+    // TODO is this neccecary? Will signing fail?
+    let sigs = psbt.inputs.iter().map(|i| i.all_partial_signatures()).collect::<Vec<_>>();
+    if flags & ROUND2 == ROUND2 {
+        // if any of the maps have min signers we should fail
+        for sig in sigs.iter() {
+            if sig.len() >= min_signers as usize {
+                return Err(ValidatePSBTError::InvalidNumberOfPartialSignatures);
+            }
+        }
+    }
+
+    // validate partial sigs in round 2
+    if flags & ROUND2_TRANSITION == ROUND2_TRANSITION {
+        if sigs.len() != psbt.inputs.len() {
+            return Err(ValidatePSBTError::InvalidNumberOfPartialSignatures);
+        }
+        // Each map should have at least min_signers number of partial sigs
+        for sig in sigs.iter() {
+            if sig.len() < min_signers as usize {
+                return Err(ValidatePSBTError::InvalidNumberOfPartialSignatures);
+            }
+        }
+
+        // Additionally we should check that the same set of signers provided partial sigs as in round 1
+        for (sc, sig) in scs.iter().zip(sigs.iter()) {
+            if sc.keys().ne(sig.keys()) {
+                return Err(ValidatePSBTError::FrostIdMismatch);
+            }
+        }
+        // Lastly the signers should ensure they are infact in the signing group before providing partial sigs
+        // That should be done outside the context of this function
+    }
+
+    let tx = psbt.clone().extract_tx();
+    for (index, psbt_input) in psbt.inputs.iter().enumerate() {
+        if flags & ROUND1 == ROUND1 {
+            // validate utxo exists in DB
+            let outpoint = tx.input[index].previous_output;
+            let utxo = db.get_utxo(outpoint).expect("valid utxo");
+            if utxo.is_none() {
+                return Err(ValidatePSBTError::UtxoNotFound);
+            }
+            // If the utxo has a eth tweak check the right one is presented in the psbt
+            let eth_tweak = utxo.clone().expect("valid utxo").eth_address;
+            if let Some(e) = eth_tweak {
+                let eth_input_tweak = psbt_input.eth_address().expect("valid eth address");
+                if eth_input_tweak != Some(&e.to_vec()) {
+                    return Err(ValidatePSBTError::EthTweakMismatch);
+                }
+            }
+            // Validate prev out is provided
+            if psbt_input.witness_utxo.is_none() {
+                return Err(ValidatePSBTError::MissingWitnessUtxo);
+            }
+            let txout = psbt_input.witness_utxo.as_ref().expect("valid witness utxo");
+            // Check txout is valid
+            let store_txout = utxo.expect("valid utxo").output;
+            if store_txout != *txout {
+                return Err(ValidatePSBTError::TxOutMismatch);
+            }
+        }
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
 mod util_tests {
     use bitcoin::{ScriptBuf, TxOut};
 
-    use reth_btc_wallet::psbt::{PsbtExt, PsbtInputExt};
     use crate::test::{create_tx, eth_vector_to_fixed_bytes, trusted_dealer_setup};
+    use reth_btc_wallet::psbt::{PsbtExt, PsbtInputExt};
 
     use super::*;
 
@@ -292,7 +451,8 @@ mod util_tests {
         assert!(signing_packages.is_err());
         assert_eq!(
             signing_packages.unwrap_err().to_string(),
-            reth_btc_wallet::psbt::PsbtToSigningPackageConversionError::MissingSigningCommitments.to_string()
+            reth_btc_wallet::psbt::PsbtToSigningPackageConversionError::MissingSigningCommitments
+                .to_string()
         );
     }
 

--- a/bin/btc-server/src/util.rs
+++ b/bin/btc-server/src/util.rs
@@ -4,7 +4,12 @@ use crate::{
     database::{Db, Utxo},
     Error, SECP,
 };
-use bitcoin::{consensus::encode as btcencode, hashes::Hash, psbt::Psbt, Amount, OutPoint};
+use bitcoin::{
+    consensus::encode as btcencode,
+    hashes::Hash,
+    psbt::{self, PartiallySignedTransaction, Psbt},
+    Amount, OutPoint,
+};
 use frost_secp256k1_tr as frost;
 use lazy_static::lazy_static;
 use reth_btc_wallet::psbt::{PsbtExt, PsbtInputExt};
@@ -12,6 +17,7 @@ use reth_btc_wallet::psbt::{PsbtExt, PsbtInputExt};
 lazy_static! {
     // TODO get a fee max amount
     static ref MAX_AMOUNT: bitcoin::Amount = bitcoin::Amount::from_sat(21_000_000 * 100_000_000);
+    static ref MAX_FEERATE: bitcoin::FeeRate = bitcoin::FeeRate::from_sat_per_vb(300).expect("valid feerate");
 }
 
 // Psbt validation flags
@@ -20,7 +26,6 @@ pub const ROUND1: u8 = 1u8;
 pub const ROUND1_TRANSITION: u8 = 1u8 << 1 | ROUND1;
 pub const ROUND2: u8 = 1u8 << 2 | ROUND1_TRANSITION;
 pub const ROUND2_TRANSITION: u8 = 1u8 << 3 | ROUND1_TRANSITION;
-pub const PSBT_FINAL: u8 = 1u8 << 4 | ROUND2_TRANSITION;
 
 /// Extension trait for OutPoint.
 pub trait OutPointExt: Into<OutPoint> {
@@ -199,6 +204,8 @@ pub enum ValidatePSBTError {
     NoOutputs,
     #[error("cannot calculate fee")]
     FeeCalculationError(bitcoin::psbt::Error),
+    #[error("cannot calculate fee rate")]
+    FeeRateCalculationError(),
     #[error("failed fee sanity check")]
     FeeSanityCheck(&'static str),
     #[error("missing witness utxo")]
@@ -254,6 +261,14 @@ pub fn validate_psbt(
         return Err(ValidatePSBTError::FeeSanityCheck("Fee cannot be greater than max amount"));
     }
 
+    // Fix fee rate check
+    // let fee_rate = psbt.fee_rate().ok_or(ValidatePSBTError::FeeRateCalculationError())?;
+    // if fee_rate > MAX_FEERATE.clone() {
+    //     return Err(ValidatePSBTError::FeeSanityCheck(
+    //         "Fee rate cannot be greater than max feerate",
+    //     ));
+    // }
+    // TODO (armins) fee rate sanity check
     // If we are just validating sanity checks we can stop here
     if flags == NO_FLAGS {
         return Ok(());
@@ -279,7 +294,7 @@ pub fn validate_psbt(
     if flags & ROUND2 == ROUND2 {
         // if any of the maps have min signers we should fail
         for sig in sigs.iter() {
-            if sig.len() >= min_signers as usize {
+            if sig.len() > min_signers as usize {
                 return Err(ValidatePSBTError::InvalidNumberOfPartialSignatures);
             }
         }
@@ -292,7 +307,7 @@ pub fn validate_psbt(
         }
         // Each map should have at least min_signers number of partial sigs
         for sig in sigs.iter() {
-            if sig.len() < min_signers as usize {
+            if sig.len() != min_signers as usize {
                 return Err(ValidatePSBTError::InvalidNumberOfPartialSignatures);
             }
         }
@@ -342,12 +357,242 @@ pub fn validate_psbt(
 
 #[cfg(test)]
 mod util_tests {
+    use crate::{
+        database,
+        test::{create_psbt, create_tx, eth_vector_to_fixed_bytes, trusted_dealer_setup},
+    };
     use bitcoin::{ScriptBuf, TxOut};
 
+<<<<<<< HEAD
     use crate::test::{create_tx, eth_vector_to_fixed_bytes, trusted_dealer_setup};
     use reth_btc_wallet::psbt::{PsbtExt, PsbtInputExt};
 
+=======
+>>>>>>> 46b78a5ec (test(btc_server): tests for `validate_psbt()`)
     use super::*;
+
+    fn db_setup() -> database::Db {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let dbdir = tmpdir.path().to_path_buf().join("db.db");
+
+        let db = database::Db::open(&dbdir).unwrap();
+        db
+    }
+
+    #[test]
+    fn should_perform_sanity_checks() {
+        let db = db_setup();
+        let psbt = create_psbt(2);
+        let res = validate_psbt(&psbt, NO_FLAGS, 2, &db);
+        assert!(res.is_ok());
+
+        // No inputs
+        let mut psbt = create_psbt(2);
+        psbt.inputs.clear();
+        let res = validate_psbt(&psbt, NO_FLAGS, 2, &db);
+        assert!(res.is_err());
+        assert_eq!(res.unwrap_err().to_string(), "inputs cannot be 0");
+
+        // No outputs
+        let mut psbt = create_psbt(2);
+        psbt.outputs.clear();
+        let res = validate_psbt(&psbt, NO_FLAGS, 2, &db);
+        assert!(res.is_err());
+        assert_eq!(res.unwrap_err().to_string(), "outputs cannot be 0");
+    }
+
+    #[test]
+    fn should_look_for_utxo_in_db() {
+        let db = db_setup();
+        let psbt = create_psbt(1);
+        let res = validate_psbt(&psbt, ROUND1, 2, &db);
+        assert!(res.is_err());
+        assert_eq!(res.unwrap_err().to_string(), "cannot find UTXO in db");
+
+        let tx = psbt.clone().extract_tx();
+        let utxo = Utxo {
+            outpoint: tx.input[0].previous_output,
+            output: psbt.inputs[0].witness_utxo.clone().unwrap(),
+            eth_address: None,
+        };
+
+        db.store_utxo(&utxo).unwrap();
+        db.flush().unwrap();
+        let res = validate_psbt(&psbt, ROUND1, 2, &db);
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn should_fail_if_eth_tweak_missing() {
+        let db = db_setup();
+        let mut psbt = create_psbt(1);
+        let tx = psbt.clone().extract_tx();
+        let eth = eth_vector_to_fixed_bytes(vec![0u8; 20]);
+        let utxo = Utxo {
+            outpoint: tx.input[0].previous_output,
+            output: psbt.inputs[0].witness_utxo.clone().unwrap(),
+            eth_address: Some(eth),
+        };
+
+        db.store_utxo(&utxo).unwrap();
+        db.flush().unwrap();
+        let res = validate_psbt(&psbt, ROUND1, 2, &db);
+        assert!(res.is_err());
+        assert_eq!(res.unwrap_err().to_string(), "eth tweak mismatch");
+
+        psbt.inputs[0].unknown.insert(ETH_ADDRESS_FIELD.clone(), vec![0u8; 20]);
+        let res = validate_psbt(&psbt, ROUND1, 2, &db);
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn should_fail_if_tx_out_mismatch() {
+        let db = db_setup();
+        let mut psbt = create_psbt(1);
+        let tx = psbt.clone().extract_tx();
+        let utxo = Utxo {
+            outpoint: tx.input[0].previous_output,
+            output: psbt.inputs[0].witness_utxo.clone().unwrap(),
+            eth_address: None,
+        };
+
+        psbt.inputs[0].witness_utxo = Some(TxOut {
+            value: 100_000_000,
+            script_pubkey: ScriptBuf::from_hex("7e").expect("valid script"),
+        });
+
+        db.store_utxo(&utxo).unwrap();
+        db.flush().unwrap();
+        let res = validate_psbt(&psbt, ROUND1, 2, &db);
+        assert!(res.is_err());
+        assert_eq!(res.unwrap_err().to_string(), "txout mismatch");
+    }
+
+    #[test]
+    fn round_1_transition_tests() {
+        let db = db_setup();
+        let mut psbt = create_psbt(1);
+        let tx = psbt.clone().extract_tx();
+        let utxo = Utxo {
+            outpoint: tx.input[0].previous_output,
+            output: psbt.inputs[0].witness_utxo.clone().unwrap(),
+            eth_address: None,
+        };
+
+        db.store_utxo(&utxo).unwrap();
+        db.flush().unwrap();
+        let res = validate_psbt(&psbt, ROUND1_TRANSITION, 2, &db);
+        assert!(res.is_err());
+        assert_eq!(res.unwrap_err().to_string(), "invalid number of signing commitments");
+
+        let frost_id1 = frost::Identifier::try_from(1u16).expect("valid id");
+        let frost_id2 = frost::Identifier::try_from(2u16).expect("valid id");
+
+        let (shares, _pk_package) = trusted_dealer_setup(2, 3);
+        let key_package1 = frost::keys::KeyPackage::try_from(
+            shares[&frost::Identifier::try_from(1u16).expect("valid id")].clone(),
+        )
+        .expect("valid key package");
+
+        let key_package2 = frost::keys::KeyPackage::try_from(
+            shares[&frost::Identifier::try_from(2u16).expect("valid id")].clone(),
+        )
+        .expect("valid key package");
+        let rng = &mut rand::thread_rng();
+
+        // generate signing commitments for each input for each frost participant
+        let (_, signing_commits1) = frost::round1::commit(key_package1.signing_share(), rng);
+        let (_, signing_commits2) = frost::round1::commit(key_package2.signing_share(), rng);
+
+        add_signing_commitments_to_psbt(&mut psbt, &vec![signing_commits1], &frost_id1);
+        add_signing_commitments_to_psbt(&mut psbt, &vec![signing_commits2], &frost_id2);
+
+        let res = validate_psbt(&psbt, ROUND1_TRANSITION, 2, &db);
+        assert!(res.is_ok());
+
+        // Round 2 at this point should pass as well. B/c we have not hit a limit in the number of signatures
+        let res = validate_psbt(&psbt, ROUND2, 2, &db);
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn round2_psbt_validation_checks() {
+        let db = db_setup();
+        let mut psbt = create_psbt(1);
+        let tx = psbt.clone().extract_tx();
+        let utxo = Utxo {
+            outpoint: tx.input[0].previous_output,
+            output: psbt.inputs[0].witness_utxo.clone().unwrap(),
+            eth_address: None,
+        };
+        let rng = &mut rand::thread_rng();
+
+        db.store_utxo(&utxo).unwrap();
+        db.flush().unwrap();
+
+        let frost_id1 = frost::Identifier::try_from(1u16).expect("valid id");
+        let (shares, _pk_package) = trusted_dealer_setup(2, 3);
+        let key_package1 = frost::keys::KeyPackage::try_from(
+            shares[&frost::Identifier::try_from(1u16).expect("valid id")].clone(),
+        )
+        .expect("valid key package");
+
+        let key_package2 = frost::keys::KeyPackage::try_from(
+            shares[&frost::Identifier::try_from(2u16).expect("valid id")].clone(),
+        )
+        .expect("valid key package");
+
+        
+
+        let (_, signing_commits1) = frost::round1::commit(key_package1.signing_share(), rng);
+        add_signing_commitments_to_psbt(&mut psbt, &vec![signing_commits1], &frost_id1);
+
+        // Lets add two signatures and use min_signers = 1
+        let sig_share1 =
+            frost::round2::SignatureShare::deserialize([1u8; 32]).expect("valid sig share");
+        let sig_share2 =
+            frost::round2::SignatureShare::deserialize([2u8; 32]).expect("valid sig share");
+
+        add_partial_signature_to_psbt(&mut psbt, &vec![sig_share1], &frost_id1);
+
+        // Should pass with 1 signature
+        let res = validate_psbt(&psbt, ROUND2, 1, &db);
+        assert!(res.is_ok());
+
+        // Should fail with two signatures
+        let frost_id2 = frost::Identifier::try_from(2u16).expect("valid id");
+        add_partial_signature_to_psbt(&mut psbt, &vec![sig_share2], &frost_id2);
+        let res = validate_psbt(&psbt, ROUND2, 1, &db);
+        assert!(res.is_err());
+        assert_eq!(res.unwrap_err().to_string(), "invalid number of partial signatures");
+
+        // Should fail ROUND2_TRANSITION since we havent added other signers signing commit
+        let res = validate_psbt(&psbt, ROUND2_TRANSITION, 1, &db);
+        assert!(res.is_err());
+        assert_eq!(res.unwrap_err().to_string(), "invalid number of partial signatures");
+
+        // Add other signing commit
+        let (_, signing_commits2) = frost::round1::commit(key_package2.signing_share(), rng);
+        add_signing_commitments_to_psbt(&mut psbt, &vec![signing_commits2], &frost_id2);
+        let res = validate_psbt(&psbt, ROUND2_TRANSITION, 2, &db);
+        assert!(res.is_ok());
+
+        // Should fail if there is another signer
+        let frost_id3 = frost::Identifier::try_from(3u16).expect("valid id");
+        let key_package3 = frost::keys::KeyPackage::try_from(
+            shares[&frost::Identifier::try_from(3u16).expect("valid id")].clone(),
+        ).expect("valid key package");
+
+        let (_, signing_commits3) = frost::round1::commit(key_package3.signing_share(), rng);
+        add_signing_commitments_to_psbt(&mut psbt, &vec![signing_commits3], &frost_id3);
+        let sig = frost::round2::SignatureShare::deserialize([3u8; 32]).expect("valid sig share");
+        add_partial_signature_to_psbt(&mut psbt, &vec![sig], &frost_id3);
+
+        let res = validate_psbt(&psbt, ROUND2_TRANSITION, 2, &db);
+        assert!(res.is_err());
+
+
+    }
 
     #[test]
     fn convert_bdk_fee_rate() {

--- a/bin/btc-server/src/util.rs
+++ b/bin/btc-server/src/util.rs
@@ -261,27 +261,19 @@ pub fn validate_psbt(
         return Err(ValidatePSBTError::FeeSanityCheck("Fee cannot be greater than max amount"));
     }
 
-    // Fix fee rate check
-    // let fee_rate = psbt.fee_rate().ok_or(ValidatePSBTError::FeeRateCalculationError())?;
-    // if fee_rate > MAX_FEERATE.clone() {
-    //     return Err(ValidatePSBTError::FeeSanityCheck(
-    //         "Fee rate cannot be greater than max feerate",
-    //     ));
-    // }
-    // TODO (armins) fee rate sanity check
     // If we are just validating sanity checks we can stop here
     if flags == NO_FLAGS {
         return Ok(());
     }
 
     // validate signing commitments in round 1
+    let scs = psbt.inputs.iter().map(|i| i.all_signing_commitments()).collect::<Vec<_>>();
     if flags & ROUND1_TRANSITION == ROUND1_TRANSITION {
-        let scs = psbt.inputs.iter().map(|i| i.all_signing_commitments()).collect::<Vec<_>>();
         if scs.len() != psbt.inputs.len() {
             return Err(ValidatePSBTError::InvalidNumberOfSigningCommitments);
         }
         // Each map should have atleast min_signers number of signing commitments
-        for sc in scs {
+        for sc in &scs {
             if sc.len() < min_signers as usize {
                 return Err(ValidatePSBTError::InvalidNumberOfSigningCommitments);
             }
@@ -334,8 +326,8 @@ pub fn validate_psbt(
             // If the utxo has a eth tweak check the right one is presented in the psbt
             let eth_tweak = utxo.clone().expect("valid utxo").eth_address;
             if let Some(e) = eth_tweak {
-                let eth_input_tweak = psbt_input.eth_address().expect("valid eth address");
-                if eth_input_tweak != Some(&e.to_vec()) {
+                let eth_input_tweak = psbt_input.eth_address();
+                if eth_input_tweak != Some(e) {
                     return Err(ValidatePSBTError::EthTweakMismatch);
                 }
             }
@@ -357,19 +349,13 @@ pub fn validate_psbt(
 
 #[cfg(test)]
 mod util_tests {
+    use super::*;
     use crate::{
         database,
         test::{create_psbt, create_tx, eth_vector_to_fixed_bytes, trusted_dealer_setup},
     };
     use bitcoin::{ScriptBuf, TxOut};
-
-<<<<<<< HEAD
-    use crate::test::{create_tx, eth_vector_to_fixed_bytes, trusted_dealer_setup};
     use reth_btc_wallet::psbt::{PsbtExt, PsbtInputExt};
-
-=======
->>>>>>> 46b78a5ec (test(btc_server): tests for `validate_psbt()`)
-    use super::*;
 
     fn db_setup() -> database::Db {
         let tmpdir = tempfile::tempdir().unwrap();
@@ -440,7 +426,7 @@ mod util_tests {
         assert!(res.is_err());
         assert_eq!(res.unwrap_err().to_string(), "eth tweak mismatch");
 
-        psbt.inputs[0].unknown.insert(ETH_ADDRESS_FIELD.clone(), vec![0u8; 20]);
+        psbt.inputs[0].set_eth_address(eth);
         let res = validate_psbt(&psbt, ROUND1, 2, &db);
         assert!(res.is_ok());
     }
@@ -504,8 +490,8 @@ mod util_tests {
         let (_, signing_commits1) = frost::round1::commit(key_package1.signing_share(), rng);
         let (_, signing_commits2) = frost::round1::commit(key_package2.signing_share(), rng);
 
-        add_signing_commitments_to_psbt(&mut psbt, &vec![signing_commits1], &frost_id1);
-        add_signing_commitments_to_psbt(&mut psbt, &vec![signing_commits2], &frost_id2);
+        psbt.inputs[0].set_signing_commitment(frost_id1, &signing_commits1);
+        psbt.inputs[0].set_signing_commitment(frost_id2, &signing_commits2);
 
         let res = validate_psbt(&psbt, ROUND1_TRANSITION, 2, &db);
         assert!(res.is_ok());
@@ -542,10 +528,8 @@ mod util_tests {
         )
         .expect("valid key package");
 
-        
-
         let (_, signing_commits1) = frost::round1::commit(key_package1.signing_share(), rng);
-        add_signing_commitments_to_psbt(&mut psbt, &vec![signing_commits1], &frost_id1);
+        psbt.inputs[0].set_signing_commitment(frost_id1, &signing_commits1);
 
         // Lets add two signatures and use min_signers = 1
         let sig_share1 =
@@ -553,7 +537,7 @@ mod util_tests {
         let sig_share2 =
             frost::round2::SignatureShare::deserialize([2u8; 32]).expect("valid sig share");
 
-        add_partial_signature_to_psbt(&mut psbt, &vec![sig_share1], &frost_id1);
+        psbt.inputs[0].set_partial_signature(frost_id1, &sig_share1);
 
         // Should pass with 1 signature
         let res = validate_psbt(&psbt, ROUND2, 1, &db);
@@ -561,7 +545,7 @@ mod util_tests {
 
         // Should fail with two signatures
         let frost_id2 = frost::Identifier::try_from(2u16).expect("valid id");
-        add_partial_signature_to_psbt(&mut psbt, &vec![sig_share2], &frost_id2);
+        psbt.inputs[0].set_partial_signature(frost_id2, &sig_share2);
         let res = validate_psbt(&psbt, ROUND2, 1, &db);
         assert!(res.is_err());
         assert_eq!(res.unwrap_err().to_string(), "invalid number of partial signatures");
@@ -573,7 +557,7 @@ mod util_tests {
 
         // Add other signing commit
         let (_, signing_commits2) = frost::round1::commit(key_package2.signing_share(), rng);
-        add_signing_commitments_to_psbt(&mut psbt, &vec![signing_commits2], &frost_id2);
+        psbt.inputs[0].set_signing_commitment(frost_id2, &signing_commits2);
         let res = validate_psbt(&psbt, ROUND2_TRANSITION, 2, &db);
         assert!(res.is_ok());
 
@@ -581,17 +565,16 @@ mod util_tests {
         let frost_id3 = frost::Identifier::try_from(3u16).expect("valid id");
         let key_package3 = frost::keys::KeyPackage::try_from(
             shares[&frost::Identifier::try_from(3u16).expect("valid id")].clone(),
-        ).expect("valid key package");
+        )
+        .expect("valid key package");
 
         let (_, signing_commits3) = frost::round1::commit(key_package3.signing_share(), rng);
-        add_signing_commitments_to_psbt(&mut psbt, &vec![signing_commits3], &frost_id3);
+        psbt.inputs[0].set_signing_commitment(frost_id3, &signing_commits3);
         let sig = frost::round2::SignatureShare::deserialize([3u8; 32]).expect("valid sig share");
-        add_partial_signature_to_psbt(&mut psbt, &vec![sig], &frost_id3);
+        psbt.inputs[0].set_partial_signature(frost_id3, &sig);
 
         let res = validate_psbt(&psbt, ROUND2_TRANSITION, 2, &db);
         assert!(res.is_err());
-
-
     }
 
     #[test]
@@ -692,7 +675,6 @@ mod util_tests {
         psbt.inputs[0].witness_utxo = Some(TxOut { value: 1000, script_pubkey: ScriptBuf::new() });
 
         let signing_packages = psbt.signing_packages();
-        println!("{:?}", signing_packages);
         assert!(signing_packages.is_err());
         assert_eq!(
             signing_packages.unwrap_err().to_string(),

--- a/crates/consensus/authority/src/signing.rs
+++ b/crates/consensus/authority/src/signing.rs
@@ -490,7 +490,7 @@ where
         self.new_round1_signing_package(
             self.personal_frost_identifier.serialize().to_vec(),
             signing_session_id,
-            psbt,
+            signing_round1_package.clone().psbt,
         )
         .await?;
 


### PR DESCRIPTION
This psbt needs to be validated at each stage. By both the signers and coordinator. Most of this validation is duplicated in each rpc endpoint. This PR refactors it into a single util methods

This might be overkill but I also realized that the signers may modify the original PSBT by adding additional inputs and/or outputs. And the coordinator as of now doesnt check for this. Could be good to check for this 


