### PR TITLE
chore(btc_server): bump tokio to 1.30.0

### DIFF
--- a/bin/btc-server/Cargo.toml
+++ b/bin/btc-server/Cargo.toml
@@ -56,7 +56,7 @@ tempfile = "3.6.0"
 thiserror = "1.0.43"
 
 # for tonic
-tokio = { version = "1.37.0", features = ["full"] }
+tokio = { version = "1.38.0", features = ["full"] }
 
 #config
 toml = "0.8.4"


### PR DESCRIPTION
Fixes security alert: https://github.com/botanix-labs/Macbeth/security/dependabot/5