### PR TITLE
authority: Cleanly exit block fetcher task on channel close 

### DIFF
--- a/crates/consensus/authority/src/block_fetcher.rs
+++ b/crates/consensus/authority/src/block_fetcher.rs
@@ -104,7 +104,7 @@ where
     pub async fn start_task(&mut self) {
         // only a federation node has a btc_server
         let is_fed_node = self.btc_server.is_some();
-        let consensus: Arc<dyn Consensus> = Arc::new(self.consensus.clone());
+        let consensus = Arc::new(self.consensus.clone());
         let full_block_client = FullBlockClient::new(self.network_client.clone(), consensus);
 
         loop {
@@ -115,18 +115,12 @@ where
                 return;
             }
 
-            let new_block = match self.block_import_rx.try_recv() {
-                Ok(b) => b,
-                Err(error) => match error {
-                    TryRecvError::Empty => {
-                        debug!(target: "consensus::authority", "No new blocks from peers");
-                        continue;
-                    }
-                    TryRecvError::Disconnected => {
-                        debug!(target: "consensus::authority", "Block import channel disconnected");
-                        continue;
-                    }
-                },
+            let new_block = match self.block_import_rx.recv().await {
+                Some(b) => b,
+                None => {
+                    debug!(target: "consensus::authority", "Block import channel disconnected");
+                    continue;
+                }
             };
 
             let block = new_block.block.block.clone();

--- a/crates/consensus/authority/src/block_fetcher.rs
+++ b/crates/consensus/authority/src/block_fetcher.rs
@@ -118,8 +118,10 @@ where
             let new_block = match self.block_import_rx.recv().await {
                 Some(b) => b,
                 None => {
-                    debug!(target: "consensus::authority", "Block import channel disconnected");
-                    continue;
+                    info!(target: "consensus::authority",
+                        "block fetcher task shutting down (channel closed)",
+                    );
+                    return;
                 }
             };
 

--- a/crates/consensus/authority/src/frost_task.rs
+++ b/crates/consensus/authority/src/frost_task.rs
@@ -192,7 +192,7 @@ where
                 }
             }
             // receive over a channel message from other peers and update our state machine
-            if let Ok((_peerid, msg)) = peer_messages_rx.try_recv() {
+            while let Ok((_peerid, msg)) = peer_messages_rx.try_recv() {
                 match msg {
                     PeerMessageResponse::Pbft(_) => {
                         // Nothing to do for pbft related messages. Those are handled by the pbft

--- a/crates/consensus/authority/src/pbft_task.rs
+++ b/crates/consensus/authority/src/pbft_task.rs
@@ -166,7 +166,7 @@ where
                 }
             }
             // receive over a channel message from other peers and update our state machine
-            if let Ok((peer_id, msg)) = peer_messages_rx.try_recv() {
+            while let Ok((peer_id, msg)) = peer_messages_rx.try_recv() {
                 match msg {
                     PeerMessageResponse::Pbft(pbft_response) => {
                         let PbftResponse { response_type, data } = pbft_response;


### PR DESCRIPTION
Built on and now replaces https://github.com/botanix-labs/Macbeth/pull/273. Some informative comments there.