### PR TITLE
Scott/355 feature get block filters from bitcoind and store in memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6635,6 +6635,7 @@ dependencies = [
  "assert_matches",
  "backon",
  "bitcoin",
+ "bitcoincore-rpc",
  "boyer-moore-magiclen",
  "clap",
  "client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6725,6 +6725,7 @@ name = "reth-authority-consensus"
 version = "0.1.0-alpha.20"
 dependencies = [
  "bitcoin",
+ "bitcoincore-rpc",
  "btc-server",
  "clap",
  "client",

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -125,6 +125,7 @@ tonic = "0.9.2"
 
 ## Bitcoin
 bitcoin = "0.30.2"
+bitcoincore-rpc = "0.17.0"
 
 ## Url
 url = "2.2"

--- a/bin/reth/src/poa_builder.rs
+++ b/bin/reth/src/poa_builder.rs
@@ -12,7 +12,7 @@ use crate::{
 use eyre::Context;
 use fdlimit::raise_fd_limit;
 use futures::{future::Either, stream, stream_select, StreamExt};
-use reth_authority_consensus::{AuthorityConsensusBuilder, utils::{is_testnet, get_confirmation_depth}};
+use reth_authority_consensus::{AuthorityConsensusBuilder, task::BlockFilterData, utils::{is_testnet, get_confirmation_depth}};
 use reth_beacon_consensus::{
     hooks::{EngineHooks, PruneHook},
     BeaconConsensusEngine, BeaconConsensusEngineError, MIN_BLOCKS_FOR_PIPELINE_RUN,
@@ -189,7 +189,7 @@ impl<DB: Database + DatabaseMetrics + DatabaseMetadata + 'static> NodeBuilderWit
         // fetch and store bitcoin block filters
         let is_testnet = is_testnet(self.config.chain.chain.id());
         let confirmation_depth = get_confirmation_depth(is_testnet);
-        let bitcoin_block_filters: Arc<RwLock<Option<Vec<(json::GetBlockFilterResult, u64)>>>> = Arc::new(RwLock::new(None));
+        let bitcoin_block_filters: Arc<RwLock<Option<Vec<BlockFilterData>>>> = Arc::new(RwLock::new(None));
         let bitcoin_block_filters_clone = bitcoin_block_filters.clone();
         let bitcoind_config_clone = bitcoind_config.clone();
 
@@ -197,7 +197,7 @@ impl<DB: Database + DatabaseMetrics + DatabaseMetadata + 'static> NodeBuilderWit
             let sleep_ms = tokio::time::Duration::from_millis(5000);
             let bitcoind_client =  BitcoindClient::new(bitcoind_config_clone).expect("Unable to create bitcoind client");
 
-            let mut current_filters: Vec<(json::GetBlockFilterResult, u64)> = match bitcoin_block_filters.read().await.clone() {
+            let mut current_filters: Vec<BlockFilterData> = match bitcoin_block_filters.read().await.clone() {
                 Some(filters) => filters,
                 None => Vec::new(),
             };
@@ -213,12 +213,12 @@ impl<DB: Database + DatabaseMetrics + DatabaseMetadata + 'static> NodeBuilderWit
 
                 // prune filters older than confirmation_depth
                 let confirmation_depth_u64 = <u32 as Into<u64>>::into(confirmation_depth);
-                current_filters.retain(|(_, filter_height)| *filter_height > tip - confirmation_depth_u64);
+                current_filters.retain(|filter| filter.block_height > tip - confirmation_depth_u64);
                 
                 let start = tip -  confirmation_depth_u64;
                 for height in start..=tip {
                     // don't fetch filters we already have
-                    if !current_filters.is_empty() && current_filters.iter().any(|(_, filter_height)| *filter_height == height) {
+                    if !current_filters.is_empty() && current_filters.iter().any(|filter| filter.block_height == height) {
                         continue;
                     }
                     let block_hash = match bitcoind_client.get_block_hash(height).await {
@@ -232,7 +232,12 @@ impl<DB: Database + DatabaseMetrics + DatabaseMetadata + 'static> NodeBuilderWit
                     
                     match bitcoind_client.get_block_filter(block_hash).await {
                         Ok(block_filter) => {
-                            current_filters.push((block_filter, height));
+                            let block_filter_data = BlockFilterData {
+                                block_hash,
+                                block_height: height,
+                                filter: block_filter.filter,
+                            };
+                            current_filters.push(block_filter_data);
                         }
                         Err(_) => {
                             error!(target: "reth::cli", "Failed to fetch block filter. Retrying...");

--- a/bin/reth/src/poa_builder.rs
+++ b/bin/reth/src/poa_builder.rs
@@ -12,7 +12,7 @@ use crate::{
 use eyre::Context;
 use fdlimit::raise_fd_limit;
 use futures::{future::Either, stream, stream_select, StreamExt};
-use reth_authority_consensus::AuthorityConsensusBuilder;
+use reth_authority_consensus::{AuthorityConsensusBuilder, utils::{is_testnet, get_confirmation_depth}};
 use reth_beacon_consensus::{
     hooks::{EngineHooks, PruneHook},
     BeaconConsensusEngine, BeaconConsensusEngineError, MIN_BLOCKS_FOR_PIPELINE_RUN,
@@ -55,6 +55,8 @@ use client::BtcServerClient;
 use reth_btc_wallet::bitcoind::{BitcoindClient, BitcoindConfig};
 use rsntp::AsyncSntpClient;
 use tokio::time::Duration;
+
+use bitcoincore_rpc::json;
 
 /// Re-export `NodeConfig` from `reth_node_core`.
 pub use reth_node_core::node_config::NodeConfig;
@@ -183,6 +185,60 @@ impl<DB: Database + DatabaseMetrics + DatabaseMetadata + 'static> NodeBuilderWit
                 ));
             }
         }
+
+        // fetch and store bitcoin block filters
+        let is_testnet = is_testnet(self.config.chain.chain.id());
+        let confirmation_depth = get_confirmation_depth(is_testnet);
+        let bitcoin_block_filters: Arc<RwLock<Option<Vec<(json::GetBlockFilterResult, u64)>>>> =
+        Arc::new(RwLock::new(None));
+        let bitcoin_block_filters_clone = bitcoin_block_filters.clone();
+        let bitcoind_config_clone = bitcoind_config.clone();
+
+        executor.spawn_critical("async bitcoin block filter task", Box::pin(async move {
+            let sleep_ms = tokio::time::Duration::from_millis(5000);
+            let bitcoind_client =  BitcoindClient::new(bitcoind_config_clone).expect("Unable to create bitcoind client");
+
+            let mut current_filters: Vec<(json::GetBlockFilterResult, u64)> = match bitcoin_block_filters.read().await.clone() {
+                Some(filters) => filters,
+                None => Vec::new(),
+            };
+            loop {
+                let tip = match bitcoind_client.get_tip().await {
+                    Ok(tip) => tip,
+                    Err(_) => {
+                        error!(target: "reth::cli", "Failed to fetch the tip. Retrying...");
+                        tokio::time::sleep(sleep_ms).await;
+                        continue;
+                    }
+                };
+                
+                let start = tip -  <u32 as Into<u64>>::into(confirmation_depth);
+                for height in start..=tip {
+                    let block_hash = match bitcoind_client.get_block_hash(height).await {
+                        Ok(block_hash) => block_hash,
+                        Err(_) => {
+                            error!(target: "reth::cli", "Failed to fetch block hash. Retrying...");
+                            tokio::time::sleep(sleep_ms).await;
+                            break;
+                        }
+                    };
+                    
+                    match bitcoind_client.get_block_filter(block_hash).await {
+                        Ok(block_filter) => {
+                            current_filters.push((block_filter, height));
+                        }
+                        Err(_) => {
+                            error!(target: "reth::cli", "Failed to fetch block filter. Retrying...");
+                            tokio::time::sleep(sleep_ms).await;
+                            break;
+                        }
+                    }
+                }
+                let mut filters_write = bitcoin_block_filters.write().await;
+                *filters_write = Some(current_filters.clone());
+                drop(filters_write);
+            }
+        }));
 
         let bitcoind_config = bitcoind_config.clone();
         executor.spawn_critical(

--- a/bin/reth/src/poa_builder.rs
+++ b/bin/reth/src/poa_builder.rs
@@ -189,8 +189,7 @@ impl<DB: Database + DatabaseMetrics + DatabaseMetadata + 'static> NodeBuilderWit
         // fetch and store bitcoin block filters
         let is_testnet = is_testnet(self.config.chain.chain.id());
         let confirmation_depth = get_confirmation_depth(is_testnet);
-        let bitcoin_block_filters: Arc<RwLock<Option<Vec<(json::GetBlockFilterResult, u64)>>>> =
-        Arc::new(RwLock::new(None));
+        let bitcoin_block_filters: Arc<RwLock<Option<Vec<(json::GetBlockFilterResult, u64)>>>> = Arc::new(RwLock::new(None));
         let bitcoin_block_filters_clone = bitcoin_block_filters.clone();
         let bitcoind_config_clone = bitcoind_config.clone();
 
@@ -206,14 +205,22 @@ impl<DB: Database + DatabaseMetrics + DatabaseMetadata + 'static> NodeBuilderWit
                 let tip = match bitcoind_client.get_tip().await {
                     Ok(tip) => tip,
                     Err(_) => {
-                        error!(target: "reth::cli", "Failed to fetch the tip. Retrying...");
+                        error!(target: "reth::cli", "Failed to fetch the tip in block filter task. Retrying...");
                         tokio::time::sleep(sleep_ms).await;
                         continue;
                     }
                 };
+
+                // prune filters older than confirmation_depth
+                let confirmation_depth_u64 = <u32 as Into<u64>>::into(confirmation_depth);
+                current_filters.retain(|(_, filter_height)| *filter_height > tip - confirmation_depth_u64);
                 
-                let start = tip -  <u32 as Into<u64>>::into(confirmation_depth);
+                let start = tip -  confirmation_depth_u64;
                 for height in start..=tip {
+                    // don't fetch filters we already have
+                    if !current_filters.is_empty() && current_filters.iter().any(|(_, filter_height)| *filter_height == height) {
+                        continue;
+                    }
                     let block_hash = match bitcoind_client.get_block_hash(height).await {
                         Ok(block_hash) => block_hash,
                         Err(_) => {
@@ -239,6 +246,7 @@ impl<DB: Database + DatabaseMetrics + DatabaseMetadata + 'static> NodeBuilderWit
                 drop(filters_write);
             }
         }));
+        info!(target: "reth::cli", "Spawned async bitcoin block filter task");
 
         let bitcoind_config = bitcoind_config.clone();
         executor.spawn_critical(
@@ -467,6 +475,7 @@ impl<DB: Database + DatabaseMetrics + DatabaseMetadata + 'static> NodeBuilderWit
             canon_state_notification_sender.clone(),
             btc_server_client.clone(),
             bitcoin_block_headers_clone,
+            bitcoin_block_filters_clone,
             bitcoind_config,
             secp256k1::Secp256k1::new(),
             network_sk,

--- a/crates/btc-wallet/src/bitcoind.rs
+++ b/crates/btc-wallet/src/bitcoind.rs
@@ -1,4 +1,4 @@
-use bitcoincore_rpc::{json::GetChainTipsResultStatus, Auth, Client, RpcApi};
+use bitcoincore_rpc::{json::{self, GetChainTipsResultStatus}, Auth, Client, RpcApi};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use thiserror::Error;
@@ -20,6 +20,8 @@ pub enum BitcoindError {
     TransactionBroadcastFailed(bitcoincore_rpc::Error),
     #[error("Block index failed")]
     BlockIndexStatusFailed(bitcoincore_rpc::Error),
+    #[error("Block filter retrieval failed")]
+    BlockFilterRetrievalFailed(bitcoincore_rpc::Error),
 }
 
 #[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
@@ -77,6 +79,14 @@ impl BitcoindClient {
         let block_hash =
             self.rpc.get_block_hash(height).map_err(BitcoindError::BlockHeaderRetrievalFailed)?;
         Ok(block_hash)
+    }
+
+    pub async fn get_block_filter(&self, block_hash: bitcoin::BlockHash) -> Result<json::GetBlockFilterResult, BitcoindError> {
+        let filter = self
+            .rpc
+            .get_block_filter(&block_hash)
+            .map_err(BitcoindError::BlockFilterRetrievalFailed)?;
+        Ok(filter)
     }
 
     pub async fn get_tip(&self) -> Result<u64, BitcoindError> {
@@ -149,6 +159,10 @@ mod tests {
         match tip {
             Ok(tip) => {
                 assert!(tip > 0);
+                // test additional endpoints
+                let block_hash = client.get_block_hash(tip).await;
+                let block_filter = client.get_block_filter(block_hash.unwrap()).await;
+                assert!(block_filter.is_ok());
             }
             Err(e) => {
                 panic!("Got error {:?}", e);

--- a/crates/consensus/authority/Cargo.toml
+++ b/crates/consensus/authority/Cargo.toml
@@ -56,6 +56,7 @@ frost-secp256k1-tr = { git = "https://github.com/mimoo/frost", branch = "mimoo/f
 
 ## Bitcoin
 bitcoin = "0.30.2"
+bitcoincore-rpc = "0.17.0"
 
 ## Crypto
 secp256k1 = { workspace = true, features = [

--- a/crates/consensus/authority/src/builder.rs
+++ b/crates/consensus/authority/src/builder.rs
@@ -31,6 +31,8 @@ use tokio::sync::{
 use crate::sync::SyncController;
 use tracing::error;
 
+use bitcoincore_rpc::json;
+
 /// Builder type for confirguring the setup
 pub struct AuthorityConsensusBuilder<Client, EvmConfig, Engine: EngineTypes> {
     #[allow(dead_code)]
@@ -41,6 +43,7 @@ pub struct AuthorityConsensusBuilder<Client, EvmConfig, Engine: EngineTypes> {
     canon_state_notification: CanonStateNotificationSender,
     btc_server: BtcServerClient<tonic::transport::Channel>,
     bitcoin_block_header: Arc<RwLock<Option<(bitcoin::block::Header, u32)>>>,
+    bitcoin_block_filters: Arc<RwLock<Option<Vec<(json::GetBlockFilterResult, u64)>>>>,
     bitcoind_config: BitcoindConfig,
     secp: Secp256k1<All>,
     sk: secp256k1::SecretKey,
@@ -88,6 +91,7 @@ where
         canon_state_notification: CanonStateNotificationSender,
         btc_server: BtcServerClient<tonic::transport::Channel>,
         bitcoin_block_header: Arc<RwLock<Option<(bitcoin::block::Header, u32)>>>,
+        bitcoin_block_filters: Arc<RwLock<Option<Vec<(json::GetBlockFilterResult, u64)>>>>,
         bitcoind_config: BitcoindConfig,
         secp: Secp256k1<All>,
         // TODO (armins) This should be Arc protected
@@ -161,6 +165,7 @@ where
             canon_state_notification,
             btc_server,
             bitcoin_block_header,
+            bitcoin_block_filters,
             bitcoind_config,
             secp,
             sk,
@@ -197,6 +202,7 @@ where
             to_engine,
             canon_state_notification,
             bitcoin_block_header,
+            bitcoin_block_filters,
             bitcoind_config,
             secp,
             sk,
@@ -249,6 +255,7 @@ where
             storage,
             btc_server,
             bitcoin_block_header,
+            bitcoin_block_filters,
             bitcoind_client,
             secp,
             sk,

--- a/crates/consensus/authority/src/builder.rs
+++ b/crates/consensus/authority/src/builder.rs
@@ -29,6 +29,7 @@ use tokio::sync::{
 };
 
 use crate::sync::SyncController;
+use crate::task::BlockFilterData;
 use tracing::error;
 
 use bitcoincore_rpc::json;
@@ -43,7 +44,7 @@ pub struct AuthorityConsensusBuilder<Client, EvmConfig, Engine: EngineTypes> {
     canon_state_notification: CanonStateNotificationSender,
     btc_server: BtcServerClient<tonic::transport::Channel>,
     bitcoin_block_header: Arc<RwLock<Option<(bitcoin::block::Header, u32)>>>,
-    bitcoin_block_filters: Arc<RwLock<Option<Vec<(json::GetBlockFilterResult, u64)>>>>,
+    bitcoin_block_filters: Arc<RwLock<Option<Vec<BlockFilterData>>>>,
     bitcoind_config: BitcoindConfig,
     secp: Secp256k1<All>,
     sk: secp256k1::SecretKey,
@@ -91,7 +92,7 @@ where
         canon_state_notification: CanonStateNotificationSender,
         btc_server: BtcServerClient<tonic::transport::Channel>,
         bitcoin_block_header: Arc<RwLock<Option<(bitcoin::block::Header, u32)>>>,
-        bitcoin_block_filters: Arc<RwLock<Option<Vec<(json::GetBlockFilterResult, u64)>>>>,
+        bitcoin_block_filters: Arc<RwLock<Option<Vec<BlockFilterData>>>>,
         bitcoind_config: BitcoindConfig,
         secp: Secp256k1<All>,
         // TODO (armins) This should be Arc protected

--- a/crates/consensus/authority/src/lib.rs
+++ b/crates/consensus/authority/src/lib.rs
@@ -60,7 +60,7 @@ mod epoch_manager;
 mod frost_task;
 mod sync;
 mod task;
-mod utils;
+pub mod utils;
 mod voting;
 
 pub use builder::AuthorityConsensusBuilder;

--- a/crates/consensus/authority/src/lib.rs
+++ b/crates/consensus/authority/src/lib.rs
@@ -59,7 +59,7 @@ mod engine_util;
 mod epoch_manager;
 mod frost_task;
 mod sync;
-mod task;
+pub mod task;
 pub mod utils;
 mod voting;
 

--- a/crates/consensus/authority/src/task.rs
+++ b/crates/consensus/authority/src/task.rs
@@ -1,4 +1,5 @@
 use crate::{epoch_manager::EpochManager, Storage};
+use bitcoin::BlockHash;
 use reth_beacon_consensus::BeaconEngineMessage;
 
 use reth_btc_wallet::bitcoind::BitcoindClient;
@@ -40,7 +41,7 @@ pub struct BlockProductionTask<Client, EvmConfig, Engine: EngineTypes> {
     /// Recent bitcoin block headers
     pub(crate) bitcoin_block_header: Arc<RwLock<Option<(bitcoin::block::Header, u32)>>>,
     /// Recent bitcoin block filters
-    pub(crate) bitcoin_block_filters: Arc<RwLock<Option<Vec<(json::GetBlockFilterResult, u64)>>>>,
+    pub(crate) bitcoin_block_filters: Arc<RwLock<Option<Vec<BlockFilterData>>>>,
     /// Bitcoind client
     pub(crate) bitcoind_client: BitcoindClient,
     /// Instance of secp
@@ -79,7 +80,7 @@ where
         storage: Storage<Client>,
         btc_server: BtcServerClient<tonic::transport::Channel>,
         bitcoin_block_header: Arc<RwLock<Option<(bitcoin::block::Header, u32)>>>,
-        bitcoin_block_filters: Arc<RwLock<Option<Vec<(json::GetBlockFilterResult, u64)>>>>,
+        bitcoin_block_filters: Arc<RwLock<Option<Vec<BlockFilterData>>>>,
         bitcoind_client: BitcoindClient,
         secp: Secp256k1<All>,
         sk: secp256k1::SecretKey,
@@ -127,4 +128,11 @@ impl<Client, EvmConfig: std::fmt::Debug, Engine: EngineTypes> std::fmt::Debug
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Authority Block Production Task").finish_non_exhaustive()
     }
+}
+
+#[derive(Clone)]
+pub struct BlockFilterData {
+    pub block_hash: BlockHash,
+    pub block_height: u64,
+    pub filter: Vec<u8>,
 }

--- a/crates/consensus/authority/src/task.rs
+++ b/crates/consensus/authority/src/task.rs
@@ -22,6 +22,8 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 
 use client::BtcServerClient;
 
+use bitcoincore_rpc::json;
+
 pub struct BlockProductionTask<Client, EvmConfig, Engine: EngineTypes> {
     /// The configured chain spec
     pub(crate) chain_spec: Arc<ChainSpec>,
@@ -37,6 +39,8 @@ pub struct BlockProductionTask<Client, EvmConfig, Engine: EngineTypes> {
     pub(crate) btc_server: BtcServerClient<tonic::transport::Channel>,
     /// Recent bitcoin block headers
     pub(crate) bitcoin_block_header: Arc<RwLock<Option<(bitcoin::block::Header, u32)>>>,
+    /// Recent bitcoin block filters
+    pub(crate) bitcoin_block_filters: Arc<RwLock<Option<Vec<(json::GetBlockFilterResult, u64)>>>>,
     /// Bitcoind client
     pub(crate) bitcoind_client: BitcoindClient,
     /// Instance of secp
@@ -75,6 +79,7 @@ where
         storage: Storage<Client>,
         btc_server: BtcServerClient<tonic::transport::Channel>,
         bitcoin_block_header: Arc<RwLock<Option<(bitcoin::block::Header, u32)>>>,
+        bitcoin_block_filters: Arc<RwLock<Option<Vec<(json::GetBlockFilterResult, u64)>>>>,
         bitcoind_client: BitcoindClient,
         secp: Secp256k1<All>,
         sk: secp256k1::SecretKey,
@@ -91,6 +96,7 @@ where
             pipe_line_events: None,
             btc_server,
             bitcoin_block_header,
+            bitcoin_block_filters,
             bitcoind_client,
             secp,
             sk,

--- a/crates/consensus/authority/src/utils.rs
+++ b/crates/consensus/authority/src/utils.rs
@@ -329,14 +329,14 @@ pub(crate) fn get_recent_block_height_or_zero(
     })
 }
 
-pub(crate) fn get_confirmation_depth(is_testnet: bool) -> u32 {
+pub fn get_confirmation_depth(is_testnet: bool) -> u32 {
     match is_testnet {
         true => SIGNET_PEGIN_CONFIRMATION_DEPTH,
         false => MAINNET_PEGIN_CONFIRMATION_DEPTH,
     }
 }
 
-pub(crate) fn is_testnet(chain_id: u64) -> bool {
+pub fn is_testnet(chain_id: u64) -> bool {
     chain_id == BOTANIX_TESTNET.chain().id()
 }
 


### PR DESCRIPTION
Tested and it's working. Mark updated our bitcoind args to pass `blockfilterindex=1` so filters are being created and can be consumed.