### PR TITLE
sanitizing discovery key

### DIFF
--- a/crates/node-core/src/args/secret_key.rs
+++ b/crates/node-core/src/args/secret_key.rs
@@ -37,7 +37,9 @@ pub fn get_secret_key(secret_key_path: &Path) -> Result<SecretKey, SecretKeyErro
     match exists {
         Ok(true) => {
             let contents = fs::read_to_string(secret_key_path)?;
-            Ok(contents
+            let sanitized_key =
+                contents.chars().filter(|c| c.is_ascii_hexdigit()).collect::<String>();
+            Ok(sanitized_key
                 .as_str()
                 .parse::<SecretKey>()
                 .map_err(SecretKeyError::SecretKeyDecodeError)?)


### PR DESCRIPTION
So far we have had many problems with discovery keys in a file with extra tabs and other hard to catch characters. This MR  enables us to sanitize the latter and not worry anymore about formatting, indentations etc.