### PR TITLE
fixes for cleanup and weird behaviour

### DIFF
--- a/bin/test-suite/src/macros.rs
+++ b/bin/test-suite/src/macros.rs
@@ -21,7 +21,7 @@ macro_rules! run_test {
         } else {
             "FullRun"
         };
-
+        $self.destroy_context().await;
         $self.create_new_context($create_test_config).await;
 
         info!("({}) {} {}...", purple(test_type), cyan(test), "Running");

--- a/bin/test-suite/src/suite/consensus/common/events.rs
+++ b/bin/test-suite/src/suite/consensus/common/events.rs
@@ -55,7 +55,10 @@ pub async fn await_botanix_event(
     // wait for a few blocks to make sure the tx got included and mined
     while let Ok(notification) = rx.recv().await {
         if let Notifications::CanonState(canon_state_notification) = notification {
-            it_info_print!("Canon state notification", canon_state_notification);
+            it_info_print!(
+                "Canon state notification for engine index =",
+                canon_state_notification.engine_index
+            );
             let block_receipts = canon_state_notification.notification.block_receipts();
             let non_reverted_block_receipts = block_receipts
                 .into_iter()
@@ -71,7 +74,7 @@ pub async fn await_botanix_event(
                     acc.extend(receipts);
                     acc
                 });
-            it_info_print!("Final block receipts", final_block_receipts);
+            it_info_print!("Final block receipts", final_block_receipts.len());
             for block_receipt in final_block_receipts.into_iter() {
                 for log in block_receipt.logs.into_iter() {
                     for topic in log.topics() {

--- a/bin/test-suite/src/suite/consensus/common/poa_node.rs
+++ b/bin/test-suite/src/suite/consensus/common/poa_node.rs
@@ -345,13 +345,19 @@ impl PoaNodeCommandConfig for FederationMemberTestConfig {
         executor.spawn(Box::pin(async move {
             // start waiting for canon event notifications
             while let Some(canon_state_notification) = canon_events.recv().await.ok() {
-                let _ = rx_sender
-                    .send(Notifications::CanonState(CannonStateNofificationPayload {
-                        engine_index,
-                        ts: tokio::time::Instant::now(),
-                        notification: canon_state_notification,
-                    }))
-                    .expect("Failed to send canon state notification");
+                match rx_sender.send(Notifications::CanonState(CannonStateNofificationPayload {
+                    engine_index,
+                    ts: tokio::time::Instant::now(),
+                    notification: canon_state_notification,
+                })) {
+                    Ok(_) => {}
+                    // all receivers have been dropped temporarily here. Just sleep and await new
+                    // ones to be created
+                    Err(_) => {
+                        tokio::time::sleep(Duration::from_secs(1)).await;
+                        continue;
+                    }
+                }
             }
         }));
 
@@ -441,13 +447,19 @@ impl PoaNodeCommandConfig for FederationMemberTestConfig {
                             );
                             let s = SigningStatus::try_from(status.status).ok();
                             if let Some(status) = s {
-                                let _ = rx_sender
-                                    .send(Notifications::SigningStatusReport((
-                                        engine_index,
-                                        session_id,
-                                        status,
-                                    )))
-                                    .expect("Failed to send signing status report");
+                                match rx_sender.send(Notifications::SigningStatusReport((
+                                    engine_index,
+                                    session_id,
+                                    status,
+                                ))) {
+                                    Ok(_) => {}
+                                    // all receivers have been dropped temporarily here. Just sleep
+                                    // and await new ones to be created
+                                    Err(_) => {
+                                        tokio::time::sleep(Duration::from_secs(1)).await;
+                                        continue;
+                                    }
+                                }
                             }
                         }
                         Err(_) => {

--- a/bin/test-suite/src/suite/consensus/mod.rs
+++ b/bin/test-suite/src/suite/consensus/mod.rs
@@ -255,6 +255,9 @@ impl Suite for ConsensusIntegrationTestSuite {
         self.local_context.btc_servers = None;
         self.local_context.poa_nodes = None;
         self.local_context.poa_notification = None;
+
+        // allow a few seconds to pass after cleanup
+        tokio::time::sleep(Duration::from_secs(5)).await;
     }
 }
 

--- a/test_runner.sh
+++ b/test_runner.sh
@@ -4,7 +4,7 @@ set -e
 set -o pipefail
 
 # Define the list of strings
-tests_to_run=("dkg_flow" "many_inputs_signing" "utxo_commitment" "block_builder" "frost_e2e_stable" "frost_e2e_failed_signing_disconnect" "invalid_pegin" "invalid_pegout" "test_mempool_gossip")
+tests_to_run=("dkg_flow" "many_inputs_signing" "utxo_commitment" "block_builder" "frost_e2e_stable" "frost_e2e_failed_signing_disconnect" "invalid_pegin" "test_mempool_gossip")
 
 exit_codes=()
 


### PR DESCRIPTION
This MR provides 3 fixes:
1. when the test suite is run locally, the very first test simply creates context, but there might already be running btc servers so often we fail unless we cleanup the instances. For this reason I have added a cleanup part before actually constructing new context. 
2. At the end of each destructor we need a relaxation of a few secs. as processes take a while to go away completely.
3. Receiver channels are often being dropped during context destruction and channels tend to loose receivers leading to not being able to send messages. In those cases we simply retry until a new receiver comes back up.