### PR TITLE
build(ci): use rust 1.80.0 for lint job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,149 +1,149 @@
 name: lint
 
 on:
-    pull_request:
-    merge_group:
-        branches: [main]
-    push:
-        branches: [main]
+  pull_request:
+  merge_group:
+    branches: [main]
+  push:
+    branches: [main]
 
 env:
-    CARGO_TERM_COLOR: always
+  CARGO_TERM_COLOR: always
 
 jobs:
-    # Commenting out for now, will re-enable in the future
-    # clippy-binaries:
-    #   name: clippy / ethereum
-    #   runs-on: ubuntu-latest
-    #   timeout-minutes: 30
-    #   steps:
-    #     - uses: actions/checkout@v4
-    #     - name: Install Protobuf Compiler
-    #       run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-    #     - uses: dtolnay/rust-toolchain@clippy
-    #     - uses: Swatinem/rust-cache@v2
-    #       with:
-    #         cache-on-failure: true
-    #         cache-all-crates: true
-    #     - run:
-    #         cargo +nightly clippy --bin reth --workspace --features "ethereum asm-keccak jemalloc jemalloc-prof min-error-logs min-warn-logs min-info-logs min-debug-logs min-trace-logs"
-    #       env:
-    #         RUSTFLAGS: -D warnings
+  # Commenting out for now, will re-enable in the future
+  # clippy-binaries:
+  #   name: clippy / ethereum
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 30
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Install Protobuf Compiler
+  #       run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+  #     - uses: dtolnay/rust-toolchain@clippy
+  #     - uses: Swatinem/rust-cache@v2
+  #       with:
+  #         cache-on-failure: true
+  #         cache-all-crates: true
+  #     - run:
+  #         cargo +nightly clippy --bin reth --workspace --features "ethereum asm-keccak jemalloc jemalloc-prof min-error-logs min-warn-logs min-info-logs min-debug-logs min-trace-logs"
+  #       env:
+  #         RUSTFLAGS: -D warnings
 
-    # clippy:
-    #   name: clippy-checks
-    #   runs-on: ubuntu-latest
-    #   timeout-minutes: 30
-    #   steps:
-    #     - uses: actions/checkout@v4
-    #     - name: Install Protobuf Compiler
-    #       run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-    #     - uses: dtolnay/rust-toolchain@clippy
-    #     - uses: Swatinem/rust-cache@v2
-    #       with:
-    #         cache-on-failure: true
-    #         cache-all-crates: true
-    #     - run: cargo clippy --workspace --lib --examples --tests --benches --all-features --locked
-    #       env:
-    #         RUSTFLAGS: -D warnings
+  # clippy:
+  #   name: clippy-checks
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 30
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Install Protobuf Compiler
+  #       run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+  #     - uses: dtolnay/rust-toolchain@clippy
+  #     - uses: Swatinem/rust-cache@v2
+  #       with:
+  #         cache-on-failure: true
+  #         cache-all-crates: true
+  #     - run: cargo clippy --workspace --lib --examples --tests --benches --all-features --locked
+  #       env:
+  #         RUSTFLAGS: -D warnings
 
-    #Commenting out for now, will re-enable after final upstream merge
-    crate-checks:
-      runs-on: ubuntu-latest
-      timeout-minutes: 60
-      steps:
-        - uses: actions/checkout@v4
-        - uses: dtolnay/rust-toolchain@stable
-        - uses: taiki-e/install-action@cargo-hack
-        - uses: Swatinem/rust-cache@v2
-          with:
-            cache-on-failure: true
-            cache-all-crates: true
-        - name: Install Protobuf Compiler
-          run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-        - run: cargo hack check
+  #Commenting out for now, will re-enable after final upstream merge
+  crate-checks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.80.0
+      - uses: taiki-e/install-action@cargo-hack
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          cache-all-crates: true
+      - name: Install Protobuf Compiler
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - run: cargo hack check
 
