### PR TITLE
620 fix pegout fees should be taken out of pegout request

### DIFF
--- a/bin/btc-server/src/coin_selection.rs
+++ b/bin/btc-server/src/coin_selection.rs
@@ -6,7 +6,7 @@ use bdk::{
 };
 use bitcoin::{
     psbt::{Error as PsbtError, ExtractTxError, Psbt},
-    Amount, FeeRate, OutPoint, ScriptBuf, Transaction, TxOut,
+    Amount, FeeRate, OutPoint, ScriptBuf, TxOut,
 };
 use reth_btc_wallet::TAPROOT_KEYSPEND_SATISFACTION_WEIGHT;
 
@@ -20,6 +20,16 @@ pub enum CoinSelectionError {
     PsbtError(#[from] PsbtError),
     #[error("Extract tx error: {0}")]
     ExtractTxError(#[from] ExtractTxError),
+    #[error("Outputs cannot be empty")]
+    OutputsCannotBeEmpty,
+    #[error("Available utxos cannot be empty")]
+    AvailableUtxosCannotBeEmpty,
+}
+
+impl PartialEq for CoinSelectionError {
+    fn eq(&self, other: &Self) -> bool {
+        self.to_string() == other.to_string()
+    }
 }
 
 /// Coin selection
@@ -29,6 +39,14 @@ pub(crate) fn coin_selection(
     fee_rate: FeeRate,
     change_script: ScriptBuf,
 ) -> Result<Psbt, CoinSelectionError> {
+    // Perform some sanity checks
+    if outputs.is_empty() {
+        return Err(CoinSelectionError::OutputsCannotBeEmpty);
+    }
+    if available_utxos.is_empty() {
+        return Err(CoinSelectionError::AvailableUtxosCannotBeEmpty);
+    }
+
     let to_bdk = |u: &Utxo| {
         bdk::WeightedUtxo {
             satisfaction_weight: TAPROOT_KEYSPEND_SATISFACTION_WEIGHT.to_wu() as usize,
@@ -139,6 +157,7 @@ mod tests {
     use std::collections::HashMap;
 
     use crate::{
+        coin_selection::CoinSelectionError,
         database::Utxo,
         test_utils::test_utils::{
             create_random_pegout_id, create_tx, random_p2tr_keyspend_script, random_p2wpkh_script,
@@ -153,6 +172,27 @@ mod tests {
     // The ideal test case here would iterate over many outputs with varying values
     // checking each time that the fee per output is met and that the change is correct
     // And would also covert the case where change is not needed
+    #[test]
+    fn coin_selection_sanity_checks() {
+        let change_script = random_p2tr_keyspend_script();
+        let res = coin_selection(
+            HashMap::new(),
+            vec![],
+            FeeRate::from_sat_per_vb(3).unwrap(),
+            change_script.clone(),
+        );
+        assert_eq!(res.err(), Some(CoinSelectionError::OutputsCannotBeEmpty));
+
+        let output_script = random_p2wpkh_script();
+        let res = coin_selection(
+            HashMap::new(),
+            vec![(TxOut { script_pubkey: output_script, value: Amount::from_sat(1000) }, None)],
+            FeeRate::from_sat_per_vb(3).unwrap(),
+            change_script.clone(),
+        );
+        assert_eq!(res.err(), Some(CoinSelectionError::AvailableUtxosCannotBeEmpty));
+    }
+
     #[test]
     fn idk_yet() {
         let app = setup();

--- a/bin/btc-server/src/coin_selection.rs
+++ b/bin/btc-server/src/coin_selection.rs
@@ -1,34 +1,25 @@
 use std::collections::HashMap;
 
-use bdk::wallet::coin_selection::{CoinSelectionAlgorithm, Error as BdkCoinselectionError};
-use bitcoin::{psbt::Psbt, Amount, FeeRate, OutPoint, ScriptBuf, Transaction, TxOut};
-use reth_btc_wallet::{psbt::PsbtInputExt, TAPROOT_KEYSPEND_SATISFACTION_WEIGHT};
+use bdk::{
+    psbt::PsbtUtils,
+    wallet::coin_selection::{CoinSelectionAlgorithm, Error as BdkCoinselectionError},
+};
+use bitcoin::{
+    psbt::{Error as PsbtError, ExtractTxError, Psbt},
+    Amount, FeeRate, OutPoint, ScriptBuf, Transaction, TxOut,
+};
+use reth_btc_wallet::TAPROOT_KEYSPEND_SATISFACTION_WEIGHT;
 
 use crate::{database::Utxo, pegout_id::PegoutId, util::OutPointExt, Error};
-
-pub trait TransactionExt {
-    fn calculate_absolute_fee(&self, fee_rate: &FeeRate) -> Amount;
-    fn calculate_fee_per_output(&self, fee_rate: &FeeRate) -> Amount;
-}
-
-impl TransactionExt for Transaction {
-    fn calculate_absolute_fee(&self, fee_rate: &FeeRate) -> Amount {
-        let vsize = self.vsize();
-        let fee = fee_rate.to_sat_per_vb_ceil() * vsize as u64;
-        Amount::from_sat(fee)
-    }
-
-    fn calculate_fee_per_output(&self, fee_rate: &FeeRate) -> Amount {
-        let absolute_fee = self.calculate_absolute_fee(fee_rate);
-        let fee_per_output = absolute_fee / self.output.len() as u64;
-        fee_per_output
-    }
-}
 
 #[derive(Debug, Error)]
 pub enum CoinSelectionError {
     #[error("Coin selection error: {0}")]
     CoinSelectionBdk(#[from] BdkCoinselectionError),
+    #[error("PSBT error: {0}")]
+    PsbtError(#[from] PsbtError),
+    #[error("Extract tx error: {0}")]
+    ExtractTxError(#[from] ExtractTxError),
 }
 
 /// Coin selection
@@ -55,11 +46,11 @@ pub(crate) fn coin_selection(
             }),
         }
     };
+    let coin_select = bdk::wallet::coin_selection::BranchAndBoundCoinSelection::new(0);
 
     // Now we're going to hijack BDK coin selection real quick..
     let bdk_utxos = available_utxos.values().map(to_bdk).collect::<Vec<_>>();
 
-    let coin_select = bdk::wallet::coin_selection::BranchAndBoundCoinSelection::new(0);
     let target_amount = outputs.iter().map(|o| o.0.value).sum::<Amount>();
 
     // Try once with finalized, then add pending and try again.
@@ -67,8 +58,7 @@ pub(crate) fn coin_selection(
         .coin_select(
             vec![],
             bdk_utxos.clone(),
-            // we dont want to pay any fee out of the change output
-            FeeRate::ZERO,
+            fee_rate,
             target_amount.to_sat(),
             &change_script, // drain_script
         )
@@ -88,7 +78,7 @@ pub(crate) fn coin_selection(
         bdk::wallet::coin_selection::Excess::NoChange { .. } => None,
     };
 
-    let pegouts = outputs
+    let mut pegouts = outputs
         .into_iter()
         .map(|(txout, pegout_id)| {
             if let Some(pegout_id) = pegout_id {
@@ -98,84 +88,71 @@ pub(crate) fn coin_selection(
             }
         })
         .collect::<Vec<_>>();
+    let selected_inputs: Vec<reth_btc_wallet::transaction::Input> = selected
+        .iter()
+        .map(|s| reth_btc_wallet::transaction::Input {
+            outpoint: s.outpoint,
+            output: s.output.clone(),
+            eth_address: s.eth_address,
+        })
+        .collect();
 
     let original_psbt = reth_btc_wallet::transaction::create_psbt(
-        selected
-            .iter()
-            .map(|s| reth_btc_wallet::transaction::Input {
-                outpoint: s.outpoint,
-                output: s.output.clone(),
-                eth_address: s.eth_address,
-            })
-            .collect(),
+        selected_inputs.clone(),
         pegouts.clone(),
-        Some(TxOut {
-            script_pubkey: change_script.clone(),
-            // TODO remove placeholder value
-            value: Amount::from_sat(550),
-        }),
+        change.clone(),
     );
 
-    let vsize = original_psbt.clone().extract_tx_unchecked_fee_rate().vsize();
-    println!("vsize = {:?}", vsize);
-
-    let fee_per_output =
-        Amount::from_sat((fee_rate.to_sat_per_vb_ceil() * vsize as u64) / pegouts.len() as u64);
+    let absolute_fee = Amount::from_sat(original_psbt.fee_amount().expect("no missing any txouts"));
+    println!("absolute_fee = {:?}", absolute_fee);
+    let fee_per_output = absolute_fee / pegouts.len() as u64;
     println!("fee_per_output = {:?}", fee_per_output);
-    println!("target_amount = {:?}", target_amount);
-    let mut tx = original_psbt.clone().extract_tx_unchecked_fee_rate();
-    // substract fee from non-change outputs
-    for output in tx.output.iter_mut() {
-        if output.script_pubkey != change_script {
-            output.value -= fee_per_output;
-        }
+
+    for (output, _pegout_id) in pegouts.iter_mut() {
+        output.value -= fee_per_output;
     }
 
-    let amount_left_over = tx.output.iter().map(|o| o.value).sum::<Amount>() - target_amount;
-    println!("amount_left_over = {:?}", amount_left_over);
+    let updated_changed = {
+        if let Some(mut ch) = change.clone() {
+            ch.value += absolute_fee;
+            Some(ch)
+        } else {
+            None
+        }
+    };
 
-    let fees = Psbt::from_unsigned_tx(tx).unwrap().fee().unwrap();
-    println!("fees = {:?}", fees);
+    let updated_psbt =
+        reth_btc_wallet::transaction::create_psbt(selected_inputs, pegouts, updated_changed);
+
+    // Lets extract the tx, doing so will do some fee sanity checks
+    // Better to catch them here than later in signing
+    let _tx = updated_psbt.clone().extract_tx()?;
 
     // TODO should check that min relay fee rate is met
     // TODO should check that none of the outputs are now dust
 
-    Ok(original_psbt)
+    Ok(updated_psbt)
 }
 
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
 
-    use bitcoin::{secp256k1::SECP256K1, Amount, FeeRate, OutPoint, TxOut};
-
-    use rand::rngs::OsRng;
-    use reth_btc_wallet::address::generate_taproot_change_scriptpubkey;
-
     use crate::{
-        coin_selection::TransactionExt,
         database::Utxo,
-        test_utils::test_utils::{create_random_pegout_id, create_tx, setup},
+        test_utils::test_utils::{
+            create_random_pegout_id, create_tx, random_p2tr_keyspend_script, random_p2wpkh_script,
+            setup,
+        },
     };
+    use bdk::psbt::PsbtUtils;
+    use bitcoin::{Amount, FeeRate, OutPoint, TxOut};
 
     use super::coin_selection;
 
-    #[test]
-    fn test_calculate_abolute_fee() {
-        let tx = create_tx(1, 1, None);
-        let fee_rate = FeeRate::from_sat_per_vb(3).unwrap();
-        let fee = tx.calculate_absolute_fee(&fee_rate);
-        // TODO assertions
-    }
-
-    #[test]
-    fn test_calculate_fee_per_output() {
-        let tx = create_tx(1, 1, None);
-        let fee_rate = FeeRate::from_sat_per_vb(3).unwrap();
-        let fee = (&tx).calculate_fee_per_output(&fee_rate);
-        println!("fee = {:?}", fee);
-    }
-
+    // The ideal test case here would iterate over many outputs with varying values
+    // checking each time that the fee per output is met and that the change is correct
+    // And would also covert the case where change is not needed
     #[test]
     fn idk_yet() {
         let app = setup();
@@ -195,30 +172,23 @@ mod tests {
         let x = utxos.iter().map(|u| u).collect::<Vec<_>>();
         app.add_pegins(&x).expect("add pegins");
 
-        let key_pair = bitcoin::secp256k1::generate_keypair(&mut OsRng);
-        let change_script = generate_taproot_change_scriptpubkey(&key_pair.1);
-
-        let pk = bitcoin::PublicKey::from_private_key(
-            SECP256K1,
-            &bitcoin::PrivateKey::generate(bitcoin::Network::Regtest),
-        );
-        let output_script =
-            bitcoin::Address::p2wpkh(&pk, bitcoin::Network::Regtest).unwrap().script_pubkey();
+        let change_script = random_p2tr_keyspend_script();
+        let output_script = random_p2wpkh_script();
 
         let mut available_utxos: HashMap<OutPoint, Utxo> = HashMap::new();
         for utxo in app.db.get_all_utxos().unwrap() {
             available_utxos.insert(utxo.outpoint, utxo);
         }
 
-        let pbst = coin_selection(
+        let psbt = coin_selection(
             available_utxos,
             vec![
                 (
-                    TxOut { script_pubkey: output_script.clone(), value: Amount::from_sat(1_000) },
+                    TxOut { script_pubkey: output_script.clone(), value: Amount::from_sat(1000) },
                     Some(create_random_pegout_id()),
                 ),
                 (
-                    TxOut { script_pubkey: output_script, value: Amount::from_sat(1_000) },
+                    TxOut { script_pubkey: output_script, value: Amount::from_sat(1000) },
                     Some(create_random_pegout_id()),
                 ),
             ],
@@ -226,7 +196,9 @@ mod tests {
             change_script,
         )
         .unwrap();
-        let tx = pbst.extract_tx().unwrap();
+        let tx = psbt.clone().extract_tx().unwrap();
+        let fee_rate = psbt.fee_rate();
+        println!("fee_rate = {:?}", fee_rate);
 
         // print inputs
         for input in tx.input {

--- a/bin/btc-server/src/coin_selection.rs
+++ b/bin/btc-server/src/coin_selection.rs
@@ -1,0 +1,240 @@
+use std::collections::HashMap;
+
+use bdk::wallet::coin_selection::{CoinSelectionAlgorithm, Error as BdkCoinselectionError};
+use bitcoin::{psbt::Psbt, Amount, FeeRate, OutPoint, ScriptBuf, Transaction, TxOut};
+use reth_btc_wallet::{psbt::PsbtInputExt, TAPROOT_KEYSPEND_SATISFACTION_WEIGHT};
+
+use crate::{database::Utxo, pegout_id::PegoutId, util::OutPointExt, Error};
+
+pub trait TransactionExt {
+    fn calculate_absolute_fee(&self, fee_rate: &FeeRate) -> Amount;
+    fn calculate_fee_per_output(&self, fee_rate: &FeeRate) -> Amount;
+}
+
+impl TransactionExt for Transaction {
+    fn calculate_absolute_fee(&self, fee_rate: &FeeRate) -> Amount {
+        let vsize = self.vsize();
+        let fee = fee_rate.to_sat_per_vb_ceil() * vsize as u64;
+        Amount::from_sat(fee)
+    }
+
+    fn calculate_fee_per_output(&self, fee_rate: &FeeRate) -> Amount {
+        let absolute_fee = self.calculate_absolute_fee(fee_rate);
+        let fee_per_output = absolute_fee / self.output.len() as u64;
+        fee_per_output
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum CoinSelectionError {
+    #[error("Coin selection error: {0}")]
+    CoinSelectionBdk(#[from] BdkCoinselectionError),
+}
+
+/// Coin selection
+pub(crate) fn coin_selection(
+    available_utxos: HashMap<OutPoint, Utxo>,
+    outputs: Vec<(TxOut, Option<PegoutId>)>,
+    fee_rate: FeeRate,
+    change_script: ScriptBuf,
+) -> Result<Psbt, CoinSelectionError> {
+    let to_bdk = |u: &Utxo| {
+        bdk::WeightedUtxo {
+            satisfaction_weight: TAPROOT_KEYSPEND_SATISFACTION_WEIGHT.to_wu() as usize,
+            utxo: bdk::Utxo::Local(bdk::LocalOutput {
+                outpoint: u.outpoint.to_bdk(),
+                txout: bdk::bitcoin::TxOut {
+                    script_pubkey: u.output.script_pubkey.to_bytes().into(),
+                    value: u.output.value,
+                },
+                keychain: bdk::KeychainKind::External,
+                is_spent: false,
+                derivation_index: 0, // we're not using this
+                // Also not used
+                confirmation_time: bdk::chain::ConfirmationTime::Confirmed { height: 1, time: 1 },
+            }),
+        }
+    };
+
+    // Now we're going to hijack BDK coin selection real quick..
+    let bdk_utxos = available_utxos.values().map(to_bdk).collect::<Vec<_>>();
+
+    let coin_select = bdk::wallet::coin_selection::BranchAndBoundCoinSelection::new(0);
+    let target_amount = outputs.iter().map(|o| o.0.value).sum::<Amount>();
+
+    // Try once with finalized, then add pending and try again.
+    let selection = coin_select
+        .coin_select(
+            vec![],
+            bdk_utxos.clone(),
+            // we dont want to pay any fee out of the change output
+            FeeRate::ZERO,
+            target_amount.to_sat(),
+            &change_script, // drain_script
+        )
+        .map_err(CoinSelectionError::CoinSelectionBdk)?;
+
+    let selected = selection
+        .selected
+        .iter()
+        .map(|s| available_utxos.get(&OutPoint::from_bdk(s.outpoint())))
+        .filter_map(|s| if s.is_some() { s } else { None })
+        .collect::<Vec<_>>();
+
+    let change = match selection.excess {
+        bdk::wallet::coin_selection::Excess::Change { amount, .. } => {
+            Some(TxOut { script_pubkey: change_script.clone(), value: Amount::from_sat(amount) })
+        }
+        bdk::wallet::coin_selection::Excess::NoChange { .. } => None,
+    };
+
+    let pegouts = outputs
+        .into_iter()
+        .map(|(txout, pegout_id)| {
+            if let Some(pegout_id) = pegout_id {
+                (txout, Some(pegout_id.as_bytes()))
+            } else {
+                (txout, None)
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let original_psbt = reth_btc_wallet::transaction::create_psbt(
+        selected
+            .iter()
+            .map(|s| reth_btc_wallet::transaction::Input {
+                outpoint: s.outpoint,
+                output: s.output.clone(),
+                eth_address: s.eth_address,
+            })
+            .collect(),
+        pegouts.clone(),
+        Some(TxOut {
+            script_pubkey: change_script.clone(),
+            // TODO remove placeholder value
+            value: Amount::from_sat(550),
+        }),
+    );
+
+    let vsize = original_psbt.clone().extract_tx_unchecked_fee_rate().vsize();
+    println!("vsize = {:?}", vsize);
+
+    let fee_per_output =
+        Amount::from_sat((fee_rate.to_sat_per_vb_ceil() * vsize as u64) / pegouts.len() as u64);
+    println!("fee_per_output = {:?}", fee_per_output);
+    println!("target_amount = {:?}", target_amount);
+    let mut tx = original_psbt.clone().extract_tx_unchecked_fee_rate();
+    // substract fee from non-change outputs
+    for output in tx.output.iter_mut() {
+        if output.script_pubkey != change_script {
+            output.value -= fee_per_output;
+        }
+    }
+
+    let amount_left_over = tx.output.iter().map(|o| o.value).sum::<Amount>() - target_amount;
+    println!("amount_left_over = {:?}", amount_left_over);
+
+    let fees = Psbt::from_unsigned_tx(tx).unwrap().fee().unwrap();
+    println!("fees = {:?}", fees);
+
+    // TODO should check that min relay fee rate is met
+    // TODO should check that none of the outputs are now dust
+
+    Ok(original_psbt)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use bitcoin::{secp256k1::SECP256K1, Amount, FeeRate, OutPoint, TxOut};
+
+    use rand::rngs::OsRng;
+    use reth_btc_wallet::address::generate_taproot_change_scriptpubkey;
+
+    use crate::{
+        coin_selection::TransactionExt,
+        database::Utxo,
+        test_utils::test_utils::{create_random_pegout_id, create_tx, setup},
+    };
+
+    use super::coin_selection;
+
+    #[test]
+    fn test_calculate_abolute_fee() {
+        let tx = create_tx(1, 1, None);
+        let fee_rate = FeeRate::from_sat_per_vb(3).unwrap();
+        let fee = tx.calculate_absolute_fee(&fee_rate);
+        // TODO assertions
+    }
+
+    #[test]
+    fn test_calculate_fee_per_output() {
+        let tx = create_tx(1, 1, None);
+        let fee_rate = FeeRate::from_sat_per_vb(3).unwrap();
+        let fee = (&tx).calculate_fee_per_output(&fee_rate);
+        println!("fee = {:?}", fee);
+    }
+
+    #[test]
+    fn idk_yet() {
+        let app = setup();
+        // Add 15 utxos
+        let tx = create_tx(15, 1, None);
+
+        let mut utxos = vec![];
+        for i in 0..5 {
+            let utxo = crate::database::Utxo::new(
+                OutPoint::new(tx.input[i].previous_output.txid, i as u32),
+                tx.output[0].clone(),
+                None,
+            );
+            utxos.push(utxo.clone());
+        }
+
+        let x = utxos.iter().map(|u| u).collect::<Vec<_>>();
+        app.add_pegins(&x).expect("add pegins");
+
+        let key_pair = bitcoin::secp256k1::generate_keypair(&mut OsRng);
+        let change_script = generate_taproot_change_scriptpubkey(&key_pair.1);
+
+        let pk = bitcoin::PublicKey::from_private_key(
+            SECP256K1,
+            &bitcoin::PrivateKey::generate(bitcoin::Network::Regtest),
+        );
+        let output_script =
+            bitcoin::Address::p2wpkh(&pk, bitcoin::Network::Regtest).unwrap().script_pubkey();
+
+        let mut available_utxos: HashMap<OutPoint, Utxo> = HashMap::new();
+        for utxo in app.db.get_all_utxos().unwrap() {
+            available_utxos.insert(utxo.outpoint, utxo);
+        }
+
+        let pbst = coin_selection(
+            available_utxos,
+            vec![
+                (
+                    TxOut { script_pubkey: output_script.clone(), value: Amount::from_sat(1_000) },
+                    Some(create_random_pegout_id()),
+                ),
+                (
+                    TxOut { script_pubkey: output_script, value: Amount::from_sat(1_000) },
+                    Some(create_random_pegout_id()),
+                ),
+            ],
+            FeeRate::from_sat_per_vb(3).unwrap(),
+            change_script,
+        )
+        .unwrap();
+        let tx = pbst.extract_tx().unwrap();
+
+        // print inputs
+        for input in tx.input {
+            println!("input = {:?}", input);
+        }
+        // print outsputs
+        for output in tx.output {
+            println!("output = {:?}", output);
+        }
+    }
+}

--- a/bin/btc-server/src/coin_selection.rs
+++ b/bin/btc-server/src/coin_selection.rs
@@ -35,6 +35,8 @@ impl PartialEq for CoinSelectionError {
 /// Coin selection
 pub(crate) fn coin_selection(
     available_utxos: HashMap<OutPoint, Utxo>,
+    // Currently unused, will be used for conflicting inputs
+    #[allow(unused)] required_utxos: HashMap<OutPoint, Utxo>,
     outputs: Vec<(TxOut, PegoutId)>,
     fee_rate: FeeRate,
     change_script: ScriptBuf,
@@ -117,9 +119,7 @@ pub(crate) fn coin_selection(
     );
 
     let absolute_fee = Amount::from_sat(original_psbt.fee_amount().expect("no missing any txouts"));
-    println!("absolute_fee = {:?}", absolute_fee);
     let fee_per_output = absolute_fee / pegouts.len() as u64;
-    println!("fee_per_output = {:?}", fee_per_output);
 
     for (output, _pegout_id) in pegouts.iter_mut() {
         output.value -= fee_per_output;
@@ -172,6 +172,7 @@ mod tests {
         let change_script = random_p2tr_keyspend_script();
         let res = coin_selection(
             HashMap::new(),
+            HashMap::new(),
             vec![],
             FeeRate::from_sat_per_vb(3).unwrap(),
             change_script.clone(),
@@ -180,6 +181,7 @@ mod tests {
 
         let output_script = random_p2wpkh_script();
         let res = coin_selection(
+            HashMap::new(),
             HashMap::new(),
             vec![(
                 TxOut { script_pubkey: output_script, value: Amount::from_sat(1000) },
@@ -192,59 +194,88 @@ mod tests {
     }
 
     #[test]
-    fn idk_yet() {
+    fn should_take_fee_out_of_outputs() {
         let app = setup();
         // Add 15 utxos
         let tx = create_tx(15, 1, None);
-
+        let change_script = random_p2tr_keyspend_script();
+        let output_script = random_p2wpkh_script();
         let mut utxos = vec![];
         for i in 0..5 {
             let utxo = crate::database::Utxo::new(
                 OutPoint::new(tx.input[i].previous_output.txid, i as u32),
+                // Each prevout has a value of 1000 sats
                 tx.output[0].clone(),
                 None,
             );
             utxos.push(utxo.clone());
         }
 
-        let x = utxos.iter().map(|u| u).collect::<Vec<_>>();
-        app.add_pegins(&x).expect("add pegins");
-
-        let change_script = random_p2tr_keyspend_script();
-        let output_script = random_p2wpkh_script();
+        let available_utxos = utxos.iter().map(|u| u).collect::<Vec<_>>();
+        app.add_pegins(&available_utxos).expect("add pegins");
 
         let mut available_utxos: HashMap<OutPoint, Utxo> = HashMap::new();
         for utxo in app.db.get_all_utxos().unwrap() {
             available_utxos.insert(utxo.outpoint, utxo);
         }
 
+        let required_utxos = HashMap::new();
+        let desired_fee_rate = FeeRate::from_sat_per_vb(3).unwrap();
+        let desired_amount_per_output = Amount::from_sat(1000);
         let psbt = coin_selection(
             available_utxos,
+            required_utxos,
             vec![
                 (
-                    TxOut { script_pubkey: output_script.clone(), value: Amount::from_sat(1000) },
+                    TxOut {
+                        script_pubkey: output_script.clone(),
+                        value: desired_amount_per_output,
+                    },
                     create_random_pegout_id(),
                 ),
                 (
-                    TxOut { script_pubkey: output_script, value: Amount::from_sat(1000) },
+                    TxOut { script_pubkey: output_script, value: desired_amount_per_output },
                     create_random_pegout_id(),
                 ),
             ],
-            FeeRate::from_sat_per_vb(3).unwrap(),
-            change_script,
+            desired_fee_rate,
+            change_script.clone(),
         )
         .unwrap();
         let tx = psbt.clone().extract_tx().unwrap();
-        let fee_rate = psbt.fee_rate();
+        let fee_rate = psbt.fee_rate().unwrap();
         println!("fee_rate = {:?}", fee_rate);
+        println!("desired_fee_rate = {:?}", desired_fee_rate);
+        // make_tx is hardcoded to have 1000 sats per output
+        let total_amount_being_spent = Amount::from_sat((tx.input.len() * 1000) as u64);
+        let pegout_outputs =
+            tx.output.iter().filter(|o| o.script_pubkey != change_script).collect::<Vec<_>>();
+        let change_output = tx.output.iter().find(|o| o.script_pubkey == change_script).unwrap();
+        let change_output_value = change_output.value;
+        let pegout_outputs_value = pegout_outputs.iter().map(|o| o.value).sum::<Amount>();
+        let total_output_value = pegout_outputs_value + change_output_value;
 
-        // print inputs
-        for input in tx.input {
-            println!("input = {:?}", input);
+        // First some sanity checks
+        // if we are requesting 2000 sats we need to spend > 2000 sats to cover the fee
+        assert_eq!(tx.input.len(), 3);
+        // Ensure we have 2 outputs
+        assert_eq!(pegout_outputs.len(), 2);
+
+        // Check that the total output value is less than the total amount being spent
+        // i.e some fees are being taken out
+        assert!(total_output_value < total_amount_being_spent);
+
+        // Check that the fee per output is correct
+        let fee_per_output =
+            (total_amount_being_spent - total_output_value) / pegout_outputs.len() as u64;
+        for pegout_output in pegout_outputs.iter() {
+            assert_eq!(pegout_output.value, desired_amount_per_output - fee_per_output);
         }
-        // print outsputs
-        for output in tx.output {
-            println!("output = {:?}", output);
-        }
+
+        // Check that the change output is correct
+        assert_eq!(
+            change_output.value,
+            total_amount_being_spent - desired_amount_per_output * pegout_outputs.len() as u64
+        );
     }
 }

--- a/bin/btc-server/src/coin_selection.rs
+++ b/bin/btc-server/src/coin_selection.rs
@@ -35,7 +35,7 @@ impl PartialEq for CoinSelectionError {
 /// Coin selection
 pub(crate) fn coin_selection(
     available_utxos: HashMap<OutPoint, Utxo>,
-    outputs: Vec<(TxOut, Option<PegoutId>)>,
+    outputs: Vec<(TxOut, PegoutId)>,
     fee_rate: FeeRate,
     change_script: ScriptBuf,
 ) -> Result<Psbt, CoinSelectionError> {
@@ -98,14 +98,9 @@ pub(crate) fn coin_selection(
 
     let mut pegouts = outputs
         .into_iter()
-        .map(|(txout, pegout_id)| {
-            if let Some(pegout_id) = pegout_id {
-                (txout, Some(pegout_id.as_bytes()))
-            } else {
-                (txout, None)
-            }
-        })
+        .map(|(txout, pegout_id)| (txout, pegout_id.as_bytes()))
         .collect::<Vec<_>>();
+
     let selected_inputs: Vec<reth_btc_wallet::transaction::Input> = selected
         .iter()
         .map(|s| reth_btc_wallet::transaction::Input {
@@ -186,7 +181,10 @@ mod tests {
         let output_script = random_p2wpkh_script();
         let res = coin_selection(
             HashMap::new(),
-            vec![(TxOut { script_pubkey: output_script, value: Amount::from_sat(1000) }, None)],
+            vec![(
+                TxOut { script_pubkey: output_script, value: Amount::from_sat(1000) },
+                create_random_pegout_id(),
+            )],
             FeeRate::from_sat_per_vb(3).unwrap(),
             change_script.clone(),
         );
@@ -225,11 +223,11 @@ mod tests {
             vec![
                 (
                     TxOut { script_pubkey: output_script.clone(), value: Amount::from_sat(1000) },
-                    Some(create_random_pegout_id()),
+                    create_random_pegout_id(),
                 ),
                 (
                     TxOut { script_pubkey: output_script, value: Amount::from_sat(1000) },
-                    Some(create_random_pegout_id()),
+                    create_random_pegout_id(),
                 ),
             ],
             FeeRate::from_sat_per_vb(3).unwrap(),

--- a/bin/btc-server/src/coordinator.rs
+++ b/bin/btc-server/src/coordinator.rs
@@ -1,12 +1,12 @@
-use bdk::{
-    miniscript::psbt::Error as PsbtError,
-    wallet::coin_selection::{CoinSelectionAlgorithm, Error as BdkCoinselectionError},
-};
+use bdk::miniscript::psbt::Error as PsbtError;
+use std::time::{Instant, SystemTime};
+
+use crate::coin_selection::CoinSelectionError;
 use bitcoin::{
     hashes::sha256,
     psbt::{ExtractTxError, Psbt},
     secp256k1::PublicKey,
-    Address, Amount, BlockHash, FeeRate, OutPoint, ScriptBuf, TxOut,
+    Address, BlockHash, FeeRate, ScriptBuf, TxOut,
 };
 use bitcoincore_rpc::RpcApi;
 use client::SigningStatus;
@@ -15,16 +15,15 @@ use reth_btc_wallet::{
     psbt::{EthAddress, PsbtExt as BtcPsbtExt, PsbtInputExt},
     transaction::CalculateSighashError,
     util::{VerifyingKeyExt, VerifyingKeyExtError},
-    TAPROOT_KEYSPEND_SATISFACTION_WEIGHT,
 };
-use std::time::{Instant, SystemTime};
 
 use crate::{
+    coin_selection,
     database::{Error as DbError, Utxo},
     pegout_id::PegoutId,
     util::{
-        get_available_utxos, validate_psbt, OutPointExt, ValidatePSBTError, NO_FLAGS, ROUND1,
-        ROUND1_TRANSITION, ROUND2,
+        get_available_utxos, validate_psbt, ValidatePSBTError, NO_FLAGS, ROUND1, ROUND1_TRANSITION,
+        ROUND2,
     },
     App, Error,
 };
@@ -44,8 +43,6 @@ pub enum CoordinatorError {
     InvalidSigningPackage(&'static str),
     #[error("failed to convert verifying key to secp pk")]
     FailedToConvertVerifyingKeyToSecpPk(#[from] VerifyingKeyExtError),
-    #[error("Coin Selection error: {0}")]
-    CoinSelection(#[from] BdkCoinselectionError),
     #[error("Failed to calculate sighash: {0}")]
     FailedToCalculateSighash(#[from] CalculateSighashError),
     #[error("Pbst error: {0}")]
@@ -82,6 +79,8 @@ pub enum CoordinatorError {
     MissingFinalScript,
     #[error("missing signing package at index: {0}")]
     MissingSigningPackageAtIndex(usize),
+    #[error("coin selection error: {0}")]
+    CoinSelectionErr(#[from] CoinSelectionError),
 }
 
 impl<BitcoindClient> App<BitcoindClient>
@@ -229,83 +228,8 @@ where
         let (available_utxos, _tracked_inputs) =
             get_available_utxos(&self.db).await.map_err(CoordinatorError::Db)?;
 
-        let to_bdk = |u: &Utxo| {
-            bdk::WeightedUtxo {
-                satisfaction_weight: TAPROOT_KEYSPEND_SATISFACTION_WEIGHT.to_wu() as usize,
-                utxo: bdk::Utxo::Local(bdk::LocalOutput {
-                    outpoint: u.outpoint.to_bdk(),
-                    txout: bdk::bitcoin::TxOut {
-                        script_pubkey: u.output.script_pubkey.to_bytes().into(),
-                        value: u.output.value,
-                    },
-                    keychain: bdk::KeychainKind::External,
-                    is_spent: false,
-                    derivation_index: 0, // we're not using this
-                    // Also not used
-                    confirmation_time: bdk::chain::ConfirmationTime::Confirmed {
-                        height: 1,
-                        time: 1,
-                    },
-                }),
-            }
-        };
-
-        // Now we're going to hijack BDK coin selection real quick..
-        let bdk_utxos = available_utxos.values().map(to_bdk).collect::<Vec<_>>();
-        let coin_select = bdk::wallet::coin_selection::BranchAndBoundCoinSelection::new(0);
-        let target_amount = outputs.iter().map(|o| o.0.value).sum::<Amount>();
-
-        // Try once with finalized, then add pending and try again.
-        let selection = coin_select
-            .coin_select(
-                vec![],
-                bdk_utxos,
-                fee_rate,
-                target_amount.to_sat(),
-                &change_script, // drain_script
-            )
-            .map_err(CoordinatorError::CoinSelection)?;
-
-        let selected = selection
-            .selected
-            .iter()
-            .map(|s| available_utxos.get(&OutPoint::from_bdk(s.outpoint())))
-            .filter_map(|s| if s.is_some() { s } else { None })
-            .collect::<Vec<_>>();
-        let change = match selection.excess {
-            bdk::wallet::coin_selection::Excess::Change { amount, .. } => Some(TxOut {
-                script_pubkey: change_script.clone(),
-                value: Amount::from_sat(amount),
-            }),
-            bdk::wallet::coin_selection::Excess::NoChange { .. } => None,
-        };
-
-        let pegout_ids = outputs
-            .into_iter()
-            .map(|(txout, pegout_id)| {
-                if let Some(pegout_id) = pegout_id {
-                    (txout, Some(pegout_id.as_bytes()))
-                } else {
-                    (txout, None)
-                }
-            })
-            .collect::<Vec<_>>();
-
-        let psbt = reth_btc_wallet::transaction::create_psbt(
-            selected
-                .iter()
-                .map(|s| reth_btc_wallet::transaction::Input {
-                    outpoint: s.outpoint,
-                    output: s.output.clone(),
-                    eth_address: s.eth_address,
-                })
-                .collect(),
-            pegout_ids,
-            change,
-        );
-
-        info!("make_tx psbt = {}", psbt);
-
+        let psbt =
+            coin_selection::coin_selection(available_utxos, outputs, fee_rate, change_script)?;
         // Sanity check that we created a valid PSBT
         // This should not fail
         validate_psbt(&psbt, NO_FLAGS, self.min_signers, &self.db)?;

--- a/bin/btc-server/src/coordinator.rs
+++ b/bin/btc-server/src/coordinator.rs
@@ -1,5 +1,8 @@
 use bdk::miniscript::psbt::Error as PsbtError;
-use std::time::{Instant, SystemTime};
+use std::{
+    collections::HashMap,
+    time::{Instant, SystemTime},
+};
 
 use crate::coin_selection::CoinSelectionError;
 use bitcoin::{
@@ -228,8 +231,13 @@ where
         let (available_utxos, _tracked_inputs) =
             get_available_utxos(&self.db).await.map_err(CoordinatorError::Db)?;
 
-        let psbt =
-            coin_selection::coin_selection(available_utxos, outputs, fee_rate, change_script)?;
+        let psbt = coin_selection::coin_selection(
+            available_utxos,
+            HashMap::new(),
+            outputs,
+            fee_rate,
+            change_script,
+        )?;
         // Sanity check that we created a valid PSBT
         // This should not fail
         validate_psbt(&psbt, NO_FLAGS, self.min_signers, &self.db)?;

--- a/bin/btc-server/src/coordinator.rs
+++ b/bin/btc-server/src/coordinator.rs
@@ -204,7 +204,7 @@ where
 
     pub(crate) async fn make_tx(
         &self,
-        outputs: Vec<(TxOut, Option<PegoutId>)>,
+        outputs: Vec<(TxOut, PegoutId)>,
         fee_rate: FeeRate,
         change_script: ScriptBuf,
         checkpoint_block: BlockHash,

--- a/bin/btc-server/src/main.rs
+++ b/bin/btc-server/src/main.rs
@@ -1166,7 +1166,7 @@ mod test {
         assert_eq!(error_response.code(), Code::Internal);
         assert_eq!(
             error_response.message(),
-            "internal error: Failed to make tx: Failed to validate psbt: inputs cannot be 0"
+            "internal error: Failed to make tx: coin selection error: Outputs cannot be empty"
         );
 
         // now generate some random utxos and save them

--- a/bin/btc-server/src/main.rs
+++ b/bin/btc-server/src/main.rs
@@ -3,6 +3,7 @@ extern crate log;
 #[macro_use]
 extern crate serde;
 
+mod coin_selection;
 mod config;
 mod coordinator;
 mod database;

--- a/bin/btc-server/src/server.rs
+++ b/bin/btc-server/src/server.rs
@@ -353,8 +353,8 @@ where
         }
         let outputs = pending_pegouts
             .iter()
-            .map(|p| (TxOut { value: p.value, script_pubkey: p.spk.clone() }, Some(p.id)))
-            .collect::<Vec<(TxOut, Option<PegoutId>)>>();
+            .map(|p| (TxOut { value: p.value, script_pubkey: p.spk.clone() }, p.id))
+            .collect::<Vec<(TxOut, PegoutId)>>();
 
         let pk_package = self
             .db

--- a/bin/btc-server/src/test_utils.rs
+++ b/bin/btc-server/src/test_utils.rs
@@ -13,8 +13,8 @@ pub mod test_utils {
     };
     use bitcoincore_rpc::json::{EstimateMode, EstimateSmartFeeResult};
     use frost_secp256k1_tr as frost;
-    use rand::{thread_rng, RngCore};
-    use reth_btc_wallet::util::VerifyingKeyExt;
+    use rand::{rngs::OsRng, thread_rng, RngCore};
+    use reth_btc_wallet::{address::generate_taproot_change_scriptpubkey, util::VerifyingKeyExt};
     use tempfile::TempDir;
     use tokio::sync::Mutex;
     use url::Url;
@@ -151,6 +151,12 @@ pub mod test_utils {
         let mut eth_addr = [0u8; 20];
         eth_addr.copy_from_slice(&eth);
         eth_addr
+    }
+
+    pub fn random_p2tr_keyspend_script() -> ScriptBuf {
+        let key_pair = bitcoin::secp256k1::generate_keypair(&mut OsRng);
+        let change_script = generate_taproot_change_scriptpubkey(&key_pair.1);
+        change_script
     }
 
     pub fn random_p2wpkh_script() -> ScriptBuf {

--- a/crates/btc-wallet/src/transaction.rs
+++ b/crates/btc-wallet/src/transaction.rs
@@ -7,6 +7,7 @@ use bitcoin::{
 use crate::psbt::{PegoutId, PsbtInputExt, PsbtOutputExt};
 
 /// Utxo DTO struct
+#[derive(Debug, Clone)]
 pub struct Input {
     pub outpoint: OutPoint,
     pub output: TxOut,

--- a/crates/btc-wallet/src/transaction.rs
+++ b/crates/btc-wallet/src/transaction.rs
@@ -17,7 +17,7 @@ pub struct Input {
 /// Create psbt with proprietary tweak fields
 pub fn create_psbt(
     inputs: Vec<Input>,
-    outputs: Vec<(TxOut, Option<PegoutId>)>,
+    outputs: Vec<(TxOut, PegoutId)>,
     change: Option<TxOut>,
 ) -> Psbt {
     let mut output: Vec<TxOut> = outputs.iter().map(|(out, _)| out).cloned().collect();
@@ -51,11 +51,9 @@ pub fn create_psbt(
 
     // add output meta
     for (psbt_output, (_out, pegout_id)) in psbt.outputs.iter_mut().zip(outputs.iter()) {
-        if let Some(id) = pegout_id {
-            // Pegout ids are stored in the proprietary field to be checked and validated
-            // by peers
-            psbt_output.set_pegout_id(*id);
-        }
+        // Pegout ids are stored in the proprietary field to be checked and validated
+        // by peers
+        psbt_output.set_pegout_id(*pegout_id);
     }
 
     psbt

--- a/crates/btc-wallet/src/transaction.rs
+++ b/crates/btc-wallet/src/transaction.rs
@@ -25,7 +25,7 @@ pub fn create_psbt(
         output.push(change);
     }
     let tx = bitcoin::Transaction {
-        version: bitcoin::transaction::Version(2i32),
+        version: bitcoin::transaction::Version::TWO,
         lock_time: bitcoin::locktime::absolute::LockTime::ZERO,
         input: inputs
             .iter()


### PR DESCRIPTION
## Description
Users need to paying for L1 pegout fees. If fees are deducted from the federation wallet change outputs then we will slowly de-peg the sidechain. 
The solution is simple. Perform coin selection and create an optional change output. Afterwards deduct each pegout output by the absolute fee / pegouts.len. And then increase the change output value by the absolute value. 