### PR TITLE
Feature/chore/remove client from storage

### DIFF
--- a/crates/consensus/authority/src/block_builder.rs
+++ b/crates/consensus/authority/src/block_builder.rs
@@ -58,9 +58,13 @@ where
             return;
         }
 
-        let storage = self.storage.write().await;
-        let (best_block, best_hash) = storage.get_best_block_and_hash().expect("best block exists");
-        drop(storage);
+        let best_block = self.client.best_block_number().expect("best block number exists");
+        let best_hash =
+            self.client.block_hash(best_block).expect("best block hash exists").unwrap_or_else(
+                || {
+                    panic!("best block hash is valid");
+                },
+            );
 
         // use authority address as suggested fee recipient
         let authority_pub_key = secp256k1::PublicKey::from_secret_key_global(&self.sk);
@@ -138,7 +142,7 @@ where
             return;
         }
 
-        let mut storage = self.storage.write().await;
+        let mut storage = self.storage.inner.write().await;
         // retrieve aggregate key
         let secp_pk = match storage.aggregate_public_key {
             Some(pk) => pk,
@@ -161,6 +165,7 @@ where
             Some(botanix_consensus_pkg.clone()),
             &self.sk,
             self.evm_config.clone(),
+            &self.client,
         ) {
             Ok(ret) => ret,
             Err(err) => {
@@ -197,14 +202,13 @@ where
             }
         };
 