-    # Commenting out for now, will re-enable in once we have a MSRV
-    #   msrv:
-    #     name: MSRV
-    #     runs-on: botanix-actions-runner
-    #     timeout-minutes: 60
-    #     steps:
-    #       - uses: actions/checkout@v4
-    #       - name: Install Protobuf Compiler
-    #         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-    #       - uses: dtolnay/rust-toolchain@master
-    #         with:
-    #           toolchain: "1.77.2" # MSRV
-    #       - uses: Swatinem/rust-cache@v2
-    #         with:
-    #           cache-on-failure: true
-    #           cache-all-crates: true
-    #       - run: cargo build --bin reth --workspace
-    #         env:
-    #           RUSTFLAGS: -D warnings
+  # Commenting out for now, will re-enable in once we have a MSRV
+  #   msrv:
+  #     name: MSRV
+  #     runs-on: botanix-actions-runner
+  #     timeout-minutes: 60
+  #     steps:
+  #       - uses: actions/checkout@v4
+  #       - name: Install Protobuf Compiler
+  #         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+  #       - uses: dtolnay/rust-toolchain@master
+  #         with:
+  #           toolchain: "1.77.2" # MSRV
+  #       - uses: Swatinem/rust-cache@v2
+  #         with:
+  #           cache-on-failure: true
+  #           cache-all-crates: true
+  #       - run: cargo build --bin reth --workspace
+  #         env:
+  #           RUSTFLAGS: -D warnings
 
-    # Commenting out for now, will re-enable in the future
-    # docs:
-    #   name: docs
-    #   runs-on: ubuntu-latest
-    #   timeout-minutes: 30
-    #   steps:
-    #     - uses: actions/checkout@v4
-    #     - name: Install Protobuf Compiler
-    #       run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-    #     - uses: dtolnay/rust-toolchain@nightly
-    #     - uses: Swatinem/rust-cache@v2
-    #       with:
-    #         cache-on-failure: true
-    #         cache-all-crates: true
+  # Commenting out for now, will re-enable in the future
+  # docs:
+  #   name: docs
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 30
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Install Protobuf Compiler
+  #       run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+  #     - uses: dtolnay/rust-toolchain@nightly
+  #     - uses: Swatinem/rust-cache@v2
+  #       with:
+  #         cache-on-failure: true
+  #         cache-all-crates: true
 
-    #     - run: cargo docs --document-private-items
-    #       env:
-    #         # Keep in sync with ./book.yml:jobs.build
-    #         # This should only add `-D warnings`
-    #         RUSTDOCFLAGS:
-    #           --cfg docsrs --show-type-layout --generate-link-to-definition --enable-index-page
-    #           -Zunstable-options -D warnings
+  #     - run: cargo docs --document-private-items
+  #       env:
+  #         # Keep in sync with ./book.yml:jobs.build
+  #         # This should only add `-D warnings`
+  #         RUSTDOCFLAGS:
+  #           --cfg docsrs --show-type-layout --generate-link-to-definition --enable-index-page
+  #           -Zunstable-options -D warnings
 
-    fmt:
-        name: fmt
-        runs-on: ubuntu-latest
-        timeout-minutes: 30
-        steps:
-            - uses: actions/checkout@v4
-            - uses: dtolnay/rust-toolchain@nightly
-              with:
-                  components: rustfmt
-            - run: cargo fmt --all --check
+  fmt:
+    name: fmt
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.80.0
+        with:
+          components: rustfmt
+      - run: cargo fmt --all --check
 
-    codespell:
-      runs-on: ubuntu-latest
-      timeout-minutes: 30
-      steps:
-        - uses: actions/checkout@v4
-        - uses: codespell-project/actions-codespell@v2
-          with:
-            skip: "*.json"
+  codespell:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: codespell-project/actions-codespell@v2
+        with:
+          skip: "*.json"
 
-    grafana:
-      runs-on: ubuntu-latest
-      timeout-minutes: 30
-      steps:
-        - uses: actions/checkout@v4
-        - name: Check dashboard JSON with jq
-          uses: sergeysova/jq-action@v2
-          with:
-            cmd: jq empty etc/grafana/dashboards/overview.json
+  grafana:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check dashboard JSON with jq
+        uses: sergeysova/jq-action@v2
+        with:
+          cmd: jq empty etc/grafana/dashboards/overview.json
 
-    lint-success:
-        name: lint success
-        runs-on: ubuntu-latest
-        if: always()
-        needs: [crate-checks, fmt, grafana]
-        timeout-minutes: 30
-        steps:
-            - name: Decide whether the needed jobs succeeded or failed
-              uses: re-actors/alls-green@release/v1
-              with:
-                  jobs: ${{ toJSON(needs) }}
+  lint-success:
+    name: lint success
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [crate-checks, fmt, grafana]
+    timeout-minutes: 30
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
the only non-formatting changes are
`dtolnay/rust-toolchain@stable` > `dtolnay/rust-toolchain@1.80.0`

this is so we can run 1.80.0 locally and `cargo fmt` will produce the same results as the runner
and 1.80.0 is the targeted version in the repo `Cargo.toml`