### PR TITLE
Feature/btc server track mempool drops

### DIFF
--- a/bin/btc-server/src/coin_selection.rs
+++ b/bin/btc-server/src/coin_selection.rs
@@ -197,7 +197,7 @@ mod tests {
     fn should_take_fee_out_of_outputs() {
         let app = setup();
         // Add 15 utxos
-        let tx = create_tx(15, 1, None);
+        let tx = create_tx(15, 1, None, false);
         let change_script = random_p2tr_keyspend_script();
         let output_script = random_p2wpkh_script();
         let mut utxos = vec![];

--- a/bin/btc-server/src/database.rs
+++ b/bin/btc-server/src/database.rs
@@ -965,7 +965,7 @@ mod tests {
 
     #[test]
     fn from_db_utxo_to_rpc_utxo() {
-        let tx = create_tx(1, 1, None);
+        let tx = create_tx(1, 1, None, false);
         let utxo = Utxo::new(
             OutPoint::new(tx.txid(), 0),
             tx.output.get(0).expect("one output").clone(),
@@ -990,7 +990,7 @@ mod tests {
     fn test_storing_single_utxo() {
         let (db, _temp_dir) = setup_db();
 
-        let tx = create_tx(2, 1, None);
+        let tx = create_tx(2, 1, None, false);
         let utxo = Utxo::new(
             OutPoint::new(tx.txid(), 0),
             tx.output.get(0).expect("one output").clone(),
@@ -1009,7 +1009,7 @@ mod tests {
         let num_txs = 5;
         let mut utxos = vec![];
         for _ in 0..num_txs {
-            let tx = create_tx(2, 1, None);
+            let tx = create_tx(2, 1, None, false);
             let utxo = Utxo::new(
                 OutPoint::new(tx.txid(), 0),
                 tx.output.get(0).expect("one output").clone(),
@@ -1042,7 +1042,7 @@ mod tests {
         let num_txs = 5;
         let mut utxos = vec![];
         for _ in 0..num_txs {
-            let tx = create_tx(1, 1, None);
+            let tx = create_tx(1, 1, None, false);
             let utxo = Utxo::new(
                 OutPoint::new(tx.txid(), 0),
                 tx.output.get(0).expect("one output").clone(),
@@ -1067,7 +1067,7 @@ mod tests {
         let num_txs = 5;
         let mut utxos = vec![];
         for _ in 0..num_txs {
-            let tx = create_tx(1, 1, None);
+            let tx = create_tx(1, 1, None, false);
             let utxo = Utxo::new(
                 OutPoint::new(tx.txid(), 0),
                 tx.output.get(0).expect("one output").clone(),
@@ -1099,7 +1099,7 @@ mod tests {
         let num_txs = 5;
         let mut utxos = vec![];
         for _ in 0..num_txs {
-            let tx = create_tx(2, 1, None);
+            let tx = create_tx(2, 1, None, false);
             let utxo = Utxo::new(
                 OutPoint::new(tx.txid(), 0),
                 tx.output.get(0).expect("one output").clone(),
@@ -1132,7 +1132,7 @@ mod tests {
         let num_txs = 5;
         let mut utxos = vec![];
         for _ in 0..num_txs {
-            let tx = create_tx(2, 1, None);
+            let tx = create_tx(2, 1, None, false);
             let utxo = Utxo::new(
                 OutPoint::new(tx.txid(), 0),
                 tx.output.get(0).expect("one output").clone(),
@@ -1153,7 +1153,7 @@ mod tests {
         assert_eq!(merkle_root, merkle_root2);
 
         // Adding an additional utxo should change the merkle root
-        let tx = create_tx(2, 1, None);
+        let tx = create_tx(2, 1, None, false);
         let utxo = Utxo::new(
             OutPoint::new(tx.txid(), 1),
             tx.output.get(0).expect("one output").clone(),
@@ -1170,7 +1170,7 @@ mod tests {
     fn test_reading_session_ids() {
         let (db, _temp_dir) = setup_db();
 
-        let tx = create_tx(2, 1, None);
+        let tx = create_tx(2, 1, None, false);
         let psbt = Psbt::from_unsigned_tx(tx).unwrap();
         let signing_session_id: [u8; 32] = [0; 32];
         db.update_psbt(&signing_session_id, &psbt).unwrap();
@@ -1184,7 +1184,7 @@ mod tests {
     fn test_getting_session_id_status() {
         let (db, _temp_dir) = setup_db();
 
-        let tx = create_tx(2, 1, None);
+        let tx = create_tx(2, 1, None, false);
         let psbt = Psbt::from_unsigned_tx(tx).unwrap();
         let signing_session_id: [u8; 32] = [0; 32];
         db.update_psbt(&signing_session_id, &psbt).unwrap();
@@ -1210,7 +1210,7 @@ mod tests {
     #[test]
     fn test_tracked_txs_e2e() {
         let (db, _temp_dir) = setup_db();
-        let tx = create_tx(5, 2, None);
+        let tx = create_tx(5, 2, None, false);
         let pegout_reqs = vec![PegoutRequest {
             spk: tx.output[0].script_pubkey.clone(),
             value: tx.output[0].value,
@@ -1250,7 +1250,7 @@ mod tests {
         let num_txs = 5;
         let mut txs = vec![];
         for _ in 0..num_txs {
-            let tx = create_tx(5, 2, None);
+            let tx = create_tx(5, 2, None, false);
             let pegout_reqs = vec![PegoutRequest {
                 spk: tx.output[0].script_pubkey.clone(),
                 value: tx.output[0].value,
@@ -1287,7 +1287,7 @@ mod tests {
         let num_txs = 5;
         let mut txs = vec![];
         for _ in 0..num_txs {
-            let tx = create_tx(5, 2, None);
+            let tx = create_tx(5, 2, None, false);
             let pegout_reqs = vec![PegoutRequest {
                 spk: tx.output[0].script_pubkey.clone(),
                 value: tx.output[0].value,
@@ -1320,7 +1320,7 @@ mod tests {
     #[test]
     fn test_update_tracked_tx_merkle_root() {
         let (db, _temp_dir) = setup_db();
-        let tx = create_tx(5, 2, None);
+        let tx = create_tx(5, 2, None, false);
         let pegout_reqs = vec![PegoutRequest {
             spk: tx.output[0].script_pubkey.clone(),
             value: tx.output[0].value,
@@ -1346,7 +1346,7 @@ mod tests {
         let merkle_root2 = db.get_tracked_tx_merkle_root().unwrap().unwrap();
         assert_eq!(merkle_root, merkle_root2);
 
-        let tx2 = create_tx(5, 2, None);
+        let tx2 = create_tx(5, 2, None, false);
         let pegout_reqs = vec![PegoutRequest {
             spk: tx2.output[0].script_pubkey.clone(),
             value: tx.output[0].value,
@@ -1378,7 +1378,7 @@ mod tests {
 
         assert!(merkle_root.is_none());
 
-        let tx = create_tx(5, 2, None);
+        let tx = create_tx(5, 2, None, false);
 
         let pegout_req = PegoutRequest {
             botanix_height: 0,
@@ -1414,7 +1414,7 @@ mod tests {
     #[test]
     fn clear_pending_pegouts_should_clear_db() {
         let (db, _temp_dir) = setup_db();
-        let tx = create_tx(5, 2, None);
+        let tx = create_tx(5, 2, None, false);
 
         let pegout_req = PegoutRequest {
             botanix_height: 0,
@@ -1435,7 +1435,7 @@ mod tests {
     #[test]
     fn reset_pending_pegouts_should_clear_db_and_readd() {
         let (db, _temp_dir) = setup_db();
-        let tx = create_tx(5, 2, None);
+        let tx = create_tx(5, 2, None, false);
 
         let pegout_req = PegoutRequest {
             botanix_height: 0,
@@ -1446,7 +1446,7 @@ mod tests {
         db.store_pending_pegout(&pegout_req).unwrap();
         db.flush().unwrap();
 
-        let tx2 = create_tx(5, 2, None);
+        let tx2 = create_tx(5, 2, None, false);
         let pegout_req2 = PegoutRequest {
             botanix_height: 0,
             id: create_random_pegout_id(),
@@ -1464,7 +1464,7 @@ mod tests {
     #[test]
     fn clear_tracked_txs_should_clear_db() {
         let (db, _temp_dir) = setup_db();
-        let tx = create_tx(5, 2, None);
+        let tx = create_tx(5, 2, None, false);
         let pegout_requests = vec![PegoutRequest {
             spk: tx.output[0].script_pubkey.clone(),
             value: tx.output[0].value,
@@ -1492,7 +1492,7 @@ mod tests {
     #[test]
     fn reset_tracked_txs_should_clear_db_and_readd() {
         let (db, _temp_dir) = setup_db();
-        let tx = create_tx(5, 2, None);
+        let tx = create_tx(5, 2, None, false);
         let pegout_requests = vec![PegoutRequest {
             spk: tx.output[0].script_pubkey.clone(),
             value: tx.output[0].value,
@@ -1510,7 +1510,7 @@ mod tests {
         db.store_tracked_tx(&tracked_tx).unwrap();
         db.flush().unwrap();
 
-        let tx2 = create_tx(5, 2, None);
+        let tx2 = create_tx(5, 2, None, false);
         let pegout_requests2 = vec![PegoutRequest {
             spk: tx2.output[0].script_pubkey.clone(),
             value: tx2.output[0].value,

--- a/bin/btc-server/src/main.rs
+++ b/bin/btc-server/src/main.rs
@@ -1195,7 +1195,7 @@ mod test {
 
         // add a couple of pegin utxos to spend
         for _ in 0..10 {
-            let dummy_tx = create_tx(1, 1, None);
+            let dummy_tx = create_tx(1, 1, None, false);
             let utxo =
                 Utxo::new(dummy_tx.input[0].previous_output, dummy_tx.output[0].clone(), None);
             app.add_pegins(&[&utxo]).expect("valid pegin utxo");
@@ -1384,7 +1384,7 @@ mod test {
 
         // now generate some random utxos and save them
         for _ in 0..3 {
-            let dummy_tx = create_tx(1, 1, None);
+            let dummy_tx = create_tx(1, 1, None, false);
             let utxo =
                 Utxo::new(dummy_tx.input[0].previous_output, dummy_tx.output[0].clone(), None);
             app.db.store_utxos(&[&utxo]).expect("Failed to store UTXO");
@@ -1608,7 +1608,7 @@ mod test {
 
         // now generate some random utxos and save them
         for _ in 0..3 {
-            let dummy_tx = create_tx(1, 1, None);
+            let dummy_tx = create_tx(1, 1, None, false);
             let utxo =
                 Utxo::new(dummy_tx.input[0].previous_output, dummy_tx.output[0].clone(), None);
             app.db.store_utxos(&[&utxo]).expect("Failed to store UTXO");

--- a/bin/btc-server/src/pegout_scheduler.rs
+++ b/bin/btc-server/src/pegout_scheduler.rs
@@ -819,7 +819,7 @@ mod tests {
         frost_id,
         test_utils::test_utils::{
             create_block, create_random_pegout_id, create_tx, pegout_requests_from_tx,
-            random_p2wpkh_script, setup_db, trusted_dealer_setup,
+            random_p2wpkh_script, setup_db, trusted_dealer_setup, MockBitcoind,
         },
     };
 
@@ -830,7 +830,7 @@ mod tests {
 
     #[test]
     fn tracked_tx_utils() {
-        let tx = create_tx(0, 0, None);
+        let tx = create_tx(0, 0, None, false);
         let tx = Tx {
             txid: tx.txid(),
             tx,
@@ -845,7 +845,7 @@ mod tests {
         assert_eq!(tx.change().count(), 0);
 
         // 5 inputs, 2 outputs
-        let dummy_tx = create_tx(5, 2, None);
+        let dummy_tx = create_tx(5, 2, None, false);
         assert_eq!(dummy_tx.input.len(), 5);
         assert_eq!(dummy_tx.output.len(), 2);
 
@@ -876,7 +876,7 @@ mod tests {
         db.set_pubkey_package(pk_package).expect("set public key package");
         db.set_key_package(key_package).expect("set key package");
 
-        let tx = create_tx(3, 3, None);
+        let tx = create_tx(3, 3, None, false);
         let pegout_idxs = vec![0, 1];
         let change_idxs = vec![2];
 
@@ -944,8 +944,8 @@ mod tests {
 
         let mut pegout_scheduler =
             PegoutScheduler::new(101, vec![], bitcoin::BlockHash::all_zeros(), db);
-        let tx1 = create_tx(3, 3, None);
-        let tx2 = create_tx(3, 3, None);
+        let tx1 = create_tx(3, 3, None, false);
+        let tx2 = create_tx(3, 3, None, false);
         let txs = vec![tx1.clone(), tx2.clone()];
         let pegouts1 = pegout_requests_from_tx(&tx1, &[0, 1]);
         let pegouts2 = pegout_requests_from_tx(&tx2, &[0, 1]);
@@ -986,8 +986,8 @@ mod tests {
 
         let mut pegout_scheduler =
             PegoutScheduler::new(101, vec![], bitcoin::BlockHash::all_zeros(), db.clone());
-        let tx1 = create_tx(3, 3, Some(change_output.clone()));
-        let tx2 = create_tx(3, 3, Some(change_output));
+        let tx1 = create_tx(3, 3, Some(change_output.clone()), false);
+        let tx2 = create_tx(3, 3, Some(change_output), false);
         let txs = vec![tx1.clone(), tx2.clone()];
         let pegouts1 = pegout_requests_from_tx(&tx1, &[0, 1, 2]);
         let pegouts2 = pegout_requests_from_tx(&tx2, &[0, 1, 2]);
@@ -1033,7 +1033,7 @@ mod tests {
 
         let mut pegout_scheduler =
             PegoutScheduler::new(101, vec![], bitcoin::BlockHash::all_zeros(), db.clone());
-        let tx = create_tx(3, 1, Some(change_output));
+        let tx = create_tx(3, 1, Some(change_output), false);
         let pegouts = pegout_requests_from_tx(&tx, &[0]);
         pegout_scheduler.add_tx(tx.clone(), &pegouts, SystemTime::now());
 
@@ -1069,7 +1069,7 @@ mod tests {
 
         let mut pegout_scheduler =
             PegoutScheduler::new(101, vec![], bitcoin::BlockHash::all_zeros(), db.clone());
-        let tx = create_tx(3, 2, None);
+        let tx = create_tx(3, 2, None, false);
         // Here we should be tracking indices 0 and 1.
         // But we are tracking 0 as a pegout, therefore output 1 is going to be mistaken as change
         let pegouts = pegout_requests_from_tx(&tx, &[0]);
@@ -1112,6 +1112,7 @@ mod tests {
             3,
             2,
             Some(TxOut { value: Amount::from_sat(1000), script_pubkey: incorrect_change_spk }),
+            false,
         );
 
         let pegouts = pegout_requests_from_tx(&tx, &[0, 1]);
@@ -1138,7 +1139,7 @@ mod tests {
     #[test]
     fn start_with_existing_tracked_txs() {
         let db = setup_db().0;
-        let tx = create_tx(1, 2, None);
+        let tx = create_tx(1, 2, None, false);
         let pegouts = pegout_requests_from_tx(&tx, &[0]);
         let tracked_tx = Tx {
             txid: tx.txid(),
@@ -1176,7 +1177,7 @@ mod tests {
         let mut last_block_hash = bitcoin::BlockHash::all_zeros();
 
         for _ in 0..100 {
-            let tx = create_tx(1, 2, Some(change_output.clone()));
+            let tx = create_tx(1, 2, Some(change_output.clone()), false);
             let pegouts = pegout_requests_from_tx(&tx, &[0]);
             pegout_scheduler.add_tx(tx.clone(), &pegouts, SystemTime::now());
             let block = create_block(vec![tx], last_block_hash);
@@ -1195,7 +1196,7 @@ mod tests {
     #[test]
     fn test_un_track_tx() {
         let db = setup_db().0;
-        let tx = create_tx(1, 2, None);
+        let tx = create_tx(1, 2, None, false);
         let pegouts = pegout_requests_from_tx(&tx, &[0]);
         let tracked_tx = Tx {
             txid: tx.txid(),
@@ -1229,7 +1230,7 @@ mod tests {
         let db = setup_db().0;
         let mut pegout_scheduler =
             PegoutScheduler::new(1, vec![], bitcoin::BlockHash::all_zeros(), db.clone());
-        let tx = create_tx(1, 2, None);
+        let tx = create_tx(1, 2, None, false);
         let pegouts = pegout_requests_from_tx(&tx, &[0]);
 
         let tracked_tx = pegout_scheduler.add_tx(tx.clone(), &pegouts, SystemTime::now());
@@ -1255,7 +1256,7 @@ mod tests {
     #[test]
     fn tracked_pegout_request_ids_should_return_ids() {
         let db = setup_db().0;
-        let tx = create_tx(1, 2, None);
+        let tx = create_tx(1, 2, None, false);
         let pegouts = pegout_requests_from_tx(&tx, &[0]);
         let tracked_tx = Tx {
             txid: tx.txid(),
@@ -1271,5 +1272,60 @@ mod tests {
         let pegout_request_ids = pegout_scheduler.tracked_pegout_request_ids();
         assert_eq!(pegout_request_ids.len(), 1);
         assert_eq!(pegout_request_ids[0], pegouts[0].id);
+    }
+
+    #[test]
+    fn track_mempool_should_add_back_pegout_when_still_in_mempool() {
+        let db = setup_db().0;
+        let mut pegout_scheduler =
+            PegoutScheduler::new(101, vec![], bitcoin::BlockHash::all_zeros(), db.clone());
+        let tx = create_tx(1, 2, None, false);
+        let pegouts = pegout_requests_from_tx(&tx, &[0]);
+        pegout_scheduler.add_tx(tx.clone(), &pegouts, SystemTime::now());
+
+        let mock_bitcoind = MockBitcoind::new();
+        let mut checkpoint = mock_bitcoind
+            .get_block_header_info(&bitcoin::BlockHash::all_zeros())
+            .expect("valid checkpoint");
+        // increase time for checkpoint block so tracked tx is older
+        checkpoint.time = checkpoint.time + 5;
+
+        let result = pegout_scheduler.track_mempool(&mock_bitcoind, checkpoint);
+        assert!(result.is_ok());
+
+        // assert the pegout was added to pending pegouts
+        let pending_pegouts = db.get_pending_pegouts().expect("pending pegouts exist");
+        assert_eq!(pending_pegouts.len(), 1);
+        assert_eq!(pending_pegouts[0], pegouts[0]);
+    }
+
+    #[test]
+    fn track_mempool_should_untrack_and_add_back_pegout_when_not_in_mempool() {
+        let db = setup_db().0;
+        let mut pegout_scheduler =
+            PegoutScheduler::new(101, vec![], bitcoin::BlockHash::all_zeros(), db.clone());
+        // mock bitcoind will trigger error path for `getmempoolentry` for a specific txid
+        // so pass true to create_tx() to make it deterministic which is
+        // "c5473905cc714c8b63f229246478e4e85faf32b96babffe4bba2ba8ddc05be3e" for this test
+        let tx = create_tx(1, 2, None, true);
+        let pegouts = pegout_requests_from_tx(&tx, &[0]);
+        pegout_scheduler.add_tx(tx.clone(), &pegouts, SystemTime::now());
+
+        let mock_bitcoind = MockBitcoind::new();
+        let mut checkpoint = mock_bitcoind
+            .get_block_header_info(&bitcoin::BlockHash::all_zeros())
+            .expect("valid checkpoint");
+        // increase time for checkpoint block so tracked tx is older
+        checkpoint.time = checkpoint.time + 5;
+
+        let result = pegout_scheduler.track_mempool(&mock_bitcoind, checkpoint);
+        assert!(result.is_ok());
+
+        // assert the pegout was added to pending pegouts
+        let pending_pegouts = db.get_pending_pegouts().expect("pending pegouts exist");
+        assert_eq!(pending_pegouts.len(), 1);
+
+        // assert there are no tracked txs
+        assert_eq!(pegout_scheduler.txs.len(), 0);
     }
 }

--- a/bin/btc-server/src/pegout_scheduler.rs
+++ b/bin/btc-server/src/pegout_scheduler.rs
@@ -599,6 +599,62 @@ impl PegoutScheduler {
         self.last_blocks.push_back(BlockInfo { hash, relevant_txs, relevant_inputs });
     }
 
+    /// Check if tx has been dropped from the mempool or reorged
+    ///
+    /// Steps:
+    /// 1) Determine the timestamp of the checkpoint block
+    /// 2) Get txs older than timestamp
+    /// 3) Check if tx still exists
+    /// 4) If not, untrack the tx
+    /// 5) and add the pegout back to the pending pegout set
+    pub fn track_mempool(
+        &mut self,
+        bitcoind: &impl RpcApi,
+        checkpoint: bitcoincore_rpc::json::GetBlockHeaderResult,
+    ) -> Result<(), SyncError> {
+        // 1) Determine the timestamp of the checkpoint block
+        let cp_time = checkpoint.block_time();
+        // 2) Get txs older than timestamp
+        let maybe_dropped_txs = self
+            .txs
+            .values()
+            .filter(|tx| tx.created < cp_time)
+            .map(|tx| tx.txid)
+            .collect::<Vec<_>>();
+        // 3) Check if tx still exists
+        for txid in maybe_dropped_txs {
+            // TODO(scott): first check if tx is in the `finalized outputs` if we implement this
+            // see Updates section in `https://github.com/botanix-labs/botanix/issues/701`
+
+            // a tx that is in a deeply confirmed block should have been handled already
+            // so check if still in mempool
+            let tx = self.txs.get(&txid).expect("tx should exist").clone();
+            match bitcoind.get_mempool_entry(&txid) {
+                Ok(_) => {
+                    warn!("Tx {} still in the mempool", txid);
+
+                    // add the tx back to pending pegouts so it can be retried
+                    // validate_psbt() will enforce the retry tx will have a conflicting input
+                    // so multiple outputs for the pegout are not created
+                    self.add_tx_back_to_pending(&tx)?;
+
+                    continue;
+                }
+                Err(e) => {
+                    // we've already checked if the tx is in the finalized outputs list
+                    // so it has been dropped or there was a reorg
+                    warn!("Tx {} not in the mempool or finalized outputs list: {}", txid, e);
+                    // 4) untrack the tx
+                    self.un_track_tx(&txid)?;
+                    // 5) add the pegout back to the pending pegout set
+                    self.add_tx_back_to_pending(&tx)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     /// Sync with new blocks and stop when the [checkpoint] block gets finalized.
     ///
     /// We take the database closure to reduce coupling with database module.
@@ -693,25 +749,21 @@ impl PegoutScheduler {
             }
         }
 
-        // Here we can additionally check for txs are tracked for a long periods of time
-        // And no longer are in the mempool
-        // TODO
-
-        if self.last_finalized == checkpoint {
-            info!("Checkpoint reached: {}", checkpoint);
-            Ok(())
-        } else {
-            let last_info = bitcoind.get_block_header_info(&self.last_finalized);
-            let cp_info = bitcoind.get_block_header_info(&checkpoint);
-            if let (Ok(last), Ok(cp)) = (last_info, cp_info) {
-                debug!(
-                    "Checkpoint not reached: last={:?}, checkpoint={:?}, tip={:?}",
-                    last, cp, tip
-                );
+        let last_info = bitcoind.get_block_header_info(&self.last_finalized);
+        let cp_info = bitcoind.get_block_header_info(&checkpoint);
+        if let (Ok(last), Ok(cp)) = (last_info, cp_info) {
+            if self.last_finalized == checkpoint {
+                info!("Checkpoint reached: {}", checkpoint);
+                return Ok(());
             }
-            update_telemetry_error!(telemetry, SyncError::CheckPointNotReached);
-            Err(SyncError::CheckPointNotReached)
+
+            debug!("Checkpoint not reached: last={:?}, checkpoint={:?}, tip={:?}", last, cp, tip);
+
+            // handle txs that are still in the mempool, have been dropped or there was a reorg
+            self.track_mempool(bitcoind, cp)?;
         }
+        update_telemetry_error!(telemetry, SyncError::CheckPointNotReached);
+        Err(SyncError::CheckPointNotReached)
     }
 }
 

--- a/bin/btc-server/src/test_utils.rs
+++ b/bin/btc-server/src/test_utils.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 pub mod test_utils {
+    use crate::serde::ser::Error;
     use std::{
         collections::{BTreeMap, HashMap},
         sync::Arc,
@@ -76,9 +77,22 @@ pub mod test_utils {
         fn call<T: for<'a> serde::de::Deserialize<'a>>(
             &self,
             method: &str,
-            _params: &[serde_json::Value],
+            params: &[serde_json::Value],
         ) -> Result<T, bitcoincore_rpc::Error> {
-            println!("call: {:?}, {:?}", method, _params);
+            println!("call: {:?}, {:?}", method, params);
+
+            let mut raw_args = Vec::new();
+            if params.len() > 0 {
+                raw_args = params
+                    .iter()
+                    .map(|a| {
+                        let json_string = serde_json::to_string(a)?;
+                        serde_json::value::RawValue::from_string(json_string)
+                    })
+                    .map(|a| a.map_err(|e| bitcoincore_rpc::Error::Json(e)))
+                    .collect::<Result<Vec<_>, _>>()?;
+            }
+
             if method == "getblockchaininfo" {
                 return Ok(serde_json::from_str("{\"initialblockdownload\": false}").unwrap());
             }
@@ -99,7 +113,24 @@ pub mod test_utils {
                 let current_time =
                     SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
                 return Ok(serde_json::from_str(
-                    &format!("{{\"hash\": \"{block_hash}\", \"confirmations\": 1, \"height\": 1, \"version\": 1, \"version_hex\": \"01000000\", \"merkleroot\": \"{block_hash}\", \"time\": {current_time}, \"mediantime\": {current_time}, \"nonce\": 1, \"bits\": \"1d00ffff\", \"difficulty\": 1, \"chainwork\": \"0000000000000000000000000000000000000000000000000000000000000001\", \"nTx\": 1, \"previousblockhash\": \"{block_hash}\", \"nextblockhash\": \"{block_hash}\"}}",),
+                    &format!("{{\"hash\": \"{block_hash}\", \"confirmations\": 1, \"height\": 1, \"version\": 1, \"version_hex\": \"01000000\", \"merkleroot\": \"{block_hash}\", \"time\": {current_time}, \"mediantime\": {current_time}, \"nonce\": 1, \"bits\": \"1d00ffff\", \"difficulty\": 1, \"chainwork\": \"0000000000000000000000000000000000000000000000000000000000000001\", \"nTx\": 1, \"previousblockhash\": \"{block_hash}\", \"nextblockhash\": \"{block_hash}\"}}")
+                ).unwrap());
+            }
+            if method == "getmempoolentry" {
+                // error case is triggered by a specific txid
+                let error_txid = String::from(
+                    "c5473905cc714c8b63f229246478e4e85faf32b96babffe4bba2ba8ddc05be3e",
+                );
+                if raw_args.len() > 0 &&
+                    raw_args[0].get().to_string().trim_matches('\"') == error_txid
+                {
+                    return Err(bitcoincore_rpc::Error::Json(serde_json::error::Error::custom(
+                        "tx not in mempool",
+                    )));
+                }
+
+                let txid = Txid::from_byte_array([0u8; 32]);
+                return Ok(serde_json::from_str(&format!("{{\"size\": 250, \"weight\": 1000, \"time\": 1680000000, \"height\": 680000, \"descendantcount\": 2, \"descendantsize\": 500, \"ancestorcount\": 1, \"ancestorsize\": 250, \"wtxid\": \"{txid}\", \"fees\": {{\"base\": 1000, \"modified\": 1100, \"ancestor\": 1200, \"descendant\": 1300}}, \"depends\": [\"{txid}\"], \"spentby\": [\"{txid}\"], \"bip125-replaceable\": true, \"unbroadcast\": false}}",),
                 ).unwrap());
             }
 
@@ -168,6 +199,15 @@ pub mod test_utils {
         spk
     }
 
+    pub fn deterministic_p2wpkh_script() -> ScriptBuf {
+        let sk =
+            bitcoin::PrivateKey::from_wif("cV4G8b983VToX9qL5u82qKVNkVEMs3F3gSdf3s1ormG5S5vi2Gi6")
+                .unwrap();
+        let pk = sk.public_key(SECP256K1);
+        let spk = Address::p2wpkh(&pk, NETWORK).unwrap().script_pubkey();
+
+        spk
+    }
     pub fn setup() -> App<MockBitcoind> {
         let mock_bitcoind = MockBitcoind::new();
 
@@ -230,8 +270,17 @@ pub mod test_utils {
     }
 
     // Util function to create a btc tx with random inputs and outputs as defined by fn params
-    pub fn create_tx(num_inputs: usize, num_outputs: usize, change: Option<TxOut>) -> Transaction {
-        let txid = random_txid();
+    pub fn create_tx(
+        num_inputs: usize,
+        num_outputs: usize,
+        change: Option<TxOut>,
+        deterministic: bool, /* sets specific txid and p2wpkh_script so tx.txid is
+                              * deterministic which is useful in tests */
+    ) -> Transaction {
+        let txid = match deterministic {
+            true => Txid::from_byte_array([13u8; 32]),
+            false => random_txid(),
+        };
 
         let mut inputs = vec![];
         for i in 0..num_inputs {
@@ -246,9 +295,13 @@ pub mod test_utils {
 
         let mut outputs = vec![];
         for _ in 0..num_outputs {
+            let script_pubkey = match deterministic {
+                true => deterministic_p2wpkh_script(),
+                false => random_p2wpkh_script(),
+            };
             outputs.push(TxOut {
                 value: Amount::from_sat(1000),
-                script_pubkey: random_p2wpkh_script(),
+                script_pubkey: script_pubkey.clone(),
             });
         }
 
@@ -299,7 +352,7 @@ pub mod test_utils {
     }
 
     pub fn create_psbt(num_inputs: usize, num_outputs: usize, change: Option<TxOut>) -> Psbt {
-        let tx = create_tx(num_inputs, num_outputs, change);
+        let tx = create_tx(num_inputs, num_outputs, change, false);
 
         let weight = tx.weight();
         let fee = FEERATE * weight;

--- a/bin/btc-server/src/util.rs
+++ b/bin/btc-server/src/util.rs
@@ -1063,7 +1063,7 @@ mod util_tests {
         let (_, signing_commits2_0) = frost::round1::commit(key_package2.signing_share(), rng);
         let (_, signing_commits2_1) = frost::round1::commit(key_package2.signing_share(), rng);
 
-        let tx = create_tx(num_inputs, 1, None);
+        let tx = create_tx(num_inputs, 1, None, false);
 
         let mut psbt = Psbt::from_unsigned_tx(tx.clone()).unwrap();
         // Add signing commitments to the psbt for each input
@@ -1100,7 +1100,7 @@ mod util_tests {
         let sig_share2_1 =
             frost::round2::SignatureShare::deserialize(&[4u8; 32]).expect("valid sig share");
 
-        let tx = create_tx(num_inputs, 1, None);
+        let tx = create_tx(num_inputs, 1, None, false);
         let mut psbt = Psbt::from_unsigned_tx(tx.clone()).unwrap();
         // Add signing commitments to the psbt for each input
         psbt.inputs[0].set_partial_signature(frost_id1, &sig_share1_0);
@@ -1122,7 +1122,7 @@ mod util_tests {
 
     #[test]
     fn signing_package_conversion_should_fail_when_missing_signing_commitments() {
-        let tx = create_tx(1, 1, None);
+        let tx = create_tx(1, 1, None, false);
         let mut psbt = Psbt::from_unsigned_tx(tx.clone()).unwrap();
         psbt.inputs[0].witness_utxo =
             Some(TxOut { value: Amount::from_sat(1000), script_pubkey: ScriptBuf::new() });
@@ -1159,7 +1159,7 @@ mod util_tests {
         let (_, signing_commits2_1) = frost::round1::commit(key_package2.signing_share(), rng);
 
         // Set up the psbt
-        let tx = create_tx(num_inputs, 1, None);
+        let tx = create_tx(num_inputs, 1, None, false);
         let mut psbt = Psbt::from_unsigned_tx(tx.clone()).unwrap();
         // Add signing commitments and TxOut to the psbt for each input
         psbt.inputs[0].witness_utxo =
@@ -1306,7 +1306,7 @@ mod util_tests {
         let (db, _temp_dir) = setup_db();
 
         // create a tracked tx with a pegout request
-        let tx = create_tx(5, 2, None);
+        let tx = create_tx(5, 2, None, false);
         let pegout_id = create_random_pegout_id();
         let pegout_requests = vec![PegoutRequest {
             spk: tx.output[0].script_pubkey.clone(),
@@ -1339,7 +1339,7 @@ mod util_tests {
         let (db, _temp_dir) = setup_db();
 
         // create a tracked tx with a pegout request
-        let tx = create_tx(5, 2, None);
+        let tx = create_tx(5, 2, None, false);
         let pegout_id = create_random_pegout_id();
         let pegout_request = PegoutRequest {
             spk: tx.output[0].script_pubkey.clone(),

--- a/bin/test-suite/src/suite/consensus/common/bitcoind_node.rs
+++ b/bin/test-suite/src/suite/consensus/common/bitcoind_node.rs
@@ -84,6 +84,7 @@ impl BitcoindNodeConfig {
             "-server=1",
             "-txindex=1",
             "-fallbackfee=0.00005",
+            "-persistmempool=0",
         ];
 
         Ok(SpawnedBitcoindProcess {

--- a/bin/test-suite/src/suite/consensus/frost/mod.rs
+++ b/bin/test-suite/src/suite/consensus/frost/mod.rs
@@ -12,5 +12,6 @@ pub mod test_mempool_gossip;
 pub mod test_pending_pegouts;
 pub mod test_round1_then_new_signing_session;
 pub mod test_signing;
+pub mod test_track_mempool;
 pub mod test_utxo_commitment;
 pub mod test_utxo_sync;

--- a/bin/test-suite/src/suite/consensus/frost/test_signing.rs
+++ b/bin/test-suite/src/suite/consensus/frost/test_signing.rs
@@ -188,6 +188,13 @@ pub async fn all_clients_have_same_wallet_state(
     Ok(())
 }
 
+// Need to define a custom struct as breaking changes in bitcoin-core will cause the
+// deserialization to fail
+#[derive(Deserialize)]
+pub struct BlockChainInfoRes {
+    pub blocks: u64,
+}
+
 pub async fn test_many_inputs_signing(
     suite: &ConsensusIntegrationTestSuite,
 ) -> anyhow::Result<(), anyhow::Error> {
@@ -400,13 +407,6 @@ pub async fn test_many_inputs_signing(
     assert_eq!(utxos.len(), 5);
     bitcoind.generate_to_address(1, &address).expect("generate regtest block");
     all_clients_have_same_wallet_state(&mut clients).await?;
-
-    // Need to define a custom struct as breaking changes in bitcoin-core will cause the
-    // deserialization to fail
-    #[derive(Deserialize)]
-    struct BlockChainInfoRes {
-        blocks: u64,
-    }
 
     let deep_tip = bitcoind.call::<BlockChainInfoRes>("getblockchaininfo", &[]).unwrap().blocks -
         (BOTANIX_TESTNET.parent_confirmation_depth as u64);

--- a/bin/test-suite/src/suite/consensus/frost/test_track_mempool.rs
+++ b/bin/test-suite/src/suite/consensus/frost/test_track_mempool.rs
@@ -1,0 +1,217 @@
+use std::str::FromStr;
+
+use crate::suite::{
+    consensus::{
+        frost::test_signing::{do_signing, BlockChainInfoRes, Pegin},
+        CreateTestConfig,
+    },
+    Suite,
+};
+use bitcoin::{consensus::Encodable, Address};
+use bitcoin_hashes::Hash;
+use bitcoincore_rpc::RpcApi;
+use btcserverlib::pegout_id::PegoutId;
+use hex::{self, encode as hex_encode};
+use rand::{rngs::StdRng, RngCore, SeedableRng};
+use reth_chainspec::BOTANIX_TESTNET;
+
+use crate::{
+    it_info_print,
+    suite::consensus::{
+        common::events::BITCOIND_WALLET_NAME,
+        frost::{
+            error::Error,
+            test_dkg::{do_dkg, send_pegin_notification, send_pegout_notification},
+        },
+        ConsensusIntegrationTestSuite,
+    },
+    utils::generate_blocks,
+};
+
+const NUM_PEGINS: usize = 5;
+
+pub async fn test_track_mempool(
+    suite: &mut ConsensusIntegrationTestSuite,
+) -> Result<(), anyhow::Error> {
+    let bitcoind = suite.global_context.bitcoind_rpc();
+    // Load up the bitcoin wallet and generate some blocks
+    for wallet in bitcoind.list_wallets()? {
+        it_info_print!("#UNLOADING WALLET?", &wallet);
+        let _ = bitcoind.unload_wallet(Some(&wallet))?;
+    }
+    let create_res = bitcoind.create_wallet(BITCOIND_WALLET_NAME, None, None, None, None);
+    if create_res.is_err() {
+        tracing::info!("Wallet already exists, loading wallet ...");
+        // wallet already exists, load wallet
+        let _ = bitcoind.load_wallet(BITCOIND_WALLET_NAME);
+    }
+    generate_blocks(&bitcoind, 202).await;
+
+    // create pegins container
+    let mut pegins = vec![];
+
+    // create btc server clients
+    let mut clients = suite
+        .local_context
+        .btc_server_clients
+        .clone()
+        .expect("btc server rpc clients to be defined");
+
+    // run the dkg
+    do_dkg(&mut clients).await?;
+
+    // pegin and pegout which will create, sign, and broadcast a psbt honoring pending pegouts
+    // this will cause the signers to track the tx in their db
+    // we will intentionally generate blocks while leaving the tracked tx in the mempool for testing
+
+    let amount_to_send = bitcoin::Amount::from_sat(100_000);
+    // create pegins
+    for _ in 0..NUM_PEGINS {
+        let eth_address = ethers::core::types::Address::random();
+        // Lets get the gateway address for this eth address
+        let mut client =
+            clients.get(0).cloned().ok_or_else(|| anyhow::anyhow!("client not found"))?;
+        let res = client
+            .get_gateway_address(tonic::Request::new(client::GetGatewayAddressRequest {
+                eth_address: hex_encode(eth_address),
+            }))
+            .await
+            .map_err(Error::Request)?
+            .into_inner();
+        let btc_address = Address::from_str(&res.gateway_address)?.assume_checked();
+        let txid = bitcoind.send_to_address(
+            &btc_address,
+            amount_to_send,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )?;
+
+        // Generate some block to confirm it
+        generate_blocks(&bitcoind, 2).await;
+
+        let tx_res = bitcoind.get_transaction(&txid, None)?;
+        let pegin_tx = tx_res.transaction()?;
+        let spk = btc_address.script_pubkey();
+        let (vout, pegin_output) = pegin_tx
+            .output
+            .iter()
+            .enumerate()
+            .find(|(_, o)| o.script_pubkey == spk)
+            .ok_or_else(|| anyhow::anyhow!("pegin output not found"))?;
+
+        pegins.push(Pegin {
+            eth_address,
+            btc_address,
+            outpoint: bitcoin::OutPoint { txid, vout: vout as u32 },
+            amount: pegin_output.value,
+        });
+    }
+
+    // get the aggregate pk from any of the clients
+    // Here we are signing for inputs that are tweaked differently
+
+    // Notify pegins to all peers
+    for c in clients.iter_mut() {
+        for pegin in pegins.iter() {
+            let ot = pegin.outpoint;
+            let mut txid_bytes = Vec::with_capacity(32);
+            ot.txid.consensus_encode(&mut txid_bytes)?;
+            send_pegin_notification(
+                c,
+                pegin.btc_address.clone(),
+                hex_encode(pegin.eth_address),
+                txid_bytes.try_into().map_err(|_| anyhow::anyhow!("invalid txid"))?,
+                ot.vout,
+                pegin.amount.to_sat(),
+            )
+            .await?;
+        }
+    }
+
+    let mut rand = StdRng::from_entropy();
+    let mut pegout_id_bytes = [0u8; 36];
+    rand.fill_bytes(&mut pegout_id_bytes);
+    let pegout_id =
+        PegoutId::from_bytes(&pegout_id_bytes).map_err(|_| anyhow::anyhow!("invalid pegout id"))?;
+
+    let secp = bitcoin::secp256k1::Secp256k1::new();
+    let sk = bitcoin::PrivateKey::generate(bitcoin::Network::Regtest);
+    let pk = sk.public_key(&secp);
+
+    let spk = bitcoin::Address::p2wpkh(&pk, bitcoin::Network::Regtest)?.script_pubkey();
+
+    // Notify there is a pending pegout
+    let amount = bitcoin::Amount::from_sat(100_000);
+    for c in clients.iter_mut() {
+        // Each pegin is 100_000 satoshis, spending 100_000 should spend at least 2 inputs
+        send_pegout_notification(c, amount.to_sat(), 1, pegout_id, spk.clone()).await?;
+    }
+    // signs, broadcasts, and tracks the psbt honoring pending pegouts
+    let tracked_tx = do_signing(&mut clients, &bitcoind, &[1u8; 32]).await?;
+
+    // assert the pegout is not in the pending pegout list
+    let pending_pegouts = clients[0]
+        .get_pending_pegouts(tonic::Request::new(client::Empty {}))
+        .await
+        .expect("get pending pegouts")
+        .into_inner();
+    let pending_pegout_ids =
+        pending_pegouts.pending_pegouts.iter().map(|p| p.pegout_id.clone()).collect::<Vec<_>>();
+    println!("pending_pegouts: {:?}", pending_pegout_ids);
+    assert!(!pending_pegout_ids.contains(&pegout_id_bytes.to_vec()));
+
+    // kill bitcoind so mempool is cleared (conf is set to not persist mempool)
+    suite
+        .local_context
+        .bitcoind_process
+        .as_mut()
+        .expect("bitcoind process to exist")
+        .destroy_all_async()
+        .await;
+
+    // restart bitcoind
+    let mut test_config = CreateTestConfig::default();
+    test_config.create_bitcoind_node = true;
+    suite.create_new_local_context(test_config).await?;
+
+    // check the tx does not exist in the mempool
+    let tx_ids = bitcoind.get_raw_mempool().expect("mempool should exist");
+    assert!(!tx_ids.contains(&tracked_tx.txid()));
+
+    // we have a tracked tx in the signers db but the tx doesn't exist in the mempool or in a block
+    // now we can generate enough blocks so the tracked tx is older than the bitcoin checkpoint
+    generate_blocks(&bitcoind, BOTANIX_TESTNET.parent_confirmation_depth).await;
+
+    // sync the signers to the bitcoin checkpoint
+    let deep_tip = bitcoind.call::<BlockChainInfoRes>("getblockchaininfo", &[]).unwrap().blocks -
+        (BOTANIX_TESTNET.parent_confirmation_depth as u64);
+    let deep_block_hash = bitcoind.get_block_hash(deep_tip).unwrap();
+
+    for c in clients.iter_mut() {
+        c.tx_index_new_checkpoint(tonic::Request::new(client::SyncTxIndexRequest {
+            checkpoint_block_hash: deep_block_hash.to_byte_array().to_vec(),
+        }))
+        .await
+        .expect("valid checkpoint");
+    }
+
+    // when the signers synced their pegout schedulers,
+    // they should have removed the tracked tx and added it back to the pending pegout list
+    // since it's older than the checkpoint and doesn't exist in the mempool
+    let pending_pegouts = clients[0]
+        .get_pending_pegouts(tonic::Request::new(client::Empty {}))
+        .await
+        .expect("get pending pegouts")
+        .into_inner();
+    let pending_pegout_ids =
+        pending_pegouts.pending_pegouts.iter().map(|p| p.pegout_id.clone()).collect::<Vec<_>>();
+    println!("pending_pegouts: {:?}", pending_pegout_ids);
+    // assert the pegout is in the pending pegout list
+    assert!(pending_pegout_ids.contains(&pegout_id_bytes.to_vec()));
+
+    Ok(())
+}

--- a/bin/test-suite/src/suite/consensus/mod.rs
+++ b/bin/test-suite/src/suite/consensus/mod.rs
@@ -513,6 +513,15 @@ impl Suite for ConsensusIntegrationTestSuite {
                 },
                 frost::test_round1_then_new_signing_session::test_round1_then_new_signing_session
             ),
+            "test_track_mempool" => run_test!(
+                self,
+                CreateTestConfig {
+                    create_bitcoind_node: true,
+                    create_btc_servers: true,
+                    ..Default::default()
+                },
+                frost::test_track_mempool::test_track_mempool
+            ),
             _ => {
                 panic!("Test not found");
             }


### PR DESCRIPTION
ready for review

I've added an int test but not to the `test_runner` file. We need to refactor the test-suite a bit to get the functionality I need in the test.

Here is the issue that describes this: https://github.com/botanix-labs/botanix/issues/877