### PR TITLE
fix: only apply botanix block producer fee split if one is provided

### DIFF
--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -386,7 +386,7 @@ where
         self.init_env(&block.header, total_difficulty);
         self.apply_beacon_root_contract_call(block)?;
         let (receipts, cumulative_gas_used, total_block_fees) =
-            self.execute_transactions(block, total_difficulty, botanix_consensus_pkg)?;
+            self.execute_transactions(block, total_difficulty, botanix_consensus_pkg.clone())?;
 
         // Check if gas used matches the value set in header.
         if block.gas_used != cumulative_gas_used {
@@ -398,12 +398,16 @@ where
             .into());
         }
         let time = Instant::now();
-        let block_builder_address = get_block_producer_address(&block.header.clone());
+        let block_builder_address = if botanix_consensus_pkg.is_some() {
+            Some(get_block_producer_address(&block.header.clone()))
+        } else {
+            None
+        };
         self.apply_post_execution_state_change(
             block,
             total_difficulty,
             Some(total_block_fees),
-            Some(block_builder_address),
+            block_builder_address,
         )?;
         self.stats.apply_post_execution_state_changes_duration += time.elapsed();
 

--- a/crates/revm/src/state_change.rs
+++ b/crates/revm/src/state_change.rs
@@ -43,16 +43,16 @@ pub fn post_block_balance_increments(
             calc::block_reward(base_block_reward, ommers.len());
     }
 
-    // split block fees between builder and botanix
-    let (botanix_fees, builder_fees) =
-        utils::block_fees_split(total_block_fees.expect("Total block fees to exist"));
+    if let Some(block_producer) = block_builder_address {
+        // split block fees between builder and botanix
+        let (botanix_fees, builder_fees) =
+            utils::block_fees_split(total_block_fees.expect("Total block fees to exist"));
 
-    *balance_increments
-        .entry(Address::from_str(BOTANIX_FEES_RECIPIENT).expect("Recipient to exist"))
-        .or_default() += botanix_fees;
-    *balance_increments
-        .entry(block_builder_address.expect("Block builder address to exist"))
-        .or_default() += builder_fees;
+        *balance_increments
+            .entry(Address::from_str(BOTANIX_FEES_RECIPIENT).expect("Recipient to exist"))
+            .or_default() += botanix_fees;
+        *balance_increments.entry(block_producer).or_default() += builder_fees;
+    }
 
     // process withdrawals
     insert_post_block_withdrawals_balance_increments(


### PR DESCRIPTION
Ef state tests are failing b/c block_builder_address is expected to exist but outside PoA consensus it will not