### PR TITLE
Fix/dkg/round2 shares

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12493,6 +12493,7 @@ dependencies = [
  "dotenv",
  "ethers",
  "eyre",
+ "frost-secp256k1-tr",
  "hex",
  "port-killer",
  "pretty_assertions",

--- a/bin/btc-server/src/dkg.rs
+++ b/bin/btc-server/src/dkg.rs
@@ -70,7 +70,9 @@ where
 
     pub(crate) async fn add_round2_dkg(
         &self,
+        // Peer's identifier
         frost_id: frost::Identifier,
+        // Peer's round 2 package
         package: frost::keys::dkg::round2::Package,
     ) -> Result<(), DKGError> {
         if self.db.get_key_package()?.is_some() {

--- a/bin/btc-server/src/dkg.rs
+++ b/bin/btc-server/src/dkg.rs
@@ -37,7 +37,7 @@ where
             return Err(DKGError::AlreadyHaveKeyPackage);
         }
 
-        if let Some(round1_dkg) = self.frost_round1_dkg.clone() {
+        if let Some(round1_dkg) = self.frost_round1_dkg.lock().await.clone() {
             // Retrieve round 1 packages from peers
             // Here we don't check we have enough that should be done by the frost lib
             // So we just propogate the error
@@ -53,13 +53,15 @@ where
         }
     }
 
-    pub(crate) fn get_round1_dkg(&self) -> Result<frost::keys::dkg::round1::Package, DKGError> {
+    pub(crate) async fn get_round1_dkg(
+        &self,
+    ) -> Result<frost::keys::dkg::round1::Package, DKGError> {
         // Already have done dkg
         // This function should error
         if self.db.get_key_package()?.is_some() {
             return Err(DKGError::AlreadyHaveKeyPackage);
         }
-        if let Some(round1_dkg) = self.frost_round1_dkg.clone() {
+        if let Some(round1_dkg) = self.frost_round1_dkg.lock().await.clone() {
             Ok(round1_dkg.1)
         } else {
             Err(DKGError::MissingRound1DkgPackage)
@@ -108,12 +110,13 @@ where
         // Clear out round 2 secret
         if dkg_done {
             self.frost_round2_dkg.lock().await.take();
+            self.frost_round1_dkg.lock().await.take();
         }
 
         return Ok(());
     }
 
-    pub(crate) fn add_round1_dkg(
+    pub(crate) async fn add_round1_dkg(
         &self,
         frost_id: frost::Identifier,
         dkg_round1: frost::keys::dkg::round1::Package,
@@ -125,7 +128,7 @@ where
         if frost_id == self.identifier {
             return Err(DKGError::CannotAddOwnDkgPackage);
         }
-        if self.frost_round1_dkg.as_ref().expect("valid dkg round1").1 == dkg_round1 {
+        if self.frost_round1_dkg.lock().await.as_ref().expect("valid dkg round1").1 == dkg_round1 {
             return Err(DKGError::CannotAddOwnDkgPackage);
         }
         // Should not add if we have max signers

--- a/bin/btc-server/src/dkg.rs
+++ b/bin/btc-server/src/dkg.rs
@@ -69,7 +69,7 @@ where
     pub(crate) async fn add_round2_dkg(
         &self,
         frost_id: frost::Identifier,
-        packages: BTreeMap<frost::Identifier, frost::keys::dkg::round2::Package>,
+        package: frost::keys::dkg::round2::Package,
     ) -> Result<(), DKGError> {
         if self.db.get_key_package()?.is_some() {
             return Err(DKGError::AlreadyHaveKeyPackage);
@@ -78,36 +78,30 @@ where
         if frost_id == self.identifier {
             return Err(DKGError::InvalidFrostPeerId);
         }
-        for (id, package) in packages.iter() {
-            // Look for our package and store it
-            if self.identifier == *id {
-                if self.db.add_round2_dkg(frost_id, package.clone())? {
-                    self.db.flush()?;
-                    debug!("Stored round2 dkg from peer: {:?}", frost_id);
-                } else {
-                    warn!("Duplicate round2 dkg from peer: {:?}", frost_id);
-                }
-                // If we have a max_signers round2 packages we can generate and save the key package
-                let round2_packages = self.db.get_round2_dkg_packages()?;
-                if round2_packages.len() as u16 == self.max_signers - 1 {
-                    let round1_packages = self.db.get_round1_dkg_packages()?;
-                    if let Some(round2_secret) = self.frost_round2_dkg.lock().await.clone() {
-                        let pk_res = frost::keys::dkg::part3(
-                            &round2_secret,
-                            &round1_packages,
-                            &round2_packages,
-                        )?;
 
-                        self.db.set_key_package(pk_res.0.clone())?;
-                        self.db.set_pubkey_package(pk_res.1.clone())?;
-                        self.db.flush()?;
-                    }
-                }
+        if self.db.add_round2_dkg(frost_id, package.clone())? {
+            self.db.flush()?;
+            debug!("Stored round2 dkg from peer: {:?}", frost_id);
+        } else {
+            warn!("Duplicate round2 dkg from peer: {:?}", frost_id);
+        }
+        // If we have a max_signers round2 packages we can generate and save the key package
+        let round2_packages = self.db.get_round2_dkg_packages()?;
+        if round2_packages.len() as u16 == self.max_signers - 1 {
+            let round1_packages = self.db.get_round1_dkg_packages()?;
+            if let Some(round2_secret) = self.frost_round2_dkg.lock().await.clone() {
+                let pk_res =
+                    frost::keys::dkg::part3(&round2_secret, &round1_packages, &round2_packages)?;
 
-                return Ok(());
+                self.db.set_key_package(pk_res.0.clone())?;
+                self.db.set_pubkey_package(pk_res.1.clone())?;
+                self.db.flush()?;
+                // TODO Zero out the round2 secret
             }
         }
-        Err(DKGError::InvalidRound2DkgPayloadMissingPackage)
+
+        return Ok(());
+        // Err(DKGError::InvalidRound2DkgPayloadMissingPackage)
     }
 
     pub(crate) fn add_round1_dkg(

--- a/bin/btc-server/src/dkg.rs
+++ b/bin/btc-server/src/dkg.rs
@@ -86,6 +86,7 @@ where
             warn!("Duplicate round2 dkg from peer: {:?}", frost_id);
         }
         // If we have a max_signers round2 packages we can generate and save the key package
+        let mut dkg_done = false;
         let round2_packages = self.db.get_round2_dkg_packages()?;
         if round2_packages.len() as u16 == self.max_signers - 1 {
             let round1_packages = self.db.get_round1_dkg_packages()?;
@@ -96,12 +97,20 @@ where
                 self.db.set_key_package(pk_res.0.clone())?;
                 self.db.set_pubkey_package(pk_res.1.clone())?;
                 self.db.flush()?;
-                // TODO Zero out the round2 secret
+
+                dkg_done = true;
+            } else {
+                return Err(DKGError::InvalidRound2DkgPayloadMissingPackage);
             }
         }
 
+        // Signing at this point is successful
+        // Clear out round 2 secret
+        if dkg_done {
+            self.frost_round2_dkg.lock().await.take();
+        }
+
         return Ok(());
-        // Err(DKGError::InvalidRound2DkgPayloadMissingPackage)
     }
 
     pub(crate) fn add_round1_dkg(

--- a/bin/btc-server/src/main.rs
+++ b/bin/btc-server/src/main.rs
@@ -654,6 +654,13 @@ mod test {
         let pk1 = app1.get_public_key().expect("valid public key request");
         let pk2 = app2.get_public_key().expect("valid public key request");
         assert_eq!(pk1, pk2);
+
+        // Check that round 1 and round 2 secrets are none now
+        // assert!(app1.frost_round1_dkg.is_none());
+        assert!(app1.frost_round2_dkg.lock().await.is_none());
+
+        // assert!(app2.frost_round1_dkg.is_none());
+        assert!(app2.frost_round2_dkg.lock().await.is_none());
     }
 
     // Signing tests

--- a/bin/btc-server/src/main.rs
+++ b/bin/btc-server/src/main.rs
@@ -97,11 +97,11 @@ struct App<BitcoinRpcApi> {
     /// spend the same operations twice.
     tx_lock: Arc<Mutex<()>>,
     identifier: frost::Identifier,
-    // TODO (armins) check that you have threshold amount of signers when accepting dkg packages
     max_signers: u16,
     min_signers: u16,
-    frost_round1_dkg:
-        Option<(frost::keys::dkg::round1::SecretPackage, frost::keys::dkg::round1::Package)>,
+    frost_round1_dkg: Arc<
+        Mutex<Option<(frost::keys::dkg::round1::SecretPackage, frost::keys::dkg::round1::Package)>>,
+    >,
     frost_round2_dkg: Arc<Mutex<Option<frost::keys::dkg::round2::SecretPackage>>>,
     /// The signing nonces for the current signing session
     /// We will replace this value in the case of a new signing session
@@ -203,7 +203,7 @@ where
             pegout_scheduler: pegout_manager,
             tx_lock: Arc::new(Mutex::new(())),
             identifier: frost_identifier,
-            frost_round1_dkg: round1_dkg,
+            frost_round1_dkg: Arc::new(Mutex::new(round1_dkg)),
             frost_round2_dkg: Arc::new(Mutex::new(None)),
             frost_round1_nonces: Arc::new(Mutex::new(None)),
             config,
@@ -407,16 +407,16 @@ mod test {
         assert_eq!(pk_result.err().unwrap().to_string(), "missing key package");
     }
 
-    #[test]
-    fn round1_dkg_should_fail_when_missing_keys() {
+    #[tokio::test]
+    async fn round1_dkg_should_fail_when_missing_keys() {
         let app = setup();
-        let round1_dkg = app.get_round1_dkg();
+        let round1_dkg = app.get_round1_dkg().await;
         assert!(round1_dkg.is_err());
         assert_eq!(round1_dkg.err().unwrap().to_string(), "missing round1 dkg package");
     }
 
-    #[test]
-    fn round1_dkg_should_fail_pk_package_is_present() {
+    #[tokio::test]
+    async fn round1_dkg_should_fail_pk_package_is_present() {
         let app = setup();
         let (secret_shares, pk_pkg) = trusted_dealer_setup(2, 3);
         let secret_share = secret_shares.values().collect::<Vec<_>>()[0];
@@ -427,38 +427,38 @@ mod test {
         app.db.set_pubkey_package(pk_pkg.clone()).unwrap();
         app.db.set_key_package(key_package.clone()).unwrap();
 
-        let round1_dkg = app.get_round1_dkg();
+        let round1_dkg = app.get_round1_dkg().await;
         assert!(round1_dkg.is_err());
         assert_eq!(round1_dkg.err().unwrap().to_string(), "already have key package");
     }
 
-    #[test]
-    fn round1_dkg_should_get_round1_dkg() {
+    #[tokio::test]
+    async fn round1_dkg_should_get_round1_dkg() {
         let mut app = setup();
         let rng = thread_rng();
 
-        app.frost_round1_dkg = Some(
+        app.frost_round1_dkg = Arc::new(Mutex::new(Some(
             frost::keys::dkg::part1(app.identifier, app.max_signers, app.min_signers, rng.clone())
                 .unwrap(),
-        );
-        let round1_dkg = app.get_round1_dkg();
+        )));
+        let round1_dkg = app.get_round1_dkg().await;
         assert!(round1_dkg.is_ok());
         // if we repeat the call we should get the same result
 
-        let round1_dkg2 = app.get_round1_dkg();
+        let round1_dkg2 = app.get_round1_dkg().await;
         assert!(round1_dkg2.is_ok());
         assert_eq!(round1_dkg.unwrap(), round1_dkg2.unwrap());
 
         // However if we modify the round1_dkg we should get a different result
         // we dont' have to modify the whole package, the rng should create new coefficients
-        app.frost_round1_dkg = Some(
+        app.frost_round1_dkg = Arc::new(Mutex::new(Some(
             frost::keys::dkg::part1(app.identifier, app.max_signers, app.min_signers, rng.clone())
                 .unwrap(),
-        );
+        )));
     }
 
-    #[test]
-    fn should_add_round1_dkg() {
+    #[tokio::test]
+    async fn should_add_round1_dkg() {
         let mut app = setup();
         let rng = thread_rng();
         // generate round1 dkgs
@@ -475,30 +475,32 @@ mod test {
                 .unwrap(),
             );
         }
-        app.frost_round1_dkg = Some(round1_dkgs[0].clone());
+        app.frost_round1_dkg = Arc::new(Mutex::new(Some(round1_dkgs[0].clone())));
 
         // Should not be able to add ourselves -- when identifier is the same
-        let res = app.add_round1_dkg(app.identifier, round1_dkgs[0].clone().1);
+        let res = app.add_round1_dkg(app.identifier, round1_dkgs[0].clone().1).await;
         assert!(res.is_err());
         assert_eq!(res.err().unwrap().to_string(), "cannot add own dkg package");
         // Should not be able to add ourselves -- when package is the same
-        let res = app.add_round1_dkg(
-            // Different peers id, the original is `1u16`
-            frost_id!(2),
-            round1_dkgs[0].clone().1,
-        );
+        let res = app
+            .add_round1_dkg(
+                // Different peers id, the original is `1u16`
+                frost_id!(2),
+                round1_dkgs[0].clone().1,
+            )
+            .await;
 
         assert!(res.is_err());
         assert_eq!(res.err().unwrap().to_string(), "cannot add own dkg package");
 
         // Add round 1 dkg from peer
-        let res = app.add_round1_dkg(frost_id!(2), round1_dkgs[1].clone().1);
+        let res = app.add_round1_dkg(frost_id!(2), round1_dkgs[1].clone().1).await;
         assert!(res.is_ok());
         let pkgs = app.db.get_round1_dkg_packages().unwrap();
         // Check it updates the db
         assert!(pkgs.contains_key(&frost::Identifier::try_from(2u16).unwrap()));
         // Adding the same round 1 dkg should not make a difference
-        let res = app.add_round1_dkg(frost_id!(2), round1_dkgs[1].clone().1);
+        let res = app.add_round1_dkg(frost_id!(2), round1_dkgs[1].clone().1).await;
         assert!(res.is_ok());
         let pkgs = app.db.get_round1_dkg_packages().unwrap();
         // Check it updates the db
@@ -506,7 +508,7 @@ mod test {
         assert_eq!(pkgs.len(), 1);
 
         // Should be able to add different round 1 dkg
-        let res = app.add_round1_dkg(frost_id!(3), round1_dkgs[2].clone().1);
+        let res = app.add_round1_dkg(frost_id!(3), round1_dkgs[2].clone().1).await;
         assert!(res.is_ok());
         let pkgs = app.db.get_round1_dkg_packages().unwrap();
         // Check it updates the db
@@ -520,7 +522,7 @@ mod test {
             frost::keys::dkg::part1(frost_id!(4), app.max_signers, app.min_signers, rng.clone())
                 .unwrap();
 
-        let res = app.add_round1_dkg(frost_id!(4), extra.1);
+        let res = app.add_round1_dkg(frost_id!(4), extra.1).await;
         assert!(res.is_err());
         assert_eq!(res.err().unwrap().to_string(), "dkg max signers reached");
     }
@@ -570,7 +572,7 @@ mod test {
                 .unwrap(),
             );
         }
-        app.frost_round1_dkg = Some(round1_dkgs[0].clone());
+        app.frost_round1_dkg = Arc::new(Mutex::new(Some(round1_dkgs[0].clone())));
 
         let round2_dkg = app.get_round2_dkg().await;
         assert!(round2_dkg.is_err());
@@ -579,8 +581,8 @@ mod test {
             "internal FROST error: Incorrect number of packages."
         );
 
-        app.add_round1_dkg(frost_id!(2), round1_dkgs[1].clone().1).expect("valid round1 dkg");
-        app.add_round1_dkg(frost_id!(3), round1_dkgs[2].clone().1).expect("valid round1 dkg");
+        app.add_round1_dkg(frost_id!(2), round1_dkgs[1].clone().1).await.expect("valid round1 dkg");
+        app.add_round1_dkg(frost_id!(3), round1_dkgs[2].clone().1).await.expect("valid round1 dkg");
 
         let round2_dkg = app.get_round2_dkg().await.expect("valid round 2 transition");
         assert_eq!(round2_dkg.len(), 2);
@@ -610,22 +612,34 @@ mod test {
         }
         // 1st participant round 1
         app1.identifier = frost_id!(1);
-        app1.frost_round1_dkg = Some(round1_dkgs[0].clone());
-        app1.add_round1_dkg(frost_id!(2), round1_dkgs[1].clone().1).expect("valid round1 dkg");
-        app1.add_round1_dkg(frost_id!(3), round1_dkgs[2].clone().1).expect("valid round1 dkg");
+        app1.frost_round1_dkg = Arc::new(Mutex::new(Some(round1_dkgs[0].clone())));
+        app1.add_round1_dkg(frost_id!(2), round1_dkgs[1].clone().1)
+            .await
+            .expect("valid round1 dkg");
+        app1.add_round1_dkg(frost_id!(3), round1_dkgs[2].clone().1)
+            .await
+            .expect("valid round1 dkg");
         let p1_dkg2 = app1.get_round2_dkg().await.expect("valid round 2 transition");
 
         // 2nd participant round 1
-        app2.frost_round1_dkg = Some(round1_dkgs[1].clone());
+        app2.frost_round1_dkg = Arc::new(Mutex::new(Some(round1_dkgs[1].clone())));
         app2.identifier = frost_id!(2);
-        app2.add_round1_dkg(frost_id!(1), round1_dkgs[0].clone().1).expect("valid round1 dkg");
-        app2.add_round1_dkg(frost_id!(3), round1_dkgs[2].clone().1).expect("valid round1 dkg");
+        app2.add_round1_dkg(frost_id!(1), round1_dkgs[0].clone().1)
+            .await
+            .expect("valid round1 dkg");
+        app2.add_round1_dkg(frost_id!(3), round1_dkgs[2].clone().1)
+            .await
+            .expect("valid round1 dkg");
         let p2_dkg2 = app2.get_round2_dkg().await.expect("valid round 2 transition");
         // 3rd participant round 1
-        app3.frost_round1_dkg = Some(round1_dkgs[2].clone());
+        app3.frost_round1_dkg = Arc::new(Mutex::new(Some(round1_dkgs[2].clone())));
         app3.identifier = frost_id!(3);
-        app3.add_round1_dkg(frost_id!(1), round1_dkgs[0].clone().1).expect("valid round1 dkg");
-        app3.add_round1_dkg(frost_id!(2), round1_dkgs[1].clone().1).expect("valid round1 dkg");
+        app3.add_round1_dkg(frost_id!(1), round1_dkgs[0].clone().1)
+            .await
+            .expect("valid round1 dkg");
+        app3.add_round1_dkg(frost_id!(2), round1_dkgs[1].clone().1)
+            .await
+            .expect("valid round1 dkg");
         let p3_dkg2 = app3.get_round2_dkg().await.expect("valid round 2 transition");
 
         // Round 2 dkg for 1st participant

--- a/bin/btc-server/src/main.rs
+++ b/bin/btc-server/src/main.rs
@@ -37,7 +37,7 @@ use std::{
 };
 
 use alloy_rpc_types_engine::{JwtError, JwtSecret};
-use bitcoin::{BlockHash, Transaction, TxOut};
+use bitcoin::{BlockHash, Transaction};
 use bitcoincore_rpc::{Auth, RpcApi};
 use config::Config;
 use frost_secp256k1_tr as frost;
@@ -591,6 +591,135 @@ mod test {
     }
 
     #[tokio::test]
+    async fn should_not_accept_round2_dkg_from_ourselves_or_others() {
+        let mut app1 = setup();
+        let mut app2 = setup();
+        let rng = thread_rng();
+        let mut round1_dkgs = vec![];
+        // reminder that frost identifiers start at 1
+        for index in 1..(app1.max_signers + 1) {
+            round1_dkgs.push(
+                frost::keys::dkg::part1(
+                    frost_id!(index),
+                    app1.max_signers,
+                    app1.min_signers,
+                    rng.clone(),
+                )
+                .unwrap(),
+            );
+        }
+
+        // Round 1 DKG for p1
+        app1.identifier = frost_id!(1);
+        app1.frost_round1_dkg = Arc::new(Mutex::new(Some(round1_dkgs[0].clone())));
+        app1.add_round1_dkg(frost_id!(2), round1_dkgs[1].clone().1)
+            .await
+            .expect("valid round1 dkg");
+        app1.add_round1_dkg(frost_id!(3), round1_dkgs[2].clone().1)
+            .await
+            .expect("valid round1 dkg");
+        let p1_dkg2 = app1.get_round2_dkg().await.expect("valid round 2 transition");
+
+        // Round 2 DKG for p2
+        app2.identifier = frost_id!(2);
+        app2.frost_round1_dkg = Arc::new(Mutex::new(Some(round1_dkgs[1].clone())));
+        app2.add_round1_dkg(frost_id!(1), round1_dkgs[0].clone().1)
+            .await
+            .expect("valid round1 dkg");
+        app2.add_round1_dkg(frost_id!(3), round1_dkgs[2].clone().1)
+            .await
+            .expect("valid round1 dkg");
+        let p2_dkg2 = app2.get_round2_dkg().await.expect("valid round 2 transition");
+
+        let p1_share = p2_dkg2.get(&frost_id!(1)).unwrap();
+        let res = app1.add_round2_dkg(frost_id!(1), p1_share.clone()).await;
+        assert!(res.is_err());
+        assert_eq!(res.err().unwrap().to_string(), "invalid frost peer id");
+        // Should not add someone else's share
+        // For some reason this is fine?!
+        // let p2_share = p1_dkg2.get(&frost_id!(3)).unwrap();
+        // let res = app1.add_round2_dkg(frost_id!(2), p2_share.clone()).await;
+        // assert!(res.is_err());
+        // assert_eq!(res.err().unwrap().to_string(), "invalid frost peer id");
+    }
+
+    #[tokio::test]
+    async fn should_fail_dkg_when_round1_pkg_is_stale() {
+        // DKG should fail all together if you are using a round1 secret that does not belong to
+        // this DKG round
+        let rng: rand::prelude::ThreadRng = thread_rng();
+        // We essentially need to emulate dkg here
+        let mut app1 = setup();
+        let mut app2 = setup();
+        let mut app3 = setup();
+        let mut round1_dkgs = vec![];
+        // Reminder that frost ids index at 1
+        for index in 1..(app1.max_signers + 1) {
+            round1_dkgs.push(
+                frost::keys::dkg::part1(
+                    frost::Identifier::try_from(index).expect("valid id"),
+                    app1.max_signers,
+                    app1.min_signers,
+                    rng.clone(),
+                )
+                .unwrap(),
+            );
+        }
+        // 1st participant round 1
+        app1.identifier = frost_id!(1);
+        app1.frost_round1_dkg = Arc::new(Mutex::new(Some(round1_dkgs[0].clone())));
+        app1.add_round1_dkg(frost_id!(2), round1_dkgs[1].clone().1)
+            .await
+            .expect("valid round1 dkg");
+        app1.add_round1_dkg(frost_id!(3), round1_dkgs[2].clone().1)
+            .await
+            .expect("valid round1 dkg");
+        let p1_dkg2 = app1.get_round2_dkg().await.expect("valid round 2 transition");
+
+        // 2nd participant round 1
+        app2.frost_round1_dkg = Arc::new(Mutex::new(Some(round1_dkgs[1].clone())));
+        app2.identifier = frost_id!(2);
+        app2.add_round1_dkg(frost_id!(1), round1_dkgs[0].clone().1)
+            .await
+            .expect("valid round1 dkg");
+        app2.add_round1_dkg(frost_id!(3), round1_dkgs[2].clone().1)
+            .await
+            .expect("valid round1 dkg");
+        let p2_dkg2 = app2.get_round2_dkg().await.expect("valid round 2 transition");
+
+        // 3rd participant round 1
+        app3.frost_round1_dkg = Arc::new(Mutex::new(Some(round1_dkgs[2].clone())));
+        app3.identifier = frost_id!(3);
+        app3.add_round1_dkg(frost_id!(1), round1_dkgs[0].clone().1)
+            .await
+            .expect("valid round1 dkg");
+        app3.add_round1_dkg(frost_id!(2), round1_dkgs[1].clone().1)
+            .await
+            .expect("valid round1 dkg");
+        let p3_dkg2 = app3.get_round2_dkg().await.expect("valid round 2 transition");
+
+        // Now lets re-generate the round 1 package for the first participant
+        let new_round1_pkg =
+            frost::keys::dkg::part1(frost_id!(1), app1.max_signers, app1.min_signers, rng.clone())
+                .unwrap();
+        app1.frost_round1_dkg = Arc::new(Mutex::new(Some(new_round1_pkg)));
+
+        // Round 2 dkg for 2'nd participant
+        // However adding the shares from participant 1 to others should fail
+        let new_p1_dkg2 = app1.get_round2_dkg().await.unwrap();
+
+        let p2_share = new_p1_dkg2.get(&frost_id!(2)).unwrap();
+        let _ =
+            app2.add_round2_dkg(frost_id!(1), p2_share.clone()).await.expect("valid round2 dkg");
+        let p2_share = p3_dkg2.get(&frost_id!(2)).unwrap();
+        let res = app2.add_round2_dkg(frost_id!(3), p2_share.clone()).await;
+        // This will fail because some round2 shares have been generated with different round1
+        // coefficients
+        assert!(res.is_err());
+        assert_eq!(res.err().unwrap().to_string(), "internal FROST error: Invalid secret share.");
+    }
+
+    #[tokio::test]
     async fn should_add_round2_dkg_packages() {
         let rng: rand::prelude::ThreadRng = thread_rng();
         // We essentially need to emulate dkg here
@@ -670,10 +799,10 @@ mod test {
         assert_eq!(pk1, pk2);
 
         // Check that round 1 and round 2 secrets are none now
-        // assert!(app1.frost_round1_dkg.is_none());
+        assert!(app1.frost_round1_dkg.lock().await.is_none());
         assert!(app1.frost_round2_dkg.lock().await.is_none());
 
-        // assert!(app2.frost_round1_dkg.is_none());
+        assert!(app2.frost_round1_dkg.lock().await.is_none());
         assert!(app2.frost_round2_dkg.lock().await.is_none());
     }
 

--- a/bin/btc-server/src/main.rs
+++ b/bin/btc-server/src/main.rs
@@ -629,8 +629,10 @@ mod test {
         let p3_dkg2 = app3.get_round2_dkg().await.expect("valid round 2 transition");
 
         // Round 2 dkg for 1st participant
-        app1.add_round2_dkg(frost_id!(2), p2_dkg2.clone()).await.expect("valid round2 dkg");
-        app1.add_round2_dkg(frost_id!(3), p3_dkg2.clone()).await.expect("valid round2 dkg");
+        let p1_share = p2_dkg2.get(&frost_id!(1)).unwrap();
+        app1.add_round2_dkg(frost_id!(2), p1_share.clone()).await.expect("valid round2 dkg");
+        let p1_share = p3_dkg2.get(&frost_id!(1)).unwrap();
+        app1.add_round2_dkg(frost_id!(3), p1_share.clone()).await.expect("valid round2 dkg");
 
         // The dkg session should have concluded by now
         let pk_package1 = app1.db.get_public_key_package().expect("valid pk package");
@@ -640,16 +642,15 @@ mod test {
 
         // Lets complete the round 2 dkg for the another participant
         // And compare the results
-        app2.add_round2_dkg(frost_id!(1), p1_dkg2.clone()).await.expect("valid round2 dkg");
-        app2.add_round2_dkg(frost_id!(3), p3_dkg2.clone()).await.expect("valid round2 dkg");
+        let p2_share = p1_dkg2.get(&frost_id!(2)).unwrap();
+        app2.add_round2_dkg(frost_id!(1), p2_share.clone()).await.expect("valid round2 dkg");
+        let p2_share = p3_dkg2.get(&frost_id!(2)).unwrap();
+        app2.add_round2_dkg(frost_id!(3), p2_share.clone()).await.expect("valid round2 dkg");
 
         let pk_package2 = app1.db.get_public_key_package().expect("valid pk package");
         assert!(pk_package2.is_some());
         assert_eq!(pk_package1, pk_package2);
 
-        let _eth = eth_vector_to_fixed_bytes(
-            hex::decode("86Bb524A1c7703C02BcEc36D1C4218aADb7D643D").unwrap(),
-        );
         let pk1 = app1.get_public_key().expect("valid public key request");
         let pk2 = app2.get_public_key().expect("valid public key request");
         assert_eq!(pk1, pk2);

--- a/bin/btc-server/src/server.rs
+++ b/bin/btc-server/src/server.rs
@@ -487,6 +487,8 @@ where
         req: tonic::Request<rpc::Empty>,
     ) -> Result<tonic::Response<rpc::DkgPayload>, tonic::Status> {
         self.validate_jwt(&req)?;
+        // Each package is unique for a peer.
+        // Upstream caller must ensure that the package is sent to that specific peer
         let round2_packages = self
             .get_round2_dkg()
             .await

--- a/bin/btc-server/src/server.rs
+++ b/bin/btc-server/src/server.rs
@@ -467,13 +467,13 @@ where
             error!("Failed to parse frost peer id: {}", e);
             badarg!("Failed to parse frost peer id: {}", e)
         })?;
-        let packages: BTreeMap<frost::Identifier, frost::keys::dkg::round2::Package> =
+        let package: frost::keys::dkg::round2::Package =
             serde_json::from_slice(req.payload.as_slice()).map_err(|e| {
                 error!("Failed to deserialize round2 dkg package: {}", e);
                 badarg!("Failed to deserialize round2 dkg package: {}", e)
             })?;
 
-        self.add_round2_dkg(frost_id, packages).await.map_err(|e| {
+        self.add_round2_dkg(frost_id, package).await.map_err(|e| {
             error!("Failed to add round2 dkg: {}", e);
             badarg!("Failed to add round2 dkg: {}", e)
         })?;

--- a/bin/btc-server/src/server.rs
+++ b/bin/btc-server/src/server.rs
@@ -517,6 +517,7 @@ where
                 badarg!("Failed to deserialize round1 dkg package: {}", e)
             })?;
         self.add_round1_dkg(frost_id, dkg_round1)
+            .await
             .map_err(|e| internal!("Failed to add round1 dkg: {}", e))?;
         Ok(tonic::Response::new(rpc::Empty {}))
     }
@@ -530,6 +531,7 @@ where
         self.validate_jwt(&req)?;
         let round1_dkg_package = self
             .get_round1_dkg()
+            .await
             .map_err(|e| internal!("Failed to get round1 dkg package: {}", e))?;
 
         let res = rpc::DkgPayload {

--- a/bin/btc-server/src/test_utils.rs
+++ b/bin/btc-server/src/test_utils.rs
@@ -176,7 +176,7 @@ pub mod test_utils {
             identifier: frost_id!(1u16),
             max_signers: 3,
             min_signers: 2,
-            frost_round1_dkg: None,
+            frost_round1_dkg: Arc::new(Mutex::new(None)),
             frost_round2_dkg: Arc::new(Mutex::new(None)),
             frost_round1_nonces: Arc::new(Mutex::new(None)),
             btc_signing_server_jwt_secret: None,

--- a/bin/btc-server/src/test_utils.rs
+++ b/bin/btc-server/src/test_utils.rs
@@ -201,7 +201,6 @@ pub mod test_utils {
                 fall_back_fee_rate_sat_per_vbyte: 30,
             },
         };
-        println!("App setup complete");
 
         app
     }

--- a/bin/test-suite/Cargo.toml
+++ b/bin/test-suite/Cargo.toml
@@ -43,6 +43,11 @@ reth-tracing.workspace = true
 ## Bitcoin rpc
 bitcoincore-rpc.workspace = true
 
+
+# frost
+# TODO update this to the zcash frost library when tr is merged in
+frost-secp256k1-tr = { git = "https://github.com/0xBEEFCAF3/frost", branch = "additional-tweaks",  features = ["serde", "serialization"] }
+
 # crates.io dependencies
 askama = "0.12.1"
 port-killer = "0.1.0"

--- a/bin/test-suite/src/suite/consensus/frost/test_dkg.rs
+++ b/bin/test-suite/src/suite/consensus/frost/test_dkg.rs
@@ -3,9 +3,16 @@ use crate::{it_error_print, suite::consensus::ConsensusIntegrationTestSuite};
 use bitcoin::{consensus::Encodable, Address, Amount};
 use btcserverlib::pegout_id::PegoutId;
 use client::{self, BtcServerClient};
+use frost_secp256k1_tr as frost;
 use rand::{rngs::StdRng, RngCore, SeedableRng};
-use std::{str::FromStr, vec};
+use std::{collections::BTreeMap, str::FromStr, vec};
 use tonic::transport::Channel;
+
+macro_rules! frost_id {
+    ($index:expr) => {
+        frost::Identifier::derive($index.to_le_bytes().as_slice()).expect("valid id")
+    };
+}
 
 pub async fn dkg_flow(suite: &ConsensusIntegrationTestSuite) -> Result<(), Error> {
     // create btc server clients
@@ -59,6 +66,12 @@ pub async fn dkg_flow(suite: &ConsensusIntegrationTestSuite) -> Result<(), Error
 }
 
 pub async fn do_dkg(clients: &mut [client::BtcServerClient<Channel>]) -> Result<(), Error> {
+    // creating a mapping of client index to fronst identifier
+    let mut frost_id_map = BTreeMap::new();
+    for (i, _) in clients.iter().enumerate() {
+        let frost_id = frost_id!(i as u16);
+        frost_id_map.insert(frost_id, i);
+    }
     // Round 1 dkg
     let mut round1_packages = vec![];
     for c in clients.iter_mut() {
@@ -107,17 +120,27 @@ pub async fn do_dkg(clients: &mut [client::BtcServerClient<Channel>]) -> Result<
         }
     }
 
-    // Send round 2 dkg packages to each respective participant
-    for (i, c) in clients.iter_mut().enumerate() {
-        for (j, p) in round2_packages.iter().enumerate() {
-            if i != j {
-                c.new_round2_dkg_package(tonic::Request::new(client::DkgPayload {
-                    identifier: p.identifier.clone(),
-                    payload: p.payload.clone(),
+    // Send dkg round2 shares to each recepient
+    for (i, p) in round2_packages.iter().enumerate() {
+        let from_frost_id = frost_id!(i as u16).serialize().to_vec();
+        let round2_shares = p.payload.clone();
+        let shares = serde_json::from_slice::<
+            BTreeMap<frost::Identifier, frost::keys::dkg::round2::Package>,
+        >(&round2_shares)
+        .expect("Failed to deserialize round 2 shares");
+
+        // there should always be n-1 shares
+        assert_eq!(shares.len(), clients.len() - 1);
+        for (j, (identifier, payload)) in shares.iter().enumerate() {
+            let client_index = frost_id_map.get(&identifier).unwrap();
+            let mut client = clients[*client_index].clone();
+            client
+                .new_round2_dkg_package(tonic::Request::new(client::DkgPayload {
+                    identifier: from_frost_id.clone(),
+                    payload: serde_json::to_vec(&payload).unwrap(),
                 }))
                 .await
                 .map_err(Error::Request)?;
-            }
         }
     }
     Ok(())

--- a/crates/consensus/authority/Cargo.toml
+++ b/crates/consensus/authority/Cargo.toml
@@ -19,7 +19,7 @@ reth-consensus.workspace = true
 reth-beacon-consensus = { path = "../beacon" }
 reth-blockchain-tree.workspace = true
 reth-ethereum-consensus.workspace = true
-reth-primitives.workspace = true
+reth-primitives = { workspace = true, features = ["secp256k1"] }
 reth-execution-errors.workspace = true
 reth-chainspec.workspace = true
 reth-evm-ethereum.workspace = true

--- a/crates/consensus/authority/src/dkg.rs
+++ b/crates/consensus/authority/src/dkg.rs
@@ -2,9 +2,12 @@ use btcserverlib::extended_client::BtcServerExtendedClient;
 use client::{DkgPayload, Empty, GetPublicKeyResponse};
 use frost_secp256k1_tr as frost;
 use reth_network::frost::{
-    manager::{peer_id_to_identifier, FrostCommand, FrostConfig, PeerData, ToFrostManager},
+    manager::{
+        authority_index_to_frost_identifier, FrostCommand, FrostConfig, PeerData, ToFrostManager,
+    },
     DkgEventResponseType, DkgResponse, FrostPeerCommand, PeerMessageResponse,
 };
+use reth_network_peers::pk2id;
 use reth_rpc_types::PeerId;
 use std::{
     collections::{BTreeMap, HashMap},
@@ -64,6 +67,8 @@ pub(crate) enum Error {
     MissingKeyPackage,
     #[error("Failed to send peer command {0}")]
     Send(SendError<FrostPeerCommand>),
+    #[error("Peer id not found")]
+    PeerIdNotFound,
 }
 
 impl From<FrostParseError> for Error {
@@ -102,11 +107,13 @@ pub(crate) struct DKGStateMachine<EF, BF, DB, ToFrostMan> {
     state: DKGState,
     personal_frost_identifier: frost::Identifier,
     public_key_package: Option<secp256k1::PublicKey>,
+    #[allow(dead_code)]
     frost_config: FrostConfig,
+    // Mapping for frost id to peer id
+    frost_id_map: HashMap<frost::Identifier, PeerId>,
     // coordiantor only fields
-    // Key frost id, values are round 1 and round 2 packages respectively
+    // Key frost id, values are round 1
     round1_packages: BTreeMap<Vec<u8>, Vec<u8>>,
-    round2_packages: BTreeMap<Vec<u8>, Vec<u8>>,
 }
 
 impl<EF, BF, DB, ToFrostMan> DKGStateMachine<EF, BF, DB, ToFrostMan>
@@ -122,7 +129,16 @@ where
         frost_config: FrostConfig,
     ) -> Self {
         let personal_frost_identifier: frost::Identifier =
-            peer_id_to_identifier(frost_config.authority_index as u16);
+            authority_index_to_frost_identifier(frost_config.authority_index as u16);
+
+        let mut frost_id_map = HashMap::new();
+        for (index, pk) in frost_config.authorities.iter().enumerate() {
+            frost_id_map.insert(authority_index_to_frost_identifier(index as u16), pk2id(&pk));
+        }
+
+        info!(target: "consensus::authority::dkg::new", "personal frost id: {:?}", personal_frost_identifier);
+        info!(target: "consensus::authority::dkg::new", "frost id map: {:?}", frost_id_map);
+
         Self {
             btc_client,
             storage,
@@ -132,23 +148,7 @@ where
             public_key_package: None,
             frost_config,
             round1_packages: BTreeMap::new(),
-            round2_packages: BTreeMap::new(),
-        }
-    }
-
-    /// Resets the state machine to its initial state
-    #[allow(dead_code)]
-    pub(crate) fn reset(self) -> Self {
-        Self {
-            btc_client: self.btc_client,
-            storage: self.storage,
-            frost_handle: self.frost_handle,
-            state: DKGState::Initial,
-            personal_frost_identifier: self.personal_frost_identifier,
-            public_key_package: None,
-            frost_config: self.frost_config,
-            round1_packages: BTreeMap::new(),
-            round2_packages: BTreeMap::new(),
+            frost_id_map,
         }
     }
 
@@ -348,7 +348,7 @@ where
 
     pub(crate) fn coordinator_identifier(&self) -> frost::Identifier {
         // the 0th peer is always the coordinator
-        peer_id_to_identifier(0)
+        authority_index_to_frost_identifier(0)
     }
 
     pub(crate) async fn get_all_peers_handle(&self) -> Result<HashMap<PeerId, PeerData>, Error> {
@@ -397,6 +397,7 @@ where
         Ok(())
     }
 
+    /// Gossip to all peers
     async fn gossip_to_peers(
         &self,
         dkg_payload: DkgPayload,
@@ -420,6 +421,35 @@ where
                 }
             }
         }
+        Ok(())
+    }
+
+    /// Gossip to a single peer
+    async fn gossip_to_peer(
+        &self,
+        dkg_payload: DkgPayload,
+        response_type: DkgEventResponseType,
+        peer_id: PeerId,
+    ) -> Result<(), Error> {
+        let connected_peers = self.get_all_peers_handle().await?;
+        let resp = PeerMessageResponse::Dkg(DkgResponse {
+            response_type: response_type.clone(),
+            identifier: dkg_payload.identifier.clone(),
+            data: dkg_payload.payload.clone(),
+        });
+        let peer_data = connected_peers.get(&peer_id);
+
+        if let Some(sender) = peer_data {
+            sender
+                .peer_commands_tx
+                .clone()
+                .expect("should have a peer commands tx for every peer")
+                .send(FrostPeerCommand::PeerMessage(resp))
+                .map_err(Error::Send)?;
+        } else {
+            warn!(target: "consensus::authority::dkg::gossip_to_peer", "Peer {:?} not found durring DKG protocol", peer_id);
+        }
+
         Ok(())
     }
 
@@ -455,6 +485,9 @@ where
         Ok(())
     }
 
+    /// Coordinator processing round 1 packages
+    /// During round1 dkg the coordinator collects round 1 packages from peers and gossips them to
+    /// all peers
     pub(crate) async fn process_round1_coordinator(
         &mut self,
         identifier: Vec<u8>,
@@ -491,7 +524,7 @@ where
             "round 1 package added successfully"
         );
         // Check if we are ready to progress to round 2
-        let dkg2_package = match self.get_round2_dkg_package().await {
+        let _ = match self.get_round2_dkg_package().await {
             Ok(dkg2_package) => dkg2_package,
             Err(e) => {
                 // its ok to error here if we don't have enough packages
@@ -499,8 +532,6 @@ where
                 return Err(e);
             }
         };
-        // Save our own round 2 package to memory
-        self.round2_packages.insert(dkg2_package.identifier.clone(), dkg2_package.payload.clone());
 
         // We have suffecient round 1 messages to progress to round 2
         // Now we need to gossip each round 1 message to all peers
@@ -516,6 +547,8 @@ where
         Ok(())
     }
 
+    /// Non-coordinator processing round 1 packages request
+    /// This is a request from the coordinator to send round 1 packages to the coordinator
     pub(crate) async fn process_round1_request(&mut self) -> Result<(), Error> {
         let round1_package = self.get_round1_dkg_package().await?;
         // Gossip to coordinator
@@ -523,6 +556,9 @@ where
         Ok(())
     }
 
+    /// As a non-coordinator process round 1 packages
+    /// The coordinator will collect round 1 packages from peers and send them to us individually
+    /// In the future this could be a single package containing all the round 1 packages
     pub(crate) async fn process_round1(
         &mut self,
         identifier: Vec<u8>,
@@ -559,67 +595,37 @@ where
                 return Err(e);
             }
         };
-
+        let round2_shares = dkg2_package.payload.clone();
         info!(target: "consensus::authority::dkg::process_round1", "ready to move to round 2");
-        if let Err(e) =
-            self.gossip_to_coordinator(dkg2_package, DkgEventResponseType::DkgRound2).await
-        {
-            error!(target: "consensus::authority::dkg::process_round1", "Error gossiping round 2 to peers {:?}", e);
-            self.state = DKGState::DkgFailed;
-            return Err(e);
-        }
+        let shares = serde_json::from_slice::<
+            BTreeMap<frost::Identifier, frost::keys::dkg::round2::Package>,
+        >(&round2_shares)
+        .map_err(|_| Error::FailedToGetRound2Packages)?;
 
-        Ok(())
-    }
-
-    pub(crate) async fn process_round2_coordinator(
-        &mut self,
-        identifier: Vec<u8>,
-        payload: Vec<u8>,
-    ) -> Result<(), Error> {
-        // If we are not the coordinator, we should not be processing this round 1 package response
-        if self.personal_frost_identifier != self.coordinator_identifier() {
-            warn!(target: "consensus::authority::dkg::process_round2_coordinator", "Not the coordinator, ignoring round 1 package");
-            return Ok(());
-        }
-
-        // return if the sending identifier is us
-        if self.personal_frost_identifier == deserialize_frost_peer_id(identifier.clone())? {
-            warn!(target: "consensus::authority::dkg::process_round2_coordinator", "Received our own round 1 package");
-            return Ok(());
-        }
-        // Save in btc server
-        self.add_round2_dkg_package(identifier.clone(), payload.clone()).await?;
-        // Add to the round 2 packages
-        self.round2_packages.insert(identifier, payload);
-
-        // Once we get the pk we know we are done with round 2
-        let agg_public_key = self.get_public_key().await?;
-        info!(target: "consensus::authority::dkg::process_round2_coordinator", "Got pubkey_package: {:?}", agg_public_key.publickey);
-        // gossip all the round 2 packages to all peers
-        for (identifier, payload) in self.round2_packages.iter() {
-            self.gossip_to_peers(
-                DkgPayload { identifier: identifier.clone(), payload: payload.clone() },
+        for (identifier, round2_payload) in shares.iter() {
+            let peer_id = self.frost_id_map.get(&identifier).ok_or(Error::PeerIdNotFound)?;
+            self.gossip_to_peer(
+                DkgPayload {
+                    // From us
+                    identifier: self.personal_frost_identifier.serialize().to_vec(),
+                    payload: serde_json::to_vec(&round2_payload).unwrap(),
+                },
                 DkgEventResponseType::DkgRound2,
+                peer_id.clone(),
             )
             .await?;
         }
 
-        self.process_round3().await?;
-
         Ok(())
     }
 
+    /// All peers processing round 2 packages
+    /// The coordinator DOES NOT have any special responsiblities here for round 2
     pub(crate) async fn process_round2(
         &mut self,
         identifier: Vec<u8>,
         payload: Vec<u8>,
     ) -> Result<(), Error> {
-        // ensure we are not the coordinator
-        if self.personal_frost_identifier == self.coordinator_identifier() {
-            self.process_round2_coordinator(identifier, payload).await?;
-            return Ok(());
-        }
         info!(target: "consensus::authority::dkg::process_round2",
             "our id: {:?},\n peers id:  {:?}",
             self.personal_frost_identifier,

--- a/crates/consensus/authority/src/frost_task.rs
+++ b/crates/consensus/authority/src/frost_task.rs
@@ -11,7 +11,7 @@ use btcserverlib::extended_client::{BtcServerExtendedClient, GrpcClientError};
 use reth_chainspec::ChainSpec;
 use reth_network::{
     frost::{
-        manager::{peer_id_to_identifier, FrostCommand, FrostConfig, ToFrostManager},
+        manager::{authority_index_to_frost_identifier, FrostCommand, FrostConfig, ToFrostManager},
         DkgEventResponseType, DkgResponse, FrostPeerCommand, PeerMessageResponse,
         SigningEventResponseType, SigningResponse,
     },
@@ -209,7 +209,8 @@ where
         }
 
         loop {
-            let my_frost_id = peer_id_to_identifier(self.frost_config.authority_index as u16);
+            let my_frost_id =
+                authority_index_to_frost_identifier(self.frost_config.authority_index as u16);
             let is_coordinator = self.dkg_state_machine.coordinator_identifier() == my_frost_id;
             // start dkg only when we are in turn + initial state + no public key
             if is_coordinator &&

--- a/crates/consensus/authority/src/pbft.rs
+++ b/crates/consensus/authority/src/pbft.rs
@@ -8,7 +8,7 @@ use reth_consensus_common::utils::{current_inturn_index, is_inturn, unix_timesta
 use reth_evm::execute::{BlockExecutorProvider, Executor};
 use reth_execution_errors::{BlockExecutionError, BlockValidationError};
 use reth_network::frost::{
-    manager::{peer_id_to_identifier, FrostCommand, FrostConfig, PeerData, ToFrostManager},
+    manager::{authority_index_to_frost_identifier, FrostCommand, FrostConfig, PeerData, ToFrostManager},
     FrostPeerCommand, PbftEventResponseType, PbftResponse, PeerMessageResponse,
 };
 use reth_network_p2p::HeadersClient;
@@ -233,7 +233,7 @@ where
         consensus: AuthorityConsensus,
     ) -> Self {
         let personal_frost_identifier: frost::Identifier =
-            peer_id_to_identifier(config.authority_index as u16);
+            authority_index_to_frost_identifier(config.authority_index as u16);
         info!(
             target: "consensus::authority::pbft::new",
             "Frost identifier used: {:?} - {:?}",

--- a/crates/consensus/authority/src/signing.rs
+++ b/crates/consensus/authority/src/signing.rs
@@ -13,7 +13,9 @@ use reth_consensus_common::utils::{
     current_inturn_index, get_in_turn_interval, is_inturn, unix_timestamp, CoordinatorInterval,
 };
 use reth_network::frost::{
-    manager::{peer_id_to_identifier, FrostCommand, FrostConfig, PeerData, ToFrostManager},
+    manager::{
+        authority_index_to_frost_identifier, FrostCommand, FrostConfig, PeerData, ToFrostManager,
+    },
     FrostPeerCommand, PeerMessageResponse, SigningEventResponseType, SigningResponse,
 };
 use reth_rpc_types::PeerId;
@@ -158,7 +160,7 @@ where
         task_executor: TaskExecutor,
     ) -> Self {
         let personal_frost_identifier: frost::Identifier =
-            peer_id_to_identifier(frost_config.authority_index as u16);
+            authority_index_to_frost_identifier(frost_config.authority_index as u16);
 
         let signing_states: SigningStatesMap = Arc::new(RwLock::new(HashMap::default()));
         let signing_states_clone = Arc::clone(&signing_states);
@@ -569,7 +571,7 @@ where
                     leader_selection_window,
                 );
                 let current_inturn_authority_frost_identifier =
-                    peer_id_to_identifier(current_inturn_authority_index as u16);
+                    authority_index_to_frost_identifier(current_inturn_authority_index as u16);
                 let coord = all_connected_frost_peers.iter().find_map(|(_peer_id, peer_data)| {
                     peer_data.frost_identifier.as_ref().and_then(|frost_id| {
                         if *frost_id == current_inturn_authority_frost_identifier {

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -72,7 +72,7 @@ pub fn create_noop_executor_provider(
         chain_spec,
         EthEvmConfig::default(),
         MockBitcoindFactory::new(BitcoindConfig::default()),
-        bitcoin::Network::Bitcoin,
+        bitcoin::Network::Regtest,
     )
 }
 

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -19,7 +19,6 @@ revm-primitives.workspace = true
 reth-prune-types.workspace = true
 reth-storage-errors.workspace = true
 reth-execution-types.workspace = true
-#reth-interfaces.workspace = true
 
 revm.workspace = true
 alloy-eips.workspace = true

--- a/crates/net/network/src/frost/manager.rs
+++ b/crates/net/network/src/frost/manager.rs
@@ -195,7 +195,8 @@ impl FrostManager {
                     // only if we have an already connection established
                     if let Some(peer_data) = self.peers_connections.get_mut(&peer_id) {
                         // add the peer conn mapped to a frost id based on authority index
-                        peer_data.frost_identifier = index.map(|i| peer_id_to_identifier(i as u16));
+                        peer_data.frost_identifier =
+                            index.map(|i| authority_index_to_frost_identifier(i as u16));
                         info!(target: "network::frost::on_network_event", "Received NetworkFrostEvent::PeerConfirmed event from peer with id = {}, frost identifier = {:?}", peer_id, peer_data.frost_identifier);
                     } else {
                         warn!(target: "network::frost::on_network_event", "Received NetworkFrostEvent::PeerConfirmed event, but peer with id {} does not seem to be connected yet", peer_id);
@@ -389,8 +390,7 @@ impl FrostConfig {
 }
 
 /// Maps an authority index to a frost specific identifier
-// TODO rename this to authority_index to frost id
-pub fn peer_id_to_identifier(authority_index: u16) -> frost::Identifier {
+pub fn authority_index_to_frost_identifier(authority_index: u16) -> frost::Identifier {
     frost::Identifier::derive(authority_index.to_le_bytes().as_slice())
         .expect("can derive identifier")
 }

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -46,8 +46,10 @@ pub use block::{
 /// Botanix specific stuff
 pub mod botanix;
 
+#[cfg(feature = "secp256k1")]
 /// Extra data header helpers
 pub mod extra_data_header;
+#[cfg(feature = "secp256k1")]
 /// Header extension helpers
 pub mod header_ext;
 

--- a/test_runner.sh
+++ b/test_runner.sh
@@ -16,6 +16,9 @@ for test in "${tests_to_run[@]}"; do
   # Set the environment variable
   export TEST_TO_RUN="$test"
 
+  # kill all btc-servers that may be running from previous test runs
+  killall btc-server || true
+
   # Call make
   make start-test-suite
   exit_codes+=("$?")


### PR DESCRIPTION
Its crutial in round2 that we send each participant their respective partial share. Which is our polynomial evaluated at their index. however if every partipant has all the shares this can lead to a key cancellation or rouge key attack.

Documentation is provided here: https://frost.zfnd.org/tutorial/dkg.html
Some TODOs for my self:

- [x] update frost networking protocol
- [x] more unit tests!
- [x] zero out round 1 secret after dkg is successful
