### PR TITLE
fix(btc-server): missing pk

### DIFF
--- a/bin/btc-server/src/coordinator.rs
+++ b/bin/btc-server/src/coordinator.rs
@@ -413,16 +413,22 @@ where
             }
         }?;
 
+        let tx = psbt.clone().extract_tx()?;
         // If the coordinator participated in signing they have already tracked the tx
         // however, if the coordinator did not participate in signing they need to track the
         // tx now
-        let tx = psbt.clone().extract_tx()?;
-
         let pending_pegouts = self.db.get_pending_pegouts()?;
-        let pending_pegout_ids = pending_pegouts.iter().map(|p| p.id).collect::<Vec<PegoutId>>();
+        let pegout_ids = psbt
+            .pegout_ids()
+            .iter()
+            .map(|p| PegoutId::from_bytes(p).expect("values are 36 bytes"))
+            .collect::<Vec<PegoutId>>();
+
+        let pending_pegouts =
+            pending_pegouts.into_iter().filter(|p| pegout_ids.contains(&p.id)).collect::<Vec<_>>();
 
         self.add_tracked_tx(tx.clone(), &pending_pegouts, SystemTime::now()).await?;
-        self.db.remove_pending_pegout(&pending_pegout_ids)?;
+        self.db.remove_pending_pegout(&pegout_ids)?;
         self.db.flush()?;
 
         if let Some(tx_id) = tx_id {

--- a/bin/btc-server/src/database.rs
+++ b/bin/btc-server/src/database.rs
@@ -751,7 +751,7 @@ mod tests {
     use crate::{
         pegout_scheduler::{PegoutRequest, Tx},
         test_utils::test_utils::{
-            create_n_outputs_tx, create_random_pegout_id, create_tx, random_p2wpkh_script, setup_db,
+            create_random_pegout_id, create_tx, random_p2wpkh_script, setup_db,
         },
     };
 
@@ -813,7 +813,7 @@ mod tests {
 
     #[test]
     fn from_db_utxo_to_rpc_utxo() {
-        let tx = create_tx(1, None);
+        let tx = create_tx(1, 1, None);
         let utxo = Utxo::new(
             OutPoint::new(tx.txid(), 0),
             tx.output.get(0).expect("one output").clone(),
@@ -838,7 +838,7 @@ mod tests {
     fn test_storing_single_utxo() {
         let (db, _temp_dir) = setup_db();
 
-        let tx = create_tx(2, None);
+        let tx = create_tx(2, 1, None);
         let utxo = Utxo::new(
             OutPoint::new(tx.txid(), 0),
             tx.output.get(0).expect("one output").clone(),
@@ -857,7 +857,7 @@ mod tests {
         let num_txs = 5;
         let mut utxos = vec![];
         for _ in 0..num_txs {
-            let tx = create_tx(2, None);
+            let tx = create_tx(2, 1, None);
             let utxo = Utxo::new(
                 OutPoint::new(tx.txid(), 0),
                 tx.output.get(0).expect("one output").clone(),
@@ -890,7 +890,7 @@ mod tests {
         let num_txs = 5;
         let mut utxos = vec![];
         for _ in 0..num_txs {
-            let tx = create_tx(1, None);
+            let tx = create_tx(1, 1, None);
             let utxo = Utxo::new(
                 OutPoint::new(tx.txid(), 0),
                 tx.output.get(0).expect("one output").clone(),
@@ -915,7 +915,7 @@ mod tests {
         let num_txs = 5;
         let mut utxos = vec![];
         for _ in 0..num_txs {
-            let tx = create_tx(1, None);
+            let tx = create_tx(1, 1, None);
             let utxo = Utxo::new(
                 OutPoint::new(tx.txid(), 0),
                 tx.output.get(0).expect("one output").clone(),
@@ -947,7 +947,7 @@ mod tests {
         let num_txs = 5;
         let mut utxos = vec![];
         for _ in 0..num_txs {
-            let tx = create_tx(2, None);
+            let tx = create_tx(2, 1, None);
             let utxo = Utxo::new(
                 OutPoint::new(tx.txid(), 0),
                 tx.output.get(0).expect("one output").clone(),
@@ -980,7 +980,7 @@ mod tests {
         let num_txs = 5;
         let mut utxos = vec![];
         for _ in 0..num_txs {
-            let tx = create_tx(2, None);
+            let tx = create_tx(2, 1, None);
             let utxo = Utxo::new(
                 OutPoint::new(tx.txid(), 0),
                 tx.output.get(0).expect("one output").clone(),
@@ -1001,7 +1001,7 @@ mod tests {
         assert_eq!(merkle_root, merkle_root2);
 
         // Adding an additional utxo should change the merkle root
-        let tx = create_tx(2, None);
+        let tx = create_tx(2, 1, None);
         let utxo = Utxo::new(
             OutPoint::new(tx.txid(), 1),
             tx.output.get(0).expect("one output").clone(),
@@ -1018,7 +1018,7 @@ mod tests {
     fn test_reading_session_ids() {
         let (db, _temp_dir) = setup_db();
 
-        let tx = create_tx(2, None);
+        let tx = create_tx(2, 1, None);
         let psbt = Psbt::from_unsigned_tx(tx).unwrap();
         let signing_session_id: [u8; 32] = [0; 32];
         db.update_psbt(&signing_session_id, &psbt).unwrap();
@@ -1032,7 +1032,7 @@ mod tests {
     fn test_getting_session_id_status() {
         let (db, _temp_dir) = setup_db();
 
-        let tx = create_tx(2, None);
+        let tx = create_tx(2, 1, None);
         let psbt = Psbt::from_unsigned_tx(tx).unwrap();
         let signing_session_id: [u8; 32] = [0; 32];
         db.update_psbt(&signing_session_id, &psbt).unwrap();
@@ -1058,7 +1058,7 @@ mod tests {
     #[test]
     fn test_tracked_txs_e2e() {
         let (db, _temp_dir) = setup_db();
-        let tx = create_n_outputs_tx(5, 2);
+        let tx = create_tx(5, 2, None);
         let pegout_reqs = vec![PegoutRequest {
             spk: tx.output[0].script_pubkey.clone(),
             value: tx.output[0].value,
@@ -1095,7 +1095,7 @@ mod tests {
     #[test]
     fn test_update_tracked_tx_merkle_root() {
         let (db, _temp_dir) = setup_db();
-        let tx = create_n_outputs_tx(5, 2);
+        let tx = create_tx(5, 2, None);
         let pegout_reqs = vec![PegoutRequest {
             spk: tx.output[0].script_pubkey.clone(),
             value: tx.output[0].value,
@@ -1121,9 +1121,9 @@ mod tests {
         let merkle_root2 = db.get_tracked_tx_merkle_root().unwrap().unwrap();
         assert_eq!(merkle_root, merkle_root2);
 
-        let tx2 = create_n_outputs_tx(5, 2);
+        let tx2 = create_tx(5, 2, None);
         let pegout_reqs = vec![PegoutRequest {
-            spk: tx.output[0].script_pubkey.clone(),
+            spk: tx2.output[0].script_pubkey.clone(),
             value: tx.output[0].value,
             id: create_random_pegout_id(),
             botanix_height: 0,
@@ -1153,7 +1153,7 @@ mod tests {
 
         assert!(merkle_root.is_none());
 
-        let tx = create_n_outputs_tx(5, 2);
+        let tx = create_tx(5, 2, None);
 
         let pegout_req = PegoutRequest {
             botanix_height: 0,

--- a/bin/btc-server/src/main.rs
+++ b/bin/btc-server/src/main.rs
@@ -816,7 +816,7 @@ mod test {
     async fn should_fail_to_get_to_sign_package_without_dkg() {
         let app = setup();
         let signing_session_id = [0u8; 32];
-        let mut psbt = create_psbt(1, None);
+        let mut psbt = create_psbt(1, 1, None);
         let tx = psbt.clone().unsigned_tx;
         // Add the utxo
         let utxo = Utxo::new(tx.input[0].previous_output, tx.output[0].clone(), None);
@@ -863,7 +863,7 @@ mod test {
 
         let pegout_id = store_pending_pegout(&app.db);
 
-        let mut psbt = create_psbt(1, Some(get_change(&app.db)));
+        let mut psbt = create_psbt(1, 1, Some(get_change(&app.db)));
         psbt.outputs[0].set_pegout_id(pegout_id.as_bytes());
 
         let tx = psbt.clone().extract_tx().expect("valid tx");
@@ -891,7 +891,7 @@ mod test {
 
         let pegout_id = store_pending_pegout(&app.db);
 
-        let mut psbt = create_psbt(1, Some(get_change(&app.db)));
+        let mut psbt = create_psbt(1, 1, Some(get_change(&app.db)));
         psbt.outputs[0].set_pegout_id(pegout_id.as_bytes());
 
         let tx = psbt.clone().extract_tx().expect("valid tx");
@@ -931,7 +931,7 @@ mod test {
 
         let pegout_id = store_pending_pegout(&app_coordinator.db);
 
-        let mut psbt = create_psbt(1, Some(get_change(&app_coordinator.db)));
+        let mut psbt = create_psbt(1, 1, Some(get_change(&app_coordinator.db)));
         psbt.outputs[0].set_pegout_id(pegout_id.as_bytes());
 
         let tx = psbt.clone().extract_tx().expect("valid tx");
@@ -1008,7 +1008,7 @@ mod test {
 
         let pegout_id = store_pending_pegout(&app.db);
 
-        let mut psbt = create_psbt(1, Some(get_change(&app.db)));
+        let mut psbt = create_psbt(1, 1, Some(get_change(&app.db)));
         psbt.outputs[0].set_pegout_id(pegout_id.as_bytes());
 
         // Add pegin utxo
@@ -1172,7 +1172,7 @@ mod test {
         // store pending pegout
         let pegout_id = store_pending_pegout(&app.db);
 
-        let mut psbt = create_psbt(1, Some(get_change(&app.db)));
+        let mut psbt = create_psbt(1, 1, Some(get_change(&app.db)));
         psbt.outputs[0].set_pegout_id(pegout_id.as_bytes());
 
         let response = validate_outputs(&psbt, &app.db);
@@ -1217,7 +1217,7 @@ mod test {
             reth_btc_wallet::address::generate_taproot_change_scriptpubkey(&secp_pk);
         let change = TxOut { value: Amount::from_sat(500), script_pubkey: change_script };
 
-        let mut psbt = create_psbt(1, Some(change));
+        let mut psbt = create_psbt(1, 1, Some(change));
         psbt.outputs[0].set_pegout_id(pegout_id.as_bytes());
 
         let response = validate_outputs(&psbt, &app.db);
@@ -1252,7 +1252,7 @@ mod test {
 
         let change = TxOut { value: Amount::from_sat(500), script_pubkey: ScriptBuf::default() };
 
-        let mut psbt = create_psbt(1, Some(change));
+        let mut psbt = create_psbt(1, 1, Some(change));
         psbt.outputs[0].set_pegout_id(pegout_id.as_bytes());
 
         let response = validate_outputs(&psbt, &app.db);

--- a/bin/btc-server/src/pegout_scheduler.rs
+++ b/bin/btc-server/src/pegout_scheduler.rs
@@ -10,8 +10,12 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use bitcoin::{Amount, Block, BlockHash, OutPoint, Transaction, TxOut, Txid};
+use bitcoin::{Amount, Block, BlockHash, OutPoint, ScriptBuf, Transaction, TxOut, Txid};
 use bitcoincore_rpc::RpcApi;
+use reth_btc_wallet::{
+    address::generate_taproot_change_scriptpubkey,
+    util::{VerifyingKeyExt, VerifyingKeyExtError},
+};
 use thiserror::Error;
 
 use crate::{database, pegout_id::PegoutId};
@@ -158,6 +162,14 @@ impl OutputMeta {
     }
 }
 
+#[derive(Debug, Error)]
+pub enum ChangeOutputError {
+    #[error("key conversion error {0}")]
+    KeyConversion(#[from] VerifyingKeyExtError),
+    #[error("db error {0}")]
+    Db(#[from] database::Error),
+}
+
 pub struct PegoutScheduler {
     /// The number of blocks to track txs for.
     conf_window: u32,
@@ -213,6 +225,18 @@ impl PegoutScheduler {
         }
 
         ret
+    }
+
+    /// internal util to get change spk from db
+    fn get_change_spk(&self) -> Result<ScriptBuf, ChangeOutputError> {
+        let agg_pk = self
+            .db
+            .get_public_key_package()?
+            .expect("pk key package should exist")
+            .verifying_key()
+            .to_secp_pk()?;
+        let change_spk = generate_taproot_change_scriptpubkey(&agg_pk);
+        Ok(change_spk)
     }
 
     /// Get the last finalized block hash.
@@ -348,6 +372,7 @@ impl PegoutScheduler {
     /// Finalize a block by adding the UTXOs that are deeply confirmed back to the database.
     /// This is also where we remove tracked transactions
     fn finalize_block(&mut self, block: &BlockInfo) -> Result<(), database::Error> {
+        let change_spk = self.get_change_spk().expect("dkg should have been performed");
         // To make sure we only update the index when the db is also synced,
         // first try store the new finalized UTXOs to the db, then update the index.
         let mut all_inputs = block.relevant_inputs.iter().copied().collect::<HashSet<_>>();
@@ -356,6 +381,10 @@ impl PegoutScheduler {
             // Add back the change to the utxo set
             let mut change_utxos = vec![];
             for (outpoint, output) in tx.change() {
+                if output.script_pubkey != change_spk {
+                    warn!("Change output being tracked is not a p2tr: {:?}", output);
+                    continue;
+                }
                 change_utxos.push(database::Utxo {
                     outpoint,
                     output: output.clone(),
@@ -585,16 +614,24 @@ pub enum BlockError {
 #[cfg(test)]
 mod tests {
     use bitcoin::hashes::Hash;
+    use frost_secp256k1_tr as frost;
 
-    use crate::test_utils::test_utils::{
-        create_block, create_n_outputs_tx, create_random_pegout_id, pegout_requests_from_tx,
-        setup_db,
+    use crate::{
+        frost_id,
+        test_utils::test_utils::{
+            create_block, create_random_pegout_id, create_tx, pegout_requests_from_tx,
+            random_p2wpkh_script, setup_db, trusted_dealer_setup,
+        },
     };
 
     use super::*;
+
+    const MIN_SIGNERS: u16 = 2;
+    const MAX_SIGNERS: u16 = 3;
+
     #[test]
     fn tracked_tx_utils() {
-        let tx = create_n_outputs_tx(0, 0);
+        let tx = create_tx(0, 0, None);
         let tx = Tx {
             txid: tx.txid(),
             tx,
@@ -609,7 +646,7 @@ mod tests {
         assert_eq!(tx.change().count(), 0);
 
         // 5 inputs, 2 outputs
-        let dummy_tx = create_n_outputs_tx(5, 2);
+        let dummy_tx = create_tx(5, 2, None);
         assert_eq!(dummy_tx.input.len(), 5);
         assert_eq!(dummy_tx.output.len(), 2);
 
@@ -633,8 +670,14 @@ mod tests {
     #[test]
     fn test_track_tx() {
         let db = setup_db().0;
+        let (shares, pk_package) = trusted_dealer_setup(MIN_SIGNERS, MAX_SIGNERS);
+        let key_package = frost::keys::KeyPackage::try_from(shares[&frost_id!(1u16)].clone())
+            .expect("valid key package");
 
-        let tx = create_n_outputs_tx(3, 3);
+        db.set_pubkey_package(pk_package).expect("set public key package");
+        db.set_key_package(key_package).expect("set key package");
+
+        let tx = create_tx(3, 3, None);
         let pegout_idxs = vec![0, 1];
         let change_idxs = vec![2];
 
@@ -693,10 +736,17 @@ mod tests {
     #[test]
     fn test_add_block() {
         let db = setup_db().0;
+        let (shares, pk_package) = trusted_dealer_setup(MIN_SIGNERS, MAX_SIGNERS);
+        let key_package = frost::keys::KeyPackage::try_from(shares[&frost_id!(1u16)].clone())
+            .expect("valid key package");
+
+        db.set_pubkey_package(pk_package).expect("set public key package");
+        db.set_key_package(key_package).expect("set key package");
+
         let mut pegout_scheduler =
             PegoutScheduler::new(101, vec![], bitcoin::BlockHash::all_zeros(), db);
-        let tx1 = create_n_outputs_tx(3, 3);
-        let tx2 = create_n_outputs_tx(3, 3);
+        let tx1 = create_tx(3, 3, None);
+        let tx2 = create_tx(3, 3, None);
         let txs = vec![tx1.clone(), tx2.clone()];
         let pegouts1 = pegout_requests_from_tx(&tx1, &[0, 1]);
         let pegouts2 = pegout_requests_from_tx(&tx2, &[0, 1]);
@@ -723,13 +773,25 @@ mod tests {
     #[test]
     fn test_finalize_block() {
         let db = setup_db().0;
+        let (shares, pk_package) = trusted_dealer_setup(MIN_SIGNERS, MAX_SIGNERS);
+        let key_package = frost::keys::KeyPackage::try_from(shares[&frost_id!(1u16)].clone())
+            .expect("valid key package");
+
+        db.set_pubkey_package(pk_package).expect("set public key package");
+        db.set_key_package(key_package).expect("set key package");
+
+        let agg_pk =
+            db.get_public_key_package().unwrap().unwrap().verifying_key().to_secp_pk().unwrap();
+        let change_spk = generate_taproot_change_scriptpubkey(&agg_pk);
+        let change_output = TxOut { value: Amount::from_sat(1000), script_pubkey: change_spk };
+
         let mut pegout_scheduler =
             PegoutScheduler::new(101, vec![], bitcoin::BlockHash::all_zeros(), db.clone());
-        let tx1 = create_n_outputs_tx(3, 3);
-        let tx2 = create_n_outputs_tx(3, 3);
+        let tx1 = create_tx(3, 3, Some(change_output.clone()));
+        let tx2 = create_tx(3, 3, Some(change_output));
         let txs = vec![tx1.clone(), tx2.clone()];
-        let pegouts1 = pegout_requests_from_tx(&tx1, &[0, 1]);
-        let pegouts2 = pegout_requests_from_tx(&tx2, &[0, 1]);
+        let pegouts1 = pegout_requests_from_tx(&tx1, &[0, 1, 2]);
+        let pegouts2 = pegout_requests_from_tx(&tx2, &[0, 1, 2]);
 
         pegout_scheduler.add_tx(tx1.clone(), &pegouts1, SystemTime::now());
         pegout_scheduler.add_tx(tx2.clone(), &pegouts2, SystemTime::now());
@@ -756,18 +818,110 @@ mod tests {
     }
 
     #[test]
-    fn finalizing_non_change_pegout() {
+    fn finalizing_one_change_output() {
         let db = setup_db().0;
+        let (shares, pk_package) = trusted_dealer_setup(MIN_SIGNERS, MAX_SIGNERS);
+        let key_package = frost::keys::KeyPackage::try_from(shares[&frost_id!(1u16)].clone())
+            .expect("valid key package");
+
+        db.set_pubkey_package(pk_package).expect("set public key package");
+        db.set_key_package(key_package).expect("set key package");
+
+        let agg_pk =
+            db.get_public_key_package().unwrap().unwrap().verifying_key().to_secp_pk().unwrap();
+        let change_spk = generate_taproot_change_scriptpubkey(&agg_pk);
+        let change_output = TxOut { value: Amount::from_sat(1000), script_pubkey: change_spk };
+
         let mut pegout_scheduler =
             PegoutScheduler::new(101, vec![], bitcoin::BlockHash::all_zeros(), db.clone());
-        let tx = create_n_outputs_tx(3, 1);
+        let tx = create_tx(3, 1, Some(change_output));
         let pegouts = pegout_requests_from_tx(&tx, &[0]);
         pegout_scheduler.add_tx(tx.clone(), &pegouts, SystemTime::now());
 
         let (last_tx_txid, last_tx) = pegout_scheduler.txs.clone().into_iter().next().unwrap();
         assert_eq!(last_tx_txid, tx.txid());
         assert_eq!(last_tx.pegout_idxs, vec![0]);
-        assert!(last_tx.change_idxs.is_empty());
+        assert_eq!(last_tx.change_idxs, vec![1]);
+
+        let block = create_block(vec![tx], bitcoin::BlockHash::all_zeros());
+        pegout_scheduler.add_block(&block);
+
+        let last_blocks = pegout_scheduler.last_blocks.clone();
+        let last_block = last_blocks.back().unwrap();
+
+        pegout_scheduler.finalize_block(last_block).expect("finalize block");
+
+        let utxos = db.get_all_utxos().unwrap();
+        // there is now one change so there is one UTXO to add back to UTXO set
+        assert_eq!(utxos.len(), 1);
+    }
+
+    #[test]
+    fn finalizing_incorrect_tracked_output() {
+        // here we are tracking tx where all outputs are pegouts but one is mistaken as change
+        // The result should be that the incorrect change is NOT added back to UTXO set
+        let db = setup_db().0;
+        let (shares, pk_package) = trusted_dealer_setup(MIN_SIGNERS, MAX_SIGNERS);
+        let key_package = frost::keys::KeyPackage::try_from(shares[&frost_id!(1u16)].clone())
+            .expect("valid key package");
+
+        db.set_pubkey_package(pk_package).expect("set public key package");
+        db.set_key_package(key_package).expect("set key package");
+
+        let mut pegout_scheduler =
+            PegoutScheduler::new(101, vec![], bitcoin::BlockHash::all_zeros(), db.clone());
+        let tx = create_tx(3, 2, None);
+        // Here we should be tracking indices 0 and 1.
+        // But we are tracking 0 as a pegout, therefore output 1 is going to be mistaken as change
+        let pegouts = pegout_requests_from_tx(&tx, &[0]);
+        pegout_scheduler.add_tx(tx.clone(), &pegouts, SystemTime::now());
+
+        let (last_tx_txid, last_tx) = pegout_scheduler.txs.clone().into_iter().next().unwrap();
+        assert_eq!(last_tx_txid, tx.txid());
+        assert_eq!(last_tx.pegout_idxs, vec![0]);
+        assert_eq!(last_tx.change_idxs, vec![1]);
+
+        let block = create_block(vec![tx], bitcoin::BlockHash::all_zeros());
+        pegout_scheduler.add_block(&block);
+
+        let last_blocks = pegout_scheduler.last_blocks.clone();
+        let last_block = last_blocks.back().unwrap();
+
+        pegout_scheduler.finalize_block(last_block).expect("finalize block");
+
+        let utxos = db.get_all_utxos().unwrap();
+        // No change so there is no UTXO to add back to UTXO set
+        assert_eq!(utxos.len(), 0);
+    }
+
+    #[test]
+    fn finalizing_incorrect_change_output() {
+        // Here we are tracking tx where the incorrect change is registered
+        // The result should be that the incorrect change is NOT added back to UTXO set
+        let db = setup_db().0;
+        let (shares, pk_package) = trusted_dealer_setup(MIN_SIGNERS, MAX_SIGNERS);
+        let key_package = frost::keys::KeyPackage::try_from(shares[&frost_id!(1u16)].clone())
+            .expect("valid key package");
+
+        db.set_pubkey_package(pk_package).expect("set public key package");
+        db.set_key_package(key_package).expect("set key package");
+        let mut pegout_scheduler =
+            PegoutScheduler::new(101, vec![], bitcoin::BlockHash::all_zeros(), db.clone());
+
+        let incorrect_change_spk = random_p2wpkh_script();
+        let tx = create_tx(
+            3,
+            2,
+            Some(TxOut { value: Amount::from_sat(1000), script_pubkey: incorrect_change_spk }),
+        );
+
+        let pegouts = pegout_requests_from_tx(&tx, &[0, 1]);
+        pegout_scheduler.add_tx(tx.clone(), &pegouts, SystemTime::now());
+
+        let (last_tx_txid, last_tx) = pegout_scheduler.txs.clone().into_iter().next().unwrap();
+        assert_eq!(last_tx_txid, tx.txid());
+        assert_eq!(last_tx.pegout_idxs, vec![0, 1]);
+        assert_eq!(last_tx.change_idxs, vec![2]);
 
         let block = create_block(vec![tx], bitcoin::BlockHash::all_zeros());
         pegout_scheduler.add_block(&block);
@@ -785,7 +939,7 @@ mod tests {
     #[test]
     fn start_with_existing_tracked_txs() {
         let db = setup_db().0;
-        let tx = create_n_outputs_tx(1, 2);
+        let tx = create_tx(1, 2, None);
         let pegouts = pegout_requests_from_tx(&tx, &[0]);
         let tracked_tx = Tx {
             txid: tx.txid(),
@@ -807,12 +961,23 @@ mod tests {
     #[test]
     fn test_finalize_many_blocks() {
         let db = setup_db().0;
+        let (shares, pk_package) = trusted_dealer_setup(MIN_SIGNERS, MAX_SIGNERS);
+        let key_package = frost::keys::KeyPackage::try_from(shares[&frost_id!(1u16)].clone())
+            .expect("valid key package");
+
+        db.set_pubkey_package(pk_package).expect("set public key package");
+        db.set_key_package(key_package).expect("set key package");
+        let agg_pk =
+            db.get_public_key_package().unwrap().unwrap().verifying_key().to_secp_pk().unwrap();
+        let change_spk = generate_taproot_change_scriptpubkey(&agg_pk);
+        let change_output = TxOut { value: Amount::from_sat(1000), script_pubkey: change_spk };
+
         let mut pegout_scheduler =
             PegoutScheduler::new(1, vec![], bitcoin::BlockHash::all_zeros(), db.clone());
         let mut last_block_hash = bitcoin::BlockHash::all_zeros();
 
         for _ in 0..100 {
-            let tx = create_n_outputs_tx(1, 2);
+            let tx = create_tx(1, 2, Some(change_output.clone()));
             let pegouts = pegout_requests_from_tx(&tx, &[0]);
             pegout_scheduler.add_tx(tx.clone(), &pegouts, SystemTime::now());
             let block = create_block(vec![tx], last_block_hash);
@@ -823,6 +988,7 @@ mod tests {
             last_block_hash = last_block.hash;
             pegout_scheduler.finalize_block(last_block).expect("finalize block");
         }
+        // 100 change outputs are added back to UTXO set
         let utxos = db.get_all_utxos().unwrap();
         assert_eq!(utxos.len(), 100);
     }
@@ -830,7 +996,7 @@ mod tests {
     #[test]
     fn test_un_track_tx() {
         let db = setup_db().0;
-        let tx = create_n_outputs_tx(1, 2);
+        let tx = create_tx(1, 2, None);
         let pegouts = pegout_requests_from_tx(&tx, &[0]);
         let tracked_tx = Tx {
             txid: tx.txid(),
@@ -864,7 +1030,7 @@ mod tests {
         let db = setup_db().0;
         let mut pegout_scheduler =
             PegoutScheduler::new(1, vec![], bitcoin::BlockHash::all_zeros(), db.clone());
-        let tx = create_n_outputs_tx(1, 2);
+        let tx = create_tx(1, 2, None);
         let pegouts = pegout_requests_from_tx(&tx, &[0]);
 
         let tracked_tx = pegout_scheduler.add_tx(tx.clone(), &pegouts, SystemTime::now());

--- a/bin/btc-server/src/server.rs
+++ b/bin/btc-server/src/server.rs
@@ -185,6 +185,8 @@ where
         let utxos = utxos?;
         let utxo_refs: Vec<&Utxo> = utxos.iter().collect();
 
+        // let prev_output = self.bitcoind_client.get_raw_transaction(utxos[0].txid, None).unwrap();
+
         self.add_pegins(&utxo_refs).map_err(|e| internal!("Failed to add pegins: {}", e))?;
         info!("processed pegins.len(): {:?}", utxos.len());
 

--- a/bin/btc-server/src/signer.rs
+++ b/bin/btc-server/src/signer.rs
@@ -1,5 +1,3 @@
-use std::time::SystemTime;
-
 use bdk::miniscript::psbt::Error as PsbtError;
 use bitcoin::{
     psbt::{ExtractTxError, Psbt},
@@ -17,7 +15,7 @@ use crate::{
     coordinator::CoordinatorError,
     database,
     pegout_id::PegoutId,
-    util::{validate_outputs, validate_psbt, ValidateOutputsError, ROUND1, ROUND1_TRANSITION},
+    util::{validate_outputs, ValidateOutputsError},
     App, Error,
 };
 
@@ -307,10 +305,10 @@ where
             psbt_in.set_partial_signature(self.identifier, &sigs);
         }
 
-        let tx = psbt.clone().extract_tx()?;
+        let _tx = psbt.clone().extract_tx()?;
 
         let pending_pegouts = self.db.get_pending_pegouts()?;
-        let pending_pegout_ids = pending_pegouts.iter().map(|p| p.id).collect::<Vec<PegoutId>>();
+        let _pending_pegout_ids = pending_pegouts.iter().map(|p| p.id).collect::<Vec<PegoutId>>();
 
         // TODO(armins) we will need to re-enable this once we have conflicting inputs check
         // self.add_tracked_tx(tx.clone(), &pending_pegouts, SystemTime::now()).await?;

--- a/bin/btc-server/src/test_utils.rs
+++ b/bin/btc-server/src/test_utils.rs
@@ -222,7 +222,7 @@ pub mod test_utils {
     }
 
     // Util function to create a btc tx with random inputs and outputs as defined by fn params
-    pub fn create_tx(num_inputs: usize, change: Option<TxOut>) -> Transaction {
+    pub fn create_tx(num_inputs: usize, num_outputs: usize, change: Option<TxOut>) -> Transaction {
         let txid = random_txid();
 
         let mut inputs = vec![];
@@ -236,14 +236,13 @@ pub mod test_utils {
             });
         }
 
-        // Hardcoded one output
-        let mut outputs = vec![TxOut {
-            value: Amount::from_sat(1000),
-            script_pubkey: Address::from_str("mrpkDJFJdNGA22FaxCWw6T9oXogXfHU1rh")
-                .expect("valid address")
-                .assume_checked()
-                .script_pubkey(),
-        }];
+        let mut outputs = vec![];
+        for _ in 0..num_outputs {
+            outputs.push(TxOut {
+                value: Amount::from_sat(1000),
+                script_pubkey: random_p2wpkh_script(),
+            });
+        }
 
         if let Some(change) = change {
             outputs.push(change);
@@ -291,20 +290,8 @@ pub mod test_utils {
         block
     }
 
-    pub fn create_n_outputs_tx(num_inputs: usize, num_outputs: usize) -> Transaction {
-        let mut tx = create_tx(num_inputs, None);
-        let mut outputs = vec![];
-        for _ in 0..num_outputs {
-            outputs.push(TxOut {
-                value: Amount::from_sat(1000),
-                script_pubkey: random_p2wpkh_script(),
-            });
-        }
-        tx.output = outputs;
-        tx
-    }
-    pub fn create_psbt(num_inputs: usize, change: Option<TxOut>) -> Psbt {
-        let tx = create_tx(num_inputs, change);
+    pub fn create_psbt(num_inputs: usize, num_outputs: usize, change: Option<TxOut>) -> Psbt {
+        let tx = create_tx(num_inputs, num_outputs, change);
 
         let weight = tx.weight();
         let fee = FEERATE * weight;

--- a/bin/btc-server/src/util.rs
+++ b/bin/btc-server/src/util.rs
@@ -442,7 +442,7 @@ mod util_tests {
         app.db.set_key_package(key_package.clone()).expect("set key package");
 
         let pegout_id = store_pending_pegout(&app.db);
-        let mut psbt = create_psbt(1, Some(get_change(&app.db)));
+        let mut psbt = create_psbt(1, 1, Some(get_change(&app.db)));
         let tx = psbt.clone().extract_tx().expect("valid tx");
         let utxo = database::Utxo {
             outpoint: tx.input[0].previous_output,
@@ -460,7 +460,7 @@ mod util_tests {
 
         // No inputs
         let db = db_setup();
-        let mut psbt = create_psbt(2, None);
+        let mut psbt = create_psbt(2, 1, None);
         psbt.inputs.clear();
         let res = validate_psbt(&psbt, NO_FLAGS, 2, &db);
         assert!(res.is_err());
@@ -468,7 +468,7 @@ mod util_tests {
 
         // No outputs
         let db = db_setup();
-        let mut psbt = create_psbt(2, None);
+        let mut psbt = create_psbt(2, 1, None);
         psbt.outputs.clear();
         let res = validate_psbt(&psbt, NO_FLAGS, 2, &db);
         assert!(res.is_err());
@@ -486,7 +486,7 @@ mod util_tests {
         app.db.set_key_package(key_package.clone()).expect("set key package");
 
         let pegout_id = store_pending_pegout(&app.db);
-        let mut psbt = create_psbt(2, Some(get_change(&app.db)));
+        let mut psbt = create_psbt(2, 1, Some(get_change(&app.db)));
         psbt.outputs[0].set_pegout_id(pegout_id.as_bytes());
 
         let tx = psbt.clone().extract_tx().expect("valid tx");
@@ -540,7 +540,7 @@ mod util_tests {
         app.db.set_key_package(key_package.clone()).expect("set key package");
 
         let pegout_id = store_pending_pegout(&app.db);
-        let mut psbt = create_psbt(2, Some(get_change(&app.db)));
+        let mut psbt = create_psbt(2, 1, Some(get_change(&app.db)));
         psbt.outputs[0].set_pegout_id(pegout_id.as_bytes());
         let tx = psbt.clone().extract_tx().expect("valid tx");
         let utxo1 = database::Utxo {
@@ -602,7 +602,7 @@ mod util_tests {
 
         let pegout_id = store_pending_pegout(&app.db);
 
-        let mut psbt = create_psbt(1, Some(get_change(&app.db)));
+        let mut psbt = create_psbt(1, 1, Some(get_change(&app.db)));
         psbt.outputs[0].set_pegout_id(pegout_id.as_bytes());
 
         let res = validate_psbt(&psbt, ROUND1, 2, &app.db);
@@ -640,7 +640,7 @@ mod util_tests {
 
         let pegout_id = store_pending_pegout(&app.db);
 
-        let mut psbt = create_psbt(1, Some(get_change(&app.db)));
+        let mut psbt = create_psbt(1, 1, Some(get_change(&app.db)));
         psbt.outputs[0].set_pegout_id(pegout_id.as_bytes());
 
         let tx = psbt.clone().extract_tx().expect("valid tx");
@@ -684,7 +684,7 @@ mod util_tests {
 
         let pegout_id = store_pending_pegout(&app.db);
 
-        let mut psbt = create_psbt(1, Some(get_change(&app.db)));
+        let mut psbt = create_psbt(1, 1, Some(get_change(&app.db)));
         psbt.outputs[0].set_pegout_id(pegout_id.as_bytes());
 
         let tx = psbt.clone().extract_tx().expect("valid tx");
@@ -721,7 +721,7 @@ mod util_tests {
 
         let pegout_id = store_pending_pegout(&app.db);
 
-        let mut psbt = create_psbt(1, Some(get_change(&app.db)));
+        let mut psbt = create_psbt(1, 1, Some(get_change(&app.db)));
         psbt.outputs[0].set_pegout_id(pegout_id.as_bytes());
         let tx = psbt.clone().extract_tx().expect("valid tx");
         let utxo = database::Utxo {
@@ -799,7 +799,7 @@ mod util_tests {
 
         let pegout_id = store_pending_pegout(&app.db);
 
-        let mut psbt = create_psbt(1, Some(get_change(&app.db)));
+        let mut psbt = create_psbt(1, 1, Some(get_change(&app.db)));
         psbt.outputs[0].set_pegout_id(pegout_id.as_bytes());
 
         let tx = psbt.clone().extract_tx().expect("valid tx");
@@ -947,7 +947,7 @@ mod util_tests {
         let (_, signing_commits2_0) = frost::round1::commit(key_package2.signing_share(), rng);
         let (_, signing_commits2_1) = frost::round1::commit(key_package2.signing_share(), rng);
 
-        let tx = create_tx(num_inputs, None);
+        let tx = create_tx(num_inputs, 1, None);
 
         let mut psbt = Psbt::from_unsigned_tx(tx.clone()).unwrap();
         // Add signing commitments to the psbt for each input
@@ -984,7 +984,7 @@ mod util_tests {
         let sig_share2_1 =
             frost::round2::SignatureShare::deserialize([4u8; 32]).expect("valid sig share");
 
-        let tx = create_tx(num_inputs, None);
+        let tx = create_tx(num_inputs, 1, None);
         let mut psbt = Psbt::from_unsigned_tx(tx.clone()).unwrap();
         // Add signing commitments to the psbt for each input
         psbt.inputs[0].set_partial_signature(frost_id1, &sig_share1_0);
@@ -1006,7 +1006,7 @@ mod util_tests {
 
     #[test]
     fn signing_package_conversion_should_fail_when_missing_signing_commitments() {
-        let tx = create_tx(1, None);
+        let tx = create_tx(1, 1, None);
         let mut psbt = Psbt::from_unsigned_tx(tx.clone()).unwrap();
         psbt.inputs[0].witness_utxo =
             Some(TxOut { value: Amount::from_sat(1000), script_pubkey: ScriptBuf::new() });
@@ -1043,7 +1043,7 @@ mod util_tests {
         let (_, signing_commits2_1) = frost::round1::commit(key_package2.signing_share(), rng);
 
         // Set up the psbt
-        let tx = create_tx(num_inputs, None);
+        let tx = create_tx(num_inputs, 1, None);
         let mut psbt = Psbt::from_unsigned_tx(tx.clone()).unwrap();
         // Add signing commitments and TxOut to the psbt for each input
         psbt.inputs[0].witness_utxo =

--- a/crates/btc-wallet/src/psbt.rs
+++ b/crates/btc-wallet/src/psbt.rs
@@ -189,6 +189,11 @@ pub trait PsbtOutputExt: BorrowMut<Output> {
 impl PsbtOutputExt for Output {}
 
 pub trait PsbtExt: BorrowMut<Psbt> {
+    /// Get all pegouts ids from this PSBT
+    fn pegout_ids(&self) -> Vec<PegoutId> {
+        self.borrow().outputs.iter().filter_map(|o| o.pegout_id()).collect()
+    }
+
     /// Converts this PSBT into a vector of Frost signing packages.
     ///
     /// This function takes a PSBT as input and processes each input to generate the necessary

--- a/crates/consensus/authority/src/comet_bft/abci.rs
+++ b/crates/consensus/authority/src/comet_bft/abci.rs
@@ -741,6 +741,7 @@ where
         }
     }
 
+    /// docs: https://docs.cometbft.com/v0.38/spec/abci/abci++_methods#commit
     fn commit(&self) -> ResponseCommit {
         info!("commit request received");
         let candidate_blocks = match self.block_cache.write() {


### PR DESCRIPTION
Fixes https://github.com/botanix-labs/botanix/issues/813
The problem we are fixing here is that we have added non-change outputs as change in the pegout scheduler.
The root cause is still unsure. Its possible that certain pending pegouts were added during the time of signing. 
However skipping non tr outputs during pegout scheduling should help