### PR TITLE
479 chore improve setting signauture in edh interface

### DIFF
--- a/crates/primitives/src/extra_data_header.rs
+++ b/crates/primitives/src/extra_data_header.rs
@@ -149,12 +149,6 @@ impl ExtraDataHeader {
         }
     }
 
-    /// Set the authority signatures
-    pub fn set_signature(&mut self, signature: Vec<RecoverableSignature>) {
-        self.authority_signatures = Some(signature);
-        self.set_optional_fields_bitmask();
-    }
-
     /// Add a signature to the extra data header
     pub fn add_signature(&mut self, signature: RecoverableSignature) {
         let mut current_signatures = self.authority_signatures.clone().unwrap_or(vec![]);
@@ -645,23 +639,6 @@ mod tests {
         assert_eq!(deserialized_header.authority_signatures, None);
     }
 
-    #[test]
-    fn can_set_signature() {
-        let mut edh = ExtraDataHeader::default();
-
-        assert_eq!(edh.authority_signatures, None);
-        assert_eq!(edh.optional_fields, 0);
-        let secp = Secp256k1::new();
-        let (secret_key, _public_key) = secp.generate_keypair(&mut OsRng);
-
-        let hello_world_hash = sha256::Hash::hash("Hello world!".as_bytes());
-        let message = Message::from(hello_world_hash);
-        let signature = secp.sign_ecdsa_recoverable(&message, &secret_key);
-
-        edh.set_signature(vec![signature]);
-        assert_eq!(edh.authority_signatures.is_some(), true);
-        assert_eq!(edh.optional_fields, 1 << HAS_SIGNATURE_POS);
-    }
 
     #[test]
     fn can_add_individual_signature() {

--- a/crates/primitives/src/extra_data_header.rs
+++ b/crates/primitives/src/extra_data_header.rs
@@ -162,6 +162,20 @@ impl ExtraDataHeader {
         self.set_optional_fields_bitmask();
     }
 
+    /// Add multiple signatures to the extra data header
+    /// Will not add duplicates
+    pub fn add_signatures(&mut self, signatures: Vec<RecoverableSignature>) {
+        for sig in signatures {
+            self.add_signature(sig);
+        }
+    }
+
+    /// Removes signatures from the extra data header
+    pub fn clear_signatures(&mut self) {
+        self.authority_signatures = None;
+        self.set_optional_fields_bitmask();
+    }
+
     /// Set the optional fields bitmask based on the optional fields
     pub fn set_optional_fields_bitmask(&mut self) {
         let mut optional_fields = 0u8;
@@ -334,8 +348,7 @@ impl ExtraDataHeader {
                 set.push(*sig);
             }
 
-            self.authority_signatures = Some(set);
-            self.set_optional_fields_bitmask();
+            self.add_signatures(set);
         }
     }
 }
@@ -638,7 +651,6 @@ mod tests {
         assert_eq!(deserialized_header.authority_vote, None);
         assert_eq!(deserialized_header.authority_signatures, None);
     }
-
 
     #[test]
     fn can_add_individual_signature() {

--- a/crates/primitives/src/header.rs
+++ b/crates/primitives/src/header.rs
@@ -215,8 +215,7 @@ impl Header {
             // 2. signatures can be re-ordered without affecting the blockhash
             match this.deserialize_extra_data_header() {
                 Ok(mut extra_data) => {
-                    extra_data.authority_signatures = None;
-                    extra_data.set_optional_fields_bitmask();
+                    extra_data.clear_signatures();
 
                     // Update extra data without the signatures present in edh
                     this.add_extra_data_header(&extra_data);

--- a/crates/primitives/src/header_ext.rs
+++ b/crates/primitives/src/header_ext.rs
@@ -173,8 +173,7 @@ impl HeaderExt for Header {
         witness: BlockWitness,
     ) -> Result<(), ExtraDataHeaderDeserializeError> {
         let mut edh = self.deserialize_extra_data_header()?;
-        edh.authority_signatures = Some(witness);
-        edh.set_optional_fields_bitmask();
+        edh.add_signatures(witness);
         self.extra_data = Bytes::from(edh.serialize());
 
         Ok(())
@@ -190,8 +189,7 @@ impl HeaderExt for Header {
     fn segregated_signature_block_hash(&self) -> Result<B256, ExtraDataHeaderDeserializeError> {
         let mut this = self.clone();
         let mut edh = this.deserialize_extra_data_header()?;
-        edh.authority_signatures = None;
-        edh.set_optional_fields_bitmask();
+        edh.clear_signatures();
 
         let mut writer: Vec<u8> = vec![];
         edh.encode_into_without_signature(&mut writer).expect("Valid extra data header");
@@ -285,8 +283,7 @@ impl HeaderExt for Header {
     fn create_sighash(&self) -> Result<B256, ExtraDataHeaderDeserializeError> {
         let mut this = self.clone();
         let mut edh = this.deserialize_extra_data_header()?;
-        edh.authority_signatures = None;
-        edh.set_optional_fields_bitmask();
+        edh.clear_signatures();
 
         let mut writer: Vec<u8> = vec![];
         edh.encode_into_without_signature(&mut writer).expect("Valid extra data header");


### PR DESCRIPTION
The edh interface should require consumers to set the bitmask after setting specific fields. The two utility functions should aleviate that 