### PR TITLE
feat(btc-server): Sync entire wallet state

### DIFF
--- a/bin/reth/src/commands/poa/mod.rs
+++ b/bin/reth/src/commands/poa/mod.rs
@@ -841,26 +841,6 @@ impl<Ext: clap::Args + fmt::Debug> PoaNodeCommand<Ext> {
             //         healthcheck_task.expect("health check task exists").start_task().await;
             //     }),
             // );
-
-            // just for local testing purposes
-            // TODO: create WalletStateSync::start_task to handle this logic
-            // executor.spawn_critical(
-            //     "Wallet Sync Task",
-            //     Box::pin(async move {
-            //         loop {
-            //             tokio::time::sleep(Duration::from_secs(20)).await;
-
-            //             if let Err(err) = wallet_sync
-            //                 .as_ref()
-            //                 .expect("wallet sync task exists")
-            //                 .sync_wallet_state()
-            //                 .await
-            //             {
-            //                 error!("Error syncing wallet state: {:?}", err);
-            //             }
-            //         }
-            //     }),
-            // );
         }
 
         let initial_target = node_config.debug.tip;

--- a/bin/reth/src/commands/poa/mod.rs
+++ b/bin/reth/src/commands/poa/mod.rs
@@ -13,6 +13,7 @@ use futures::{stream_select, StreamExt, TryFutureExt};
 use reth_authority_consensus::{
     random_source_provider::RandomSourceProvider,
     utils::{is_known_minting_contract, retry_exec},
+    wallet_state_sync::WalletStateSync,
     AuthorityConsensus, AuthorityConsensusBuilder,
 };
 use reth_cli_util::{get_secret_key, parse_socket_address};
@@ -45,6 +46,7 @@ use reth_stages::StageId;
 use reth_tasks::TaskExecutor;
 use secp256k1::{PublicKey, SecretKey, SECP256K1};
 use std::{borrow::Cow, ffi::OsString, fmt, net::SocketAddr, path::PathBuf, sync::Arc};
+use tokio::time;
 use tokio_stream::wrappers::{BroadcastStream, UnboundedReceiverStream};
 
 use reth_basic_payload_builder::{BasicPayloadJobGenerator, BasicPayloadJobGeneratorConfig};
@@ -766,7 +768,7 @@ impl<Ext: clap::Args + fmt::Debug> PoaNodeCommand<Ext> {
             .with_host(cometbft_rpc_host);
 
         // Build authority Consensus
-        let (_authority_consensus, frost_task, _healthcheck_task, abci_client_builder) =
+        let (_authority_consensus, frost_task, _healthcheck_task, abci_client_builder, wallet_sync) =
             match AuthorityConsensusBuilder::try_new(
                 Arc::clone(&chain_arc.clone()),
                 blockchain_db.clone(),
@@ -837,6 +839,26 @@ impl<Ext: clap::Args + fmt::Debug> PoaNodeCommand<Ext> {
             //     "Healthcheck Task",
             //     Box::pin(async move {
             //         healthcheck_task.expect("health check task exists").start_task().await;
+            //     }),
+            // );
+
+            // just for local testing purposes
+            // TODO: create WalletStateSync::start_task to handle this logic
+            // executor.spawn_critical(
+            //     "Wallet Sync Task",
+            //     Box::pin(async move {
+            //         loop {
+            //             tokio::time::sleep(Duration::from_secs(20)).await;
+
+            //             if let Err(err) = wallet_sync
+            //                 .as_ref()
+            //                 .expect("wallet sync task exists")
+            //                 .sync_wallet_state()
+            //                 .await
+            //             {
+            //                 error!("Error syncing wallet state: {:?}", err);
+            //             }
+            //         }
             //     }),
             // );
         }

--- a/crates/consensus/authority/src/builder.rs
+++ b/crates/consensus/authority/src/builder.rs
@@ -248,21 +248,6 @@ where
         }
         .await;
 
-        // TODO: implement wallet state sync
-        // let _utxo_sync = {
-        //     if let Some(btc_server) = &btc_server_client {
-        //         let utxo_set_sync_engine = UTXOSyncEngine::new(
-        //             storage.clone(),
-        //             btc_server.clone(),
-        //             frost_handle.clone().expect("Requires frost handle"),
-        //             compressor.clone(),
-        //         );
-        //         Some(utxo_set_sync_engine)
-        //     } else {
-        //         None
-        //     }
-        // };
-
         // create frost and block production tasks if btc_server is available:
         // only federation nodes will have btc_server
         let mut frost_task = None;

--- a/crates/consensus/authority/src/builder.rs
+++ b/crates/consensus/authority/src/builder.rs
@@ -1,7 +1,7 @@
 use crate::{
     comet_bft::abci::ABCIClientBuilder, compressor::Compressor, frost_task::FrostTask,
     healthcheck_task::HealthcheckTask, random_source_provider::RandomSource,
-    utxo_sync::UTXOSyncEngine, AuthorityConsensus, Storage,
+    wallet_state_sync::WalletStateSyncEngine, AuthorityConsensus, Storage,
 };
 use btcserverlib::extended_client::GrpcClientFactory;
 use comet_bft_rpc::HttpCometBFTRpcClientFactory;
@@ -248,19 +248,20 @@ where
         }
         .await;
 
-        let _utxo_sync = {
-            if let Some(btc_server) = &btc_server_client {
-                let utxo_set_sync_engine = UTXOSyncEngine::new(
-                    storage.clone(),
-                    btc_server.clone(),
-                    frost_handle.clone().expect("Requires frost handle"),
-                    compressor.clone(),
-                );
-                Some(utxo_set_sync_engine)
-            } else {
-                None
-            }
-        };
+        // TODO: implement wallet state sync
+        // let _utxo_sync = {
+        //     if let Some(btc_server) = &btc_server_client {
+        //         let utxo_set_sync_engine = UTXOSyncEngine::new(
+        //             storage.clone(),
+        //             btc_server.clone(),
+        //             frost_handle.clone().expect("Requires frost handle"),
+        //             compressor.clone(),
+        //         );
+        //         Some(utxo_set_sync_engine)
+        //     } else {
+        //         None
+        //     }
+        // };
 
         // create frost and block production tasks if btc_server is available:
         // only federation nodes will have btc_server

--- a/crates/consensus/authority/src/builder.rs
+++ b/crates/consensus/authority/src/builder.rs
@@ -208,6 +208,7 @@ where
         Option<FrostTask<EF, BF, DB, ToFrostMan, Source>>,
         Option<HealthcheckTask<EF, BF, DB, ToFrostMan>>,
         Option<ABCIClientBuilder<EF, BF, DB>>,
+        Option<WalletStateSyncEngine<EF, BF, DB, ToFrostMan>>,
     ) {
         let Self {
             btc_server_factory,
@@ -247,6 +248,20 @@ where
             }
         }
         .await;
+
+        let wallet_sync = {
+            if let Some(btc_server) = &btc_server_client {
+                let wallet_state_sync_engine = WalletStateSyncEngine::new(
+                    storage.clone(),
+                    btc_server.clone(),
+                    frost_handle.clone().expect("Requires frost handle"),
+                    compressor.clone(),
+                );
+                Some(wallet_state_sync_engine)
+            } else {
+                None
+            }
+        };
 
         // create frost and block production tasks if btc_server is available:
         // only federation nodes will have btc_server
@@ -288,6 +303,6 @@ where
             is_fed_node,
         ));
 
-        (consensus, frost_task, healthcheck_task, abci_client_builder)
+        (consensus, frost_task, healthcheck_task, abci_client_builder, wallet_sync)
     }
 }

