### PR TITLE
fix(health_checks): pull peer socket address from network manager / fed config

### DIFF
--- a/bin/reth/src/cli/mod.rs
+++ b/bin/reth/src/cli/mod.rs
@@ -188,6 +188,7 @@ impl<Ext: clap::Args + fmt::Debug + PoaNodeCommandConfig> Cli<Ext> {
 }
 
 /// Commands to be executed
+#[warn(clippy::large_enum_variant)]
 #[derive(Debug, Subcommand)]
 pub enum Commands<Ext: clap::Args + fmt::Debug = NoArgs> {
     /// Start the node

--- a/bin/reth/src/commands/poa/mod.rs
+++ b/bin/reth/src/commands/poa/mod.rs
@@ -503,8 +503,7 @@ where {
 
         // Config executor factory
         let evm_config = EthEvmConfig::default();
-        let executor_factory =
-            EvmProcessorFactory::new(Arc::new(chain.clone()), evm_config.clone());
+        let executor_factory = EvmProcessorFactory::new(Arc::new(chain.clone()), evm_config);
 
         // Authority consensus
         let consensus = Arc::new(AuthorityConsensus::new(Arc::new(chain)));
@@ -595,7 +594,7 @@ where {
         let default_peers_path = data_dir.known_peers_path();
         let cfg_builder = self
             .network
-            .network_config(&reth_config, chain_arc.clone(), secret_key.clone(), default_peers_path)
+            .network_config(&reth_config, chain_arc.clone(), secret_key, default_peers_path)
             .with_task_executor(Box::new(executor.clone()))
             .set_head(head)
             .listener_addr(SocketAddr::new(
@@ -768,13 +767,13 @@ where {
                     pbft_task.expect("pbft task exists").start_task().await;
                 }),
             );
-            // TODO: temporarily disable healthcheck task
-            // executor.spawn_critical(
-            //     "Healthcheck Task",
-            //     Box::pin(async move {
-            //         healthcheck_task.expect("health check task exists").start_task().await;
-            //     }),
-            // );
+
+            executor.spawn_critical(
+                "Healthcheck Task",
+                Box::pin(async move {
+                    healthcheck_task.expect("health check task exists").start_task().await;
+                }),
+            );
         }
 
         executor.spawn_critical(

--- a/crates/consensus/authority/src/block_builder.rs
+++ b/crates/consensus/authority/src/block_builder.rs
@@ -328,7 +328,7 @@ where
         info!(target: "consensus::authority", "Waiting for commitments...");
 
         drop(storage);
-        let _ = match tokio::time::timeout(
+        match tokio::time::timeout(
             // Lets await another third of the block time for the PBFT commitments
             Duration::from_secs(
                 self.chain_spec.leader_selection_window.expect("to be defined for poa consensus") /

--- a/crates/consensus/authority/src/block_fetcher.rs
+++ b/crates/consensus/authority/src/block_fetcher.rs
@@ -71,6 +71,7 @@ where
         ConfigureEvmEnv + Clone + Unpin + Send + Sync + 'static + reth_node_api::ConfigureEvm,
     NetworkClient: HeadersClient + BodiesClient + Clone + Unpin + 'static,
 {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         consensus: AuthorityConsensus,
         block_import_rx: UnboundedReceiver<NewBlockMessage>,
@@ -154,7 +155,6 @@ where
                         bitcoin_checkpoint: bitcoin_block_header.expect("recent header is some"),
                         aggregate_public_key: storage
                             .aggregate_public_key
-                            .clone()
                             .expect("aggregate pk is some"),
                         btc_network: self.btc_network,
                     });
@@ -323,7 +323,7 @@ where
                         warn!(target: "consensus::authority", "Recieved block is not a direct child of the best block");
                         // need to retrieve this missing block from a peer
                         let missing_block =
-                            full_block_client.get_full_block(header.parent_hash.clone()).await;
+                            full_block_client.get_full_block(header.parent_hash).await;
                         // TODO (armins) should be using the insert with botanix consensus package
                         if let Err(e) = self.client.insert_block_without_senders(
                             missing_block.clone(),

--- a/crates/consensus/authority/src/healthcheck_task.rs
+++ b/crates/consensus/authority/src/healthcheck_task.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
+    net::SocketAddr,
     sync::Arc,
     time::Instant,
 };
@@ -115,25 +116,33 @@ where
             tokio::time::sleep(std::time::Duration::from_millis(500)).await;
         }
 
-        // get all connected authority peers
-        let (connected_peers_tx, connected_peers_rx) = tokio::sync::oneshot::channel();
-        if let Err(e) =
-            self.frost_handle.send_command(FrostCommand::GetAllConnectedPeers(connected_peers_tx))
-        {
-            error!(target: "HealthcheckTask::start_task", "Failed to send GetAllConnectedPeers frost command {:?}", e);
-        }
-        let connected_peers = match connected_peers_rx.await {
-            Ok(connected_peers) => connected_peers,
-            Err(e) => {
-                error!(target: "HealthcheckTask::start_task", "Error getting receiver handle = {:?}", e);
-                panic!("Error getting receiver handle");
-            }
-        };
+        // get all connected peers (could be authority and none-authority)
+        let all_connected_peers =
+            self.network_handle.get_all_peers().await.ok().unwrap_or_default();
+
+        // get all authority peers in the federation (at this point we must be connected to all of
+        // them)
+        let authority_peers = self
+            .storage
+            .read()
+            .await
+            .authorities
+            .iter()
+            .filter_map(|authority_pk| {
+                let authority_peer_id = pk2id(authority_pk);
+                if authority_peer_id != *self.network_handle.peer_id() {
+                    // excluse our own peer_id
+                    Some(authority_peer_id)
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<PeerId>>();
 
         // update the tracker for each authority peer_id and mark its state as healthy initially
         let mut guard = self.peers_healthcheck_tracker.write().await;
-        for (peer_id, _) in connected_peers.into_iter() {
-            let _ = guard.insert(peer_id, Instant::now());
+        for peer_id in authority_peers.iter() {
+            let _ = guard.insert(*peer_id, Instant::now());
         }
         drop(guard);
 
@@ -151,24 +160,6 @@ where
                 panic!("Error getting receiver handle");
             }
         };
-
-        // get all authority peers
-        let authority_peers = self
-            .storage
-            .read()
-            .await
-            .authorities
-            .iter()
-            .filter_map(|authority_pk| {
-                let authority_peer_id = pk2id(authority_pk);
-                if authority_peer_id != *self.network_handle.peer_id() {
-                    // excluse our own peer_id
-                    Some(authority_peer_id)
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<PeerId>>();
 
         // spawn a background task to do periodical healthchecks
         let frost_handle = self.frost_handle.clone();
@@ -228,7 +219,7 @@ where
                     continue;
                 }
 
-                // send to slack/stdout alarms about those peers
+                // print the peeers we need to reconnect with
                 let peers_to_reconnect_stringified = peers_to_reconnect
                 .clone()
                 .iter()
@@ -236,6 +227,15 @@ where
                 .collect::<Vec<String>>()
                 .join(",");
                 warn!(target: "HealthcheckTask::start_task", "Trying to reconnect to peers {} ...", peers_to_reconnect_stringified);
+
+                // now for all peers we want to reconnect with, get their socket addresses
+                let peers_to_reconnect = peers_to_reconnect
+                .iter()
+                .filter_map(|peer_id| {
+                    let peer_remote_addr = all_connected_peers.iter().find(|p| p.remote_id == *peer_id).map(|p| p.remote_addr);
+                    Some(*peer_id).zip(peer_remote_addr)
+                })
+                .collect::<Vec<(PeerId, SocketAddr)>>();
 
                 // try to reconnect to the peers whose frost subprotocol connection or physical connection has been lost to
                 if let Err(e) = frost_handle

--- a/crates/consensus/authority/src/lib.rs
+++ b/crates/consensus/authority/src/lib.rs
@@ -601,7 +601,7 @@ impl StorageInner {
             witness_data.clone(),
             recent_block_hash,
             utxo_commitment,
-            aggregated_public_key.clone(),
+            *aggregated_public_key,
         );
         header.extra_data = Bytes::from(edh.serialize());
         header.sign_block(sk).map_err(|e| {

--- a/crates/consensus/authority/src/pbft.rs
+++ b/crates/consensus/authority/src/pbft.rs
@@ -81,9 +81,9 @@ pub(crate) enum Error {
     #[error("Peer for time slot {0} already processed")]
     PeerAlreadyProcessedTimeSlot(u64),
     #[error("Recover authorities error {0}")]
-    RecoverAuthoritiesError(#[from] RecoverAuthorityError),
+    RecoverAuthorities(#[from] RecoverAuthorityError),
     #[error("Block execution error: {0}")]
-    BlockExecutionError(#[from] BlockExecutionError),
+    BlockExecution(#[from] BlockExecutionError),
     #[error("Failed to find block with hash {0}")]
     BlockHashNotFound(BlockHash),
 }
@@ -203,6 +203,7 @@ where
     EF: ExecutorFactory + Clone + 'static,
 {
     /// Constructs a new state machine with the given params
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         chain_spec: Arc<ChainSpec>,
         client: Client,

--- a/crates/net/network/src/frost/manager.rs
+++ b/crates/net/network/src/frost/manager.rs
@@ -45,8 +45,6 @@ pub struct PeerData {
     pub peer_id: PeerId,
     /// chanel use for sending commands to the peer
     pub peer_commands_tx: Option<UnboundedSender<FrostPeerCommand>>,
-    /// socket where the peer is connected
-    pub socket_addr: Option<SocketAddr>,
     /// in or outgoing connection
     pub direction: Option<Direction>,
     /// the frost identifier of the peer
@@ -72,6 +70,8 @@ pub struct FrostManager {
     authority_peerid: Vec<PeerId>,
     /// Forwards for message to the frost task
     task_forwarder_txs: Vec<mpsc::UnboundedSender<(PeerId, PeerMessageResponse)>>,
+    /// Frost configuration
+    config: FrostConfig,
 }
 
 impl FrostManager {
@@ -81,15 +81,9 @@ impl FrostManager {
         network: NetworkHandle,
         from_network: mpsc::UnboundedReceiver<NetworkFrostEvent>,
     ) -> Self {
-        let FrostConfig {
-            authority_index: _,
-            authorities,
-            min_signers: _,
-            max_signers: _,
-            authority_pk: _,
-        } = config;
         let (command_tx, command_rx) = mpsc::unbounded_channel();
-        let authority_peerid = authorities
+        let authority_peerid = config
+            .authorities
             .iter()
             .map(|pk| PeerId::from_slice(&pk.serialize_uncompressed()[1..]))
             .collect();
@@ -102,6 +96,7 @@ impl FrostManager {
             peers_connections: HashMap::default(),
             authority_peerid,
             task_forwarder_txs: Vec::new(),
+            config,
         }
     }
 
@@ -162,7 +157,6 @@ impl FrostManager {
                             peer_id,
                             direction: Some(direction),
                             peer_commands_tx: Some(to_connection),
-                            socket_addr: None,
                             frost_identifier: None,
                         },
                     );
@@ -179,20 +173,27 @@ impl FrostManager {
                     }
                 }
             }
-            NetworkFrostEvent::PeerConfirmed(peer_id, authority_index, peer_socket_addr) => {
+            NetworkFrostEvent::PeerConfirmed(peer_id) => {
                 if !self.is_authority_peer(&peer_id) {
                     warn!(target: "network::frost::on_network_event", "Received NetworkFrostEvent::PeerConfirmed event, but peer with id {} is not an authority member", peer_id);
                     return;
                 }
 
                 if self.peers_connections.contains_key(&peer_id) {
-                    let frost_identifier = peer_id_to_identifier(authority_index);
+                    let (index, _) = self
+                        .config
+                        .authorities
+                        .iter()
+                        .enumerate()
+                        .find(|(_, pk)| {
+                            peer_id == PeerId::from_slice(&pk.serialize_uncompressed()[1..])
+                        })
+                        .unzip();
                     // only if we have an already connection established
                     if let Some(peer_data) = self.peers_connections.get_mut(&peer_id) {
-                        info!(target: "network::frost::on_network_event", "Received NetworkFrostEvent::PeerConfirmed event from peer with id = {}, frost identifier = {:?}, socket address = {}. Authority index = {}", peer_id, frost_identifier, peer_socket_addr, authority_index);
                         // add the peer conn mapped to a frost id based on authority index
-                        peer_data.socket_addr = Some(peer_socket_addr);
-                        peer_data.frost_identifier = Some(frost_identifier);
+                        peer_data.frost_identifier = index.map(|i| peer_id_to_identifier(i as u16));
+                        info!(target: "network::frost::on_network_event", "Received NetworkFrostEvent::PeerConfirmed event from peer with id = {}, frost identifier = {:?}", peer_id, peer_data.frost_identifier);
                     } else {
                         warn!(target: "network::frost::on_network_event", "Received NetworkFrostEvent::PeerConfirmed event, but peer with id {} does not seem to be connected yet", peer_id);
                     }
@@ -207,19 +208,18 @@ impl FrostManager {
             FrostCommand::SendHealtcheckToPeers => {
                 self.send_healthcheck_to_peers();
             }
-            FrostCommand::ReconnectPeers(peers) => {
-                let peers_to_reconnect = peers.len();
+            FrostCommand::ReconnectPeers(disconnected_peers) => {
+                let peers_to_reconnect = disconnected_peers.len();
                 let mut reconnected_peers = 0;
-                for peer in peers.into_iter() {
-                    if let Some(peer_data) = self.peers_connections.get(&peer) {
-                        if let Some(conn_socket) = peer_data.socket_addr {
-                            info!(target: "network::frost::on_command", "Readding peer {:?} with remote address {:?} ...", peer, conn_socket.to_string());
-                            self.network.add_trusted_peer(peer, conn_socket);
-                            reconnected_peers += 1;
-                        } else {
-                            warn!(target: "network::frost::on_command", "Could not find remote socket address for peer {:?}", peer);
-                        }
+
+                for (disconnected_peer, peer_remote_addr) in disconnected_peers.into_iter() {
+                    if !self.peers_connections.contains_key(&disconnected_peer) {
+                        warn!(target: "network::frost::on_command", "Could not find peer amongst own peer connections {:?}", disconnected_peer);
+                        continue;
                     }
+                    info!(target: "network::frost::on_command", "Reconnecting peer {:?} with remote address {:?} ...", disconnected_peer, peer_remote_addr.to_string());
+                    self.network.add_trusted_peer(disconnected_peer, peer_remote_addr);
+                    reconnected_peers += 1;
                 }
                 if reconnected_peers > 0 {
                     info!(target: "network::frost::on_command", "Readded/Reconnected {}/{} peers", reconnected_peers, peers_to_reconnect);
@@ -296,7 +296,7 @@ pub enum FrostCommand {
     /// sends healthcheck messages to all peers
     SendHealtcheckToPeers,
     /// Reconect peers in case their connection got dropped
-    ReconnectPeers(Vec<PeerId>),
+    ReconnectPeers(Vec<(PeerId, SocketAddr)>),
     /// Check if connection to all federated peers is established
     CheckConnectedToAll(oneshot::Sender<bool>),
     /// Get the readily connected peers

--- a/crates/net/network/src/frost/messages.rs
+++ b/crates/net/network/src/frost/messages.rs
@@ -1,6 +1,6 @@
 #![allow(unreachable_pub)]
 use core::fmt;
-use std::{net::SocketAddr, str::FromStr};
+use std::str::FromStr;
 
 use alloy_rlp::{Decodable, Encodable};
 use reth_eth_wire::{capability::Capability, protocol::Protocol};
@@ -150,9 +150,9 @@ pub enum FrostProtoMessageKind {
     /// Pong
     Pong,
     /// Ping message with a user-defined message
-    PingMessage(PeerId, u16, SocketAddr),
-    /// Pong message with a user String id and an authority index
-    PongMessage(PeerId, u16, SocketAddr),
+    PingMessage(PeerId),
+    /// Pong message with a user peer id
+    PongMessage(PeerId),
     /// Signers will add their signing commitments to the psbt
     SignerRound1SigningPackage(SignRequest),
     /// Coordinating node will collect the PSBTs with the signing commitments
@@ -202,17 +202,17 @@ impl FrostProtoMessage {
     }
 
     /// Creates a ping message
-    pub fn ping_message(peer_id: PeerId, authority_index: u16, addr: SocketAddr) -> Self {
+    pub fn ping_message(peer_id: PeerId) -> Self {
         Self {
             message_type: FrostProtoMessageId::PingMessage,
-            message: FrostProtoMessageKind::PingMessage(peer_id, authority_index, addr),
+            message: FrostProtoMessageKind::PingMessage(peer_id),
         }
     }
     /// Creates a ping message
-    pub fn pong_message(peer_id: PeerId, authority_index: u16, addr: SocketAddr) -> Self {
+    pub fn pong_message(peer_id: PeerId) -> Self {
         Self {
             message_type: FrostProtoMessageId::PongMessage,
-            message: FrostProtoMessageKind::PongMessage(peer_id, authority_index, addr),
+            message: FrostProtoMessageKind::PongMessage(peer_id),
         }
     }
 
@@ -337,36 +337,19 @@ impl FrostProtoMessage {
             }
             FrostProtoMessageKind::Ping => {}
             FrostProtoMessageKind::Pong => {}
-            FrostProtoMessageKind::PingMessage(peer_id, authority_index, socket_addr) => {
+            FrostProtoMessageKind::PingMessage(peer_id) => {
                 // peer id
                 let peer_id_str = peer_id.to_string();
                 let peer_id_bytes = peer_id_str.as_bytes();
                 buf.put_u16_le(peer_id_bytes.len() as u16); // Store the length of the peer_id string
                 buf.put_slice(peer_id_bytes); // Store the peer_id string itself
-
-                // authority index
-                buf.put_u16_le(*authority_index); // Store the authority_index
-
-                // socket address
-                let socket_addr_str = socket_addr.to_string();
-                let socket_addr_bytes = socket_addr_str.as_bytes();
-                buf.put_u16_le(socket_addr_bytes.len() as u16); // Store the length of the socket address string
-                buf.put_slice(socket_addr_bytes); // Store the socket address string itself
             }
-            FrostProtoMessageKind::PongMessage(peer_id, authority_index, socket_addr) => {
+            FrostProtoMessageKind::PongMessage(peer_id) => {
                 // peer id
                 let peer_id_str = peer_id.to_string();
                 let peer_id_bytes = peer_id_str.as_bytes();
                 buf.put_u16_le(peer_id_bytes.len() as u16); // Store the length of the peer_id string
                 buf.put_slice(peer_id_bytes); // Store the peer_id string itself
-                                              // authority index
-                buf.put_u16_le(*authority_index); // Store the authority_index
-
-                // socket address
-                let socket_addr_str = socket_addr.to_string();
-                let socket_addr_bytes = socket_addr_str.as_bytes();
-                buf.put_u16_le(socket_addr_bytes.len() as u16); // Store the length of the socket address string
-                buf.put_slice(socket_addr_bytes); // Store the socket address string itself
             }
             FrostProtoMessageKind::SignerRound1SigningPackage(resource) => {
                 // identifier
@@ -512,16 +495,7 @@ impl FrostProtoMessage {
                 let peer_id = PeerId::from_str(peer_id_str).unwrap(); // Assuming from_str can never fail in this context
                 buf.advance(peer_id_len);
 
-                let authority_index = u16::from_le_bytes(buf[..2].try_into().unwrap());
-                buf.advance(2);
-
-                let socket_addr_len = u16::from_le_bytes(buf[..2].try_into().unwrap()) as usize;
-                buf.advance(2);
-                let socket_addr_str = std::str::from_utf8(&buf[..socket_addr_len]).unwrap();
-                let socket_addr = SocketAddr::from_str(socket_addr_str).unwrap(); // Assuming from_str can never fail
-                buf.advance(socket_addr_len);
-
-                FrostProtoMessageKind::PingMessage(peer_id, authority_index, socket_addr)
+                FrostProtoMessageKind::PingMessage(peer_id)
             }
             FrostProtoMessageId::PongMessage => {
                 let peer_id_len = u16::from_le_bytes(buf[..2].try_into().unwrap()) as usize;
@@ -530,16 +504,7 @@ impl FrostProtoMessage {
                 let peer_id = PeerId::from_str(peer_id_str).unwrap(); // Assuming from_str can never fail in this context
                 buf.advance(peer_id_len);
 
-                let authority_index = u16::from_le_bytes(buf[..2].try_into().unwrap());
-                buf.advance(2);
-
-                let socket_addr_len = u16::from_le_bytes(buf[..2].try_into().unwrap()) as usize;
-                buf.advance(2);
-                let socket_addr_str = std::str::from_utf8(&buf[..socket_addr_len]).unwrap();
-                let socket_addr = SocketAddr::from_str(socket_addr_str).unwrap(); // Assuming from_str can never fail
-                buf.advance(socket_addr_len);
-
-                FrostProtoMessageKind::PongMessage(peer_id, authority_index, socket_addr)
+                FrostProtoMessageKind::PongMessage(peer_id)
             }
             FrostProtoMessageId::SignerRound1SigningPackage => {
                 // id
@@ -714,7 +679,6 @@ mod tests {
     use reth_primitives::SealedBlock;
     #[allow(unused_imports)]
     use reth_rpc_types::PeerId;
-    use std::net::{Ipv4Addr, SocketAddr};
     #[allow(unused_imports)]
     use std::str::FromStr;
 
@@ -817,12 +781,10 @@ mod tests {
     #[test]
     fn test_ping_message_encode_decode() {
         let peer_id = PeerId::from_str("6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0").unwrap();
-        let authority_index = 2u16;
-        let socket_addr = SocketAddr::new(std::net::IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8888);
 
         let message = FrostProtoMessage {
             message_type: FrostProtoMessageId::PingMessage,
-            message: FrostProtoMessageKind::PingMessage(peer_id, authority_index, socket_addr),
+            message: FrostProtoMessageKind::PingMessage(peer_id),
         };
 
         // Encode the message
@@ -834,20 +796,8 @@ mod tests {
             .expect("Failed to decode PingMessage");
 
         // Verify that the decoded message matches the original message
-        if let FrostProtoMessageKind::PingMessage(
-            decoded_peer_id,
-            decoded_authority_index,
-            decoded_socket_addr,
-        ) = decoded_message.message
-        {
+        if let FrostProtoMessageKind::PingMessage(decoded_peer_id) = decoded_message.message {
             assert_eq!(decoded_peer_id, peer_id, "PeerId does not match");
-            assert_eq!(decoded_authority_index, authority_index, "Authority index does not match");
-            assert_eq!(
-                decoded_socket_addr.ip(),
-                std::net::IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-                "Socket addr does not match"
-            );
-            assert_eq!(decoded_socket_addr.port(), 8888, "Socket port does not match");
         } else {
             panic!("Decoded message is not a PingMessage");
         }
@@ -856,12 +806,10 @@ mod tests {
     #[test]
     fn test_pong_message_encode_decode() {
         let peer_id = PeerId::from_str("6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0").unwrap();
-        let authority_index = 20u16;
-        let socket_addr = SocketAddr::new(std::net::IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8888);
 
         let message = FrostProtoMessage {
             message_type: FrostProtoMessageId::PongMessage,
-            message: FrostProtoMessageKind::PongMessage(peer_id, authority_index, socket_addr),
+            message: FrostProtoMessageKind::PongMessage(peer_id),
         };
 
         // Encode the message
@@ -873,20 +821,8 @@ mod tests {
             .expect("Failed to decode PongMessage");
 
         // Verify that the decoded message matches the original message
-        if let FrostProtoMessageKind::PongMessage(
-            decoded_peer_id,
-            decoded_authority_index,
-            decoded_socket_addr,
-        ) = decoded_message.message
-        {
+        if let FrostProtoMessageKind::PongMessage(decoded_peer_id) = decoded_message.message {
             assert_eq!(decoded_peer_id, peer_id, "PeerId does not match");
-            assert_eq!(decoded_authority_index, authority_index, "Authority index does not match");
-            assert_eq!(
-                decoded_socket_addr.ip(),
-                std::net::IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-                "Socket addr does not match"
-            );
-            assert_eq!(decoded_socket_addr.port(), 8888, "Socket port does not match");
         } else {
             panic!("Decoded message is not a PongMessage");
         }

--- a/crates/net/network/src/frost/mod.rs
+++ b/crates/net/network/src/frost/mod.rs
@@ -1,7 +1,6 @@
 #![allow(unreachable_pub)]
 //! Testing gossiping of transactions.
 use core::fmt;
-use std::net::SocketAddr;
 
 use reth_network_api::Direction;
 use reth_primitives::SealedBlock;
@@ -23,7 +22,6 @@ pub mod protocol;
 pub struct ProtocolState {
     events: mpsc::UnboundedSender<FrostProtocolEvent>,
     peer_message_forwarder: mpsc::UnboundedSender<FrostProtocolEvent>,
-    authority_index: u16,
     network_handle: NetworkHandle,
     authorities: Vec<PeerId>,
 }
@@ -33,11 +31,10 @@ impl ProtocolState {
     pub fn new(
         events: mpsc::UnboundedSender<FrostProtocolEvent>,
         peer_message_forwarder: mpsc::UnboundedSender<FrostProtocolEvent>,
-        authority_index: u16,
         network_handle: NetworkHandle,
         authorities: Vec<PeerId>,
     ) -> Self {
-        Self { events, peer_message_forwarder, authority_index, network_handle, authorities }
+        Self { events, peer_message_forwarder, network_handle, authorities }
     }
 }
 
@@ -243,7 +240,7 @@ pub enum FrostProtocolEvent {
         response: PeerMessageResponse,
     },
     /// Peer confirmation
-    PeerConfirmed(PeerId, u16, SocketAddr),
+    PeerConfirmed(PeerId),
 }
 
 /// All events related to frost events emitted by the network.
@@ -271,7 +268,7 @@ pub enum NetworkFrostEvent {
         response: PeerMessageResponse,
     },
     /// Peer Confirmation
-    PeerConfirmed(PeerId, u16, SocketAddr),
+    PeerConfirmed(PeerId),
 }
 
 /// Commands sent by us to a peer.

--- a/crates/net/network/src/frost/protocol.rs
+++ b/crates/net/network/src/frost/protocol.rs
@@ -3,7 +3,7 @@ use futures::{Stream, StreamExt};
 use reth_eth_wire::{
     capability::SharedCapabilities, multiplex::ProtocolConnection, protocol::Protocol,
 };
-use reth_network_api::{Direction, NetworkInfo};
+use reth_network_api::Direction;
 use reth_primitives::BytesMut;
 use reth_rpc_types::PeerId;
 use std::{
@@ -21,7 +21,6 @@ use crate::{
         DkgEventResponseType, DkgResponse, SigningEventResponseType, SigningResponse,
     },
     protocol::{ConnectionHandler, OnNotSupported, ProtocolHandler},
-    NetworkHandle,
 };
 
 use super::{
@@ -125,20 +124,14 @@ impl ConnectionHandler for FrostConnectionHandler {
             conn,
             // incoming - another peer is connecting with me (set the ping message to Some),
             // outgoing - I am connecting with a peer
-            initial_ping: direction.is_outgoing().then(|| {
-                FrostProtoMessage::ping_message(
-                    *self.state.network_handle.peer_id(),
-                    self.state.authority_index,
-                    self.state.network_handle.local_addr(),
-                )
-            }),
+            initial_ping: direction
+                .is_outgoing()
+                .then(|| FrostProtoMessage::ping_message(*self.state.network_handle.peer_id())),
             // used to receive commands from me to send to the other peer
             commands: UnboundedReceiverStream::new(remote_peer_rx),
             pending_pong: None, // when the conn. is just established, there is no pending pong
-            my_authority_index: self.state.authority_index,
             my_peer_id: *self.state.network_handle.peer_id(),
             peer_id,
-            network_handle: self.state.network_handle.clone(),
         }
     }
 }
@@ -151,10 +144,8 @@ pub struct FrostProtoConnection {
     initial_ping: Option<FrostProtoMessage>,
     commands: UnboundedReceiverStream<FrostPeerCommand>,
     pending_pong: Option<oneshot::Sender<String>>,
-    my_authority_index: u16,
     my_peer_id: PeerId,
     peer_id: PeerId,
-    network_handle: NetworkHandle,
 }
 
 impl Stream for FrostProtoConnection {
@@ -175,15 +166,7 @@ impl Stream for FrostProtoConnection {
                 // answer once the pong is received
                 FrostPeerCommand::PingMessage { msg: _, response } => {
                     this.pending_pong = Some(response);
-                    let my_socket_addr = this.network_handle.local_addr();
-                    Poll::Ready(Some(
-                        FrostProtoMessage::ping_message(
-                            this.my_peer_id,
-                            this.my_authority_index,
-                            my_socket_addr,
-                        )
-                        .encoded(),
-                    ))
+                    Poll::Ready(Some(FrostProtoMessage::ping_message(this.my_peer_id).encoded()))
                 }
                 FrostPeerCommand::PeerMessage(response) => match response {
                     PeerMessageResponse::Healthcheck(healthcheck_response) => {
@@ -308,34 +291,25 @@ impl Stream for FrostProtoConnection {
                 return Poll::Ready(Some(FrostProtoMessage::pong().encoded()));
             }
             FrostProtoMessageKind::Pong => {}
-            FrostProtoMessageKind::PingMessage(peer_id, authority_index, peer_socket_addr) => {
-                info!(target: "network::frost::protocol", "Received ping message from peer with id = {:?}, auth index = {}, socket = {:?}. Replying with pong...", peer_id, authority_index, peer_socket_addr);
-                if let Err(e) = peer_message_forwarder.send(FrostProtocolEvent::PeerConfirmed(
-                    peer_id,
-                    authority_index,
-                    peer_socket_addr,
-                )) {
-                    error!(target: "network::frost::protocol", "Failed to forward received pong message from peer id {:?}, auth index = {}, socket = {:?}. Error = {:?}", peer_id, authority_index, peer_socket_addr, e);
+            FrostProtoMessageKind::PingMessage(peer_id) => {
+                info!(target: "network::frost::protocol", "Received ping message from peer with id = {:?} Replying with pong...", peer_id);
+                if let Err(e) =
+                    peer_message_forwarder.send(FrostProtocolEvent::PeerConfirmed(peer_id))
+                {
+                    error!(target: "network::frost::protocol", "Failed to forward received pong message from peer id {:?}. Error = {:?}", peer_id, e);
                 }
 
                 // answer with pong of my_authority_index
                 return Poll::Ready(Some(
-                    FrostProtoMessage::pong_message(
-                        this.my_peer_id,
-                        this.my_authority_index,
-                        this.network_handle.local_addr(),
-                    )
-                    .encoded(),
+                    FrostProtoMessage::pong_message(this.my_peer_id).encoded(),
                 ));
             }
             // other peers answers with pong message with a peer id and authority index
-            FrostProtoMessageKind::PongMessage(peer_id, authority_index, peer_socket_addr) => {
-                if let Err(e) = peer_message_forwarder.send(FrostProtocolEvent::PeerConfirmed(
-                    peer_id,
-                    authority_index,
-                    peer_socket_addr,
-                )) {
-                    error!(target: "network::frost::protocol", "Failed to forward received PongMessage from peer id {:?}, auth index = {}, socket = {:?}. Error = {:?}", peer_id, authority_index, peer_socket_addr, e);
+            FrostProtoMessageKind::PongMessage(peer_id) => {
+                if let Err(e) =
+                    peer_message_forwarder.send(FrostProtocolEvent::PeerConfirmed(peer_id))
+                {
+                    error!(target: "network::frost::protocol", "Failed to forward received PongMessage from peer id {:?}. Error = {:?}", peer_id, e);
                 }
 
                 if let Some(sender) = this.pending_pong.take() {

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -352,8 +352,6 @@ where
         let (protocol_events_tx, protocol_events_rx) = mpsc::unbounded_channel();
         let (frost_peer_messages_forwarder_tx, frost_peer_messages_forwarder_rx) =
             mpsc::unbounded_channel::<FrostProtocolEvent>();
-        let authority_index =
-            frost_config.as_ref().map(|f| f.authority_index as u16).unwrap_or_default();
         let authorities = frost_config
             .as_ref()
             .map(|f| f.authorities.clone())
@@ -367,7 +365,6 @@ where
         let protocol_state = ProtocolState::new(
             protocol_events_tx,
             frost_peer_messages_forwarder_tx,
-            authority_index,
             network_handle,
             authorities,
         );
@@ -611,12 +608,8 @@ where
             FrostProtocolEvent::PeerMessage { peer_id, response } => {
                 self.notify_frost_manager(NetworkFrostEvent::PeerMessage { peer_id, response });
             }
-            FrostProtocolEvent::PeerConfirmed(peer_id, authority_index, peer_socket_addr) => {
-                self.notify_frost_manager(NetworkFrostEvent::PeerConfirmed(
-                    peer_id,
-                    authority_index,
-                    peer_socket_addr,
-                ));
+            FrostProtocolEvent::PeerConfirmed(peer_id) => {
+                self.notify_frost_manager(NetworkFrostEvent::PeerConfirmed(peer_id));
             }
         }
     }

--- a/crates/node-core/src/args/federation_args.rs
+++ b/crates/node-core/src/args/federation_args.rs
@@ -72,7 +72,7 @@ impl FederationTomlConfig {
 
     /// Convert the config to a string
     pub fn to_string(&self) -> Result<String, Error> {
-        Ok(toml::to_string(self).map_err(Error::ParseSerializeConfig)?)
+        toml::to_string(self).map_err(Error::ParseSerializeConfig)
     }
 
     /// Extracts federation public keys and socket addresses from the config


### PR DESCRIPTION
- sockets are directly being taken from the networkHandle
- socket being transported on PeerConfirmed is removed as its not needed and reduces message size
- I could not get the peer_id , but have dropped all other stuff like pub keys and authority index since we can get them all based on the auth. confuguration
- added some clippy cleanup