### PR TITLE
fix: should not set tx index cp for non-consensus bitcoin block hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7893,6 +7893,7 @@ dependencies = [
  "async-compression",
  "bincode",
  "bitcoin",
+ "bitcoin_hashes",
  "btc-server",
  "bytes",
  "client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -534,6 +534,7 @@ secp256k1 = { version = "0.29", default-features = false, features = [
 miniscript = "11.0.0"
 bitcoin = { version = "0.31.0", features = [ "base64", "rand", "serde" ] }
 bitcoincore-rpc = "0.18.0"
+bitcoin_hashes = "0.13.0"
 
 # TODO: Remove `k256` feature: https://github.com/sigp/enr/pull/74
 enr = { version = "0.12.0", default-features = false, features = ["k256", "rust-secp256k1"] }

--- a/bin/reth/src/commands/poa/mod.rs
+++ b/bin/reth/src/commands/poa/mod.rs
@@ -452,27 +452,6 @@ impl<Ext: clap::Args + fmt::Debug> PoaNodeCommand<Ext> {
                         *bitcoin_block_header.write().await =
                             Some((header, finalized.height as u32));
                         last_tip = tip_hash;
-
-                        // Sync the bitcoind signing server's txindexer
-                        if let Some(btc_factory) = &bitcoind_signing_server_factory_clone {
-                            let res = btc_factory.build_and_connect().await;
-
-                            match res {
-                                Ok(mut client) => {
-                                    let _ = client
-                                        .tx_index_new_checkpoint(SyncTxIndexRequest {
-                                            checkpoint_block_hash: header
-                                                .block_hash()
-                                                .to_byte_array()
-                                                .to_vec(),
-                                        })
-                                        .await;
-                                }
-                                Err(e) => {
-                                    error!("Failed to connect to btc signing server: {}", e);
-                                }
-                            }
-                        }
                     }
                     tokio::time::sleep(SLEEP).await;
                 }

--- a/bin/test-suite/src/suite/consensus/frost/test_signing.rs
+++ b/bin/test-suite/src/suite/consensus/frost/test_signing.rs
@@ -164,17 +164,18 @@ pub async fn do_signing(
 }
 
 /// Assert that all clients have the same UTXO set
-pub async fn all_clients_have_same_utxo_set(
+pub async fn all_clients_have_same_wallet_state(
     clients: &mut Vec<BtcServerClient<Channel>>,
 ) -> Result<(), Error> {
     let mut utxo_merkle_root = HashSet::new();
     for c in clients.iter_mut() {
         let root = c
-            .get_utxo_merkle_root(tonic::Request::new(client::Empty {}))
+            .get_wallet_state(tonic::Request::new(client::Empty {}))
             .await
             .map_err(Error::Request)?
             .into_inner()
-            .merkle_root;
+            .wallet_state_commitment;
+
         utxo_merkle_root.insert(root);
     }
     assert_eq!(utxo_merkle_root.len(), 1);
@@ -331,7 +332,7 @@ pub async fn test_many_inputs_signing(
     assert_eq!(final_tx.output.len(), 2);
 
     // Assert that all clients have the same UTXO set
-    all_clients_have_same_utxo_set(&mut clients).await?;
+    all_clients_have_same_wallet_state(&mut clients).await?;
 
     let mut pending_pegouts = vec![];
     let number_of_pending_pegouts = 5;
@@ -389,7 +390,7 @@ pub async fn test_many_inputs_signing(
     // txs
     assert_eq!(utxos.len(), 5);
     bitcoind.generate_to_address(1, &address).expect("generate regtest block");
-    all_clients_have_same_utxo_set(&mut clients).await?;
+    all_clients_have_same_wallet_state(&mut clients).await?;
 
     // Need to define a custom struct as breaking changes in bitcoin-core will cause the
     // deserialization to fail
@@ -468,6 +469,6 @@ pub async fn test_many_inputs_signing(
     let found_match = change_ots.iter().any(|change_ot| tx_ots.contains(change_ot));
     assert!(found_match);
 
-    all_clients_have_same_utxo_set(&mut clients).await?;
+    all_clients_have_same_wallet_state(&mut clients).await?;
     Ok(())
 }

--- a/crates/consensus/authority/Cargo.toml
+++ b/crates/consensus/authority/Cargo.toml
@@ -80,6 +80,7 @@ frost-secp256k1-tr = { git = "https://github.com/0xBEEFCAF3/frost", branch = "ad
 
 ## Bitcoin
 bitcoin.workspace = true
+bitcoin_hashes.workspace = true
 
 ## Crypto
 secp256k1 = { workspace = true, features = [

--- a/crates/consensus/authority/src/frost_task.rs
+++ b/crates/consensus/authority/src/frost_task.rs
@@ -5,19 +5,14 @@ use crate::{
     dkg::DKGStateMachine,
     random_source_provider::RandomSource,
     signing::SigningStateMachine,
-    utils::{
-        extract_pegout_ids, validate_psbt_by_ids, validate_psbt_by_output, PsbtValidationError,
-    },
+    utils::validate_psbt_by_ids,
     Storage,
 };
 
-use bitcoin::{Address, Amount, Psbt};
-use btcserverlib::{
-    extended_client::{BtcServerExtendedClient, GrpcClientError},
-    pegout_id::PegoutId,
-};
+use bitcoin_hashes::Hash;
+use btcserverlib::extended_client::{BtcServerExtendedClient, GrpcClientError};
+use client::SyncTxIndexRequest;
 use reth_blockchain_tree::BlockchainTreeEngine;
-use reth_btc_wallet::psbt::PsbtOutputExt;
 use reth_chainspec::ChainSpec;
 use reth_network::{
     frost::{
@@ -27,10 +22,7 @@ use reth_network::{
     },
     NetworkHandle,
 };
-use reth_primitives::{
-    botanix::{mint_validation::try_parse_burn_event, peg_contract::PegoutData},
-    header_ext::HeaderExt,
-};
+use reth_primitives::header_ext::HeaderExt;
 use reth_provider::{
     BlockReaderIdExt, CanonChainTracker, CanonStateNotification, StateProviderFactory,
 };
@@ -255,9 +247,31 @@ where
             while let Ok(notification) = self.canon_state_notification_receiver.try_recv() {
                 match notification {
                     CanonStateNotification::Commit { new } => {
+                        let tip = new.tip();
+                        let cp_block_hash = tip
+                            .header()
+                            .deserialize_extra_data_header()
+                            .unwrap()
+                            .bitcoin_block_hash;
+
+                        match self
+                            .btc_server
+                            .tx_index_new_checkpoint(SyncTxIndexRequest {
+                                checkpoint_block_hash: cp_block_hash.to_byte_array().to_vec(),
+                            })
+                            .await
+                        {
+                            Ok(_) => {
+                                info!(target: "consensus::authority::frost_task::start_task", "Sent checkpoint to btc server");
+                            }
+                            Err(e) => {
+                                error!(target: "consensus::authority::frost_task::start_task", "Error sending checkpoint to btc server: {}", e);
+                            }
+                        }
+
                         // check if epoch block and if we are the coordinator
                         // if so, initiate signing session
-                        let tip = new.tip();
+
                         if tip.is_poa_epoch() {
                             if !self.signing_state_machine.is_coordinator() {
                                 info!("Received canon state notification during epoch block but we're not the coordinator");


### PR DESCRIPTION
the tx indexer is only meant to update its checkpoint and index its txs on bitcoin blockhashes that are suffeciently deep AND one's that have consensus