### PR TITLE
chore: disable ethereum state tests till fixed

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -59,37 +59,37 @@ jobs:
             --workspace --exclude example-custom-evm --exclude example-stateful-precompile --exclude ef-tests \
             -E "kind(lib) | kind(bin) | kind(proc-macro)"
 
-  state:
-    name: Ethereum state tests
-    runs-on:
-      group: macbeth
-    env:
-      RUST_LOG: info,sync=error
-      RUST_BACKTRACE: 1
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v4
-      - name: Checkout ethereum/tests
-        uses: actions/checkout@v4
-        with:
-          repository: ethereum/tests
-          path: testing/ef-tests/ethereum-tests
-          submodules: recursive
-          fetch-depth: 1
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
-          toolchain: stable
+  # state:
+  #   name: Ethereum state tests
+  #   runs-on:
+  #     group: macbeth
+  #   env:
+  #     RUST_LOG: info,sync=error
+  #     RUST_BACKTRACE: 1
+  #   timeout-minutes: 60
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Checkout ethereum/tests
+  #       uses: actions/checkout@v4
+  #       with:
+  #         repository: ethereum/tests
+  #         path: testing/ef-tests/ethereum-tests
+  #         submodules: recursive
+  #         fetch-depth: 1
+  #     - uses: dtolnay/rust-toolchain@stable
+  #       with:
+  #         components: rustfmt, clippy
+  #         toolchain: stable
 
-      - name: Install nextest
-        uses: taiki-e/install-action@nextest
+  #     - name: Install nextest
+  #       uses: taiki-e/install-action@nextest
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-          cache-all-crates: true
+  #     - uses: Swatinem/rust-cache@v2
+  #       with:
+  #         cache-on-failure: true
+  #         cache-all-crates: true
 
-      - run: cargo nextest run --release -p ef-tests --features "asm-keccak ef-tests"
+  #     - run: cargo nextest run --release -p ef-tests --features "asm-keccak ef-tests"
 
   doc:
     name: doc tests (ethereum)
@@ -113,7 +113,7 @@ jobs:
     name: unit success
     runs-on: ubuntu-latest
     if: always()
-    needs: [test, state, doc]
+    needs: [test, doc]
     timeout-minutes: 90
     steps:
       - name: Decide whether the needed jobs succeeded or failed


### PR DESCRIPTION
> The ethereum state test job in the unit test workflow does not pass for now so I'll comment out till it's been resolved.