-        let storage = self.storage.read().await;
+        let storage = self.storage.inner.read().await;
         // If end of epoch, process pegouts
         let mut epoch_witness: Option<Vec<Witness>> = None;
         if block.header.is_poa_epoch() {
             // get pegouts up to best block
             let mut pegouts =
-                match crate::utils::epoch_pegouts(best_block, &storage.client, self.btc_network)
-                    .await
+                match crate::utils::epoch_pegouts(best_block, &self.client, self.btc_network).await
                 {
                     Ok(epoch_pegouts) => epoch_pegouts,
                     Err(e) => {
@@ -281,7 +285,7 @@ where
 
         info!(target: "consensus::authority", "UTXO commitment: {:?}", utxo_commitment);
 
-        let mut storage = self.storage.write().await;
+        let mut storage = self.storage.inner.write().await;
         let new_header = match storage.build_and_validate_header(
             &bundle_state,
             block,
@@ -293,6 +297,7 @@ where
             &epoch_witness,
             utxo_commitment,
             &self.consensus,
+            &self.client,
         ) {
             Ok(ret) => ret,
             Err(err) => {
@@ -339,13 +344,12 @@ where
         let commited_header = sealed_block.header();
 
         // TODO(armins) assert that block hash has not changed after adding witness
-
         let sealed_block_with_senders =
             SealedBlockWithSenders::new(sealed_block.clone(), senders.clone())
                 .expect("senders are valid");
 
-        // update canon chain for rpc
-        match storage.client.insert_block_with_botanix_consensus_package(
+        // update canon chain
+        match self.client.insert_block_with_botanix_consensus_package(
             sealed_block_with_senders.clone(),
             Exhaustive,
             Some(botanix_consensus_pkg),
@@ -356,9 +360,9 @@ where
                 return;
             }
         }
-        storage.client.set_canonical_head(sealed_block.header.clone());
-        storage.client.set_safe(sealed_block.header.clone());
-        storage.client.set_finalized(sealed_block.header.clone());
+        self.client.set_canonical_head(sealed_block.header.clone());
+        self.client.set_safe(sealed_block.header.clone());
+        self.client.set_finalized(sealed_block.header.clone());
 
         match engine_util::send_fork_choice_update_payload(
             commited_header.hash_slow(),
@@ -373,7 +377,6 @@ where
                 return;
             }
         }
-        drop(storage);
 
         // Notify peers
         let new_block = NewBlock { block: block_to_commit.clone(), td: Uint::ZERO };

--- a/crates/consensus/authority/src/block_fetcher.rs
+++ b/crates/consensus/authority/src/block_fetcher.rs
@@ -42,7 +42,7 @@ pub struct BlockFetcherTask<Client, EvmConfig, Engine: EngineTypes, NetworkClien
     /// Btc Server client
     btc_server: Option<BtcServerExtendedClient>,
     /// Consensus cache
-    storage: Storage<Client>,
+    storage: Storage,
     /// Recent finalize bitcoin block checkpoint.
     bitcoin_block_header: Arc<RwLock<Option<(bitcoin::block::Header, u32)>>>,
     /// The type that defines how to configure the EVM.
@@ -53,6 +53,8 @@ pub struct BlockFetcherTask<Client, EvmConfig, Engine: EngineTypes, NetworkClien
     network_client: NetworkClient,
     /// Network Handle, used to create [FullBlockClient]
     network_handle: NetworkHandle,
+    /// Database provider
+    client: Client,
 }
 
 impl<Client, EvmConfig, Engine, NetworkClient>
@@ -75,12 +77,13 @@ where
         to_engine: UnboundedSender<BeaconEngineMessage<Engine>>,
         canon_state_notification: CanonStateNotificationSender,
         btc_server: Option<BtcServerExtendedClient>,
-        storage: Storage<Client>,
+        storage: Storage,
         bitcoin_block_header: Arc<RwLock<Option<(bitcoin::block::Header, u32)>>>,
         evm_config: EvmConfig,
         btc_network: bitcoin::Network,
         network_client: NetworkClient,
         network_handle: NetworkHandle,
+        client: Client,
     ) -> Self {
         Self {
             consensus,
@@ -94,6 +97,7 @@ where
             btc_network,
             network_client,
             network_handle,
+            client,
         }
     }
 
@@ -126,14 +130,19 @@ where
             };
 
             let block = new_block.block.block.clone();
-            let storage = self.storage.read().await;
             info!(target: "consensus::authority", "Recieved new block from peer {:?}", block.header.hash_slow());
-            let best_hash = storage.get_best_block_and_hash().expect("best block exists").1;
+
+            let best_block = self.client.best_block_number().expect("best block number exists");
+            let best_hash =
+                self.client.block_hash(best_block).expect("best block hash exists").unwrap_or_else(
+                    || {
+                        panic!("best block hash is valid");
+                    },
+                );
             if block.header.hash_slow() == best_hash {
                 warn!(target: "consensus::authority", "Recieved block is already in the chain");
                 continue;
             }
-            drop(storage);
             // Seal the block
             let sealed_block = block.clone().seal_slow();
 
@@ -183,6 +192,7 @@ where
                 sealed_block.clone(),
                 botanix_consensus_pkg.clone(),
                 self.evm_config.clone(),
+                &self.client,
             ) {
                 Ok(bundle_state) => {
                     let senders =
@@ -237,15 +247,16 @@ where
                             continue;
                         }
 
-                        let (best_block, _best_hash) =
-                            storage.get_best_block_and_hash().expect("best block exists");
+                        let best_block =
+                            self.client.best_block_number().expect("best block number exists");
                         if header.is_poa_epoch() {
                             // get the pegouts from during the epoch
                             let past_pegouts = crate::utils::epoch_pegouts(
-                                best_block, &storage.client, self.btc_network
+                                best_block, &self.client, self.btc_network,
                             ).await.map_err(|e| {
                                 error!(target: "consensus::authority", ?e, "Failed to get epoch pegouts");
                                 e
+                                // TODO (armins) remove unwrap()
                             }).unwrap();
                             pegouts.extend(past_pegouts);
                             // TODO (armins) deserialize extra data can be implenented on header
@@ -308,8 +319,8 @@ where
 
                     // Need to decide if we accepting a forked block or not
                     // There is a garuntee a quorum of signers will not sign an invalid fork
-                    let tip = storage.client.best_block_number().expect("best block exists");
-                    let best_block = storage
+                    let tip = self.client.best_block_number().expect("best block exists");
+                    let best_block = self
                         .client
                         .block_by_number(tip)
                         .expect("best block exists")
@@ -319,7 +330,8 @@ where
                         // need to retrieve this missing block from a peer
                         let missing_block =
                             full_block_client.get_full_block(header.parent_hash.clone()).await;
-                        if let Err(e) = storage.client.insert_block_without_senders(
+                        // TODO (armins) should be using the insert with botanix consensus package
+                        if let Err(e) = self.client.insert_block_without_senders(
                             missing_block.clone(),
                             BlockValidationKind::Exhaustive,
                             botanix_consensus_pkg,
@@ -327,9 +339,9 @@ where
                             error!(target: "consensus::authority", ?e, "Failed to insert forked block");
                             continue;
                         }
-                        storage.client.set_canonical_head(missing_block.header.clone());
-                        storage.client.set_safe(missing_block.header.clone());
-                        storage.client.set_finalized(missing_block.header.clone());
+                        self.client.set_canonical_head(missing_block.header.clone());
+                        self.client.set_safe(missing_block.header.clone());
+                        self.client.set_finalized(missing_block.header.clone());
                         if let Err(e) = engine_util::send_fork_choice_update_payload(
                             sealed_block.clone().hash(),
                             self.to_engine.clone(),
@@ -351,9 +363,9 @@ where
                     .unwrap();
 
                     // update canon chain for rpc
-                    storage.client.set_canonical_head(header);
-                    storage.client.set_safe(sealed_block.header.clone());
-                    storage.client.set_finalized(sealed_block.header.clone());
+                    self.client.set_canonical_head(header);
+                    self.client.set_safe(sealed_block.header.clone());
+                    self.client.set_finalized(sealed_block.header.clone());
                     drop(storage);
 
                     // TODO(armins) trie updates here are non. is that correct?

--- a/crates/consensus/authority/src/builder.rs
+++ b/crates/consensus/authority/src/builder.rs
@@ -43,10 +43,9 @@ pub struct AuthorityConsensusBuilder<
     ToFrostMan,
     NetworkClient,
 > {
-    #[allow(dead_code)]
     client: Client,
     consensus: AuthorityConsensus,
-    storage: Storage<Client>,
+    storage: Storage,
     to_engine: UnboundedSender<BeaconEngineMessage<Engine>>,
     canon_state_notification: CanonStateNotificationSender,
     btc_server: Option<BtcServerExtendedClient>,
@@ -165,7 +164,6 @@ where
 
         // Try to instantiate storage
         let storage = Storage::try_new(
-            client.clone(),
             &mut headers,
             genesis_authorities,
             authorities,
@@ -179,7 +177,7 @@ where
         })?;
 
         // Instantiate epoch manager
-        let epoch_manager = EpochManager::<Client>::new(storage.clone());
+        let epoch_manager = EpochManager::<Client>::new(storage.clone(), client.clone());
 
         Ok(Self {
             storage,
@@ -259,6 +257,7 @@ where
             btc_network,
             network_client.clone(),
             network_handle.clone(),
+            client.clone(),
         );
 
         // Set up frost notification message queue
@@ -331,6 +330,7 @@ where
                 pbft_task_notifications2_rx,
                 pbft_task_notifications1_tx,
                 btc_network,
+                client.clone(),
             );
 
             block_production_task = Some(block_production);

--- a/crates/consensus/authority/src/builder.rs
+++ b/crates/consensus/authority/src/builder.rs
@@ -169,7 +169,6 @@ where
             authorities,
             signer_index.expect("valid index"),
             pk,
-            btc_network,
         )
         .map_err(|e| {
             error!("Failed to instantiate storage: {:?}", e);

--- a/crates/consensus/authority/src/dkg.rs
+++ b/crates/consensus/authority/src/dkg.rs
@@ -1,16 +1,9 @@
-use crate::{
-    extended_client::BtcServerExtendedClient,
-    utils::{deserialize_frost_peer_id, retry_exec, FrostParseError},
-    Storage,
-};
 use client::{DkgPayload, Empty, GetPublicKeyResponse};
 use frost_secp256k1_tr as frost;
-use reth_interfaces::blockchain_tree::BlockchainTreeEngine;
 use reth_network::frost::{
     manager::{peer_id_to_identifier, FrostCommand, FrostConfig, ToFrostManager},
     DkgEventResponseType, DkgResponse, FrostPeerCommand, PeerMessageResponse,
 };
-use reth_provider::{BlockReaderIdExt, CanonChainTracker, StateProviderFactory};
 use std::{
     collections::{BTreeMap, HashMap},
     str::FromStr,
@@ -18,6 +11,12 @@ use std::{
 };
 use tokio::sync::mpsc::{error::SendError, UnboundedSender};
 use tracing::{error, info, warn};
+
+use crate::{
+    extended_client::BtcServerExtendedClient,
+    utils::{deserialize_frost_peer_id, retry_exec, FrostParseError},
+    Storage,
+};
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum Error {
@@ -116,9 +115,9 @@ impl DKGState {
 
 /// A state machine for transitioning between different DKG states
 #[derive(Debug, Clone)]
-pub(crate) struct DKGStateMachine<Client, ToFrostMan> {
+pub(crate) struct DKGStateMachine<ToFrostMan> {
     btc_client: BtcServerExtendedClient,
-    storage: Storage<Client>,
+    storage: Storage,
     frost_handle: ToFrostMan,
     state: DKGState,
     personal_frost_identifier: frost::Identifier,
@@ -126,20 +125,14 @@ pub(crate) struct DKGStateMachine<Client, ToFrostMan> {
     frost_config: FrostConfig,
 }
 
-impl<Client, ToFrostMan> DKGStateMachine<Client, ToFrostMan>
+impl<ToFrostMan> DKGStateMachine<ToFrostMan>
 where
     ToFrostMan: ToFrostManager + Clone,
-    Client: BlockReaderIdExt
-        + StateProviderFactory
-        + CanonChainTracker
-        + BlockchainTreeEngine
-        + Clone
-        + 'static,
 {
     /// Constructs a new state machine with the given params
     pub(crate) fn new(
         btc_client: BtcServerExtendedClient,
-        storage: Storage<Client>,
+        storage: Storage,
         frost_handle: ToFrostMan,
         frost_config: FrostConfig,
     ) -> Self {
@@ -182,15 +175,9 @@ where
     }
 }
 
-impl<Client, ToFrostMan> DKGStateMachine<Client, ToFrostMan>
+impl<ToFrostMan> DKGStateMachine<ToFrostMan>
 where
     ToFrostMan: ToFrostManager + Clone,
-    Client: BlockReaderIdExt
-        + StateProviderFactory
-        + CanonChainTracker
-        + BlockchainTreeEngine
-        + Clone
-        + 'static,
 {
     async fn get_round1_dkg_package(&mut self) -> Result<DkgPayload, Error> {
         let round1_payload = self.btc_client.get_round1_dkg_package(client::Empty {}).await;

--- a/crates/consensus/authority/src/epoch_manager.rs
+++ b/crates/consensus/authority/src/epoch_manager.rs
@@ -1,7 +1,7 @@
 use crate::Storage;
 use reth_consensus_common::utils;
 use reth_primitives::{header_ext::HeaderExt, BlockHashOrNumber};
-use reth_provider::{BlockReaderIdExt, CanonChainTracker, HeaderProvider, StateProviderFactory};
+use reth_provider::{BlockReaderIdExt, HeaderProvider};
 use tracing::{debug, info, warn};
 
 #[derive(Clone, Debug)]
@@ -14,15 +14,17 @@ use tracing::{debug, info, warn};
 pub(crate) struct EpochManager<Client> {
     /// Access to storage to fetch headers.
     // TODO (armins) this should be protected by an Arc.
-    pub(crate) storage: Storage<Client>,
+    pub(crate) storage: Storage,
+
+    pub(crate) client: Client,
 }
 
 impl<Client: HeaderProvider> EpochManager<Client>
 where
-    Client: BlockReaderIdExt + StateProviderFactory + CanonChainTracker + Clone + 'static,
+    Client: BlockReaderIdExt + Clone + 'static,
 {
-    pub(crate) fn new(storage: Storage<Client>) -> Self {
-        Self { storage }
+    pub(crate) fn new(storage: Storage, client: Client) -> Self {
+        Self { storage, client }
     }
 
     pub(crate) async fn poll(&mut self) -> bool {
@@ -30,27 +32,25 @@ where
         let signer_index = storage.signer_index;
         let signer_pk = storage.authority;
         let authority_len = storage.authorities.len() as u64;
-
+        drop(storage);
         // get best block
-        let best_block_number = match storage.client.best_block_number() {
+        let best_block_number = match self.client.best_block_number() {
             Ok(best_block_number) => best_block_number,
             Err(_) => {
-                drop(storage);
                 return false;
             }
         };
 
         // Check if the last signer was us
         // If so nothing to do anymore until the next timeslot
-        let latest_header = storage
+        let latest_header = self
             .client
             .header_by_hash_or_number(BlockHashOrNumber::Number(best_block_number))
             .ok()
             .flatten();
 
         if latest_header.is_none() {
-            drop(storage);
-            warn!("No latest header found");
+            warn!("No latest header found -- This should not happen please report ASAP.");
             return false;
         }
 
@@ -71,15 +71,12 @@ where
             if is_inturn && current_last_signer_validation.is_err() {
                 // made info instead of warn since this prints as soon as
                 // a block is produced and the node is still in turn
-                drop(storage);
                 debug!("Already produced the block for this turn.");
                 return false;
             }
         }
 
-        drop(storage);
         info!("Epoch manager. Member index = {}. Inturn?: {}", signer_index, is_inturn);
-
         is_inturn
     }
 }

--- a/crates/consensus/authority/src/frost_task.rs
+++ b/crates/consensus/authority/src/frost_task.rs
@@ -4,7 +4,7 @@ use crate::{
     dkg::DKGStateMachine, epoch_manager::EpochManager, extended_client::BtcServerExtendedClient,
     signing::SigningStateMachine, utils::is_active_sync_in_progress, Storage,
 };
-use reth_interfaces::blockchain_tree::BlockchainTreeEngine;
+
 use reth_network::{
     frost::{
         manager::{FrostCommand, FrostConfig, ToFrostManager},
@@ -13,7 +13,7 @@ use reth_network::{
     },
     NetworkHandle,
 };
-use reth_provider::{BlockReaderIdExt, CanonChainTracker, StateProviderFactory};
+use reth_provider::BlockReaderIdExt;
 use reth_tasks::TaskExecutor;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tracing::{debug, error, info, warn};
@@ -44,11 +44,11 @@ pub struct FrostTask<Client, ToFrostMan> {
     /// Epoch manager
     pub(crate) epoch_manager: EpochManager<Client>,
     /// dkg state machine
-    pub(crate) dkg_state_machine: DKGStateMachine<Client, ToFrostMan>,
+    pub(crate) dkg_state_machine: DKGStateMachine<ToFrostMan>,
     /// signing state machine
-    pub(crate) signing_state_machine: SigningStateMachine<Client, ToFrostMan>,
+    pub(crate) signing_state_machine: SigningStateMachine<ToFrostMan>,
     /// Shared storage to insert aggregate public key
-    pub(crate) storage: Storage<Client>,
+    pub(crate) storage: Storage,
     /// Channel to receive frost notifications (from the block production task)
     /// We only wait for init signing messages
     frost_task_rx: UnboundedReceiver<FrostNotificationMessage>,
@@ -56,13 +56,8 @@ pub struct FrostTask<Client, ToFrostMan> {
 
 impl<Client, ToFrostMan> FrostTask<Client, ToFrostMan>
 where
+    Client: BlockReaderIdExt + Clone + 'static,
     ToFrostMan: ToFrostManager + Clone,
-    Client: BlockReaderIdExt
-        + StateProviderFactory
-        + CanonChainTracker
-        + BlockchainTreeEngine
-        + Clone
-        + 'static,
 {
     /// Creates a new instance of the task
     #[allow(clippy::too_many_arguments)]
@@ -72,7 +67,7 @@ where
         frost_handle: ToFrostMan,
         epoch_manager: EpochManager<Client>,
         config: FrostConfig,
-        storage: Storage<Client>,
+        storage: Storage,
         frost_task_rx: UnboundedReceiver<FrostNotificationMessage>,
         frost_task_tx: UnboundedSender<FrostNotificationMessage>,
         task_executor: TaskExecutor,
@@ -88,7 +83,6 @@ where
 
         let signing_state_machine = SigningStateMachine::new(
             btc_server,
-            storage.clone(),
             frost_handle.clone(),
             config,
             frost_task_tx,
@@ -146,7 +140,8 @@ where
             if let Ok(secp_pk) = secp256k1::PublicKey::from_slice(
                 hex::decode(public_key.publickey).unwrap().as_slice(),
             ) {
-                let mut storage = self.storage.write().await;
+                // TODO replace with setter method
+                let mut storage = self.storage.inner.write().await;
                 storage.aggregate_public_key = Some(secp_pk);
 
                 drop(storage);

--- a/crates/consensus/authority/src/lib.rs
+++ b/crates/consensus/authority/src/lib.rs
@@ -266,6 +266,22 @@ impl Consensus for AuthorityConsensus {
     }
 }
 
+/// Collection of getters and setters for all things concerned with the authority consensus
+pub(crate) trait AuthorityStorage {
+    /// Get list of authorities
+    fn get_authorities(&self) -> Vec<secp256k1::PublicKey>;
+    /// Set the aggregate key
+    fn set_aggregate_key(&mut self, pk: secp256k1::PublicKey);
+    /// Get the aggregate key
+    fn get_aggregate_key(&self) -> Option<secp256k1::PublicKey>;
+    /// Get the signer index
+    fn get_signer_index(&self) -> usize;
+    /// Get genesis authorities
+    fn get_genesis_authorities(&self) -> Vec<secp256k1::PublicKey>;
+    /// Get the authority public key
+    fn get_authority(&self) -> secp256k1::PublicKey;
+}
+
 #[derive(Debug)]
 pub(crate) enum StorageCreationError {
     /// empty headers
@@ -336,6 +352,32 @@ pub(crate) struct StorageInner {
 }
 
 // === impl StorageInner ===
+
+impl AuthorityStorage for StorageInner {
+    fn get_authorities(&self) -> Vec<secp256k1::PublicKey> {
+        self.authorities.clone()
+    }
+
+    fn set_aggregate_key(&mut self, pk: secp256k1::PublicKey) {
+        self.aggregate_public_key = Some(pk);
+    }
+
+    fn get_aggregate_key(&self) -> Option<secp256k1::PublicKey> {
+        self.aggregate_public_key
+    }
+
+    fn get_signer_index(&self) -> usize {
+        self.signer_index
+    }
+
+    fn get_genesis_authorities(&self) -> Vec<secp256k1::PublicKey> {
+        self.genesis_authorities.clone()
+    }
+
+    fn get_authority(&self) -> secp256k1::PublicKey {
+        self.authority
+    }
+}
 
 impl StorageInner {
     /// Fills in pre-execution header fields based on the current best block and given

--- a/crates/consensus/authority/src/lib.rs
+++ b/crates/consensus/authority/src/lib.rs
@@ -286,7 +286,6 @@ impl Storage {
         authorities: Vec<secp256k1::PublicKey>,
         signer_index: usize,
         pk: secp256k1::PublicKey,
-        btc_network: bitcoin::Network,
     ) -> Result<Self, StorageCreationError> {
         if headers.is_empty() {
             return Err(StorageCreationError::EmptyHeaders);
@@ -300,7 +299,6 @@ impl Storage {
             signer_index,
             authority: pk,
             aggregate_public_key: None,
-            btc_network,
         };
 
         Ok(Self { inner: Arc::new(RwLock::new(storage)) })
@@ -335,8 +333,6 @@ pub(crate) struct StorageInner {
     /// The aggregate public key of the FROST threshold signature scheme
     /// Should get populated after DKG
     pub(crate) aggregate_public_key: Option<secp256k1::PublicKey>,
-    /// Bitcoin network
-    pub(crate) btc_network: bitcoin::Network,
 }
 
 // === impl StorageInner ===

--- a/crates/consensus/authority/src/lib.rs
+++ b/crates/consensus/authority/src/lib.rs
@@ -36,15 +36,12 @@ use reth_primitives::{
     constants::{EMPTY_RECEIPTS, EMPTY_TRANSACTIONS, ETHEREUM_BLOCK_GAS_LIMIT},
     extra_data_header::ExtraDataHeader,
     header_ext::HeaderExt,
-    proofs, public_key_to_address,
-    revm_primitives::FixedBytes,
-    Address, Block, BlockBody, BlockHash, BlockHashOrNumber, BlockWithSenders, Bloom, Bytes,
-    ChainSpec, Header, ReceiptWithBloom, SealedBlock, SealedHeader, TransactionSigned, B256,
-    EMPTY_OMMER_ROOT_HASH, U256,
+    proofs, public_key_to_address, Address, Block, BlockBody, BlockHashOrNumber, BlockWithSenders,
+    Bloom, Bytes, ChainSpec, Header, ReceiptWithBloom, SealedBlock, SealedHeader,
+    TransactionSigned, EMPTY_OMMER_ROOT_HASH, U256,
 };
 use reth_provider::{
-    BlockExecutor, BlockReaderIdExt, BundleStateWithReceipts, CanonChainTracker,
-    StateProviderFactory,
+    BlockExecutor, BlockReaderIdExt, BundleStateWithReceipts, StateProviderFactory,
 };
 use reth_revm::{
     database::StateProviderDatabase, db::states::bundle_state::BundleRetention,
@@ -277,17 +274,13 @@ pub(crate) enum StorageCreationError {
 
 /// In memory storage
 #[derive(Clone, Debug)]
-pub(crate) struct Storage<Client> {
-    pub(crate) inner: Arc<RwLock<StorageInner<Client>>>,
+pub(crate) struct Storage {
+    pub(crate) inner: Arc<RwLock<StorageInner>>,
 }
 
 // == impl Storage ===
-impl<Client> Storage<Client>
-where
-    Client: BlockReaderIdExt + StateProviderFactory + CanonChainTracker + Clone + 'static,
-{
+impl Storage {
     fn try_new(
-        client: Client,
         headers: &mut [SealedHeader],
         genesis_authorities: Vec<secp256k1::PublicKey>,
         authorities: Vec<secp256k1::PublicKey>,
@@ -302,7 +295,6 @@ where
         headers.sort_by(|a, b| a.number.cmp(&b.number));
 
         let storage = StorageInner {
-            client: client.clone(),
             genesis_authorities,
             authorities,
             signer_index,
@@ -315,21 +307,20 @@ where
     }
 
     /// Returns the write lock of the storage
-    pub(crate) async fn write(&self) -> RwLockWriteGuard<'_, StorageInner<Client>> {
+    pub(crate) async fn write(&self) -> RwLockWriteGuard<'_, StorageInner> {
         self.inner.write().await
     }
 
     #[allow(dead_code)]
     /// Returns the read lock of the storage
-    pub(crate) async fn read(&self) -> RwLockReadGuard<'_, StorageInner<Client>> {
+    pub(crate) async fn read(&self) -> RwLockReadGuard<'_, StorageInner> {
         self.inner.read().await
     }
 }
 
 #[derive(Debug)]
 /// In-memory storage for the chain the authority seal engine is building.
-pub(crate) struct StorageInner<Client> {
-    client: Client,
+pub(crate) struct StorageInner {
     /// The authority list in the genesis block
     pub(crate) genesis_authorities: Vec<secp256k1::PublicKey>,
     /// Keep track of the signers
@@ -341,62 +332,37 @@ pub(crate) struct StorageInner<Client> {
     pub(crate) signer_index: usize,
     /// Authority Signer public key
     pub(crate) authority: secp256k1::PublicKey,
-
     /// The aggregate public key of the FROST threshold signature scheme
     /// Should get populated after DKG
     pub(crate) aggregate_public_key: Option<secp256k1::PublicKey>,
-
     /// Bitcoin network
     pub(crate) btc_network: bitcoin::Network,
 }
 
 // === impl StorageInner ===
 
-impl<Client> StorageInner<Client>
-where
-    Client: BlockReaderIdExt + StateProviderFactory + CanonChainTracker + Clone + 'static,
-{
-    /// Returns the block hash for the given block number if it exists.
-    #[allow(dead_code)]
-    pub(crate) fn block_hash(&self, num: u64) -> Option<BlockHash> {
-        self.client.block_hash(num).ok().flatten()
-    }
-
-    pub(crate) fn get_best_block_and_hash(
-        &self,
-    ) -> Result<(u64, FixedBytes<32>), BlockExecutionError> {
-        let best_block = self
-            .client
-            .best_block_number()
-            .map_err(|_| BlockExecutionError::LatestBlock(ProviderError::BestBlockNotFound))?;
-
-        let best_hash = self
-            .client
-            .block_hash(best_block)
-            .map_err(|_| {
-                // can't pass block number only hash
-                BlockExecutionError::LatestBlock(ProviderError::BlockHashNotFound(B256::ZERO))
-            })?
-            .unwrap_or_else(|| {
-                panic!("{}", format!("Missing block hash for best block {:?}", best_block))
-            });
-
-        Ok((best_block, best_hash))
-    }
-
+impl StorageInner {
     /// Fills in pre-execution header fields based on the current best block and given
     /// transactions.
     pub(crate) fn build_header_template(
         &self,
         transactions: &[TransactionSigned],
         chain_spec: &Arc<ChainSpec>,
+        client: &impl BlockReaderIdExt,
     ) -> Result<Header, BlockExecutionError> {
-        let (best_block, best_hash) = self.get_best_block_and_hash()?;
+        // let (best_block, best_hash) = self.get_best_block_and_hash()?;
+        let best_block =
+            client.best_block_number().map_err(|e| BlockExecutionError::LatestBlock(e))?;
+        let best_hash = client
+            .block_hash(best_block)
+            .map_err(|e| BlockExecutionError::LatestBlock(e))?
+            .unwrap_or_else(|| {
+                panic!("best block hash not found for block number: {}", best_block);
+            });
         let timestamp = unix_timestamp();
 
         // check previous block for base fee
-        let base_fee_per_gas = self
-            .client
+        let base_fee_per_gas = client
             .header_by_hash_or_number(BlockHashOrNumber::Number(best_block))
             .expect("header to exist")
             .and_then(|parent| {
@@ -442,7 +408,6 @@ where
         &mut self,
         block: &BlockWithSenders,
         executor: &mut EVMProcessor<'_, EvmConfig>,
-        _senders: Vec<Address>,
         botanix_consensus_pkg: Option<BotanixConsensusPackage>,
         block_builder_address: Option<Address>,
     ) -> Result<(BundleStateWithReceipts, u64), BlockExecutionError>
@@ -486,6 +451,7 @@ where
         witness_data: &Option<Vec<bitcoin::witness::Witness>>,
         recent_block_hash: bitcoin::BlockHash,
         utxo_commitment: sha256::Hash,
+        client: &(impl BlockReaderIdExt + StateProviderFactory),
     ) -> Result<Header, BlockExecutionError> {
         let receipts = bundle_state.receipts_by_block(header.number);
         header.receipts_root = if receipts.is_empty() {
@@ -500,10 +466,8 @@ where
             proofs::calculate_receipt_root(&receipts_with_bloom)
         };
         header.gas_used = gas_used;
-
         // calculate the state root
-        let state_root = self
-            .client
+        let state_root = client
             .latest()
             .map_err(|_| {
                 BlockExecutionError::LatestBlock(ProviderError::StateForHashNotFound(
@@ -553,6 +517,7 @@ where
         botanix_consensus_pkg: Option<BotanixConsensusPackage>,
         sk: &secp256k1::SecretKey,
         evm_config: EvmConfig,
+        client: &(impl BlockReaderIdExt + StateProviderFactory),
     ) -> Result<(BundleStateWithReceipts, Block, u64), BlockExecutionError>
     where
         EvmConfig: ConfigureEvmEnv + Clone + 'static + reth_node_api::ConfigureEvm,
@@ -564,7 +529,7 @@ where
         }
 
         // Construct block and header
-        let header = self.build_header_template(&transactions, &chain_spec.clone())?;
+        let header = self.build_header_template(&transactions, &chain_spec.clone(), client)?;
 
         let block = Block { header, body: transactions, ommers: vec![], withdrawals: None };
         let senders = TransactionSigned::recover_signers(&block.body, block.body.len())
@@ -577,9 +542,7 @@ where
 
         // Now execute the block
         let db = State::builder()
-            .with_database_boxed(Box::new(StateProviderDatabase::new(
-                self.client.latest().unwrap(),
-            )))
+            .with_database_boxed(Box::new(StateProviderDatabase::new(client.latest().unwrap())))
             .with_bundle_update()
             .build();
 
@@ -591,7 +554,6 @@ where
         let (bundle_state, gas_used) = self.execute(
             &block_with_senders,
             &mut executor,
-            senders,
             botanix_consensus_pkg.clone(),
             Some(block_builder_address),
         )?;
@@ -613,6 +575,7 @@ where
         witness_data: &Option<Vec<bitcoin::witness::Witness>>,
         utxo_commitment: sha256::Hash,
         consensus: &AuthorityConsensus,
+        client: &(impl BlockReaderIdExt + StateProviderFactory),
     ) -> Result<SealedHeader, BlockExecutionError> {
         let Block { header, body, .. } = block;
         let body = BlockBody { transactions: body, ommers: vec![], withdrawals: None };
@@ -628,6 +591,7 @@ where
             // This is checked to be Some above
             botanix_consensus_pkg.expect("consensus pkg").bitcoin_checkpoint.0.block_hash(),
             utxo_commitment,
+            client,
         )?;
 
         // Validate EDH authorities match genesis authorities
@@ -660,6 +624,7 @@ where
         sealed_block: SealedBlock,
         botanix_consensus_pkg: Option<BotanixConsensusPackage>,
         evm_config: EvmConfig,
+        client: &(impl BlockReaderIdExt + StateProviderFactory),
     ) -> Result<BundleStateWithReceipts, BlockExecutionError>
     where
         EvmConfig: ConfigureEvmEnv + Clone + 'static + reth_node_api::ConfigureEvm,
@@ -668,9 +633,7 @@ where
 
         // Now execute the block
         let db = State::builder()
-            .with_database_boxed(Box::new(StateProviderDatabase::new(
-                self.client.latest().unwrap(),
-            )))
+            .with_database_boxed(Box::new(StateProviderDatabase::new(client.latest().unwrap())))
             .with_bundle_update()
             .build();
         let mut executor =
@@ -704,7 +667,6 @@ where
         let (bundle_state, _gas_used) = self.execute(
             &block_with_senders,
             &mut executor,
-            senders,
             botanix_consensus_pkg,
             Some(block_builder_address),
         )?;

--- a/crates/consensus/authority/src/signing.rs
+++ b/crates/consensus/authority/src/signing.rs
@@ -5,19 +5,17 @@ use crate::{
         deserialize_frost_peer_id, parse_signing_session_id, retry_exec, retry_future,
         FrostParseError,
     },
-    Storage, BLOCK_TIME_DURATION_SECS,
+    BLOCK_TIME_DURATION_SECS,
 };
 use client::{Empty, FinalizeSigningResponse, SigningPackage, SigningPackageRequest};
 use frost_secp256k1_tr as frost;
 use reth_consensus_common::utils::{
     current_inturn_index, get_in_turn_interval, is_inturn, unix_timestamp, CoordinatorInterval,
 };
-use reth_interfaces::blockchain_tree::BlockchainTreeEngine;
 use reth_network::frost::{
     manager::{peer_id_to_identifier, FrostCommand, FrostConfig, ToFrostManager},
     FrostPeerCommand, PeerMessageResponse, SigningEventResponseType, SigningResponse,
 };
-use reth_provider::{BlockReaderIdExt, CanonChainTracker, StateProviderFactory};
 use reth_tasks::TaskExecutor;
 use std::{collections::HashMap, sync::Arc, time::Duration};
 use tokio::sync::{
@@ -134,9 +132,8 @@ pub(crate) struct SigningSession {
 
 /// A state machine for transitioning between different signing states
 #[derive(Debug)]
-pub(crate) struct SigningStateMachine<Client, ToFrostMan> {
+pub(crate) struct SigningStateMachine<ToFrostMan> {
     btc_client: BtcServerExtendedClient,
-    storage: Storage<Client>,
     frost_handle: ToFrostMan,
     signing_states: Arc<RwLock<HashMap<[u8; 32], SigningSession>>>,
     personal_frost_identifier: frost::Identifier,
@@ -144,20 +141,13 @@ pub(crate) struct SigningStateMachine<Client, ToFrostMan> {
     frost_task_tx: UnboundedSender<FrostNotificationMessage>,
 }
 
-impl<Client, ToFrostMan> SigningStateMachine<Client, ToFrostMan>
+impl<ToFrostMan> SigningStateMachine<ToFrostMan>
 where
     ToFrostMan: ToFrostManager + Clone,
-    Client: BlockReaderIdExt
-        + StateProviderFactory
-        + CanonChainTracker
-        + BlockchainTreeEngine
-        + Clone
-        + 'static,
 {
     /// Constructs a new state machine with the given params
     pub(crate) fn new(
         btc_client: BtcServerExtendedClient,
-        storage: Storage<Client>,
         frost_handle: ToFrostMan,
         frost_config: FrostConfig,
         frost_task_tx: UnboundedSender<FrostNotificationMessage>,
@@ -185,7 +175,6 @@ where
 
         Self {
             btc_client,
-            storage,
             frost_handle,
             signing_states,
             personal_frost_identifier,
@@ -283,15 +272,9 @@ where
     }
 }
 
-impl<Client, ToFrostMan> SigningStateMachine<Client, ToFrostMan>
+impl<ToFrostMan> SigningStateMachine<ToFrostMan>
 where
     ToFrostMan: ToFrostManager + Clone,
-    Client: BlockReaderIdExt
-        + StateProviderFactory
-        + CanonChainTracker
-        + BlockchainTreeEngine
-        + Clone
-        + 'static,
 {
     async fn get_round1_signing_package(
         &mut self,

--- a/crates/consensus/authority/src/task.rs
+++ b/crates/consensus/authority/src/task.rs
@@ -30,7 +30,7 @@ pub struct BlockProductionTask<Client, EvmConfig, Engine: EngineTypes, ToFrostMa
     /// The active epoch
     pub(crate) epoch_manager: EpochManager<Client>,
     /// Shared storage to insert new blocks
-    pub(crate) storage: Storage<Client>,
+    pub(crate) storage: Storage,
     /// TODO: ideally this would just be a sender of hashes
     pub(crate) to_engine: UnboundedSender<BeaconEngineMessage<Engine>>,
     /// The pipeline events to listen on
@@ -63,6 +63,8 @@ pub struct BlockProductionTask<Client, EvmConfig, Engine: EngineTypes, ToFrostMa
     pub(crate) pbft_task_tx: UnboundedSender<PbftNotificationMessage>,
     /// Bitcoin Network
     pub(crate) btc_network: bitcoin::Network,
+    /// Database provider
+    pub(crate) client: Client,
 }
 impl<Client, EvmConfig, Engine: reth_node_api::EngineTypes, ToFrostMan>
     BlockProductionTask<Client, EvmConfig, Engine, ToFrostMan>
@@ -84,7 +86,7 @@ where
         consensus: AuthorityConsensus,
         to_engine: UnboundedSender<BeaconEngineMessage<Engine>>,
         _canon_state_notification: CanonStateNotificationSender,
-        storage: Storage<Client>,
+        storage: Storage,
         btc_server: BtcServerExtendedClient,
         bitcoin_block_header: Arc<RwLock<Option<(bitcoin::block::Header, u32)>>>,
         sk: secp256k1::SecretKey,
@@ -99,6 +101,7 @@ where
         pbft_task_rx: UnboundedReceiver<PbftNotificationMessage>,
         pbft_task_tx: UnboundedSender<PbftNotificationMessage>,
         btc_network: bitcoin::Network,
+        client: Client,
     ) -> Self {
         Self {
             consensus,
@@ -119,6 +122,7 @@ where
             pbft_task_rx,
             pbft_task_tx,
             btc_network,
+            client,
         }
     }
 

--- a/crates/consensus/authority/src/utils.rs
+++ b/crates/consensus/authority/src/utils.rs
@@ -13,9 +13,7 @@ use reth_botanix_lib::{
 use reth_interfaces::sync::SyncStateProvider;
 use reth_network::NetworkHandle;
 use reth_primitives::{constants::eip225::EPOCH_LENGTH, hex, Bloom, BloomInput, Log, Receipt};
-use reth_provider::{
-    BlockReaderIdExt, BundleStateWithReceipts, CanonChainTracker, StateProviderFactory,
-};
+use reth_provider::{BlockReaderIdExt, BundleStateWithReceipts};
 use reth_rpc_types::BlockHashOrNumber;
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
@@ -281,7 +279,7 @@ async fn process_botanix_log(
     bitcoin_checkpoint_height: u32,
     receipt_logs: &[Log],
     btc_network: bitcoin::Network,
-    pegin_conf_depth: u32,
+    _pegin_conf_depth: u32,
 ) -> Result<Option<PegoutData>, ProcessBotanixLogError> {
     let mut pegout: Option<PegoutData> = None;
     for topic in &log.topics().to_vec() {
@@ -420,14 +418,11 @@ pub(crate) enum EpochPegoutsError {
 /// # Returns
 ///
 /// A vector of [PegoutData] representing the pegouts in the epoch
-pub(crate) async fn epoch_pegouts<Client>(
+pub(crate) async fn epoch_pegouts(
     best_block: u64,
-    client: &Client,
+    client: &impl BlockReaderIdExt,
     btc_network: bitcoin::Network,
-) -> Result<Vec<PegoutData>, EpochPegoutsError>
-where
-    Client: BlockReaderIdExt + StateProviderFactory + CanonChainTracker + Clone + 'static,
-{
+) -> Result<Vec<PegoutData>, EpochPegoutsError> {
     let start_block = find_epoch_start(EPOCH_LENGTH, best_block);
     let mut pegouts: Vec<PegoutData> = vec![];
     for block in start_block..=best_block {


### PR DESCRIPTION
Big refactor to remove client from poa storage. 
Part of this refactor also uses more concise trait contraints where needed. Where as before we we're using this everwhere
```
Client: BlockReaderIdExt
        + StateProviderFactory
        + CanonChainTracker
        + BlockchainTreeEngine
        + Clone
        + 'static,

```

This ended up being an issue when we needed to mock storage to other crate structs unit tests. Now storage can be mocked by using the trait `AuthorityStorage`. 

As a part of https://github.com/botanix-labs/botanix/issues/494 

In the future we could also remove all the methods that create the EVM processor and execute things and have them as standalone utilities. No need to be a part of authority storage