### PR TITLE
fix typo on reth-node workflow file

### DIFF
--- a/.github/workflows/deploy-reth-node-v1.yml
+++ b/.github/workflows/deploy-reth-node-v1.yml
@@ -2,7 +2,8 @@ name: Build, Tag, and Deploy Docker Reth Node v1 Image to GCP
 
 on:
   pull_request:
-    branches: [feature/poA-consenus]
+    branches: 
+      - feature/poA-consensus
     types: [closed]
 
 jobs:


### PR DESCRIPTION
Reth Deployment workflow file had a typo in the consensus spelling which made it dormant on merges to `poA/consensus` branch