### PR TITLE
Revert "fix(btc_server): disable pegouts validation temporarily"

### DIFF
--- a/bin/btc-server/src/main.rs
+++ b/bin/btc-server/src/main.rs
@@ -623,7 +623,7 @@ mod test {
         app1.add_round1_dkg(frost_id!(3), round1_dkgs[2].clone().1)
             .await
             .expect("valid round1 dkg");
-        let _p1_dkg2 = app1.get_round2_dkg().await.expect("valid round 2 transition");
+        let p1_dkg2 = app1.get_round2_dkg().await.expect("valid round 2 transition");
 
         // Round 2 DKG for p2
         app2.identifier = frost_id!(2);

--- a/bin/btc-server/src/util.rs
+++ b/bin/btc-server/src/util.rs
@@ -224,13 +224,10 @@ pub fn validate_psbt(
         },
     };
 
-    // TODO(armins): re-enable this once we have conflicting inputs checks
-    // Its possible for a singer to have already considered a pegout to no longer be pending while
-    // the coord still thinks it is. however if there is a conflicting input we can still sign.
     // validate outputs cover all pegout ids or are change
-    // if let Err(e) = validate_outputs(psbt, db) {
-    //     return Err(ValidatePSBTError::InvalidOutputs(e.to_string()));
-    // };
+    if let Err(e) = validate_outputs(psbt, db) {
+        return Err(ValidatePSBTError::InvalidOutputs(e.to_string()));
+    };
 
     let _tx = psbt.clone().extract_tx()?;
     for (_index, _input) in psbt.inputs.iter().enumerate() {


### PR DESCRIPTION
This reverts commit 3eb003407f1a6befefaca08103ffbb6ac05101f9.