### PR TITLE
fix: handle updating state for all pegin/pegout reverts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7998,6 +7998,7 @@ dependencies = [
  "revm",
  "secp256k1 0.28.2",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -9095,6 +9096,7 @@ name = "reth-revm"
 version = "0.2.0-beta.6"
 dependencies = [
  "bitcoin",
+ "ethers",
  "reth-botanix-lib",
  "reth-consensus-common",
  "reth-evm",

--- a/bin/test-suite/src/suite/consensus/invalid_transactions/test_invalid_pegin.rs
+++ b/bin/test-suite/src/suite/consensus/invalid_transactions/test_invalid_pegin.rs
@@ -1,6 +1,6 @@
 use std::{str::FromStr, time::Duration};
 
-use bitcoin::{hashes::Hash, merkle_tree::PartialMerkleTree, Amount};
+use bitcoin::{hashes::Hash, merkle_tree::PartialMerkleTree, Amount, Txid};
 use bitcoincore_rpc::RpcApi;
 use ethers::{prelude::Provider, providers::Http};
 use reth_botanix_lib::{peg_contract::PeginMeta, utils::AmountExt};
@@ -184,7 +184,76 @@ pub async fn invalid_pegin(
     let nonce_before = botanix_eth_client.get_nonce(sender_address.clone()).await.unwrap();
     it_info_print!("Nonce before pegin", nonce_before);
 
-    it_info_print!("Sending invalid pegin transaction to mint contract");
+    it_info_print!("Sending invalid pegin with no headers to mint contract");
+    let tx_receipt = botanix_eth_client
+        .mint(
+            eth_destination.clone(),
+            amount,
+            bitcoin_block_height as u32,
+            metadata,
+            ethers::core::types::Address::random(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+    // status should be 0 (failure)
+    it_info_print!("Pegin Tx Receipt", tx_receipt);
+    assert!(tx_receipt.status.unwrap().is_zero());
+
+    // pegin address balance after pegin
+    let pegin_address_final_balance =
+        botanix_eth_client.get_botanix_balance(eth_pegin_address.as_str()).await.unwrap();
+    it_info_print!("Final pegin address balance", pegin_address_final_balance);
+
+    assert_eq!(pegin_address_initial_balance, pegin_address_final_balance);
+
+    // nonce after pegin
+    let nonce_after = botanix_eth_client.get_nonce(sender_address).await.unwrap();
+    it_info_print!("Nonce after pegin", nonce_after);
+
+    assert!(nonce_after > nonce_before);
+
+    // *************************************************** //
+
+    // create invalid pegin meta with invalid merkle proof
+    // this tests a different logic path in the mint event validation
+    let txid = Txid::all_zeros();
+    let pmt = PartialMerkleTree::from_txids(&[txid], &[true]);
+
+    let bitcoin_block_height = conf_block_info.height;
+    let meta = PeginMeta {
+        version: 0,
+        outpoint: bitcoin::OutPoint::new(pegin_tx.txid(), vout as u32),
+        address: eth_account.clone(),
+        aggregate_publickey: bitcoin::secp256k1::PublicKey::from_str(
+            gateway_address_response.aggregate_public_key.as_str(),
+        )
+        .expect("valid public key"),
+        tx: pegin_tx.clone(),
+        merkle_proof: pmt,
+        block_headers: headers,
+    };
+
+    // send the pegin transactions to all fed members
+    let serialized_pegin_meta = meta.serialize();
+    it_info_print!("Serialized pegin meta: ", hex::encode(serialized_pegin_meta.clone()));
+    let botanix_eth_client = mint_contract_instances.first().cloned().unwrap();
+    let metadata = ethers::core::types::Bytes::from(serialized_pegin_meta.clone());
+
+    // pegin address balance before pegin
+    let eth_pegin_address = eth_account.to_string();
+    let pegin_address_initial_balance =
+        botanix_eth_client.get_botanix_balance(eth_pegin_address.as_str()).await.unwrap();
+    it_info_print!("Initial pegin address balance", pegin_address_initial_balance);
+
+    // nonce before pegin
+    let sender_address = botanix_eth_client.get_sender_address();
+    it_info_print!("Sender address", sender_address);
+    let nonce_before = botanix_eth_client.get_nonce(sender_address.clone()).await.unwrap();
+    it_info_print!("Nonce before pegin", nonce_before);
+
+    it_info_print!("Sending invalid pegin with invalid pmt to mint contract");
     let tx_receipt = botanix_eth_client
         .mint(
             eth_destination.clone(),

--- a/bin/test-suite/src/suite/consensus/invalid_transactions/test_invalid_pegout.rs
+++ b/bin/test-suite/src/suite/consensus/invalid_transactions/test_invalid_pegout.rs
@@ -1,5 +1,9 @@
 use bitcoin::Amount;
 use reth_botanix_lib::utils::AmountExt;
+use reth_btc_wallet::address::EthAddress;
+use reth_cli_runner::CliRunner;
+use reth_primitives::Address;
+use std::time::Duration;
 
 use crate::{it_info_print, suite::consensus::ConsensusIntegrationTestSuite};
 
@@ -19,9 +23,22 @@ pub async fn invalid_pegout(
     let invalid_pegout_destination = ethers::core::types::Bytes::from(
         "invalid_pegout_destination".to_string().as_bytes().to_vec(),
     );
+
+    let sender_address = botanix_eth_client.get_sender_address();
+    let sender_address_string = Address::from_slice(sender_address.as_slice()).to_string();
+    // sender address balance before pegout
+    let mut sender_address_initial_balance =
+        botanix_eth_client.get_botanix_balance(sender_address_string.as_str()).await.unwrap();
+    it_info_print!("Sender address initial balance: ", sender_address_initial_balance);
+
+    // nonce before pegout
+    let nonce_before = botanix_eth_client.get_nonce(sender_address.clone()).await.unwrap();
+    it_info_print!("Nonce before pegout: ", nonce_before);
+
     // use empty pegout data
     let pegout_data = ethers::core::types::Bytes::new();
     let pegout_amount = Amount::from_btc(0.5).unwrap();
+    it_info_print!("Pegout amount: ", pegout_amount.to_wei());
     let tx_receipt = botanix_eth_client
         .burn(invalid_pegout_destination, pegout_data, pegout_amount.to_wei())
         .await
@@ -30,6 +47,24 @@ pub async fn invalid_pegout(
     it_info_print!("Pegout Tx Receipt: ", tx_receipt);
 
     assert!(tx_receipt.status.unwrap().is_zero());
+
+    // sender address balance after pegout
+    let sender_address_final_balance =
+        botanix_eth_client.get_botanix_balance(sender_address_string.as_str()).await.unwrap();
+    it_info_print!("Sender address final balance: ", sender_address_final_balance);
+
+    // subtract tx costs from initial balance
+    let tx_cost = tx_receipt.gas_used.unwrap() * tx_receipt.effective_gas_price.unwrap();
+    it_info_print!("Tx cost: ", tx_cost);
+    sender_address_initial_balance -= tx_cost;
+
+    assert_eq!(sender_address_initial_balance, sender_address_final_balance);
+
+    // nonce after pegout
+    let nonce_after = botanix_eth_client.get_nonce(sender_address.clone()).await.unwrap();
+    it_info_print!("Nonce after pegout: ", nonce_after);
+
+    assert!(nonce_after > nonce_before);
 
     Ok(())
 }

--- a/crates/botanix-lib/Cargo.toml
+++ b/crates/botanix-lib/Cargo.toml
@@ -19,7 +19,7 @@ lazy_static = "1.4.0"
 hex = "0.4.3"
 ethers = "2.0.9"
 ethabi = "18.0.0"
-
+tracing.workspace = true
 
 ## Reth
 reth-primitives.workspace = true

--- a/crates/botanix-lib/src/mint_validation.rs
+++ b/crates/botanix-lib/src/mint_validation.rs
@@ -9,6 +9,8 @@ use crate::{
     utils::AmountExt,
 };
 
+use tracing::error;
+
 lazy_static::lazy_static! {
     pub static ref MINT_TOPIC: B256 = keccak256("Mint(address,uint256,uint32,bytes)");
     pub static ref BURN_TOPIC: B256 = keccak256("Burn(address,uint256,bytes,bytes)");
@@ -35,6 +37,12 @@ impl TryFrom<B256> for GenesisContractEvents {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct PeginDataError {
+    // Pegin address and amount
+    pub pegin: (Address, ethers::types::U256),
+}
+
 #[derive(Debug)]
 pub enum MintConsensusError {
     UnexpectedLog(&'static str),
@@ -44,8 +52,12 @@ pub enum MintConsensusError {
     PegoutValidationFailed(PegoutError),
     RecentBlocksCannotBeEmpty(),
     LogParsingError(&'static str),
+    LogParsingBlockHeightError(PeginDataError),
+    LogParsingMetaDataError(PeginDataError),
+    LogParsingMintAmountError(&'static str),
     UintParsingError(&'static str),
-    FailedToConvertMetadataToBytes(),
+    FailedToConvertMetadataToBytes(PeginDataError),
+    FailedtoDeserialiseMetadata(PeginDataError),
     MintContractDidNotEmitMintTopic(),
     PegoutAmountIsInvalid(),
     InvalidPayloadFromLog(),
@@ -156,6 +168,8 @@ pub fn parse_pegin_topic(
             let destination = topic_to_address(log.topics()[1])?;
             let data = &log.data;
 
+            let pegin_data_error = PeginDataError { pegin: (destination, amount) };
+
             let decoded_params: Vec<ethers::abi::Token> = decode(
                 &[
                     ethers::abi::param_type::ParamType::Uint(256_usize),
@@ -168,7 +182,7 @@ pub fn parse_pegin_topic(
 
             let bitcoin_block_height = decoded_params
                 .get(1)
-                .ok_or(MintConsensusError::LogParsingError("Failed to parse bitcoin block height"))?
+                .ok_or(MintConsensusError::LogParsingBlockHeightError(pegin_data_error.clone()))?
                 .clone()
                 .into_uint()
                 .ok_or(MintConsensusError::UintParsingError(
@@ -178,17 +192,27 @@ pub fn parse_pegin_topic(
 
             let meta_bytes = decoded_params
                 .get(2)
-                .ok_or(MintConsensusError::LogParsingError("Failed to parse metadata"))?
+                .ok_or(MintConsensusError::LogParsingMetaDataError(pegin_data_error.clone()))?
                 .clone()
                 .into_bytes()
-                .ok_or(MintConsensusError::FailedToConvertMetadataToBytes())?;
+                .ok_or(MintConsensusError::FailedToConvertMetadataToBytes(
+                    pegin_data_error.clone(),
+                ))?;
 
             let meta = {
                 let mut proofs = Vec::new();
                 let mut offset = 0;
                 while offset < meta_bytes.len() {
                     let (proof, proof_size) = PeginMeta::deserialize(&meta_bytes[offset..])
-                        .map_err(MintConsensusError::InvalidMetadata)?;
+                        .map_err(|e| {
+                            error!(
+                                "Failed to parse pegin meta: {:?}",
+                                MintConsensusError::InvalidMetadata(e)
+                            );
+                            MintConsensusError::FailedtoDeserialiseMetadata(
+                                pegin_data_error.clone(),
+                            )
+                        })?;
                     proofs.push(proof);
                     offset += proof_size;
                 }

--- a/crates/botanix-lib/src/mint_validation.rs
+++ b/crates/botanix-lib/src/mint_validation.rs
@@ -39,8 +39,8 @@ impl TryFrom<B256> for GenesisContractEvents {
 
 #[derive(Debug, Clone)]
 pub struct PeginDataError {
-    // Pegin address and amount
-    pub pegin: (Address, ethers::types::U256),
+    // Pegin address, amount, and type (pegin/pegout)
+    pub pegin: (Address, ethers::types::U256, String),
 }
 
 #[derive(Debug)]
@@ -168,7 +168,8 @@ pub fn parse_pegin_topic(
             let destination = topic_to_address(log.topics()[1])?;
             let data = &log.data;
 
-            let pegin_data_error = PeginDataError { pegin: (destination, amount) };
+            let pegin_data_error =
+                PeginDataError { pegin: (destination, amount, String::from("Pegin")) };
 
             let decoded_params: Vec<ethers::abi::Token> = decode(
                 &[

--- a/crates/interfaces/src/error.rs
+++ b/crates/interfaces/src/error.rs
@@ -70,11 +70,11 @@ mod size_asserts {
         };
     }
 
-    static_assert_size!(RethError, 72);
-    static_assert_size!(BlockExecutionError, 64);
+    static_assert_size!(RethError, 96);
+    static_assert_size!(BlockExecutionError, 88);
     static_assert_size!(ConsensusError, 48);
     static_assert_size!(DatabaseError, 40);
     static_assert_size!(ProviderError, 48);
     static_assert_size!(NetworkError, 0);
-    static_assert_size!(CanonicalError, 64);
+    static_assert_size!(CanonicalError, 88);
 }

--- a/crates/interfaces/src/executor.rs
+++ b/crates/interfaces/src/executor.rs
@@ -80,7 +80,10 @@ pub enum BlockValidationError {
     },
     /// Error when failing to parse pegin/pegout topic
     #[error("Failed to parse topic")]
-    FailedToParseMintTopic,
+    FailedToParseMintTopic {
+        /// Optional pegin data
+        pegin: Option<(Address, U256)>,
+    },
     /// Error when pegin/pegout fails consenus validation
     #[error("Invalid Mint contract invocation")]
     MintContractViolation {

--- a/crates/interfaces/src/executor.rs
+++ b/crates/interfaces/src/executor.rs
@@ -1,3 +1,5 @@
+use core::fmt;
+
 use crate::{provider::ProviderError, trie::StateRootError};
 use ethers::types::U256;
 use reth_primitives::{
@@ -5,6 +7,24 @@ use reth_primitives::{
     PruneSegmentError, B256,
 };
 use thiserror::Error;
+
+/// Mint contract error type
+#[derive(Debug)]
+pub enum MintContractErrorType {
+    /// Pegin error
+    Pegin,
+    /// Pegout error
+    Pegout,
+}
+
+impl fmt::Display for MintContractErrorType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MintContractErrorType::Pegin => write!(f, "Pegin"),
+            MintContractErrorType::Pegout => write!(f, "Pegout"),
+        }
+    }
+}
 
 /// Transaction validation errors
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
@@ -81,14 +101,14 @@ pub enum BlockValidationError {
     /// Error when failing to parse pegin/pegout topic
     #[error("Failed to parse topic")]
     FailedToParseMintTopic {
-        /// Optional pegin data
-        pegin: Option<(Address, U256)>,
+        /// Optional pegin/pegout data: destination address, amount, and type (pegin/pegout)
+        event_data: Option<(Address, U256, String)>,
     },
     /// Error when pegin/pegout fails consenus validation
     #[error("Invalid Mint contract invocation")]
     MintContractViolation {
-        /// The pegin address and amount
-        pegin: (Address, U256),
+        /// The pegin/pegout address and amount
+        event_data: (Address, U256, String),
     },
     /// Poa specific error when Extra data header is invalid
     #[error("Invalid extra header")]

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -32,6 +32,9 @@ secp256k1 = { workspace = true, features = [
     "recovery",
 ] }
 
+# ethers
+ethers = "2.0.9"
+
 # common
 tracing.workspace = true
 tokio.workspace = true

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -1,10 +1,11 @@
+use ethers::types::U256 as EthersU256;
 #[cfg(not(feature = "optimism"))]
 use revm::DatabaseCommit;
 use revm::{
     db::StateDBBox,
     inspector_handle_register,
     interpreter::Host,
-    primitives::{CfgEnvWithHandlerCfg, ExecutionResult, ResultAndState},
+    primitives::{CfgEnvWithHandlerCfg, ExecutionResult, ResultAndState, State as EvmState},
     Evm, State,
 };
 use std::{sync::Arc, time::Instant};
@@ -28,7 +29,8 @@ use crate::{
     state_change::{apply_beacon_root_contract_call, post_block_balance_increments},
 };
 use reth_botanix_lib::mint_validation::{
-    parse_pegin_topic, parse_pegout_topic, BURN_TOPIC, MINT_CONTRACT_ADDRESS, MINT_TOPIC,
+    parse_pegin_topic, parse_pegout_topic, MintConsensusError, BURN_TOPIC, MINT_CONTRACT_ADDRESS,
+    MINT_TOPIC,
 };
 use reth_consensus_common::utils::get_block_producer_address;
 use reth_primitives::{
@@ -227,7 +229,23 @@ where
                 let pegin_data =
                     parse_pegin_topic(&log, &result.clone().into_logs()).map_err(|e| {
                         error!("Failed to parse pegin topic! {:?}", e);
-                        BlockValidationError::FailedToParseMintTopic
+                        let pegin_data_error = match e {
+                            MintConsensusError::LogParsingBlockHeightError(pegin) => Some(pegin),
+                            MintConsensusError::LogParsingMetaDataError(pegin) => Some(pegin),
+                            MintConsensusError::FailedToConvertMetadataToBytes(pegin) => {
+                                Some(pegin)
+                            }
+                            MintConsensusError::FailedtoDeserialiseMetadata(pegin) => Some(pegin),
+                            _ => None,
+                        };
+                        let mint_topic_pegin_data = if pegin_data_error.is_some() {
+                            Some(pegin_data_error.expect("pegin data error to exist").pegin)
+                        } else {
+                            None
+                        };
+                        BlockValidationError::FailedToParseMintTopic {
+                            pegin: mint_topic_pegin_data,
+                        }
                     })?;
 
                 let recent_header = consensus_pkg.expect("is some").recent_header;
@@ -255,18 +273,30 @@ where
                 }
             }
 
+            // TODO(scott) update state when pegout fails
+            // the pegout amount has already been burned and needs to be added back
             if log.topics().first() == Some(&BURN_TOPIC) {
                 let btc_network = consensus_pkg
                     .map(|package| package.btc_network)
                     .unwrap_or_else(|| bitcoin::Network::Regtest);
                 if let Err(e) = parse_pegout_topic(&log, btc_network) {
                     error!("Failed to parse pegout topic! {:?}", e);
-                    return Err(BlockValidationError::FailedToParseMintTopic.into());
+                    return Err(BlockValidationError::FailedToParseMintTopic { pegin: None }.into());
                 }
             }
         }
 
         Ok(())
+    }
+
+    /// Updates state for an account
+    fn update_state_by_address(address: Address, amount: EthersU256, state: &mut EvmState) {
+        let mut pegin_account = state.get(&address).expect("Pegin account to exist").clone();
+        // decrement balance by pegin amount
+        pegin_account.info.balance =
+            pegin_account.info.balance.saturating_sub(U256::from_le_bytes(amount.into()));
+        // update state with new balance
+        state.insert(address, pegin_account);
     }
 
     /// Runs a single transaction in the configured environment and proceeds
@@ -324,28 +354,39 @@ where
 
                             // Update state to decrement pegin address balance since pegin is being
                             // reverted
-                            if let BlockExecutionError::Validation(
-                                BlockValidationError::MintContractViolation {
-                                    pegin: (address, amount),
-                                },
-                            ) = e
-                            {
-                                let mut updated_state = state.clone();
-                                let mut pegin_account = updated_state
-                                    .get(&address)
-                                    .expect("Pegin account to exist")
-                                    .clone();
-                                // decrement balance by pegin amount
-                                pegin_account.info.balance = pegin_account
-                                    .info
-                                    .balance
-                                    .saturating_sub(U256::from_le_bytes(amount.into()));
-                                // update state with new balance
-                                updated_state.insert(address, pegin_account);
+                            match e {
+                                BlockExecutionError::Validation(
+                                    BlockValidationError::MintContractViolation {
+                                        pegin: (address, amount),
+                                    },
+                                ) => {
+                                    info!("Decrementing pegin address balance");
+                                    let mut updated_state = state.clone();
+                                    Self::update_state_by_address(
+                                        address,
+                                        amount,
+                                        &mut updated_state,
+                                    );
 
-                                ResultAndState { result: new_result, state: updated_state }
-                            } else {
-                                ResultAndState { result: new_result, state: state.clone() }
+                                    ResultAndState { result: new_result, state: updated_state }
+                                }
+                                BlockExecutionError::Validation(
+                                    BlockValidationError::FailedToParseMintTopic {
+                                        pegin: Some((address, amount)),
+                                    },
+                                ) => {
+                                    info!("Decrementing pegin address balance");
+                                    let mut updated_state = state.clone();
+                                    info!("Address: {:?}, Amount: {:?}", address, amount);
+                                    Self::update_state_by_address(
+                                        address,
+                                        amount,
+                                        &mut updated_state,
+                                    );
+
+                                    ResultAndState { result: new_result, state: updated_state }
+                                }
+                                _ => ResultAndState { result: new_result, state: state.clone() },
                             }
                         }),
                     }

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -11,7 +11,7 @@ use revm::{
 use std::{sync::Arc, time::Instant};
 
 use reth_evm::ConfigureEvm;
-use reth_interfaces::executor::{BlockExecutionError, BlockValidationError};
+use reth_interfaces::executor::{BlockExecutionError, BlockValidationError, MintContractErrorType};
 #[cfg(feature = "optimism")]
 use reth_primitives::revm::env::fill_op_tx_env;
 #[cfg(not(feature = "optimism"))]
@@ -19,7 +19,7 @@ use reth_primitives::revm::env::fill_tx_env;
 #[cfg(not(feature = "optimism"))]
 use reth_provider::BundleStateWithReceipts;
 use reth_provider::{BlockExecutor, ProviderError, PrunableBlockExecutor, StateProvider};
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, error, event, info, trace, warn};
 
 use crate::{
     batch::{BlockBatchRecord, BlockExecutorStats},
@@ -221,6 +221,8 @@ where
     fn botanix_mint_contract_checks(
         result: &ExecutionResult,
         botanix_consensus_pkg: Option<BotanixConsensusPackage>,
+        sender_address: Address, // used for reverted pegouts
+        sender_value: U256,      // used for reverted pegouts
     ) -> Result<(), BlockExecutionError> {
         let binding = botanix_consensus_pkg.clone();
         let consensus_pkg = binding.as_ref();
@@ -244,7 +246,7 @@ where
                             None
                         };
                         BlockValidationError::FailedToParseMintTopic {
-                            pegin: mint_topic_pegin_data,
+                            event_data: mint_topic_pegin_data,
                         }
                     })?;
 
@@ -258,7 +260,11 @@ where
                         if aggregate_value == pegin_data.amount {
                             warn!("Failed pegin attempt! Pegin amount should be less than aggregate value because fees are deducted.");
                             return Err(BlockValidationError::MintContractViolation {
-                                pegin: (pegin_data.account, pegin_data.amount),
+                                event_data: (
+                                    pegin_data.account,
+                                    pegin_data.amount,
+                                    MintContractErrorType::Pegin.to_string(),
+                                ),
                             }
                             .into());
                         }
@@ -266,7 +272,11 @@ where
                     Err(e) => {
                         warn!("Failed pegin attempt! {:?}", e);
                         return Err(BlockValidationError::MintContractViolation {
-                            pegin: (pegin_data.account, pegin_data.amount),
+                            event_data: (
+                                pegin_data.account,
+                                pegin_data.amount,
+                                MintContractErrorType::Pegin.to_string(),
+                            ),
                         }
                         .into());
                     }
@@ -281,7 +291,14 @@ where
                     .unwrap_or_else(|| bitcoin::Network::Regtest);
                 if let Err(e) = parse_pegout_topic(&log, btc_network) {
                     error!("Failed to parse pegout topic! {:?}", e);
-                    return Err(BlockValidationError::FailedToParseMintTopic { pegin: None }.into());
+                    return Err(BlockValidationError::FailedToParseMintTopic {
+                        event_data: Some((
+                            sender_address,
+                            sender_value.into(),
+                            MintContractErrorType::Pegout.to_string(),
+                        )),
+                    }
+                    .into());
                 }
             }
         }
@@ -290,13 +307,30 @@ where
     }
 
     /// Updates state for an account
-    fn update_state_by_address(address: Address, amount: EthersU256, state: &mut EvmState) {
-        let mut pegin_account = state.get(&address).expect("Pegin account to exist").clone();
-        // decrement balance by pegin amount
-        pegin_account.info.balance =
-            pegin_account.info.balance.saturating_sub(U256::from_le_bytes(amount.into()));
+    fn decrement_balance_by_address(address: Address, amount: EthersU256, state: &mut EvmState) {
+        let mut account = state.get(&address).expect("Account to exist").clone();
+        // decrement balance by amount
+        info!("Decrementing address: {:?} by {:?}", address, amount);
+        account.info.balance = account
+            .info
+            .balance
+            .checked_sub(U256::from_be_bytes(amount.into()))
+            .expect("No overflow for checked_sub");
         // update state with new balance
-        state.insert(address, pegin_account);
+        state.insert(address, account);
+    }
+
+    fn increment_balance_by_address(address: Address, amount: EthersU256, state: &mut EvmState) {
+        let mut account = state.get(&address).expect("Account to exist").clone();
+        // increment balance by amount
+        info!("Incrementing address: {:?} by {:?}", address, amount);
+        account.info.balance = account
+            .info
+            .balance
+            .checked_add(U256::from_be_bytes(amount.into()))
+            .expect("No overflow for checked_add");
+        // update state with new balance
+        state.insert(address, account);
     }
 
     /// Runs a single transaction in the configured environment and proceeds
@@ -335,8 +369,16 @@ where
         // ***** Botanix specific checks ******
         let out = match out {
             Ok(ResultAndState { ref result, ref state }) => {
+                // get pegout amount so can update balance if pegout reverts
+                let pegout_amount = transaction.value();
+
                 if result.is_success() && transaction.to() == Some(*MINT_CONTRACT_ADDRESS) {
-                    match Self::botanix_mint_contract_checks(result, botanix_consensus_pkg) {
+                    match Self::botanix_mint_contract_checks(
+                        result,
+                        botanix_consensus_pkg,
+                        sender,
+                        pegout_amount,
+                    ) {
                         Ok(()) => out,
                         Err(e) => Ok({
                             error!("Botanix mint contract validation failed: {:?}", e);
@@ -352,33 +394,37 @@ where
                                 output: output_match,
                             };
 
-                            // Update state to decrement pegin address balance since pegin is being
-                            // reverted
-                            match e {
+                            // Update state for reverted pegins/pegouts:
+                            // balances have been updated since tx was successful according to EVM
+                            // and we are reverting according to botanix validation
+                            let event_data = match e {
                                 BlockExecutionError::Validation(
                                     BlockValidationError::MintContractViolation {
-                                        pegin: (address, amount),
+                                        event_data: (address, amount, event_type),
                                     },
-                                ) => {
-                                    info!("Decrementing pegin address balance");
-                                    let mut updated_state = state.clone();
-                                    Self::update_state_by_address(
-                                        address,
-                                        amount,
-                                        &mut updated_state,
-                                    );
-
-                                    ResultAndState { result: new_result, state: updated_state }
-                                }
+                                ) => Some((address, amount, event_type)),
                                 BlockExecutionError::Validation(
                                     BlockValidationError::FailedToParseMintTopic {
-                                        pegin: Some((address, amount)),
+                                        event_data: Some((address, amount, event_type)),
                                     },
-                                ) => {
-                                    info!("Decrementing pegin address balance");
+                                ) => Some((address, amount, event_type)),
+                                _ => None,
+                            };
+
+                            if let Some(event_data) = event_data {
+                                let (address, amount, event_type) = event_data;
+                                if event_type == MintContractErrorType::Pegin.to_string() {
                                     let mut updated_state = state.clone();
-                                    info!("Address: {:?}, Amount: {:?}", address, amount);
-                                    Self::update_state_by_address(
+                                    Self::decrement_balance_by_address(
+                                        address,
+                                        amount,
+                                        &mut updated_state,
+                                    );
+
+                                    ResultAndState { result: new_result, state: updated_state }
+                                } else {
+                                    let mut updated_state = state.clone();
+                                    Self::increment_balance_by_address(
                                         address,
                                         amount,
                                         &mut updated_state,
@@ -386,7 +432,8 @@ where
 
                                     ResultAndState { result: new_result, state: updated_state }
                                 }
-                                _ => ResultAndState { result: new_result, state: state.clone() },
+                            } else {
+                                ResultAndState { result: new_result, state: state.clone() }
                             }
                         }),
                     }

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -5,7 +5,10 @@ use revm::{
     db::StateDBBox,
     inspector_handle_register,
     interpreter::Host,
-    primitives::{CfgEnvWithHandlerCfg, ExecutionResult, ResultAndState, State as EvmState},
+    primitives::{
+        bitvec::view::BitViewSized, CfgEnvWithHandlerCfg, ExecutionResult, ResultAndState,
+        State as EvmState,
+    },
     Evm, State,
 };
 use std::{sync::Arc, time::Instant};
@@ -283,8 +286,6 @@ where
                 }
             }
 
-            // TODO(scott) update state when pegout fails
-            // the pegout amount has already been burned and needs to be added back
             if log.topics().first() == Some(&BURN_TOPIC) {
                 let btc_network = consensus_pkg
                     .map(|package| package.btc_network)
@@ -294,7 +295,7 @@ where
                     return Err(BlockValidationError::FailedToParseMintTopic {
                         event_data: Some((
                             sender_address,
-                            sender_value.into(),
+                            EthersU256::from_little_endian(sender_value.as_le_slice()),
                             MintContractErrorType::Pegout.to_string(),
                         )),
                     }

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -307,7 +307,8 @@ where
         Ok(())
     }
 
-    /// Updates state for an account
+    /// Decrement an account by the specified amount and update state
+    /// This should only occur when a pegin reverts based on our custom validation
     fn decrement_balance_by_address(address: Address, amount: EthersU256, state: &mut EvmState) {
         let mut account = state.get(&address).expect("Account to exist").clone();
         // decrement balance by amount
@@ -321,6 +322,8 @@ where
         state.insert(address, account);
     }
 
+    /// Increment an account by the specified amount and update state
+    /// This should only occur when a pegout reverts based on our custom validation
     fn increment_balance_by_address(address: Address, amount: EthersU256, state: &mut EvmState) {
         let mut account = state.get(&address).expect("Account to exist").clone();
         // increment balance by amount


### PR DESCRIPTION
Overview:

This pr updates state for failed pegins/pegouts and covers all fail paths.

Since a pegin/pegout that gets to our validation code is considered successful by the EVM, the state has been updated with the result of the pegin/pegout: balance incremented/decremented.

So we need to update the balance to what it was prior to the pegin/pegout minus the tx cost (only for pegout bc we send pegins and get refunded in the contract method itself)