### PR TITLE
Always do fee split

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Run tests
         run: |
-          /home/runner/.cargo/bin/cargo nextest run \
+          /home/runner/.cargo/bin/cargo test run \
             --locked --features "ethereum" \
             --workspace --exclude examples --exclude ef-tests \
             -E "kind(lib) | kind(bin) | kind(proc-macro)"

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Run tests
         run: |
-          /home/runner/.cargo/bin/cargo test run \
+          /home/runner/.cargo/bin/cargo nextest run \
             --locked --features "ethereum" \
             --workspace --exclude examples --exclude ef-tests \
             -E "kind(lib) | kind(bin) | kind(proc-macro)"

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -582,10 +582,8 @@ where
             let time = Instant::now();
 
             // calclaute the total block fees
-            let recovered_transaction =
-                transaction.clone().try_into_ecrecovered().expect("transaction is signed");
             let transaction_fee =
-                recovered_transaction.effective_tip_per_gas(base_fee).expect("base fee is valid");
+                transaction.clone().effective_tip_per_gas(base_fee).expect("base fee is valid");
             total_block_fees += transaction_fee * u128::from(result.gas_used());
 
             self.db_mut().commit(state);

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -386,7 +386,7 @@ where
         self.init_env(&block.header, total_difficulty);
         self.apply_beacon_root_contract_call(block)?;
         let (receipts, cumulative_gas_used, total_block_fees) =
-            self.execute_transactions(block, total_difficulty, botanix_consensus_pkg.clone())?;
+            self.execute_transactions(block, total_difficulty, botanix_consensus_pkg)?;
 
         // Check if gas used matches the value set in header.
         if block.gas_used != cumulative_gas_used {
@@ -398,16 +398,12 @@ where
             .into());
         }
         let time = Instant::now();
-        let block_builder_address = if botanix_consensus_pkg.is_some() {
-            Some(get_block_producer_address(&block.header.clone()))
-        } else {
-            None
-        };
+        let block_builder_address = get_block_producer_address(&block.header.clone());
         self.apply_post_execution_state_change(
             block,
             total_difficulty,
             Some(total_block_fees),
-            block_builder_address,
+            Some(block_builder_address),
         )?;
         self.stats.apply_post_execution_state_changes_duration += time.elapsed();
 
@@ -586,8 +582,10 @@ where
             let time = Instant::now();
 
             // calclaute the total block fees
+            let recovered_transaction =
+                transaction.clone().try_into_ecrecovered().expect("transaction is signed");
             let transaction_fee =
-                transaction.clone().effective_tip_per_gas(base_fee).expect("base fee is valid");
+                recovered_transaction.effective_tip_per_gas(base_fee).expect("base fee is valid");
             total_block_fees += transaction_fee * u128::from(result.gas_used());
 
             self.db_mut().commit(state);

--- a/crates/revm/src/state_change.rs
+++ b/crates/revm/src/state_change.rs
@@ -43,16 +43,16 @@ pub fn post_block_balance_increments(
             calc::block_reward(base_block_reward, ommers.len());
     }
 
-    if let Some(block_producer) = block_builder_address {
-        // split block fees between builder and botanix
-        let (botanix_fees, builder_fees) =
-            utils::block_fees_split(total_block_fees.expect("Total block fees to exist"));
+    // split block fees between builder and botanix
+    let (botanix_fees, builder_fees) =
+        utils::block_fees_split(total_block_fees.expect("Total block fees to exist"));
 
-        *balance_increments
-            .entry(Address::from_str(BOTANIX_FEES_RECIPIENT).expect("Recipient to exist"))
-            .or_default() += botanix_fees;
-        *balance_increments.entry(block_producer).or_default() += builder_fees;
-    }
+    *balance_increments
+        .entry(Address::from_str(BOTANIX_FEES_RECIPIENT).expect("Recipient to exist"))
+        .or_default() += botanix_fees;
+    *balance_increments
+        .entry(block_builder_address.expect("Block builder address to exist"))
+        .or_default() += builder_fees;
 
     // process withdrawals
     insert_post_block_withdrawals_balance_increments(


### PR DESCRIPTION
this rolls back the changes from this commit https://github.com/botanix-labs/Macbeth/pull/169/commits/667af13df001a8aeb0c4405c757b5e6fc07e106e

we always need to split block fees between Botanix and block producer
this will break state tests bc they never expect the 80/20 split

can discuss refactoring state tests