### PR TITLE
Scott/378 feature block subsidy is split between block producer and botanix

### DIFF
--- a/bin/test-suite/src/suite/consensus/frost/test_block_builder.rs
+++ b/bin/test-suite/src/suite/consensus/frost/test_block_builder.rs
@@ -1,4 +1,6 @@
 use reth::core::cli::runner::CliRunner;
+use reth::primitives::{constants::BOTANIX_FEES_RECIPIENT, public_key_to_address};
+use reth_botanix_lib::extra_data_header::ExtraDataHeader;
 use std::{collections::HashSet, time::Duration};
 
 use crate::{
@@ -50,6 +52,25 @@ pub async fn block_builder(
     // create a minting contract instance
     let botanix_eth_client = targeted_fed_member.create_botanix_eth_client().await;
 
+    // get fed member and botanix address balances
+    let edh = targeted_fed_member.edh.unwrap();
+    let targeted_fed_member_pub_key = *edh.authority_signers.unwrap().first().unwrap();
+    let targeted_fed_member_ethereum_address =
+        public_key_to_address(targeted_fed_member_pub_key).to_checksum(Some(3636));
+
+    let target_fed_member_balance_before = botanix_eth_client
+        .get_botanix_balance(targeted_fed_member_ethereum_address.as_str())
+        .await
+        .unwrap();
+    it_info_print!("Targeted fed member balance before: {}", target_fed_member_balance_before);
+
+    let botanix_block_reward_address_balance_before =
+        botanix_eth_client.get_botanix_balance(BOTANIX_FEES_RECIPIENT).await.unwrap();
+    it_info_print!(
+        "Botanix block fee recipient balance before: {}",
+        botanix_block_reward_address_balance_before
+    );
+
     // create a hashmap to store tx hashes
     let mut tx_hashes_set = HashSet::new();
 
@@ -94,6 +115,39 @@ pub async fn block_builder(
                     assert!(!block_payload.1);
                     assert_eq!(block_payload.0.tx_receipts.len(), 1);
                     assert!(block_payload.0.block.number > 0);
+
+                    // get fed member and botanix block reward address balances
+                    let target_fed_member_balance_after = botanix_eth_client
+                        .get_botanix_balance(targeted_fed_member_ethereum_address.as_str())
+                        .await
+                        .unwrap();
+                    it_info_print!(
+                        "Targeted fed member balance after: {}",
+                        target_fed_member_balance_after
+                    );
+
+                    it_info_print!("Botanix block fee recipient: {}", BOTANIX_FEES_RECIPIENT);
+
+                    let botanix_block_reward_address_balance_before_after = botanix_eth_client
+                        .get_botanix_balance(BOTANIX_FEES_RECIPIENT)
+                        .await
+                        .unwrap();
+                    it_info_print!(
+                        "Botanix block reward address balance after: {}",
+                        botanix_block_reward_address_balance_before_after
+                    );
+
+                    // verfigy 80/20 block reward split is correct
+                    let target_fed_member_reward =
+                        target_fed_member_balance_after - target_fed_member_balance_before;
+                    let botanix_block_reward = botanix_block_reward_address_balance_before_after
+                        - botanix_block_reward_address_balance_before;
+
+                    let total_block_reward = target_fed_member_reward + botanix_block_reward;
+
+                    assert_eq!(target_fed_member_reward, (total_block_reward * 4) / 5); // 80%
+                    assert_eq!(botanix_block_reward, total_block_reward / 5); // 20%
+
                     return Ok(());
                 }
             }

--- a/bin/test-suite/src/suite/consensus/frost/test_block_builder.rs
+++ b/bin/test-suite/src/suite/consensus/frost/test_block_builder.rs
@@ -137,7 +137,7 @@ pub async fn block_builder(
                         botanix_block_reward_address_balance_before_after
                     );
 
-                    // verfigy 80/20 block reward split is correct
+                    // verify 80/20 block reward split is correct
                     let target_fed_member_reward =
                         target_fed_member_balance_after - target_fed_member_balance_before;
                     let botanix_block_reward = botanix_block_reward_address_balance_before_after

--- a/crates/consensus/authority/src/block_builder.rs
+++ b/crates/consensus/authority/src/block_builder.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use crate::{
-    engine_util::{self, BestTransactionsError},
+    engine_util,
     frost_task::{FrostNotification, FrostNotificationMessage},
     task::BlockProductionTask,
     utils::{get_witness_data_from_psbt, is_testnet},
@@ -15,7 +15,7 @@ use reth_interfaces::blockchain_tree::{
 };
 use reth_node_api::{ConfigureEvmEnv, EngineTypes};
 use reth_node_ethereum::EthEngineTypes;
-use reth_payload_builder::{EthBuiltPayload, EthPayloadBuilderAttributes};
+use reth_payload_builder::EthPayloadBuilderAttributes;
 use reth_primitives::{
     botanix::BotanixConsensusPackage, public_key_to_address, Block, SealedBlockWithSenders, B256,
 };

--- a/crates/consensus/authority/src/lib.rs
+++ b/crates/consensus/authority/src/lib.rs
@@ -21,7 +21,7 @@
 //! be mined.
 use reth_botanix_lib::extra_data_header::ExtraDataHeader;
 use reth_consensus_common::{
-    utils::{get_authority_address_from_header, recovery_authority, unix_timestamp},
+    utils::{get_block_producer_address, unix_timestamp},
     validation::{self, validate_poa_header_standalone},
 };
 use reth_interfaces::{
@@ -436,7 +436,7 @@ where
         let mut executor = EVMProcessor::new_with_state(chain_spec.clone(), db, evm_config);
 
         // derive block builder address to receive block fees
-        let block_builder_pub_key = secp256k1::PublicKey::from_secret_key(secp, sk);
+        let block_builder_pub_key = secp256k1::PublicKey::from_secret_key_global(sk);
         let block_builder_address = public_key_to_address(block_builder_pub_key);
         let (bundle_state, gas_used) = self.execute(
             &block_with_senders,
@@ -554,7 +554,7 @@ where
             },
         )?;
 
-        let block_builder_address = get_authority_address_from_header(&sealed_block.header.clone());
+        let block_builder_address = get_block_producer_address(&sealed_block.header.clone());
         let (bundle_state, _gas_used) = self.execute(
             &block_with_senders,
             &mut executor,

--- a/crates/consensus/authority/src/lib.rs
+++ b/crates/consensus/authority/src/lib.rs
@@ -21,7 +21,7 @@
 //! be mined.
 use reth_botanix_lib::extra_data_header::ExtraDataHeader;
 use reth_consensus_common::{
-    utils::unix_timestamp,
+    utils::{get_authority_address_from_header, recovery_authority, unix_timestamp},
     validation::{self, validate_poa_header_standalone},
 };
 use reth_interfaces::{
@@ -246,14 +246,10 @@ where
             .expect("header to exist")
             .and_then(|parent| parent.next_block_base_fee(chain_spec.base_fee_params(timestamp)));
 
-        // derive beneficary address being the producuing block federation member address
-        let beneficiary_pub_key = secp256k1::PublicKey::from_secret_key(secp, sk);
-        let beneficiary_address = public_key_to_address(beneficiary_pub_key);
-
         let mut header = Header {
             parent_hash: best_hash,
             ommers_hash: EMPTY_OMMER_ROOT_HASH,
-            beneficiary: beneficiary_address,
+            beneficiary: Address::ZERO, // burn the block reward so not to increase ether supply
             state_root: Default::default(),
             transactions_root: Default::default(),
             receipts_root: Default::default(),
@@ -296,6 +292,7 @@ where
         executor: &mut EVMProcessor<'_, EvmConfig>,
         _senders: Vec<Address>,
         botanix_consensus_pkg: Option<BotanixConsensusPackage>,
+        block_builder_address: Option<Address>,
     ) -> Result<(BundleStateWithReceipts, u64), BlockExecutionError>
     where
         EvmConfig: ConfigureEvmEnv + Clone + 'static + reth_node_api::ConfigureEvm,
@@ -303,7 +300,7 @@ where
         // set the first block to find the correct index in bundle state
         executor.set_first_block(block.number);
 
-        let (receipts, gas_used) =
+        let (receipts, gas_used, total_block_fees) =
             executor.execute_transactions(block, U256::ZERO, botanix_consensus_pkg)?;
 
         // Save receipts.
@@ -311,7 +308,12 @@ where
 
         // add post execution state change
         // Withdrawals, rewards etc.
-        executor.apply_post_execution_state_change(block, U256::ZERO)?;
+        executor.apply_post_execution_state_change(
+            block,
+            U256::ZERO,
+            Some(total_block_fees),
+            block_builder_address,
+        )?;
 
         // merge transitions
         executor.db_mut().merge_transitions(BundleRetention::Reverts);
@@ -433,11 +435,15 @@ where
 
         let mut executor = EVMProcessor::new_with_state(chain_spec.clone(), db, evm_config);
 
+        // derive block builder address to receive block fees
+        let block_builder_pub_key = secp256k1::PublicKey::from_secret_key(secp, sk);
+        let block_builder_address = public_key_to_address(block_builder_pub_key);
         let (bundle_state, gas_used) = self.execute(
             &block_with_senders,
             &mut executor,
             senders,
             botanix_consensus_pkg.clone(),
+            Some(block_builder_address),
         )?;
         Ok((bundle_state, block, gas_used))
     }
@@ -538,9 +544,7 @@ where
             BlockWithSenders::new(sealed_block.clone().unseal(), senders.clone())
                 .expect("senders are valid");
 
-        let (bundle_state, _gas_used) =
-            self.execute(&block_with_senders, &mut executor, senders, botanix_consensus_pkg)?;
-
+        // validate before executing block
         let authority_signers = self.authorities.clone();
         validate_poa_header_standalone(&sealed_block.header.clone(), &authority_signers).map_err(
             |e| {
@@ -548,6 +552,15 @@ where
                 // TODO(armins) return more expressive error
                 BlockExecutionError::Validation(BlockValidationError::InvalidExtraData)
             },
+        )?;
+
+        let block_builder_address = get_authority_address_from_header(&sealed_block.header.clone());
+        let (bundle_state, _gas_used) = self.execute(
+            &block_with_senders,
+            &mut executor,
+            senders,
+            botanix_consensus_pkg,
+            Some(block_builder_address),
         )?;
 
         Ok(bundle_state)

--- a/crates/consensus/auto-seal/src/lib.rs
+++ b/crates/consensus/auto-seal/src/lib.rs
@@ -329,14 +329,14 @@ impl StorageInner {
         // set the first block to find the correct index in bundle state
         executor.set_first_block(block.number);
 
-        let (receipts, gas_used) = executor.execute_transactions(block, U256::ZERO, None)?;
+        let (receipts, gas_used, _total_block_fees) = executor.execute_transactions(block, U256::ZERO, None)?;
 
         // Save receipts.
         executor.save_receipts(receipts)?;
 
         // add post execution state change
         // Withdrawals, rewards etc.
-        executor.apply_post_execution_state_change(block, U256::ZERO)?;
+        executor.apply_post_execution_state_change(block, U256::ZERO, None, None)?;
 
         // merge transitions
         executor.db_mut().merge_transitions(BundleRetention::Reverts);

--- a/crates/consensus/common/src/utils.rs
+++ b/crates/consensus/common/src/utils.rs
@@ -323,6 +323,14 @@ pub fn validate_inturn(
     Ok(())
 }
 
+/// Calculate the block reward split between botanix and the beneficiary
+pub fn block_reward_split(base_block_reward: u128) -> (u128, u128) {
+    // 20% of the block reward
+    let botanix_reward = base_block_reward / 5;
+    let beneficiary_reward = base_block_reward - botanix_reward;
+    (botanix_reward, beneficiary_reward)
+}
+
 mod tests {
     use std::str::FromStr;
 
@@ -672,5 +680,13 @@ mod tests {
             ]
         )
         .is_err());
+    }
+
+    #[test]
+    fn should_split_rewards() {
+        let base_block_reward = 100;
+        let (botanix_reward, beneficiary_reward) = block_reward_split(base_block_reward);
+        assert_eq!(botanix_reward, 20);
+        assert_eq!(beneficiary_reward, 80);
     }
 }

--- a/crates/consensus/common/src/utils.rs
+++ b/crates/consensus/common/src/utils.rs
@@ -550,6 +550,15 @@ mod tests {
     }
 
     #[test]
+    fn should_fail_validate_poa_block_beneficiary() {
+        let mut header = Header::default();
+        header.beneficiary = Address::from_str("0x4e0f6e05C8ca4b3dc2B7b7Ad6249B149b1980394").unwrap();
+        let result = validate_poa_block_beneficiary(&header);
+        assert!(result.is_err());
+    }
+
+
+    #[test]
     fn validate_against_parent_skip_gensis() {
         let mut parent = Header::default();
         parent.number = 0;

--- a/crates/consensus/common/src/utils.rs
+++ b/crates/consensus/common/src/utils.rs
@@ -324,7 +324,7 @@ pub fn validate_inturn(
 
 // not in authority utils because of circular dependency
 /// Get the authority address from the header
-pub fn get_authority_address_from_header(header: &Header) -> Address {
+pub fn get_block_producer_address(header: &Header) -> Address {
     let block_builder_public_key = recovery_authority(header).expect("recovered authority");
     public_key_to_address(block_builder_public_key)
 }
@@ -706,11 +706,11 @@ mod tests {
     }
 
     #[test]
-    fn should_get_authority_address_from_header() {
+    fn should_get_block_producer_address_from_header() {
         let mut header = Header::default();
         sign_block_helper(&mut header, None);
         let edh = ExtraDataHeader::deserialize(&mut header.extra_data.to_vec().as_slice()).unwrap();
-        let authority_address = get_authority_address_from_header(&header);
-        assert_eq!(authority_address, public_key_to_address(edh.authority_signers.unwrap()[0]));
+        let block_producer_address = get_block_producer_address(&header);
+        assert_eq!(block_producer_address, public_key_to_address(edh.authority_signers.unwrap()[0]));
     }
 }

--- a/crates/consensus/common/src/utils.rs
+++ b/crates/consensus/common/src/utils.rs
@@ -185,12 +185,11 @@ pub fn unix_timestamp() -> u64 {
 /// Validate poa block beneficiary
 pub fn validate_poa_block_beneficiary(
     header: &Header,
-    authority_signers: &[secp256k1::PublicKey],
 ) -> Result<(), ConsensusError> {
-    authority_signers
-        .iter()
-        .find(|pk| public_key_to_address(**pk) == header.beneficiary)
-        .ok_or(ConsensusError::BlockBeneficiaryIsNotAuthority)?;
+    if header.beneficiary != Address::ZERO {
+        return Err(ConsensusError::BlockBeneficiaryIsNotBurnAddress);
+    }
+
     Ok(())
 }
 
@@ -323,11 +322,18 @@ pub fn validate_inturn(
     Ok(())
 }
 
+// not in authority utils because of circular dependency
+/// Get the authority address from the header
+pub fn get_authority_address_from_header(header: &Header) -> Address {
+    let block_builder_public_key = recovery_authority(header).expect("recovered authority");
+    public_key_to_address(block_builder_public_key)
+}
+// not in authority utils because of circular dependency
 /// Calculate the block reward split between botanix and the beneficiary
-pub fn block_reward_split(base_block_reward: u128) -> (u128, u128) {
+pub fn block_fees_split(total_block_fees: u128) -> (u128, u128) {
     // 20% of the block reward
-    let botanix_reward = base_block_reward / 5;
-    let beneficiary_reward = base_block_reward - botanix_reward;
+    let botanix_reward = total_block_fees / 5;
+    let beneficiary_reward = total_block_fees - botanix_reward;
     (botanix_reward, beneficiary_reward)
 }
 
@@ -536,6 +542,15 @@ mod tests {
     }
 
     #[test]
+    fn should_validate_poa_block_beneficiary() {
+        // default beneficiary is the burn address
+        let header = Header::default();
+        let result = validate_poa_block_beneficiary(&header);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    #[ignore = "deprecated"]
     fn should_fail_on_unlisted_poa_beneficiary() {
         let auth_signer1 = secp256k1::PublicKey::from_secret_key(
             &secp256k1::Secp256k1::new(),
@@ -563,13 +578,13 @@ mod tests {
             secp256k1::PublicKey::from_secret_key(&secp256k1::Secp256k1::new(), &secret_key);
         let beneficiary_address = public_key_to_address(beneficiary_pub_key);
         header.beneficiary = beneficiary_address;
-        assert!(validate_poa_block_beneficiary(&header, &authority_signers).is_err());
+        // assert!(validate_poa_block_beneficiary(&header, &authority_signers).is_err());
 
         // test good signer
         let mut header = Header::default();
         let beneficiary_address = public_key_to_address(auth_signer2);
         header.beneficiary = beneficiary_address;
-        assert!(validate_poa_block_beneficiary(&header, &authority_signers).is_ok());
+        // assert!(validate_poa_block_beneficiary(&header, &authority_signers).is_ok());
     }
 
     #[test]
@@ -685,8 +700,17 @@ mod tests {
     #[test]
     fn should_split_rewards() {
         let base_block_reward = 100;
-        let (botanix_reward, beneficiary_reward) = block_reward_split(base_block_reward);
+        let (botanix_reward, beneficiary_reward) = block_fees_split(base_block_reward);
         assert_eq!(botanix_reward, 20);
         assert_eq!(beneficiary_reward, 80);
+    }
+
+    #[test]
+    fn should_get_authority_address_from_header() {
+        let mut header = Header::default();
+        sign_block_helper(&mut header, None);
+        let edh = ExtraDataHeader::deserialize(&mut header.extra_data.to_vec().as_slice()).unwrap();
+        let authority_address = get_authority_address_from_header(&header);
+        assert_eq!(authority_address, public_key_to_address(edh.authority_signers.unwrap()[0]));
     }
 }

--- a/crates/consensus/common/src/utils.rs
+++ b/crates/consensus/common/src/utils.rs
@@ -550,44 +550,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "deprecated"]
-    fn should_fail_on_unlisted_poa_beneficiary() {
-        let auth_signer1 = secp256k1::PublicKey::from_secret_key(
-            &secp256k1::Secp256k1::new(),
-            &secp256k1::SecretKey::from_str(
-                "1aabc5cc52b62b570dc69001f1ab49cd1a7056bf6312fe058f094135f2c9b019",
-            )
-            .unwrap(),
-        );
-        let auth_signer2 = secp256k1::PublicKey::from_secret_key(
-            &secp256k1::Secp256k1::new(),
-            &secp256k1::SecretKey::from_str(
-                "1bc1f5cc52b62b570dc69001f1ab49cd1a7056bf6312fe058f094135f2c9b019",
-            )
-            .unwrap(),
-        );
-        let authority_signers = vec![auth_signer1, auth_signer2];
-
-        // test bad signer
-        let mut header = Header::default();
-        let secret_key = secp256k1::SecretKey::from_str(
-            "4646464646464646464646464646464646464646464646464646464646464646",
-        )
-        .unwrap();
-        let beneficiary_pub_key =
-            secp256k1::PublicKey::from_secret_key(&secp256k1::Secp256k1::new(), &secret_key);
-        let beneficiary_address = public_key_to_address(beneficiary_pub_key);
-        header.beneficiary = beneficiary_address;
-        // assert!(validate_poa_block_beneficiary(&header, &authority_signers).is_err());
-
-        // test good signer
-        let mut header = Header::default();
-        let beneficiary_address = public_key_to_address(auth_signer2);
-        header.beneficiary = beneficiary_address;
-        // assert!(validate_poa_block_beneficiary(&header, &authority_signers).is_ok());
-    }
-
-    #[test]
     fn validate_against_parent_skip_gensis() {
         let mut parent = Header::default();
         parent.number = 0;

--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -344,7 +344,7 @@ pub fn validate_poa_header_standalone(
     utils::validate_poa_extra_data_header(header, authority_signers)?;
 
     // Validate fee benificiary
-    utils::validate_poa_block_beneficiary(header, authority_signers)?;
+    utils::validate_poa_block_beneficiary(header)?;
 
     // Validate signer is in turn
     utils::validate_inturn(header, authority_signers)?;

--- a/crates/interfaces/src/consensus.rs
+++ b/crates/interfaces/src/consensus.rs
@@ -102,6 +102,9 @@ pub enum ConsensusError {
     /// PoA specific: block beneficiary is not an authority
     #[error("block beneficiary is not an authority")]
     BlockBeneficiaryIsNotAuthority,
+    /// PoA specific: block beneficiary is not the burn address
+    #[error("block beneficiary is not the burn address")]
+    BlockBeneficiaryIsNotBurnAddress,
     /// Error when the hash of block ommer is different from the expected hash.
     #[error("mismatched block ommer hash: {0}")]
     BodyOmmersHashDiff(GotExpectedBoxed<B256>),

--- a/crates/primitives/src/constants/mod.rs
+++ b/crates/primitives/src/constants/mod.rs
@@ -200,6 +200,10 @@ pub const SIGNET_PEGIN_CONFIRMATION_DEPTH: u32 = 1;
 /// Mainnet required confirmation depth for pegins
 pub const MAINNET_PEGIN_CONFIRMATION_DEPTH: u32 = 100;
 
+// TODO: replace with actual botanix address: using placeholder address for testing purposes
+/// The address that receives the botanix block fees.
+pub const BOTANIX_FEES_RECIPIENT: &str = "0x4e0f6e05C8ca4b3dc2B7b7Ad6249B149b1980394";
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/primitives/src/constants/mod.rs
+++ b/crates/primitives/src/constants/mod.rs
@@ -200,9 +200,8 @@ pub const SIGNET_PEGIN_CONFIRMATION_DEPTH: u32 = 1;
 /// Mainnet required confirmation depth for pegins
 pub const MAINNET_PEGIN_CONFIRMATION_DEPTH: u32 = 100;
 
-// TODO: replace with actual botanix address: using placeholder address for testing purposes
-/// The address that receives the botanix block fees.
-pub const BOTANIX_FEES_RECIPIENT: &str = "0x4e0f6e05C8ca4b3dc2B7b7Ad6249B149b1980394";
+/// The address that receives the botanix block fees which is a federation member.
+pub const BOTANIX_FEES_RECIPIENT: &str = "0xb8c03cb8C9bAC79c53926E3C66344C13452105f5";
 
 #[cfg(test)]
 mod tests {

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -377,8 +377,9 @@ impl Transaction {
         let fee = max_fee_per_gas - base_fee;
 
         // Compare the fee with max_priority_fee_per_gas (or gas price for non-EIP1559 transactions)
+        // NOTE: Include the base fee so it's not burned
         if let Some(priority_fee) = self.max_priority_fee_per_gas() {
-            Some(fee.min(priority_fee))
+            Some(fee.min(priority_fee) + base_fee)
         } else {
             Some(fee)
         }

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -7,6 +7,7 @@ use crate::{
 use reth_botanix_lib::mint_validation::{
     parse_pegin_topic, parse_pegout_topic, BURN_TOPIC, MINT_CONTRACT_ADDRESS, MINT_TOPIC,
 };
+use reth_consensus_common::utils::get_authority_address_from_header;
 use reth_interfaces::executor::{BlockExecutionError, BlockValidationError};
 use reth_node_api::ConfigureEvm;
 use reth_primitives::{
@@ -212,6 +213,8 @@ where
         &mut self,
         block: &Block,
         total_difficulty: U256,
+        total_block_fees: Option<u128>,
+        block_builder_address: Option<Address>,
     ) -> Result<(), BlockExecutionError> {
         let mut balance_increments = post_block_balance_increments(
             &self.chain_spec,
@@ -222,6 +225,8 @@ where
             total_difficulty,
             &block.ommers,
             block.withdrawals.as_ref().map(Withdrawals::as_ref),
+            total_block_fees,
+            block_builder_address,
         );
 
         // Irregular state change at Ethereum DAO hardfork
@@ -380,7 +385,7 @@ where
     ) -> Result<Vec<Receipt>, BlockExecutionError> {
         self.init_env(&block.header, total_difficulty);
         self.apply_beacon_root_contract_call(block)?;
-        let (receipts, cumulative_gas_used) =
+        let (receipts, cumulative_gas_used, total_block_fees) =
             self.execute_transactions(block, total_difficulty, botanix_consensus_pkg)?;
 
         // Check if gas used matches the value set in header.
@@ -393,7 +398,13 @@ where
             .into());
         }
         let time = Instant::now();
-        self.apply_post_execution_state_change(block, total_difficulty)?;
+        let block_builder_address = get_authority_address_from_header(&block.header.clone());
+        self.apply_post_execution_state_change(
+            block,
+            total_difficulty,
+            Some(total_block_fees),
+            Some(block_builder_address),
+        )?;
         self.stats.apply_post_execution_state_changes_duration += time.elapsed();
 
         let time = Instant::now();
@@ -401,8 +412,8 @@ where
             !self
                 .prune_modes
                 .account_history
-                .map_or(false, |mode| mode.should_prune(block.number, tip)) &&
-                !self
+                .map_or(false, |mode| mode.should_prune(block.number, tip))
+                && !self
                     .prune_modes
                     .storage_history
                     .map_or(false, |mode| mode.should_prune(block.number, tip))
@@ -535,16 +546,18 @@ where
         block: &BlockWithSenders,
         total_difficulty: U256,
         botanix_consensus_pkg: Option<BotanixConsensusPackage>,
-    ) -> Result<(Vec<Receipt>, u64), BlockExecutionError> {
+    ) -> Result<(Vec<Receipt>, u64, u128), BlockExecutionError> {
         self.init_env(&block.header, total_difficulty);
 
         // perf: do not execute empty blocks
         if block.body.is_empty() {
-            return Ok((Vec::new(), 0));
+            return Ok((Vec::new(), 0, 0));
         }
 
         let mut cumulative_gas_used = 0;
         let mut receipts = Vec::with_capacity(block.body.len());
+        let base_fee = block.base_fee_per_gas;
+        let mut total_block_fees = 0_u128;
         for (sender, transaction) in block.transactions_with_sender() {
             let time = Instant::now();
             // The sum of the transaction’s gas limit, Tg, and the gas utilized in this block prior,
@@ -568,6 +581,13 @@ where
             self.stats.execution_duration += time.elapsed();
             let time = Instant::now();
 
+            // calclaute the total block fees
+            let recovered_transaction =
+                transaction.clone().try_into_ecrecovered().expect("transaction is signed");
+            let transaction_fee =
+                recovered_transaction.effective_tip_per_gas(base_fee).expect("base fee is valid");
+            total_block_fees += transaction_fee * u128::from(result.gas_used());
+
             self.db_mut().commit(state);
 
             self.stats.apply_state_duration += time.elapsed();
@@ -587,7 +607,7 @@ where
             });
         }
 
-        Ok((receipts, cumulative_gas_used))
+        Ok((receipts, cumulative_gas_used, total_block_fees))
     }
 
     fn take_output_state(&mut self) -> BundleStateWithReceipts {

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -7,7 +7,7 @@ use crate::{
 use reth_botanix_lib::mint_validation::{
     parse_pegin_topic, parse_pegout_topic, BURN_TOPIC, MINT_CONTRACT_ADDRESS, MINT_TOPIC,
 };
-use reth_consensus_common::utils::get_authority_address_from_header;
+use reth_consensus_common::utils::get_block_producer_address;
 use reth_interfaces::executor::{BlockExecutionError, BlockValidationError};
 use reth_node_api::ConfigureEvm;
 use reth_primitives::{
@@ -398,7 +398,7 @@ where
             .into());
         }
         let time = Instant::now();
-        let block_builder_address = get_authority_address_from_header(&block.header.clone());
+        let block_builder_address = get_block_producer_address(&block.header.clone());
         self.apply_post_execution_state_change(
             block,
             total_difficulty,

--- a/crates/revm/src/state_change.rs
+++ b/crates/revm/src/state_change.rs
@@ -1,7 +1,7 @@
-use reth_consensus_common::calc;
+use reth_consensus_common::{calc, utils};
 use reth_interfaces::executor::{BlockExecutionError, BlockValidationError};
 use reth_primitives::{
-    constants::SYSTEM_ADDRESS, revm::env::fill_tx_env_with_beacon_root_contract_call, Address,
+    Block, constants::SYSTEM_ADDRESS, revm::env::fill_tx_env_with_beacon_root_contract_call, Address,
     ChainSpec, Header, Withdrawal, B256, U256,
 };
 use revm::{interpreter::Host, Database, DatabaseCommit, Evm};
@@ -36,8 +36,12 @@ pub fn post_block_balance_increments(
         }
 
         // Full block reward
-        *balance_increments.entry(beneficiary).or_default() +=
-            calc::block_reward(base_block_reward, ommers.len());
+        let base_block_reward = calc::block_reward(base_block_reward, ommers.len());
+        let (botanix_reward, beneficiary_reward) = utils::block_reward_split(base_block_reward);
+        // TODO: remove placeholder botanix address with actual address
+        let botanix_address_placeholder = Address::random();
+        *balance_increments.entry(botanix_address_placeholder).or_default() += botanix_reward;
+        *balance_increments.entry(beneficiary).or_default() += beneficiary_reward;
     }
 
     // process withdrawals

--- a/crates/revm/src/state_change.rs
+++ b/crates/revm/src/state_change.rs
@@ -1,11 +1,12 @@
 use reth_consensus_common::{calc, utils};
 use reth_interfaces::executor::{BlockExecutionError, BlockValidationError};
 use reth_primitives::{
-    Block, constants::SYSTEM_ADDRESS, revm::env::fill_tx_env_with_beacon_root_contract_call, Address,
-    ChainSpec, Header, Withdrawal, B256, U256,
+    constants::{BOTANIX_FEES_RECIPIENT, SYSTEM_ADDRESS},
+    revm::env::fill_tx_env_with_beacon_root_contract_call,
+    Address, ChainSpec, Header, Withdrawal, B256, U256,
 };
 use revm::{interpreter::Host, Database, DatabaseCommit, Evm};
-use std::collections::HashMap;
+use std::{collections::HashMap, str::FromStr};
 
 /// Collect all balance changes at the end of the block.
 ///
@@ -22,6 +23,8 @@ pub fn post_block_balance_increments(
     total_difficulty: U256,
     ommers: &[Header],
     withdrawals: Option<&[Withdrawal]>,
+    total_block_fees: Option<u128>,
+    block_builder_address: Option<Address>,
 ) -> HashMap<Address, u128> {
     let mut balance_increments = HashMap::new();
 
@@ -36,13 +39,20 @@ pub fn post_block_balance_increments(
         }
 
         // Full block reward
-        let base_block_reward = calc::block_reward(base_block_reward, ommers.len());
-        let (botanix_reward, beneficiary_reward) = utils::block_reward_split(base_block_reward);
-        // TODO: remove placeholder botanix address with actual address
-        let botanix_address_placeholder = Address::random();
-        *balance_increments.entry(botanix_address_placeholder).or_default() += botanix_reward;
-        *balance_increments.entry(beneficiary).or_default() += beneficiary_reward;
+        *balance_increments.entry(beneficiary).or_default() +=
+            calc::block_reward(base_block_reward, ommers.len());
     }
+
+    // split block fees between builder and botanix
+    let (botanix_fees, builder_fees) =
+        utils::block_fees_split(total_block_fees.expect("Total block fees to exist"));
+
+    *balance_increments
+        .entry(Address::from_str(BOTANIX_FEES_RECIPIENT).expect("Recipient to exist"))
+        .or_default() += botanix_fees;
+    *balance_increments
+        .entry(block_builder_address.expect("Block builder address to exist"))
+        .or_default() += builder_fees;
 
     // process withdrawals
     insert_post_block_withdrawals_balance_increments(
@@ -72,7 +82,7 @@ where
     DB::Error: std::fmt::Display,
 {
     if !chain_spec.is_cancun_active_at_timestamp(block_timestamp) {
-        return Ok(())
+        return Ok(());
     }
 
     let parent_beacon_block_root =
@@ -85,9 +95,9 @@ where
             return Err(BlockValidationError::CancunGenesisParentBeaconBlockRootNotZero {
                 parent_beacon_block_root,
             }
-            .into())
+            .into());
         }
-        return Ok(())
+        return Ok(());
     }
 
     // get previous env
@@ -104,7 +114,7 @@ where
                 parent_beacon_block_root: Box::new(parent_beacon_block_root),
                 message: e.to_string(),
             }
-            .into())
+            .into());
         }
     };
 

--- a/crates/storage/provider/src/test_utils/executor.rs
+++ b/crates/storage/provider/src/test_utils/executor.rs
@@ -44,7 +44,7 @@ impl BlockExecutor for TestExecutor {
         _block: &BlockWithSenders,
         _total_difficulty: U256,
         _botanix_consenusus_pkg: Option<BotanixConsensusPackage>,
-    ) -> Result<(Vec<Receipt>, u64), BlockExecutionError> {
+    ) -> Result<(Vec<Receipt>, u64, u128), BlockExecutionError> {
         Err(BlockExecutionError::UnavailableForTest)
     }
 

--- a/crates/storage/provider/src/traits/executor.rs
+++ b/crates/storage/provider/src/traits/executor.rs
@@ -59,7 +59,7 @@ pub trait BlockExecutor {
         block: &BlockWithSenders,
         total_difficulty: U256,
         botanix_consensus_pkg: Option<BotanixConsensusPackage>,
-    ) -> Result<(Vec<Receipt>, u64), BlockExecutionError>;
+    ) -> Result<(Vec<Receipt>, u64, u128), BlockExecutionError>;
 
     /// Return bundle state. This is output of executed blocks.
     fn take_output_state(&mut self) -> BundleStateWithReceipts;


### PR DESCRIPTION
currently using a placeholder address for botanix...will replace with actual once we have it

Overview of how fees work now:

1. Transaction fees are sent to the beneficiary address (revm sets coinbase address to beneficiary) during tx execution.
2. After block execution and during post state updates, block rewards are sent to the beneficiary.
3. Since the beneficiary is set to the burn address of 0x0..., all fees and rewards are burned
4. At this point, Botanix is deflationary: tx fees paid by senders have been burned.
5. `processor.execute` has been refactored to determine the total block fees as it executes txs (`best_transactions_from_payload` does this and I used this as reference)
6. During post state checks/updates, `apply_post_execution_state_change` has been refactored to accept the `total_block_fees`
7. The above method calls `post_block_balance_increments` which has been refactored to split `total_block_fees` between botanix and the block builder and update/commit their new balances.
8. At this point, Botanix is back to it's exact peg of 21million since the previously burned fees have been added to botanix and the block builder accounts.
9. `test_block_builder` has been refactored to assert that block fees are split correctly.
10. Have tested manually as well.

![Screenshot 2024-04-17 at 1 47 14 PM (3)](https://github.com/botanix-labs/Macbeth/assets/22253830/fb4578c6-1dc0-4673-8758-ff87816359c3)


