### PR TITLE
ci(btc_server): independently pull async trait crate

### DIFF
--- a/bin/btc-server/Cargo.toml
+++ b/bin/btc-server/Cargo.toml
@@ -14,7 +14,7 @@ alloy-rpc-types-engine = { version = "0.2.1", default-features = false }
 anyhow = "1.0.75"
 
 #async
-async-trait = { workspace = true }
+async-trait = "0.1.68"
 base64 = "0.22.0"
 bdk = "1.0.0-alpha.1"
 bitcoin = { version = "0.31.0", features = ["base64", "rand", "serde"] }

--- a/crates/btc-wallet/Cargo.toml
+++ b/crates/btc-wallet/Cargo.toml
@@ -15,7 +15,11 @@ bitcoin = { version = "0.31.0", features = ["base64", "rand", "serde"] }
 bitcoincore-rpc = "0.18.0"
 ethers = "2.0.10"
 
-frost-secp256k1-tr = { workspace = true }
+frost-secp256k1-tr = { git = "https://github.com/0xBEEFCAF3/frost", rev = "be21f863dd782ae8ad030876964f7615ab392f0e", features = [
+    "serde",
+    "serialization",
+] }
+
 hex = "0.4.3"
 lazy_static = "1.4.0"
 miniscript = "11.0.0"


### PR DESCRIPTION
When we build the btc server docker image it has no concept of a workspace as such all workspace dependencies need to be explicitly stated