### PR TITLE
test-suite: Move abigen invocation into build.rs

### DIFF
--- a/bin/test-suite/Cargo.toml
+++ b/bin/test-suite/Cargo.toml
@@ -79,6 +79,9 @@ rand = "0.8.5"
 [dev-dependencies]
 pretty_assertions = "1.3.0"
 
+[build-dependencies]
+ethers = "2.0.11"
+
 [features]
 default = ["tests"]
 tests = []

--- a/bin/test-suite/build.rs
+++ b/bin/test-suite/build.rs
@@ -1,0 +1,11 @@
+use ethers::contract::Abigen;
+
+fn main() {
+    // generate contract abi
+    Abigen::new("MintContract", "mint_contract_abi.json")
+        .expect("Error reading mint contract json abi")
+        .generate()
+        .expect("Error generating mint contract rust defintions")
+        .write_to_file("./src/mint_contract_abi.rs")
+        .expect("Error writing mint contract rust file");
+}

--- a/bin/test-suite/src/bin/test-suite.rs
+++ b/bin/test-suite/src/bin/test-suite.rs
@@ -1,7 +1,6 @@
 #[macro_use]
 extern crate tracing;
 use anyhow::{anyhow, Context, Result};
-use ethers::contract::Abigen;
 use reth_tracing::{
     tracing_subscriber::filter::LevelFilter, LayerInfo, LogFormat, RethTracer, Tracer,
 };
@@ -14,14 +13,6 @@ use tokio::{
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 4)]
 async fn main() -> Result<()> {
-    // generate contract abi
-    Abigen::new("MintContract", "mint_contract_abi.json")
-        .expect("Error reading mint contract json abi")
-        .generate()
-        .expect("Error generating mint contract rust defintions")
-        .write_to_file("./src/mint_contract_abi.rs")
-        .expect("Error writing mint contract rust file");
-
     // init config
     dotenv::dotenv().ok();
     let cli_args: CliArgs = argh::from_env();

--- a/bin/test-suite/src/mint_contract_abi.rs
+++ b/bin/test-suite/src/mint_contract_abi.rs
@@ -10,11 +10,6 @@ pub use mint_contract::*;
     non_camel_case_types,
 )]
 pub mod mint_contract {
-    const _: () = {
-        ::core::include_bytes!(
-            "/home/evgeni/Documents/BOTANIX/Macbeth/bin/test-suite/mint_contract_abi.json",
-        );
-    };
     #[allow(deprecated)]
     fn __abi() -> ::ethers::core::abi::Abi {
         ::ethers::core::abi::ethabi::Contract {


### PR DESCRIPTION
Please as a review, verify that if you run cargo check or cargo build in the test-suite directory that it also doesn't change the `bin/test-suite/src/mint_contract_abi.rs` file.