### PR TITLE
clean up previous test folder

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -29,9 +29,6 @@ jobs:
       RUST_BACKTRACE: 1
     timeout-minutes: 60
     steps:
-      - name: Delete old test data
-        run: rm -rf /home/runner/actions-runner/_work/Macbeth
-
       - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
@@ -102,4 +99,9 @@ jobs:
             | grep 0x91c90676cab257a59cd956d7cb0bceb9b1a71d79755c23c7277a0697ccfaf8c4
 
 
-          
+  delete-old-test-data:
+    name: Delete old test data
+    runs-on: botanix-actions-runner-vm-1
+    if: always()
+    steps:
+      - run: rm -rf /home/runner/actions-runner/_work/Macbeth

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -29,6 +29,9 @@ jobs:
       RUST_BACKTRACE: 1
     timeout-minutes: 60
     steps:
+      - name: Delete old test data
+        run: rm -rf /home/runner/actions-runner/_work/Macbeth
+
       - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -29,6 +29,9 @@ jobs:
       RUST_BACKTRACE: 1
     timeout-minutes: 60
     steps:
+      - name: Delete old test data
+        run: rm -rf /home/runner/actions-runner/_work/Macbeth
+
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -66,6 +69,8 @@ jobs:
       RUST_BACKTRACE: 1
     timeout-minutes: 60
     steps:
+      - name: Delete old test data
+        run: rm -rf /home/runner/actions-runner/_work/Macbeth
       - uses: actions/checkout@v4
       - name: Checkout ethereum/tests
         uses: actions/checkout@v4
@@ -118,6 +123,8 @@ jobs:
       RUST_BACKTRACE: 1
     timeout-minutes: 90
     steps:
+      - name: Delete old test data
+        run: rm -rf /home/runner/actions-runner/_work/Macbeth
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -29,9 +29,6 @@ jobs:
       RUST_BACKTRACE: 1
     timeout-minutes: 60
     steps:
-      - name: Delete old test data
-        run: rm -rf /home/runner/actions-runner/_work/Macbeth
-
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -69,8 +66,6 @@ jobs:
       RUST_BACKTRACE: 1
     timeout-minutes: 60
     steps:
-      - name: Delete old test data
-        run: rm -rf /home/runner/actions-runner/_work/Macbeth
       - uses: actions/checkout@v4
       - name: Checkout ethereum/tests
         uses: actions/checkout@v4
@@ -123,8 +118,6 @@ jobs:
       RUST_BACKTRACE: 1
     timeout-minutes: 90
     steps:
-      - name: Delete old test data
-        run: rm -rf /home/runner/actions-runner/_work/Macbeth
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
@@ -134,6 +127,7 @@ jobs:
 
       - name: Run doctests
         run: cargo test --doc --workspace --features "ethereum"
+        
 
   unit-success:
     name: unit success


### PR DESCRIPTION
- Simple bash command to clean up stale Macbeth _work folder on self-hosted instances.