--- a/crates/consensus/authority/src/compressor.rs
+++ b/crates/consensus/authority/src/compressor.rs
@@ -50,7 +50,7 @@ pub(crate) enum SerdeError {
 
 /// Password hashing error types.
 #[derive(Debug, DisplayDoc, Error)]
-pub(crate) enum Error {
+pub enum Error {
     /// compression error: {0}
     Compression(#[from] CompressionError),
     /// serde error: {0}

--- a/crates/consensus/authority/src/frost_task.rs
+++ b/crates/consensus/authority/src/frost_task.rs
@@ -18,7 +18,7 @@ use reth_network::{
     frost::{
         manager::{authority_index_to_frost_identifier, FrostCommand, FrostConfig, ToFrostManager},
         DkgEventResponseType, DkgResponse, FrostPeerCommand, PeerMessageResponse,
-        SigningEventResponseType, SigningResponse,
+        SigningEventResponseType, SigningResponse, WalletStateResponse,
     },
     NetworkHandle,
 };
@@ -242,6 +242,12 @@ where
         Ok(prost_serialized_compressed)
     }
 
+    fn has_wallet_state(response: &WalletStateResponse) -> bool {
+        !response.utxos.is_empty() ||
+            !response.tracked_txs.is_empty() ||
+            !response.pending_pegouts.is_empty()
+    }
+
     pub async fn start_task(&mut self) {
         // before we start get a proper event receiver
         let (peer_messages_tx, peer_messages_rx) = tokio::sync::oneshot::channel();
@@ -408,10 +414,7 @@ where
                         //
                         // TODO: create separate messages for asking for wallet state and sending
                         // wallet state
-                        if !response.utxos.is_empty() ||
-                            !response.tracked_txs.is_empty() ||
-                            !response.pending_pegouts.is_empty()
-                        {
+                        if Self::has_wallet_state(&response) {
                             info!(target: "consensus::authority::wallet_syncer::start_task", "Received wallet state in frost task from peer {:?}", peerid);
                             continue;
                         }

--- a/crates/consensus/authority/src/frost_task.rs
+++ b/crates/consensus/authority/src/frost_task.rs
@@ -41,6 +41,7 @@ pub(crate) enum UtxoSetSyncSerializationError {
     Compressor(CompressorError),
 }
 
+#[derive(Debug, thiserror::Error)]
 pub(crate) enum TrackedTxSyncSerializationError {
     #[error("Received a grpc client error {0}")]
     Grpc(GrpcClientError),
@@ -48,6 +49,7 @@ pub(crate) enum TrackedTxSyncSerializationError {
     Compressor(CompressorError),
 }
 
+#[derive(Debug, thiserror::Error)]
 pub(crate) enum PendingPegoutsSyncSerializationError {
     #[error("Received a grpc client error {0}")]
     Grpc(GrpcClientError),
@@ -435,16 +437,17 @@ where
                             }
                         };
 
-                        // TODO: update WalletState to include tracked txs and pending pegouts
-
-                        response.data = serialized_compressed_utxo_set;
+                        // update response with data
+                        response.utxos = serialized_compressed_utxo_set;
+                        response.tracked_txs = serialized_compressed_tracked_txs;
+                        response.pending_pegouts = serialized_compressed_pending_pegouts;
 
                         if let Err(e) =
                             peer_handle.peer_commands_tx.send(FrostPeerCommand::PeerMessage(
                                 PeerMessageResponse::WalletState(response),
                             ))
                         {
-                            error!(target: "consensus::authority::utxo_syncer::start_task", "Error sending utxo set message to a peer: {:?}", e);
+                            error!(target: "consensus::authority::wallet_syncer::start_task", "Error sending wallet state message to a peer: {:?}", e);
                             continue;
                         }
 

--- a/crates/consensus/authority/src/frost_task.rs
+++ b/crates/consensus/authority/src/frost_task.rs
@@ -41,6 +41,20 @@ pub(crate) enum UtxoSetSyncSerializationError {
     Compressor(CompressorError),
 }
 
+pub(crate) enum TrackedTxSyncSerializationError {
+    #[error("Received a grpc client error {0}")]
+    Grpc(GrpcClientError),
+    #[error("compressor error {0}")]
+    Compressor(CompressorError),
+}
+
+pub(crate) enum PendingPegoutsSyncSerializationError {
+    #[error("Received a grpc client error {0}")]
+    Grpc(GrpcClientError),
+    #[error("compressor error {0}")]
+    Compressor(CompressorError),
+}
+
 #[allow(dead_code)]
 pub struct FrostTask<EF, BF, DB, ToFrostMan, Source> {
     /// Network Handler
@@ -161,6 +175,52 @@ where
         let prost_serialized_compressed = self.compressor.compress(&prost_serialized).await.map_err(|e| {
             error!(target: "consensus::authority::utxo_syncer::get_utxo_set", "Got compressor error {:?}", e);
             UtxoSetSyncSerializationError::Compressor(e)
+        })?;
+        Ok(prost_serialized_compressed)
+    }
+
+    async fn get_serialized_compressed_tracked_txs(
+        &mut self,
+    ) -> Result<Vec<u8>, TrackedTxSyncSerializationError> {
+        let prost_tracked_txs = self.btc_server.get_tracked_txs(client::Empty {}).await.map_err(|e| {
+            error!(target: "consensus::authority::tracked_tx_syncer::get_tracked_txs", "Got grpc error {:?}", e);
+            TrackedTxSyncSerializationError::Grpc(e)
+        })?;
+
+        // serialize the prost message
+        let prost_message_wrapper = ProstMessageSerdelizer(prost_tracked_txs);
+        let prost_serialized = prost_message_wrapper.serialize().map_err(|e| {
+            error!(target: "consensus::authority::tracked_tx_syncer::get_tracked_txs", "Got compressor error {:?}", e);
+            TrackedTxSyncSerializationError::Compressor(e)
+        })?;
+
+        // now compress the prost message
+        let prost_serialized_compressed = self.compressor.compress(&prost_serialized).await.map_err(|e| {
+            error!(target: "consensus::authority::tracked_tx_syncer::get_tracked_txs", "Got compressor error {:?}", e);
+            TrackedTxSyncSerializationError::Compressor(e)
+        })?;
+        Ok(prost_serialized_compressed)
+    }
+
+    async fn get_serialized_compressed_pending_pegouts(
+        &mut self,
+    ) -> Result<Vec<u8>, PendingPegoutsSyncSerializationError> {
+        let prost_pending_pegouts = self.btc_server.get_pending_pegouts(client::Empty {}).await.map_err(|e| {
+            error!(target: "consensus::authority::pending_pegouts_syncer::get_pending_pegouts", "Got grpc error {:?}", e);
+            PendingPegoutsSyncSerializationError::Grpc(e)
+        })?;
+
+        // serialize the prost message
+        let prost_message_wrapper = ProstMessageSerdelizer(prost_pending_pegouts);
+        let prost_serialized = prost_message_wrapper.serialize().map_err(|e| {
+            error!(target: "consensus::authority::pending_pegouts_syncer::get_pending_pegouts", "Got compressor error {:?}", e);
+            PendingPegoutsSyncSerializationError::Compressor(e)
+        })?;
+
+        // now compress the prost message
+        let prost_serialized_compressed = self.compressor.compress(&prost_serialized).await.map_err(|e| {
+            error!(target: "consensus::authority::pending_pegouts_syncer::get_pending_pegouts", "Got compressor error {:?}", e);
+            PendingPegoutsSyncSerializationError::Compressor(e)
         })?;
         Ok(prost_serialized_compressed)
     }
@@ -331,8 +391,6 @@ where
                             .expect("remove this later");
                         let peer_handle = all_peers_handle.get(&peerid).expect("remove this later");
 
-                        // TODO refactor to update all wallet state
-
                         // Note its important we do not respond to this message if we are syncing
                         // ourselves This should be checked above
                         let serialized_compressed_utxo_set = match self
@@ -350,6 +408,34 @@ where
                             warn!(target: "consensus::authority::utxo_syncer::start_task", "Received empty utxo set from database");
                             continue;
                         }
+
+                        let serialized_compressed_tracked_txs = match self
+                            .get_serialized_compressed_tracked_txs()
+                            .await
+                        {
+                            Ok(serialized_compressed_tracked_txs) => {
+                                serialized_compressed_tracked_txs
+                            }
+                            Err(e) => {
+                                error!(target: "consensus::authority::tracked_tx_syncer::start_task", "Error getting serialized compressed tracked txs: {:?}", e);
+                                continue;
+                            }
+                        };
+
+                        let serialized_compressed_pending_pegouts = match self
+                            .get_serialized_compressed_pending_pegouts()
+                            .await
+                        {
+                            Ok(serialized_compressed_pending_pegouts) => {
+                                serialized_compressed_pending_pegouts
+                            }
+                            Err(e) => {
+                                error!(target: "consensus::authority::pending_pegouts_syncer::start_task", "Error getting serialized compressed pending pegouts: {:?}", e);
+                                continue;
+                            }
+                        };
+
+                        // TODO: update WalletState to include tracked txs and pending pegouts
 
                         response.data = serialized_compressed_utxo_set;
 

--- a/crates/consensus/authority/src/frost_task.rs
+++ b/crates/consensus/authority/src/frost_task.rs
@@ -323,13 +323,15 @@ where
             // receive over a channel message from other peers and update our state machine
             while let Ok((peerid, msg)) = peer_messages_rx.try_recv() {
                 match msg {
-                    PeerMessageResponse::Utxo(mut response) => {
+                    PeerMessageResponse::WalletState(mut response) => {
                         let all_peers_handle = self
                             .dkg_state_machine
                             .get_all_peers_handle()
                             .await
                             .expect("remove this later");
                         let peer_handle = all_peers_handle.get(&peerid).expect("remove this later");
+
+                        // TODO refactor to update all wallet state
 
                         // Note its important we do not respond to this message if we are syncing
                         // ourselves This should be checked above
@@ -351,9 +353,11 @@ where
 
                         response.data = serialized_compressed_utxo_set;
 
-                        if let Err(e) = peer_handle.peer_commands_tx.send(
-                            FrostPeerCommand::PeerMessage(PeerMessageResponse::Utxo(response)),
-                        ) {
+                        if let Err(e) =
+                            peer_handle.peer_commands_tx.send(FrostPeerCommand::PeerMessage(
+                                PeerMessageResponse::WalletState(response),
+                            ))
+                        {
                             error!(target: "consensus::authority::utxo_syncer::start_task", "Error sending utxo set message to a peer: {:?}", e);
                             continue;
                         }

--- a/crates/consensus/authority/src/frost_task.rs
+++ b/crates/consensus/authority/src/frost_task.rs
@@ -166,6 +166,11 @@ where
             UtxoSetSyncSerializationError::Grpc(e)
         })?;
 
+        if prost_utxos.utxos.is_empty() {
+            warn!(target: "consensus::authority::utxo_syncer::get_utxo_set", "Received empty utxos from btc server");
+            return Ok(vec![])
+        }
+
         // serialize the prost message
         let prost_message_wrapper = ProstMessageSerdelizer(prost_utxos);
         let prost_serialized = prost_message_wrapper.serialize().map_err(|e| {
@@ -189,6 +194,11 @@ where
             TrackedTxSyncSerializationError::Grpc(e)
         })?;
 
+        if prost_tracked_txs.tracked_txs.is_empty() {
+            warn!(target: "consensus::authority::tracked_tx_syncer::get_tracked_txs", "Received empty tracked txs from btc server");
+            return Ok(vec![])
+        }
+
         // serialize the prost message
         let prost_message_wrapper = ProstMessageSerdelizer(prost_tracked_txs);
         let prost_serialized = prost_message_wrapper.serialize().map_err(|e| {
@@ -211,6 +221,11 @@ where
             error!(target: "consensus::authority::pending_pegouts_syncer::get_pending_pegouts", "Got grpc error {:?}", e);
             PendingPegoutsSyncSerializationError::Grpc(e)
         })?;
+
+        if prost_pending_pegouts.pending_pegouts.is_empty() {
+            warn!(target: "consensus::authority::pending_pegouts_syncer::get_pending_pegouts", "Received empty pending pegouts from btc server");
+            return Ok(vec![])
+        }
 
         // serialize the prost message
         let prost_message_wrapper = ProstMessageSerdelizer(prost_pending_pegouts);
@@ -386,12 +401,28 @@ where
             while let Ok((peerid, msg)) = peer_messages_rx.try_recv() {
                 match msg {
                     PeerMessageResponse::WalletState(mut response) => {
+                        // Only handle response if it has no state: responses with state are also
+                        // sent to WalletStateSyncEngine::sync_wallet_state
+                        // which updates the wallet state. This code block
+                        // handles sending our wallet state to a peer
+                        //
+                        // TODO: create separate messages for asking for wallet state and sending
+                        // wallet state
+                        if !response.utxos.is_empty() ||
+                            !response.tracked_txs.is_empty() ||
+                            !response.pending_pegouts.is_empty()
+                        {
+                            info!(target: "consensus::authority::wallet_syncer::start_task", "Received wallet state in frost task from peer {:?}", peerid);
+                            continue;
+                        }
+
                         let all_peers_handle = self
                             .dkg_state_machine
                             .get_all_peers_handle()
                             .await
-                            .expect("remove this later");
-                        let peer_handle = all_peers_handle.get(&peerid).expect("remove this later");
+                            .expect("expect all peers handle to exist");
+                        let peer_handle =
+                            all_peers_handle.get(&peerid).expect("peer handle to exist");
 
                         // Note its important we do not respond to this message if we are syncing
                         // ourselves This should be checked above
@@ -405,7 +436,6 @@ where
                                 continue;
                             }
                         };
-
                         if serialized_compressed_utxo_set.is_empty() {
                             warn!(target: "consensus::authority::utxo_syncer::start_task", "Received empty utxo set from database");
                             continue;
@@ -423,6 +453,10 @@ where
                                 continue;
                             }
                         };
+                        if serialized_compressed_tracked_txs.is_empty() {
+                            warn!(target: "consensus::authority::tracked_tx_syncer::start_task", "Received empty tracked txs from database");
+                            continue;
+                        }
 
                         let serialized_compressed_pending_pegouts = match self
                             .get_serialized_compressed_pending_pegouts()
@@ -436,12 +470,17 @@ where
                                 continue;
                             }
                         };
+                        if serialized_compressed_pending_pegouts.is_empty() {
+                            warn!(target: "consensus::authority::pending_pegouts_syncer::start_task", "Received empty pending pegouts from database");
+                            continue;
+                        }
 
                         // update response with data
                         response.utxos = serialized_compressed_utxo_set;
                         response.tracked_txs = serialized_compressed_tracked_txs;
                         response.pending_pegouts = serialized_compressed_pending_pegouts;
 
+                        info!(target: "consensus::authority::wallet_syncer::start_task", "Sending wallet state to peer {:?}", peerid);
                         if let Err(e) =
                             peer_handle.peer_commands_tx.send(FrostPeerCommand::PeerMessage(
                                 PeerMessageResponse::WalletState(response),

--- a/crates/consensus/authority/src/healthcheck_task.rs
+++ b/crates/consensus/authority/src/healthcheck_task.rs
@@ -206,9 +206,8 @@ where
                     peers_healthcheck_tracker.insert(healthcheck_response.sender, Instant::now());
                     drop(peers_healthcheck_tracker);
                 }
-                PeerMessageResponse::Utxo(_) => {
-                    // Nothing to do for utxo sync messages. Does are handled by the frost
-                    // task
+                PeerMessageResponse::WalletState(_) => {
+                    // TODO: implement
                 }
             }
         }

--- a/crates/consensus/authority/src/lib.rs
+++ b/crates/consensus/authority/src/lib.rs
@@ -59,7 +59,7 @@ mod frost_task;
 mod healthcheck_task;
 mod signing;
 pub mod utils;
-mod wallet_state_sync;
+pub mod wallet_state_sync;
 pub use builder::AuthorityConsensusBuilder;
 pub mod random_source_provider;
 

--- a/crates/consensus/authority/src/lib.rs
+++ b/crates/consensus/authority/src/lib.rs
@@ -59,7 +59,7 @@ mod frost_task;
 mod healthcheck_task;
 mod signing;
 pub mod utils;
-mod utxo_sync;
+mod wallet_state_sync;
 pub use builder::AuthorityConsensusBuilder;
 pub mod random_source_provider;
 

--- a/crates/consensus/authority/src/utils.rs
+++ b/crates/consensus/authority/src/utils.rs
@@ -333,7 +333,7 @@ pub(crate) fn generate_signing_session_id(
 /// Repersents an error related to utxo operations
 #[derive(Debug, thiserror::Error)]
 #[allow(dead_code)]
-pub(crate) enum UtxoMerkelRootError {
+pub enum UtxoMerkelRootError {
     #[error("Unparsable tx id")]
     UnparsableTxId,
     #[error("Outpoint encoding")]

--- a/crates/consensus/authority/src/wallet_state_sync.rs
+++ b/crates/consensus/authority/src/wallet_state_sync.rs
@@ -5,7 +5,10 @@ use bitcoin::{
     secp256k1::hashes::Hash,
 };
 use btcserverlib::extended_client::{BtcServerExtendedClient, GrpcClientError};
-use client::{Empty, GetAllUtxosResponse, ResetAllUtxosRequest};
+use client::{
+    Empty, GetAllUtxosResponse, GetPendingPegoutsResponse, GetTrackedTxsResponse,
+    ResetAllPendingPegoutsRequest, ResetAllTrackedTxsRequest, ResetAllUtxosRequest,
+};
 use reth_btc_wallet::bitcoind::BitcoindFactory;
 use reth_evm::execute::BlockExecutorProvider;
 use reth_network::frost::{
@@ -34,8 +37,8 @@ pub(crate) enum WalletStateSyncError {
     BtcServerClientError(#[from] GrpcClientError),
     #[error("frost manager send error: {0}")]
     FrostManagerSendError(#[from] SendError<FrostCommand>),
-    #[error("peer never responded with utxo set, timer elapsed")]
-    PeerUtxoSetTimeout,
+    #[error("peer never responded with wallet state, timer elapsed")]
+    PeerWalletStateTimeout,
     #[error("Failed to receive a frost message from a peer {0}")]
     FrostRecv(tokio::sync::oneshot::error::RecvError),
     #[error("Failed to decompress utxo set data {0}")]
@@ -111,42 +114,62 @@ where
             Ok(peer_message) => {
                 if let Some((_peer_id, peer_message)) = peer_message {
                     if let PeerMessageResponse::WalletState(wallet_state) = peer_message {
-                        // TODO: refactor to update all wallet state
-
-                        // process the utxo set
-                        debug!(target: "consensus::authority::block_fetcher::sync_wallet_state", "Got utxo set from peer {:?}", wallet_state);
-                        let data = wallet_state.data;
-                        let decompressed = self.compressor.decompress(&data).await.map_err(|e| {
-                            error!(target: "consensus::authority::block_fetcher::sync_wallet_state", "Failed to decompress utxo set data {:?}", e);
+                        // process the utxos
+                        debug!(target: "consensus::authority::sync_wallet_state", "Received wallet state from peer {:?}", wallet_state);
+                        let utxos_compressed = wallet_state.utxos;
+                        let utxos_decompressed = self.compressor.decompress(&utxos_compressed).await.map_err(|e| {
+                            error!(target: "consensus::authority::sync_wallet_state", "Failed to decompress utxos {:?}", e);
                             WalletStateSyncError::CompressorError(e)
                         })?;
+                        let utxos = ProstMessageSerdelizer::<GetAllUtxosResponse>::deserialize(
+                            utxos_decompressed,
+                        )?
+                        .utxos;
 
-                        let utxo_set = ProstMessageSerdelizer::<GetAllUtxosResponse>::deserialize(
-                            decompressed,
-                        )?;
-                        // TODO peers will also need to communicate their tracked txs and pending
-                        // pegouts
-                        // let merkel_root = generate_utxo_merkel_root(&utxo_set.utxos)?;
-                        // if merkel_root != latest_utxo_commitment {
-                        //     return Err(WalletStateSyncError::UtxoSetNotInSync(
-                        //         merkel_root,
-                        //         latest_utxo_commitment,
-                        //     ));
-                        // }
+                        // process the tracked txs
+                        let tracked_txs_compressed = wallet_state.tracked_txs;
+                        let tracked_txs_decompressed = self.compressor.decompress(&tracked_txs_compressed).await.map_err(|e| {
+                            error!(target: "consensus::authority::sync_wallet_state", "Failed to decompress tracked txs {:?}", e);
+                            WalletStateSyncError::CompressorError(e)
+                        })?;
+                        let tracked_txs =
+                            ProstMessageSerdelizer::<GetTrackedTxsResponse>::deserialize(
+                                tracked_txs_decompressed,
+                            )?
+                            .tracked_txs;
 
-                        // Report to btc server to sync utxo set
+                        // process the pending pegouts
+                        let pending_pegouts_compressed = wallet_state.pending_pegouts;
+                        let pending_pegouts_decompressed = self.compressor.decompress(&pending_pegouts_compressed).await.map_err(|e| {
+                            error!(target: "consensus::authority::sync_wallet_state", "Failed to decompress pending pegouts {:?}", e);
+                            WalletStateSyncError::CompressorError(e)
+                        })?;
+                        let pending_pegouts =
+                            ProstMessageSerdelizer::<GetPendingPegoutsResponse>::deserialize(
+                                pending_pegouts_decompressed,
+                            )?
+                            .pending_pegouts;
+
+                        // Report to btc server to sync utxos
+                        btc_server.reset_all_utxos(ResetAllUtxosRequest { utxos }).await?;
+                        // Report to btc server to sync tracked txs
                         btc_server
-                            .reset_all_utxos(ResetAllUtxosRequest { utxos: utxo_set.utxos })
+                            .reset_all_tracked_txs(ResetAllTrackedTxsRequest { tracked_txs })
+                            .await?;
+                        // Report to btc server to sync pending pegouts
+                        btc_server
+                            .reset_all_pending_pegouts(ResetAllPendingPegoutsRequest {
+                                pending_pegouts,
+                            })
                             .await?;
                     }
                 } else {
-                    // TODO better error variant
-                    return Err(WalletStateSyncError::PeerUtxoSetTimeout);
+                    return Err(WalletStateSyncError::PeerWalletStateTimeout);
                 }
             }
             Err(e) => {
-                warn!(target: "consensus::authority::block_fetcher::sync_utxo_set", ?e, "Failed to get get utxo set rom a peer within 60 secs");
-                return Err(WalletStateSyncError::PeerUtxoSetTimeout);
+                warn!(target: "consensus::authority::sync_wallet_state", ?e, "Failed to get get wallet state from a peer within 60 secs");
+                return Err(WalletStateSyncError::PeerWalletStateTimeout);
             }
         }
 

--- a/crates/consensus/authority/src/wallet_state_sync.rs
+++ b/crates/consensus/authority/src/wallet_state_sync.rs
@@ -1,13 +1,10 @@
+//! Wallet state sync module
 use std::time::Duration;
 
-use bitcoin::{
-    hashes::{sha256::Hash as Sha256Hash, FromSliceError},
-    secp256k1::hashes::Hash,
-};
+use bitcoin::hashes::{sha256::Hash as Sha256Hash, FromSliceError};
 use btcserverlib::extended_client::{BtcServerExtendedClient, GrpcClientError};
 use client::{
-    Empty, GetAllUtxosResponse, GetPendingPegoutsResponse, GetTrackedTxsResponse,
-    ResetAllPendingPegoutsRequest, ResetAllTrackedTxsRequest, ResetAllUtxosRequest,
+    GetAllUtxosResponse, GetPendingPegoutsResponse, GetTrackedTxsResponse, ResetWalletStateRequest,
 };
 use reth_btc_wallet::bitcoind::BitcoindFactory;
 use reth_evm::execute::BlockExecutorProvider;
@@ -18,47 +15,59 @@ use reth_network::frost::{
 use reth_primitives::extra_data_header::ExtraDataHeaderDeserializeError;
 use reth_provider::{BlockReaderIdExt, ProviderError};
 use tokio::sync::mpsc::error::SendError;
-use tracing::{debug, error, trace, warn};
+use tracing::{debug, error, info, trace, warn};
 
 use crate::{
     compressor::{Compressor, Error as CompressorError, ProstMessageSerdelizer},
-    utils::{generate_utxo_merkel_root, UtxoMerkelRootError},
+    utils::UtxoMerkelRootError,
     Storage,
 };
 
 #[derive(Debug, thiserror::Error)]
-#[allow(dead_code)]
-pub(crate) enum WalletStateSyncError {
+/// Wallet state synchronization errors
+pub enum WalletStateSyncError {
     #[error("db provider error: {0}")]
+    /// Latest block error
     LatestBlockError(#[from] ProviderError),
     #[error("deserilaize extra data header : {0}")]
+    /// Extra data header deserialize error
     DeserializeExtraDataHeaderError(#[from] ExtraDataHeaderDeserializeError),
     #[error("btc server client error: {0}")]
+    /// Btc server client error
     BtcServerClientError(#[from] GrpcClientError),
     #[error("frost manager send error: {0}")]
+    /// Frost manager send error
     FrostManagerSendError(#[from] SendError<FrostCommand>),
     #[error("peer never responded with wallet state, timer elapsed")]
+    /// Peer wallet state timeout
     PeerWalletStateTimeout,
     #[error("Failed to receive a frost message from a peer {0}")]
+    /// Frost recv error
     FrostRecv(tokio::sync::oneshot::error::RecvError),
     #[error("Failed to decompress utxo set data {0}")]
+    /// Compressor error
     CompressorError(#[from] CompressorError),
     #[error("Failed to generate utxo merkel root {0}")]
+    /// Utxo merkel root error
     UtxoMerkelRootError(#[from] UtxoMerkelRootError),
     #[error("UTXO set from peer is not in sync with the latest block, current utxo set merkel root: {0}, latest utxo set merkel root: {1}")]
+    /// Utxo set not in sync
     UtxoSetNotInSync(Sha256Hash, Sha256Hash),
     #[error("Failed to convert slide to sha256 hash {0}")]
+    /// Sha256 hash error
     Sha256HashError(#[from] FromSliceError),
 }
 
-#[allow(dead_code)]
-pub(crate) trait WalletStateSync {
+/// Trait for synchronizing wallet state
+#[allow(async_fn_in_trait)]
+pub trait WalletStateSync {
+    /// Synchronizes the wallet state
     async fn sync_wallet_state(&self) -> Result<(), WalletStateSyncError>;
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
-pub(crate) struct WalletStateSyncEngine<EF, BF, DB, ToFrostMan> {
+/// Engine for synchronizing wallet state
+pub struct WalletStateSyncEngine<EF, BF, DB, ToFrostMan> {
     storage: Storage<EF, BF, DB>,
     btc_server: BtcServerExtendedClient,
     to_frost_manager: ToFrostMan,
@@ -112,54 +121,74 @@ where
         // try getting the wallet state from the random peer we pinged
         match tokio::time::timeout(Duration::from_secs(60), peer_messages_rx.recv()).await {
             Ok(peer_message) => {
-                if let Some((_peer_id, peer_message)) = peer_message {
+                if let Some((peer_id, peer_message)) = peer_message {
+                    info!(target: "consensus::authority::sync_wallet_state", "Received wallet state from peer {:?}", peer_id);
+
+                    // Note: we ignore empty messages bc they are peer requests for wallet state
+                    // which are handled by the frost task or are malicious/faulty requests
+                    // that would cause the btc-server to wipe its state
                     if let PeerMessageResponse::WalletState(wallet_state) = peer_message {
                         // process the utxos
                         debug!(target: "consensus::authority::sync_wallet_state", "Received wallet state from peer {:?}", wallet_state);
                         let utxos_compressed = wallet_state.utxos;
-                        let utxos_decompressed = self.compressor.decompress(&utxos_compressed).await.map_err(|e| {
-                            error!(target: "consensus::authority::sync_wallet_state", "Failed to decompress utxos {:?}", e);
-                            WalletStateSyncError::CompressorError(e)
-                        })?;
-                        let utxos = ProstMessageSerdelizer::<GetAllUtxosResponse>::deserialize(
-                            utxos_decompressed,
-                        )?
-                        .utxos;
+                        let utxos = {
+                            if utxos_compressed.is_empty() {
+                                warn!(target: "consensus::authority::sync_wallet_state", "Peer sent empty utxos");
+                                return Ok(());
+                            } else {
+                                let utxos_decompressed = self.compressor.decompress(&utxos_compressed).await.map_err(|e| {
+                                    error!(target: "consensus::authority::sync_wallet_state", "Failed to decompress utxos {:?}", e);
+                                    WalletStateSyncError::CompressorError(e)
+                                })?;
+                                ProstMessageSerdelizer::<GetAllUtxosResponse>::deserialize(
+                                    utxos_decompressed,
+                                )?
+                                .utxos
+                            }
+                        };
 
                         // process the tracked txs
                         let tracked_txs_compressed = wallet_state.tracked_txs;
-                        let tracked_txs_decompressed = self.compressor.decompress(&tracked_txs_compressed).await.map_err(|e| {
-                            error!(target: "consensus::authority::sync_wallet_state", "Failed to decompress tracked txs {:?}", e);
-                            WalletStateSyncError::CompressorError(e)
-                        })?;
-                        let tracked_txs =
-                            ProstMessageSerdelizer::<GetTrackedTxsResponse>::deserialize(
-                                tracked_txs_decompressed,
-                            )?
-                            .tracked_txs;
+                        let tracked_txs = {
+                            if tracked_txs_compressed.is_empty() {
+                                warn!(target: "consensus::authority::sync_wallet_state", "Peer sent empty tracked txs");
+                                return Ok(());
+                            } else {
+                                let tracked_txs_decompressed = self.compressor.decompress(&tracked_txs_compressed).await.map_err(|e| {
+                                    error!(target: "consensus::authority::sync_wallet_state", "Failed to decompress tracked txs {:?}", e);
+                                    WalletStateSyncError::CompressorError(e)
+                                })?;
+                                ProstMessageSerdelizer::<GetTrackedTxsResponse>::deserialize(
+                                    tracked_txs_decompressed,
+                                )?
+                                .tracked_txs
+                            }
+                        };
 
                         // process the pending pegouts
                         let pending_pegouts_compressed = wallet_state.pending_pegouts;
-                        let pending_pegouts_decompressed = self.compressor.decompress(&pending_pegouts_compressed).await.map_err(|e| {
-                            error!(target: "consensus::authority::sync_wallet_state", "Failed to decompress pending pegouts {:?}", e);
-                            WalletStateSyncError::CompressorError(e)
-                        })?;
-                        let pending_pegouts =
-                            ProstMessageSerdelizer::<GetPendingPegoutsResponse>::deserialize(
-                                pending_pegouts_decompressed,
-                            )?
-                            .pending_pegouts;
+                        let pending_pegouts = {
+                            if pending_pegouts_compressed.is_empty() {
+                                warn!(target: "consensus::authority::sync_wallet_state", "Peer sent empty pending pegouts");
+                                return Ok(());
+                            } else {
+                                let pending_pegouts_decompressed = self.compressor.decompress(&pending_pegouts_compressed).await.map_err(|e| {
+                                    error!(target: "consensus::authority::sync_wallet_state", "Failed to decompress pending pegouts {:?}", e);
+                                    WalletStateSyncError::CompressorError(e)
+                                })?;
+                                ProstMessageSerdelizer::<GetPendingPegoutsResponse>::deserialize(
+                                    pending_pegouts_decompressed,
+                                )?
+                                .pending_pegouts
+                            }
+                        };
 
-                        // Report to btc server to sync utxos
-                        btc_server.reset_all_utxos(ResetAllUtxosRequest { utxos }).await?;
-                        // Report to btc server to sync tracked txs
+                        // Report to btc server to reset the wallet state
                         btc_server
-                            .reset_all_tracked_txs(ResetAllTrackedTxsRequest { tracked_txs })
-                            .await?;
-                        // Report to btc server to sync pending pegouts
-                        btc_server
-                            .reset_all_pending_pegouts(ResetAllPendingPegoutsRequest {
-                                pending_pegouts,
+                            .reset_wallet_state(ResetWalletStateRequest {
+                                utxos: utxos.clone(),
+                                tracked_txs: tracked_txs.clone(),
+                                pending_pegouts: pending_pegouts.clone(),
                             })
                             .await?;
                     }

--- a/crates/consensus/authority/src/wallet_state_sync.rs
+++ b/crates/consensus/authority/src/wallet_state_sync.rs
@@ -25,7 +25,7 @@ use crate::{
 
 #[derive(Debug, thiserror::Error)]
 #[allow(dead_code)]
-pub(crate) enum UtxoSyncError {
+pub(crate) enum WalletStateSyncError {
     #[error("db provider error: {0}")]
     LatestBlockError(#[from] ProviderError),
     #[error("deserilaize extra data header : {0}")]
@@ -49,20 +49,20 @@ pub(crate) enum UtxoSyncError {
 }
 
 #[allow(dead_code)]
-pub(crate) trait UTXOSync {
-    async fn sync_utxo_set(&self) -> Result<(), UtxoSyncError>;
+pub(crate) trait WalletStateSync {
+    async fn sync_wallet_state(&self) -> Result<(), WalletStateSyncError>;
 }
 
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
-pub(crate) struct UTXOSyncEngine<EF, BF, DB, ToFrostMan> {
+pub(crate) struct WalletStateSyncEngine<EF, BF, DB, ToFrostMan> {
     storage: Storage<EF, BF, DB>,
     btc_server: BtcServerExtendedClient,
     to_frost_manager: ToFrostMan,
     compressor: Compressor,
 }
 
-impl<EF, BF, DB, ToFrostMan> UTXOSyncEngine<EF, BF, DB, ToFrostMan>
+impl<EF, BF, DB, ToFrostMan> WalletStateSyncEngine<EF, BF, DB, ToFrostMan>
 where
     BF: BitcoindFactory + Clone + 'static,
     EF: BlockExecutorProvider + Clone + 'static,
@@ -79,7 +79,7 @@ where
     }
 }
 
-impl<EF, BF, DB, ToFrostMan> UTXOSync for UTXOSyncEngine<EF, BF, DB, ToFrostMan>
+impl<EF, BF, DB, ToFrostMan> WalletStateSync for WalletStateSyncEngine<EF, BF, DB, ToFrostMan>
 where
     BF: BitcoindFactory + Clone + 'static,
     EF: BlockExecutorProvider + Clone + 'static,
@@ -87,50 +87,39 @@ where
     DB: BlockReaderIdExt + Clone + 'static,
 {
     // Note: this function should not be called unless we are fully synced
-    async fn sync_utxo_set(&self) -> Result<(), UtxoSyncError> {
+    async fn sync_wallet_state(&self) -> Result<(), WalletStateSyncError> {
         trace!(target: "consensus::authority::UTXOSync::sync_utxo_set", "syncing utxo set");
         let client = self.storage.client.clone();
         let mut btc_server = self.btc_server.clone();
 
         let latest_header = client.latest_header()?.expect("should get latest block");
-        // let latest_merkle_root = latest_header.get_utxo_set_merkle_root()?;
-
         if latest_header.number == 0 {
             debug!(target: "consensus::authority::UTXOSync::sync_utxo_set", "genesis block, no utxo set to sync");
             return Ok(());
         }
 
-        // get utxo set from btc server
-        let latest_wallet_state = btc_server.get_wallet_state(Empty {}).await?;
-        let latest_utxo_commitment =
-            Sha256Hash::from_slice(latest_wallet_state.utxo_root.as_slice())?;
-        // if latest_merkel_root == latest_utxo_commitment {
-        //     debug!(target: "consensus::authority::UTXOSync::sync_utxo_set", "utxo set is in
-        // sync");     // All done! We are in sync
-        //     return Ok(());
-        // }
-
         // Since we are not in sync, we need to get the utxo set from a peer
         let (peer_messages_tx, peer_messages_rx) = tokio::sync::oneshot::channel();
         self.to_frost_manager
             .send_command(FrostCommand::GetPeerMessagesStream(peer_messages_tx))?;
-        // TODO remove unwrap()
-        let mut peer_messages_rx = peer_messages_rx.await.unwrap();
+        let mut peer_messages_rx = peer_messages_rx.await.expect("peer messages rx to be open");
 
-        // Request the utxo set from a peer
+        // Request the wallet state from a peer
         // TODO should sample many wallet states from N peers
-        self.to_frost_manager.send_command(FrostCommand::GetUtxoSetFromPeer)?;
-        // try getting the utxo set from the random peer we pinged
+        self.to_frost_manager.send_command(FrostCommand::GetWalletStateFromPeer)?;
+        // try getting the wallet state from the random peer we pinged
         match tokio::time::timeout(Duration::from_secs(60), peer_messages_rx.recv()).await {
             Ok(peer_message) => {
                 if let Some((_peer_id, peer_message)) = peer_message {
-                    if let PeerMessageResponse::Utxo(utxo_set) = peer_message {
+                    if let PeerMessageResponse::WalletState(wallet_state) = peer_message {
+                        // TODO: refactor to update all wallet state
+
                         // process the utxo set
-                        debug!(target: "consensus::authority::block_fetcher::sync_utxo_set", "Got utxo set from peer {:?}", utxo_set);
-                        let data = utxo_set.data;
+                        debug!(target: "consensus::authority::block_fetcher::sync_wallet_state", "Got utxo set from peer {:?}", wallet_state);
+                        let data = wallet_state.data;
                         let decompressed = self.compressor.decompress(&data).await.map_err(|e| {
-                            error!(target: "consensus::authority::block_fetcher::sync_utxo_set", "Failed to decompress utxo set data {:?}", e);
-                            UtxoSyncError::CompressorError(e)
+                            error!(target: "consensus::authority::block_fetcher::sync_wallet_state", "Failed to decompress utxo set data {:?}", e);
+                            WalletStateSyncError::CompressorError(e)
                         })?;
 
                         let utxo_set = ProstMessageSerdelizer::<GetAllUtxosResponse>::deserialize(
@@ -138,13 +127,13 @@ where
                         )?;
                         // TODO peers will also need to communicate their tracked txs and pending
                         // pegouts
-                        let merkel_root = generate_utxo_merkel_root(&utxo_set.utxos)?;
-                        if merkel_root != latest_utxo_commitment {
-                            return Err(UtxoSyncError::UtxoSetNotInSync(
-                                merkel_root,
-                                latest_utxo_commitment,
-                            ));
-                        }
+                        // let merkel_root = generate_utxo_merkel_root(&utxo_set.utxos)?;
+                        // if merkel_root != latest_utxo_commitment {
+                        //     return Err(WalletStateSyncError::UtxoSetNotInSync(
+                        //         merkel_root,
+                        //         latest_utxo_commitment,
+                        //     ));
+                        // }
 
                         // Report to btc server to sync utxo set
                         btc_server
@@ -153,12 +142,12 @@ where
                     }
                 } else {
                     // TODO better error variant
-                    return Err(UtxoSyncError::PeerUtxoSetTimeout);
+                    return Err(WalletStateSyncError::PeerUtxoSetTimeout);
                 }
             }
             Err(e) => {
                 warn!(target: "consensus::authority::block_fetcher::sync_utxo_set", ?e, "Failed to get get utxo set rom a peer within 60 secs");
-                return Err(UtxoSyncError::PeerUtxoSetTimeout);
+                return Err(WalletStateSyncError::PeerUtxoSetTimeout);
             }
         }
 

--- a/crates/consensus/authority/src/wallet_state_sync.rs
+++ b/crates/consensus/authority/src/wallet_state_sync.rs
@@ -98,7 +98,6 @@ where
             return Ok(());
         }
 
-        // Since we are not in sync, we need to get the utxo set from a peer
         let (peer_messages_tx, peer_messages_rx) = tokio::sync::oneshot::channel();
         self.to_frost_manager
             .send_command(FrostCommand::GetPeerMessagesStream(peer_messages_tx))?;

--- a/crates/net/network/src/frost/manager.rs
+++ b/crates/net/network/src/frost/manager.rs
@@ -1,5 +1,6 @@
 use super::{
-    FrostPeerCommand, FrostProtocolEvent, HealthcheckResponse, PeerMessageResponse, UtxoSetResponse,
+    FrostPeerCommand, FrostProtocolEvent, HealthcheckResponse, PeerMessageResponse,
+    WalletStateResponse,
 };
 use crate::{session::Direction, NetworkHandle};
 use frost_secp256k1_tr as frost;
@@ -242,7 +243,7 @@ impl FrostManager {
         self.prune_closed_connections();
 
         match cmd {
-            FrostCommand::GetUtxoSetFromPeer => {
+            FrostCommand::GetWalletStateFromPeer => {
                 // choose a random peer
                 let random_authority_index =
                     rand::thread_rng().gen_range(0..self.peers_connections.len() - 1);
@@ -251,7 +252,8 @@ impl FrostManager {
                     Some(peer_data) => {
                         let peer_data = peer_data.first().expect("will always have one element");
                         match peer_data.peer_commands_tx.send(FrostPeerCommand::PeerMessage(
-                            PeerMessageResponse::Utxo(UtxoSetResponse { data: vec![] }),
+                            // send request to frost task
+                            PeerMessageResponse::WalletState(WalletStateResponse { data: vec![] }),
                         )) {
                             Ok(_) => {
                                 debug!(target: "network::frost::on_command", "UtxoSet sent to peer {:?}", peer_data.peer_id);
@@ -375,8 +377,8 @@ pub enum FrostCommand {
     GetAllConnectedPeers(oneshot::Sender<HashMap<PeerId, PeerData>>),
     /// Get a receiver for streaming peer messages
     GetPeerMessagesStream(oneshot::Sender<mpsc::UnboundedReceiver<(PeerId, PeerMessageResponse)>>),
-    /// Get UTXO set from peer
-    GetUtxoSetFromPeer,
+    /// Get wallet sate from peer
+    GetWalletStateFromPeer,
 }
 
 /// Config type for initiating a [`FrostManager`] instance.

--- a/crates/net/network/src/frost/manager.rs
+++ b/crates/net/network/src/frost/manager.rs
@@ -377,7 +377,7 @@ pub enum FrostCommand {
     GetAllConnectedPeers(oneshot::Sender<HashMap<PeerId, PeerData>>),
     /// Get a receiver for streaming peer messages
     GetPeerMessagesStream(oneshot::Sender<mpsc::UnboundedReceiver<(PeerId, PeerMessageResponse)>>),
-    /// Get wallet sate from peer
+    /// Get wallet state from peer
     GetWalletStateFromPeer,
 }
 

--- a/crates/net/network/src/frost/manager.rs
+++ b/crates/net/network/src/frost/manager.rs
@@ -252,8 +252,11 @@ impl FrostManager {
                     Some(peer_data) => {
                         let peer_data = peer_data.first().expect("will always have one element");
                         match peer_data.peer_commands_tx.send(FrostPeerCommand::PeerMessage(
-                            // send request to frost task
-                            PeerMessageResponse::WalletState(WalletStateResponse { data: vec![] }),
+                            PeerMessageResponse::WalletState(WalletStateResponse {
+                                utxos: vec![],
+                                tracked_txs: vec![],
+                                pending_pegouts: vec![],
+                            }),
                         )) {
                             Ok(_) => {
                                 debug!(target: "network::frost::on_command", "UtxoSet sent to peer {:?}", peer_data.peer_id);

--- a/crates/net/network/src/frost/messages.rs
+++ b/crates/net/network/src/frost/messages.rs
@@ -8,6 +8,7 @@ use reth_primitives::{Buf, BufMut, BytesMut};
 
 const MESSAGE_VERSION: usize = 0;
 const UTXO_SET_MESSAGE_VERSION: usize = 0;
+const WALLET_STATE_MESSAGE_VERSION: usize = 0;
 
 /// A structured healthcheck message
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -93,6 +94,28 @@ impl UtxoRequest {
     }
 }
 
+/// A structured wallet state message
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WalletStateRequest {
+    /// The version of the request message
+    pub version: u16,
+    /// wallet state data
+    pub data: Vec<u8>,
+}
+
+impl fmt::Display for WalletStateRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Wallet state data size: {} bytes", self.data.len())
+    }
+}
+
+impl WalletStateRequest {
+    /// Constructs a new wallet state request using a data payload.
+    pub const fn new(data: Vec<u8>) -> Self {
+        Self { version: WALLET_STATE_MESSAGE_VERSION as u16, data }
+    }
+}
+
 /// Enum defining the frost message type as u8
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -123,6 +146,8 @@ pub enum FrostProtoMessageId {
     Healthcheck = 0x0B,
     /// Round 1 Dkg request message
     Round1DkgRequest = 0x0C,
+    /// WalletState
+    WalletState = 0x0D,
 }
 
 /// Enum defining the frost message kind
@@ -154,6 +179,8 @@ pub enum FrostProtoMessageKind {
     Utxo(UtxoRequest),
     /// Health
     Healthcheck(HealthcheckRequest),
+    /// Wallet state message
+    WalletState(WalletStateRequest),
 }
 
 /// An protocol message, containing a message ID and payload.
@@ -265,6 +292,14 @@ impl FrostProtoMessage {
         }
     }
 
+    /// Creates a wallet state message
+    pub const fn wallet_state_message(resource: WalletStateRequest) -> Self {
+        Self {
+            message_type: FrostProtoMessageId::WalletState,
+            message: FrostProtoMessageKind::WalletState(resource),
+        }
+    }
+
     /// Peer healthcheck
     pub const fn peer_health_message(resource: HealthcheckRequest) -> Self {
         Self {
@@ -336,6 +371,11 @@ impl FrostProtoMessage {
                 buf.put_u16_le(receiver_bytes.len() as u16); // Length of the receiver
                 buf.put_slice(receiver_bytes); // Receiver bytes
             }
+            FrostProtoMessageKind::WalletState(resource) => {
+                // serialize the data
+                buf.put_u64_le(resource.data.len() as u64); // Use u64 to support larger data sizes
+                buf.put_slice(&resource.data);
+            }
         }
         buf
     }
@@ -361,6 +401,7 @@ impl FrostProtoMessage {
             0x0A => FrostProtoMessageId::Utxo,
             0x0B => FrostProtoMessageId::Healthcheck,
             0x0C => FrostProtoMessageId::Round1DkgRequest,
+            0x0D => FrostProtoMessageId::WalletState,
             _ => return None,
         };
         let message = match message_type {
@@ -550,6 +591,15 @@ impl FrostProtoMessage {
                 buf.advance(receiver_len);
 
                 FrostProtoMessageKind::Healthcheck(HealthcheckRequest { sender, receiver })
+            }
+            FrostProtoMessageId::WalletState => {
+                // wallet state
+                let wallet_state_len = u64::from_le_bytes(buf[..8].try_into().unwrap()) as usize;
+                buf.advance(8);
+                let wallet_state = buf[..wallet_state_len].to_vec();
+                buf.advance(wallet_state_len);
+
+                FrostProtoMessageKind::WalletState(WalletStateRequest::new(wallet_state))
             }
         };
         Some(Self { message_type, message })

--- a/crates/net/network/src/frost/messages.rs
+++ b/crates/net/network/src/frost/messages.rs
@@ -99,20 +99,33 @@ impl UtxoRequest {
 pub struct WalletStateRequest {
     /// The version of the request message
     pub version: u16,
-    /// wallet state data
-    pub data: Vec<u8>,
+    /// utxos
+    pub utxos: Vec<u8>,
+    /// tracked transactions
+    pub tracked_txs: Vec<u8>,
+    /// pending pegouts
+    pub pending_pegouts: Vec<u8>,
 }
 
 impl fmt::Display for WalletStateRequest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Wallet state data size: {} bytes", self.data.len())
+        write!(
+            f,
+            "WalletStateRequest:\n\
+            - UTXOs: {} bytes\n\
+            - Tracked Transactions: {} bytes\n\
+            - Pending Pegouts: {} bytes",
+            self.utxos.len(),
+            self.tracked_txs.len(),
+            self.pending_pegouts.len()
+        )
     }
 }
 
 impl WalletStateRequest {
     /// Constructs a new wallet state request using a data payload.
-    pub const fn new(data: Vec<u8>) -> Self {
-        Self { version: WALLET_STATE_MESSAGE_VERSION as u16, data }
+    pub const fn new(utxos: Vec<u8>, tracked_txs: Vec<u8>, pending_pegouts: Vec<u8>) -> Self {
+        Self { version: WALLET_STATE_MESSAGE_VERSION as u16, utxos, tracked_txs, pending_pegouts }
     }
 }
 
@@ -372,9 +385,17 @@ impl FrostProtoMessage {
                 buf.put_slice(receiver_bytes); // Receiver bytes
             }
             FrostProtoMessageKind::WalletState(resource) => {
-                // serialize the data
-                buf.put_u64_le(resource.data.len() as u64); // Use u64 to support larger data sizes
-                buf.put_slice(&resource.data);
+                // serialize the utxos
+                buf.put_u64_le(resource.utxos.len() as u64); // Use u64 to support larger utxos sizes
+                buf.put_slice(&resource.utxos);
+
+                // serialize the tracked txs
+                buf.put_u64_le(resource.tracked_txs.len() as u64); // Use u64 to support larger tracked txs sizes
+                buf.put_slice(&resource.tracked_txs);
+
+                // serialize the pending pegouts
+                buf.put_u64_le(resource.pending_pegouts.len() as u64); // Use u64 to support larger pending pegouts sizes
+                buf.put_slice(&resource.pending_pegouts);
             }
         }
         buf
@@ -593,13 +614,27 @@ impl FrostProtoMessage {
                 FrostProtoMessageKind::Healthcheck(HealthcheckRequest { sender, receiver })
             }
             FrostProtoMessageId::WalletState => {
-                // wallet state
-                let wallet_state_len = u64::from_le_bytes(buf[..8].try_into().unwrap()) as usize;
+                // utxos
+                let utxos_len = u64::from_le_bytes(buf[..8].try_into().unwrap()) as usize;
                 buf.advance(8);
-                let wallet_state = buf[..wallet_state_len].to_vec();
-                buf.advance(wallet_state_len);
+                let utxos = buf[..utxos_len].to_vec();
+                buf.advance(utxos_len);
 
-                FrostProtoMessageKind::WalletState(WalletStateRequest::new(wallet_state))
+                // tracked txs
+                let tracked_txs_len = u64::from_le_bytes(buf[..8].try_into().unwrap()) as usize;
+                buf.advance(8);
+                let tracked_txs = buf[..tracked_txs_len].to_vec();
+
+                // pending pegouts
+                let pending_pegouts_len = u64::from_le_bytes(buf[..8].try_into().unwrap()) as usize;
+                buf.advance(8);
+                let pending_pegouts = buf[..pending_pegouts_len].to_vec();
+
+                FrostProtoMessageKind::WalletState(WalletStateRequest::new(
+                    utxos,
+                    tracked_txs,
+                    pending_pegouts,
+                ))
             }
         };
         Some(Self { message_type, message })

--- a/crates/net/network/src/frost/messages.rs
+++ b/crates/net/network/src/frost/messages.rs
@@ -624,11 +624,13 @@ impl FrostProtoMessage {
                 let tracked_txs_len = u64::from_le_bytes(buf[..8].try_into().unwrap()) as usize;
                 buf.advance(8);
                 let tracked_txs = buf[..tracked_txs_len].to_vec();
+                buf.advance(tracked_txs_len);
 
                 // pending pegouts
                 let pending_pegouts_len = u64::from_le_bytes(buf[..8].try_into().unwrap()) as usize;
                 buf.advance(8);
                 let pending_pegouts = buf[..pending_pegouts_len].to_vec();
+                buf.advance(pending_pegouts_len);
 
                 FrostProtoMessageKind::WalletState(WalletStateRequest::new(
                     utxos,

--- a/crates/net/network/src/frost/messages.rs
+++ b/crates/net/network/src/frost/messages.rs
@@ -649,7 +649,7 @@ mod tests {
     use super::{
         DkgRequest, FrostProtoMessage, FrostProtoMessageId, FrostProtoMessageKind, SignRequest,
     };
-    use super::{HealthcheckRequest, UtxoRequest};
+    use super::{HealthcheckRequest, UtxoRequest, WalletStateRequest};
     use itertools::Itertools;
     #[allow(unused_imports)]
     use reth_primitives::SealedBlock;
@@ -807,6 +807,48 @@ mod tests {
             );
         } else {
             panic!("Decoded message is not a Healthcheck Message");
+        }
+    }
+
+    #[test]
+    fn test_wallet_state_encode_decode() {
+        let utxos = "utxos".to_owned();
+        let tracked_txs = "tracked_txs".to_owned();
+        let pending_pegouts = "pending_pegouts".to_owned();
+
+        let utxos_bytes = utxos.bytes().collect_vec();
+        let tracked_txs_bytes = tracked_txs.bytes().collect_vec();
+        let pending_pegouts_bytes = pending_pegouts.bytes().collect_vec();
+
+        let message = FrostProtoMessage {
+            message_type: FrostProtoMessageId::WalletState,
+            message: FrostProtoMessageKind::WalletState(WalletStateRequest::new(
+                utxos_bytes,
+                tracked_txs_bytes,
+                pending_pegouts_bytes,
+            )),
+        };
+
+        // Encode the message
+        let encoded_bytes = message.encoded();
+
+        // Simulate receiving the encoded bytes and decoding them
+        let mut encoded_bytes_slice: &[u8] = &encoded_bytes;
+        let decoded_message = FrostProtoMessage::decode_message(&mut encoded_bytes_slice)
+            .expect("Failed to decode WalletStateMessage");
+
+        // Verify that the decoded message matches the original message
+        if let FrostProtoMessageKind::WalletState(wallet_state_request) = decoded_message.message {
+            let decoded_utxos = String::from_utf8(wallet_state_request.utxos).unwrap();
+            let decoded_tracked_txs = String::from_utf8(wallet_state_request.tracked_txs).unwrap();
+            let decoded_pending_pegouts =
+                String::from_utf8(wallet_state_request.pending_pegouts).unwrap();
+
+            assert_eq!(decoded_utxos, utxos, "utxos does not match");
+            assert_eq!(decoded_tracked_txs, tracked_txs, "tracked_txs does not match");
+            assert_eq!(decoded_pending_pegouts, pending_pegouts, "pending_pegouts does not match");
+        } else {
+            panic!("Decoded message is not a WalletState Message");
         }
     }
 }

--- a/crates/net/network/src/frost/mod.rs
+++ b/crates/net/network/src/frost/mod.rs
@@ -21,8 +21,8 @@ pub enum PeerMessageResponse {
     Dkg(DkgResponse),
     /// Signing response
     Signing(SigningResponse),
-    /// UTXO related responses
-    Utxo(UtxoSetResponse),
+    /// Wallet state related response
+    WalletState(WalletStateResponse),
     /// Healtcheck response
     Healthcheck(HealthcheckResponse),
 }
@@ -32,7 +32,7 @@ impl fmt::Display for PeerMessageResponse {
         match self {
             Self::Dkg(response) => write!(f, "DKG Response: {}", response),
             Self::Signing(response) => write!(f, "Signing Response: {}", response),
-            Self::Utxo(response) => write!(f, "Utxo Response: {}", response),
+            Self::WalletState(response) => write!(f, "Wallet state Response: {}", response),
             Self::Healthcheck(response) => {
                 write!(f, "Health Response: {:?}", response)
             }
@@ -73,6 +73,19 @@ pub struct UtxoSetResponse {
 impl fmt::Display for UtxoSetResponse {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Utxo data Size: {} bytes", self.data.len())
+    }
+}
+
+/// Response structure for internal communication
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct WalletStateResponse {
+    /// Wallet State Data (Compressed and Serialized)
+    pub data: Vec<u8>,
+}
+
+impl fmt::Display for WalletStateResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Wallet State Data Size: {} bytes", self.data.len())
     }
 }
 

--- a/crates/net/network/src/frost/mod.rs
+++ b/crates/net/network/src/frost/mod.rs
@@ -77,16 +77,28 @@ impl fmt::Display for UtxoSetResponse {
 }
 
 /// Response structure for internal communication
-// TODO: add more fields to represent full wallet state
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct WalletStateResponse {
-    /// Wallet State Data (Compressed and Serialized)
-    pub data: Vec<u8>,
+    /// Serialized utxos
+    pub utxos: Vec<u8>,
+    /// Serialized tracked transactions
+    pub tracked_txs: Vec<u8>,
+    /// Serialized pending pegouts  
+    pub pending_pegouts: Vec<u8>,
 }
 
 impl fmt::Display for WalletStateResponse {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Wallet State Data Size: {} bytes", self.data.len())
+        write!(
+            f,
+            "WalletStateResponse:\n\
+            - UTXOs: {} bytes\n\
+            - Tracked Transactions: {} bytes\n\
+            - Pending Pegouts: {} bytes",
+            self.utxos.len(),
+            self.tracked_txs.len(),
+            self.pending_pegouts.len()
+        )
     }
 }
 

--- a/crates/net/network/src/frost/mod.rs
+++ b/crates/net/network/src/frost/mod.rs
@@ -21,7 +21,7 @@ pub enum PeerMessageResponse {
     Dkg(DkgResponse),
     /// Signing response
     Signing(SigningResponse),
-    /// Wallet state related response
+    /// Wallet state response
     WalletState(WalletStateResponse),
     /// Healtcheck response
     Healthcheck(HealthcheckResponse),
@@ -77,6 +77,7 @@ impl fmt::Display for UtxoSetResponse {
 }
 
 /// Response structure for internal communication
+// TODO: add more fields to represent full wallet state
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct WalletStateResponse {
     /// Wallet State Data (Compressed and Serialized)

--- a/crates/net/network/src/frost/protocol.rs
+++ b/crates/net/network/src/frost/protocol.rs
@@ -17,8 +17,9 @@ use tracing::{error, info, warn};
 
 use crate::{
     frost::{
-        messages::DkgRequest, DkgEventResponseType, DkgResponse, SigningEventResponseType,
-        SigningResponse,
+        messages::{DkgRequest, WalletStateRequest},
+        DkgEventResponseType, DkgResponse, SigningEventResponseType, SigningResponse,
+        WalletStateResponse,
     },
     protocol::{ConnectionHandler, OnNotSupported, ProtocolHandler},
 };
@@ -28,7 +29,6 @@ use super::{
         FrostProtoMessage, FrostProtoMessageKind, HealthcheckRequest, SignRequest, UtxoRequest,
     },
     FrostPeerCommand, FrostProtocolEvent, HealthcheckResponse, PeerMessageResponse,
-    UtxoSetResponse,
 };
 
 /// Frost Protocol Handler
@@ -264,10 +264,10 @@ impl Stream for FrostProtoConnection {
                             }
                         }
                     }
-                    PeerMessageResponse::Utxo(utxo_response) => {
-                        let UtxoSetResponse { data } = utxo_response;
-                        let req = UtxoRequest::new(data);
-                        Poll::Ready(Some(FrostProtoMessage::utxo_message(req).encoded()))
+                    PeerMessageResponse::WalletState(wallet_state_response) => {
+                        let WalletStateResponse { data } = wallet_state_response;
+                        let req = WalletStateRequest::new(data);
+                        Poll::Ready(Some(FrostProtoMessage::wallet_state_message(req).encoded()))
                     }
                 },
             };
@@ -286,7 +286,7 @@ impl Stream for FrostProtoConnection {
 
         // react on message type sent to us by another peer
         // The frost manager will handle this req (often by forwarding it to another task) and
-        // the a response will be send on command_rx for us to send back to another
+        // the response will be sent on command_rx for us to send back to another
         // peer
         let protocol_events_tx = this.protocol_events_tx.clone();
         info!(target: "network::frost::protocol", "Receivers count: {}", protocol_events_tx.receiver_count());
@@ -407,12 +407,16 @@ impl Stream for FrostProtoConnection {
                     error!(target: "network::frost::protocol", "Failed to forward received CoordinatorRound2SigningPackage message. Error = {:?}", e);
                 }
             }
-            FrostProtoMessageKind::Utxo(data) => {
+            FrostProtoMessageKind::WalletState(data) => {
                 let _ = protocol_events_tx.send(FrostProtocolEvent::PeerMessage {
-                    response: PeerMessageResponse::Utxo(UtxoSetResponse { data: data.data }),
+                    response: PeerMessageResponse::WalletState(WalletStateResponse {
+                        data: data.data,
+                    }),
                     peer_id: this.peer_id,
                 });
             }
+            // deprecated: TODO remove
+            FrostProtoMessageKind::Utxo(_data) => {}
         }
 
         Poll::Pending

--- a/crates/net/network/src/frost/protocol.rs
+++ b/crates/net/network/src/frost/protocol.rs
@@ -25,9 +25,7 @@ use crate::{
 };
 
 use super::{
-    messages::{
-        FrostProtoMessage, FrostProtoMessageKind, HealthcheckRequest, SignRequest, UtxoRequest,
-    },
+    messages::{FrostProtoMessage, FrostProtoMessageKind, HealthcheckRequest, SignRequest},
     FrostPeerCommand, FrostProtocolEvent, HealthcheckResponse, PeerMessageResponse,
 };
 

--- a/crates/net/network/src/frost/protocol.rs
+++ b/crates/net/network/src/frost/protocol.rs
@@ -265,8 +265,9 @@ impl Stream for FrostProtoConnection {
                         }
                     }
                     PeerMessageResponse::WalletState(wallet_state_response) => {
-                        let WalletStateResponse { data } = wallet_state_response;
-                        let req = WalletStateRequest::new(data);
+                        let WalletStateResponse { utxos, tracked_txs, pending_pegouts } =
+                            wallet_state_response;
+                        let req = WalletStateRequest::new(utxos, tracked_txs, pending_pegouts);
                         Poll::Ready(Some(FrostProtoMessage::wallet_state_message(req).encoded()))
                     }
                 },
@@ -410,7 +411,9 @@ impl Stream for FrostProtoConnection {
             FrostProtoMessageKind::WalletState(data) => {
                 let _ = protocol_events_tx.send(FrostProtocolEvent::PeerMessage {
                     response: PeerMessageResponse::WalletState(WalletStateResponse {
-                        data: data.data,
+                        utxos: data.utxos,
+                        tracked_txs: data.tracked_txs,
+                        pending_pegouts: data.pending_pegouts,
                     }),
                     peer_id: this.peer_id,
                 });


### PR DESCRIPTION
this pr wires up the wallet state sync ability but does not "turn it on": there's no task that invokes `sync_wallet_state()`