### PR TITLE
773 fixnet frost messages should authenticate coord based on peer id not id passed in payload

### DIFF
--- a/bin/btc-server/README.md
+++ b/bin/btc-server/README.md
@@ -2,18 +2,18 @@
 
 Bitcoin signer service that interacts with a database and performs transaction signing and related operations. Below is an overview of the main components and functionality provided by this code.
 
-### Building and Running
+## Building and Running
 
-    Ensure you have Rust and Cargo installed on your system.
+Ensure you have Rust and Cargo installed on your system.
 
-    Run `make start-btc-server-1` from the project root directory
+Run `make start-btc-server-1` from the project root directory
 
 
-    To just generate the client. run `cargo build`.
+To just generate the client. run `cargo build --features conflicting_input`.
 
-    Take a look at the integration test suite in `bin/test-suite` for examples of using the client.
+Take a look at the integration test suite in `bin/test-suite` for examples of using the client.
 
-### Troubleshooting
+## Troubleshooting
 
 if you have having issues with the grpc reflection server, for example:
 `Grpc server: Join Error grpc reflection server error: error decoding FileDescriptorSet from buffer`

--- a/crates/consensus/authority/src/dkg.rs
+++ b/crates/consensus/authority/src/dkg.rs
@@ -17,11 +17,7 @@ use std::{
 use tokio::sync::mpsc::error::SendError;
 use tracing::{debug, error, info, warn};
 
-use crate::{
-    metrics::AuthorityMetrics,
-    utils::{deserialize_frost_peer_id, FrostParseError},
-    Storage,
-};
+use crate::{metrics::AuthorityMetrics, utils::FrostParseError, Storage};
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum Error {
@@ -91,7 +87,7 @@ pub(crate) struct DKGStateMachine<EF, BF, DB, ToFrostMan, BtcServerClient> {
     frost_id_map: HashMap<frost::Identifier, PeerId>,
     // coordiantor only fields
     // Key frost id, values are round 1
-    round1_packages: BTreeMap<Vec<u8>, Vec<u8>>,
+    round1_packages: BTreeMap<frost::Identifier, Vec<u8>>,
     metrics: Arc<AuthorityMetrics>,
 }
 
@@ -136,7 +132,6 @@ where
     }
 
     /// Returns the public key package
-    #[allow(dead_code)]
     pub(crate) fn get_public_key_package(&self) -> Option<secp256k1::PublicKey> {
         self.public_key_package
     }
@@ -185,10 +180,10 @@ where
 
     async fn add_round1_dkg_package(
         &mut self,
-        identifier: Vec<u8>,
+        frost_identifier: &frost::Identifier,
         payload: Vec<u8>,
     ) -> Result<(), Error> {
-        let req = client::DkgPayload { identifier, payload };
+        let req = client::DkgPayload { identifier: frost_identifier.serialize().to_vec(), payload };
         match self.btc_client.new_round1_dkg_package(req).await {
             Ok(round2_payload) => round2_payload,
             Err(e) => return Err(Error::from(e)),
@@ -198,10 +193,10 @@ where
 
     async fn add_round2_dkg_package(
         &mut self,
-        identifier: Vec<u8>,
+        frost_identifier: &frost::Identifier,
         payload: Vec<u8>,
     ) -> Result<(), Error> {
-        let req = client::DkgPayload { identifier, payload };
+        let req = client::DkgPayload { identifier: frost_identifier.serialize().to_vec(), payload };
         match self.btc_client.new_round2_dkg_package(req).await {
             Ok(round2_payload) => round2_payload,
             Err(e) => return Err(Error::from(e)),
@@ -330,7 +325,7 @@ where
             our_round1.identifier.len(),
             our_round1.payload.len()
         );
-        self.round1_packages.insert(our_round1.identifier, our_round1.payload);
+        self.round1_packages.insert(self.personal_frost_identifier, our_round1.payload);
 
         // Start by sending round 1 requests
         self.gossip_to_peers(
@@ -394,7 +389,7 @@ where
     /// all peers
     pub(crate) async fn process_round1_coordinator(
         &mut self,
-        identifier: Vec<u8>,
+        frost_identifier: &frost::Identifier,
         payload: Vec<u8>,
     ) -> Result<(), Error> {
         // If we are not the coordinator, we should not be processing this round 1 package response
@@ -407,7 +402,7 @@ where
         }
 
         // return if the sending identifier is us
-        if self.personal_frost_identifier == deserialize_frost_peer_id(identifier.clone())? {
+        if self.personal_frost_identifier == *frost_identifier {
             warn!(
                 target: "consensus::authority::dkg::process_round1_coordinator",
                 "Received our own round 1 package"
@@ -415,13 +410,13 @@ where
             return Ok(());
         }
         // add the transmitted round 1 package data
-        if let Err(e) = self.add_round1_dkg_package(identifier.clone(), payload.clone()).await {
+        if let Err(e) = self.add_round1_dkg_package(frost_identifier, payload.clone()).await {
             error!(
                 target: "consensus::authority::dkg::process_round1_coordinator",
                 "Error adding round 1 dkg package {:?}", e
             );
         }
-        self.round1_packages.insert(identifier, payload);
+        self.round1_packages.insert(*frost_identifier, payload);
 
         info!(
             target: "consensus::authority::dkg::process_round1_coordinator",
@@ -442,7 +437,10 @@ where
         // This includes our own round 1 package
         for (identifier, payload) in self.round1_packages.iter() {
             self.gossip_to_peers(
-                DkgPayload { identifier: identifier.clone(), payload: payload.clone() },
+                DkgPayload {
+                    identifier: identifier.serialize().to_vec(),
+                    payload: payload.clone(),
+                },
                 DkgEventResponseType::DkgRound1,
             )
             .await?;
@@ -468,28 +466,28 @@ where
     /// In the future this could be a single package containing all the round 1 packages
     pub(crate) async fn process_round1(
         &mut self,
-        identifier: Vec<u8>,
+        frost_identifier: &frost::Identifier,
         payload: Vec<u8>,
     ) -> Result<(), Error> {
         // Ensure we are not the coordinator
         if self.personal_frost_identifier == self.coordinator_identifier() {
-            self.process_round1_coordinator(identifier, payload).await?;
+            self.process_round1_coordinator(frost_identifier, payload).await?;
             return Ok(());
         }
         info!(
             target: "consensus::authority::dkg::process_round1","identifiers {:?} {:?}",
             self.personal_frost_identifier,
-            deserialize_frost_peer_id(identifier.clone())?
+            frost_identifier
         );
 
         // return if the sending identifier is us
-        if self.personal_frost_identifier == deserialize_frost_peer_id(identifier.clone())? {
+        if self.personal_frost_identifier == *frost_identifier {
             warn!(target: "consensus::authority::dkg::process_round1", "Received our own round 1 package");
             return Ok(());
         }
 
         // add the transmitted round 1 package data
-        if let Err(e) = self.add_round1_dkg_package(identifier, payload).await {
+        if let Err(e) = self.add_round1_dkg_package(frost_identifier, payload).await {
             error!(target: "consensus::authority::dkg::process_round1", "Error adding round 1 dkg package {:?}", e);
         }
         self.metrics.received_round1_dkg_packages.increment(1);
@@ -512,23 +510,23 @@ where
     /// The coordinator DOES NOT have any special responsibilities here for round 2
     pub(crate) async fn process_round2(
         &mut self,
-        identifier: Vec<u8>,
+        frost_identifier: &frost::Identifier,
         payload: Vec<u8>,
     ) -> Result<(), Error> {
         info!(target: "consensus::authority::dkg::process_round2",
             "our id: {:?},\n peers id:  {:?}",
             self.personal_frost_identifier,
-            deserialize_frost_peer_id(identifier.clone())?
+            frost_identifier
         );
 
         // return if the sending identifier is us
-        if self.personal_frost_identifier == deserialize_frost_peer_id(identifier.clone())? {
+        if self.personal_frost_identifier == *frost_identifier {
             warn!(target: "consensus::authority::dkg::process_round2", "Received our own round 1 package");
             return Ok(());
         }
 
         // add the transmitted round 2 package data
-        if let Err(e) = self.add_round2_dkg_package(identifier, payload).await {
+        if let Err(e) = self.add_round2_dkg_package(frost_identifier, payload).await {
             warn!(target: "consensus::authority::dkg::process_round2", "Error adding round 2 dkg package {:?}", e);
             // We dont want to fail the whole dkg process if we can't add another's round2
             return Ok(());

--- a/crates/consensus/authority/src/frost_task.rs
+++ b/crates/consensus/authority/src/frost_task.rs
@@ -6,7 +6,7 @@ use crate::{
     metrics::AuthorityMetrics,
     random_source_provider::RandomSource,
     signing::SigningStateMachine,
-    utils::validate_psbt_by_ids,
+    utils::{deserialize_frost_peer_id, validate_psbt_by_ids},
     Storage,
 };
 
@@ -413,8 +413,11 @@ where
             }
 
             // receive over a channel message from other peers and update our state machine
-            while let Ok((peerid, msg)) = peer_messages_rx.try_recv() {
-                match msg {
+            while let Ok(message_context) = peer_messages_rx.try_recv() {
+                let peer_message = message_context.message;
+                let peer_id = message_context.peer_id;
+                let frost_identifier = message_context.frost_identifier;
+                match peer_message {
                     PeerMessageResponse::WalletState(mut response) => {
                         // Only handle response if it has no state: responses with state are also
                         // sent to WalletStateSyncEngine::sync_wallet_state
@@ -424,7 +427,7 @@ where
                         // TODO: create separate messages for asking for wallet state and sending
                         // wallet state
                         if Self::has_wallet_state(&response) {
-                            info!(target: "consensus::authority::wallet_syncer::start_task", "Received wallet state in frost task from peer {:?}", peerid);
+                            info!(target: "consensus::authority::wallet_syncer::start_task", "Received wallet state in frost task from peer {:?}", peer_id);
                             continue;
                         }
 
@@ -434,7 +437,7 @@ where
                             .await
                             .expect("expect all peers handle to exist");
                         let peer_handle =
-                            all_peers_handle.get(&peerid).expect("peer handle to exist");
+                            all_peers_handle.get(&peer_id).expect("peer handle to exist");
 
                         // Note its important we do not respond to this message if we are syncing
                         // ourselves This should be checked above
@@ -492,7 +495,7 @@ where
                         response.tracked_txs = serialized_compressed_tracked_txs;
                         response.pending_pegouts = serialized_compressed_pending_pegouts;
 
-                        info!(target: "consensus::authority::wallet_syncer::start_task", "Sending wallet state to peer {:?}", peerid);
+                        info!(target: "consensus::authority::wallet_syncer::start_task", "Sending wallet state to peer {:?}", peer_id);
                         if let Err(e) =
                             peer_handle.peer_commands_tx.send(FrostPeerCommand::PeerMessage(
                                 PeerMessageResponse::WalletState(response),
@@ -510,6 +513,13 @@ where
                     }
                     PeerMessageResponse::Dkg(dkg_response) => {
                         let DkgResponse { response_type, identifier, data } = dkg_response;
+                        let frost_identifier = match deserialize_frost_peer_id(identifier) {
+                            Ok(frost_identifier) => frost_identifier,
+                            Err(e) => {
+                                error!(target: "consensus::authority::frost_task::start_task", "Error deserializing frost identifier in DKG payload {:?}", e);
+                                continue;
+                            }
+                        };
                         match response_type {
                             DkgEventResponseType::DkgRound1Request => {
                                 match self.dkg_state_machine.process_round1_request().await {
@@ -522,7 +532,10 @@ where
                                 }
                             }
                             DkgEventResponseType::DkgRound1 => {
-                                match self.dkg_state_machine.process_round1(identifier, data).await
+                                match self
+                                    .dkg_state_machine
+                                    .process_round1(&frost_identifier, data)
+                                    .await
                                 {
                                     Ok(_) => {
                                         info!(target: "consensus::authority::frost_task::start_task", "Processed Round 1 dkg package successfully")
@@ -533,7 +546,10 @@ where
                                 }
                             }
                             DkgEventResponseType::DkgRound2 => {
-                                match self.dkg_state_machine.process_round2(identifier, data).await
+                                match self
+                                    .dkg_state_machine
+                                    .process_round2(&frost_identifier, data)
+                                    .await
                                 {
                                     Ok(_) => {
                                         info!(target: "consensus::authority::frost_task::start_task", "Processed Round 2 dkg package successfully")
@@ -546,7 +562,7 @@ where
                         }
                     }
                     PeerMessageResponse::Signing(signing_response) => {
-                        let SigningResponse { response_type, identifier, signing_session_id, psbt } =
+                        let SigningResponse { response_type, signing_session_id, psbt } =
                             signing_response;
                         let signing_session_id = FixedBytes::from_slice(&signing_session_id);
                         match response_type {
@@ -572,7 +588,11 @@ where
 
                                 if let Err(e) = self
                                     .signing_state_machine
-                                    .signer_process_round1(identifier, signing_session_id, psbt)
+                                    .signer_process_round1(
+                                        &frost_identifier,
+                                        signing_session_id,
+                                        psbt,
+                                    )
                                     .await
                                 {
                                     error!(target: "consensus::authority::frost_task::SignerRound1SigningPackage", "Peer Error processing round 1 signing {:?}", e);
@@ -601,7 +621,7 @@ where
                                 if let Err(e) = self
                                     .signing_state_machine
                                     .coordinator_process_round1(
-                                        identifier,
+                                        &frost_identifier,
                                         signing_session_id,
                                         psbt,
                                     )
@@ -632,7 +652,11 @@ where
 
                                 if let Err(e) = self
                                     .signing_state_machine
-                                    .signer_process_round2(identifier, signing_session_id, psbt)
+                                    .signer_process_round2(
+                                        &frost_identifier,
+                                        signing_session_id,
+                                        psbt,
+                                    )
                                     .await
                                 {
                                     error!(target: "consensus::authority::frost_task::SignerRound2SigningPackage", "Peer Error processing round 2 signing package {:?}", e);
@@ -661,7 +685,7 @@ where
                                 if let Err(e) = self
                                     .signing_state_machine
                                     .coordinator_process_round2(
-                                        identifier,
+                                        &frost_identifier,
                                         signing_session_id,
                                         psbt,
                                     )

--- a/crates/consensus/authority/src/healthcheck_task.rs
+++ b/crates/consensus/authority/src/healthcheck_task.rs
@@ -195,8 +195,9 @@ where
         let peers_healthcheck_tracker = Arc::clone(&self.peers_healthcheck_tracker);
 
         // receive over a channel message from other peers
-        while let Some((_peerid, msg)) = peer_messages_rx.recv().await {
-            match msg {
+        while let Some(message_context) = peer_messages_rx.recv().await {
+            let peer_message = message_context.message;
+            match peer_message {
                 PeerMessageResponse::Dkg(_) => {
                     // Nothing to do for dkg related messages. Does are handled by the frost
                     // task

--- a/crates/consensus/authority/src/lib.rs
+++ b/crates/consensus/authority/src/lib.rs
@@ -63,6 +63,7 @@ pub mod wallet_state_sync;
 pub use builder::AuthorityConsensusBuilder;
 pub mod metrics;
 pub mod random_source_provider;
+/// Expose test utils for unit testing
 pub mod test_utils;
 
 /// Max EDH size; for specific details see [ExtraDataHeader]

--- a/crates/consensus/authority/src/signing.rs
+++ b/crates/consensus/authority/src/signing.rs
@@ -288,14 +288,14 @@ where
 
     async fn new_round1_signing_package(
         &mut self,
-        identifier: Vec<u8>,
+        frost_identifier: &frost::Identifier,
         signing_session_id: FixedBytes<32>,
         psbt: Vec<u8>,
     ) -> Result<(), Error> {
         let new_round1_signing_package = self
             .btc_client
             .new_round1_signing_package(SigningPackage {
-                identifier,
+                identifier: frost_identifier.serialize().to_vec(),
                 psbt,
                 signing_session_id: signing_session_id.to_vec(),
             })
@@ -310,14 +310,14 @@ where
 
     async fn new_round2_signing_package(
         &mut self,
-        identifier: Vec<u8>,
+        frost_identifier: &frost::Identifier,
         signing_session_id: FixedBytes<32>,
         psbt: Vec<u8>,
     ) -> Result<(), Error> {
         let new_round2_signing_package = self
             .btc_client
             .new_round2_signing_package(SigningPackage {
-                identifier,
+                identifier: frost_identifier.serialize().to_vec(),
                 psbt,
                 signing_session_id: signing_session_id.to_vec(),
             })
@@ -451,7 +451,6 @@ where
     pub(crate) async fn gossip_to_peers(
         &mut self,
         signing_package: SigningPackage,
-        my_frost_identifier: Vec<u8>,
         response_type: SigningEventResponseType,
     ) -> Result<(), Error> {
         let SigningPackage { identifier: _, signing_session_id, psbt } = signing_package;
@@ -471,7 +470,6 @@ where
                 if connected_peer.frost_identifier != self.personal_frost_identifier {
                     let resp = PeerMessageResponse::Signing(SigningResponse {
                         response_type,
-                        identifier: my_frost_identifier.clone(),
                         signing_session_id: signing_session_id.clone(),
                         psbt: psbt.clone(),
                     });
@@ -542,8 +540,9 @@ where
         // then we send the psbt to other peers
         let signing_round1_package =
             self.get_round1_signing_package(signing_session_id, psbt).await?;
+        let my_frost_identifier = self.personal_frost_identifier;
         self.new_round1_signing_package(
-            self.personal_frost_identifier.serialize().to_vec(),
+            &my_frost_identifier,
             signing_session_id,
             signing_round1_package.clone().psbt,
         )
@@ -555,7 +554,6 @@ where
         if let Err(e) = self
             .gossip_to_peers(
                 signing_round1_package,
-                self.personal_frost_identifier.serialize().to_vec(),
                 SigningEventResponseType::SignerRound1SigningPackage,
             )
             .await
@@ -570,7 +568,7 @@ where
     /// A signer processes round 1 signing packages
     pub(crate) async fn signer_process_round1(
         &mut self,
-        identifier: Vec<u8>,
+        identifier: &frost::Identifier,
         signing_session_id: FixedBytes<32>,
         psbt: Vec<u8>,
     ) -> Result<(), Error> {
@@ -588,7 +586,7 @@ where
 
         // check coordinator is sending the request
         let coordinator_frost_identifier = coordinator_peer_data.frost_identifier;
-        if coordinator_frost_identifier.serialize().to_vec() != identifier {
+        if coordinator_frost_identifier != *identifier {
             warn!(target: "consensus::authority::signing::signer_process_round1", "Round 1 signing request not from coordinator");
             return Ok(());
         }
@@ -632,7 +630,6 @@ where
         if coordinator_frost_identifier != self.personal_frost_identifier {
             let resp = PeerMessageResponse::Signing(SigningResponse {
                 response_type: SigningEventResponseType::CoordinatorRound1SigningPackage,
-                identifier: signing_package_round1.identifier.clone(),
                 signing_session_id: signing_package_round1.signing_session_id.clone(),
                 psbt: signing_package_round1.psbt.clone(),
             });
@@ -657,7 +654,7 @@ where
     /// A coordinator processes round 1 signing packages
     pub(crate) async fn coordinator_process_round1(
         &mut self,
-        identifier: Vec<u8>,
+        frost_identifier: &frost::Identifier,
         signing_session_id: FixedBytes<32>,
         psbt: Vec<u8>,
     ) -> Result<(), Error> {
@@ -673,22 +670,23 @@ where
             warn!(target: "consensus::authority::signing::coordinator_process_round1", "we are not the coordinator");
             return Ok(());
         }
+        let my_frost_identifier = self.personal_frost_identifier;
 
         info!(
             target: "consensus::authority::signing::coordinator_process_round1",
             "identifiers my peer id: {:?}, other peerid {:?}",
-            self.personal_frost_identifier,
-            deserialize_frost_peer_id(identifier.clone())?
+            my_frost_identifier,
+            frost_identifier
         );
 
         // return if the sending identifier is us
-        if self.personal_frost_identifier == deserialize_frost_peer_id(identifier.clone())? {
+        if my_frost_identifier == *frost_identifier {
             return Ok(());
         }
 
         // add the transmitted round 1 package data
         if let Err(e) =
-            self.new_round1_signing_package(identifier.clone(), signing_session_id, psbt).await
+            self.new_round1_signing_package(frost_identifier, signing_session_id, psbt).await
         {
             error!(target: "consensus::authority::signing::coordinator_process_round1","Error adding round 1 signing package {:?}", e);
             return Ok(());
@@ -702,7 +700,7 @@ where
                 .get_round2_signing_package(signing_session_id, to_sign_payload.psbt.clone())
                 .await?;
             self.new_round2_signing_package(
-                self.personal_frost_identifier.serialize().to_vec(),
+                &my_frost_identifier,
                 signing_session_id,
                 cord_round2.psbt,
             )
@@ -715,7 +713,6 @@ where
             if let Err(e) = self
                 .gossip_to_peers(
                     to_sign_payload.clone(),
-                    self.personal_frost_identifier.serialize().to_vec(),
                     SigningEventResponseType::SignerRound2SigningPackage,
                 )
                 .await
@@ -735,7 +732,7 @@ where
     /// A signer processes round 2 signing request
     pub(crate) async fn signer_process_round2(
         &mut self,
-        identifier: Vec<u8>,
+        frost_identifier: &frost::Identifier,
         signing_session_id: FixedBytes<32>,
         psbt: Vec<u8>,
     ) -> Result<(), Error> {
@@ -758,7 +755,7 @@ where
 
         // check coordinator is sending the request
         let coordinator_frost_identifier = coordinator_peer_data.frost_identifier;
-        if coordinator_frost_identifier.serialize().to_vec() != identifier {
+        if coordinator_frost_identifier != *frost_identifier {
             warn!(target: "consensus::authority::signing::signer_process_round2", "Round 2 signing request not from coordinator");
             return Ok(());
         }
@@ -784,7 +781,6 @@ where
 
         let resp = PeerMessageResponse::Signing(SigningResponse {
             response_type: SigningEventResponseType::CoordinatorRound2SigningPackage,
-            identifier: signing_package_round2.identifier.clone(),
             signing_session_id: signing_package_round2.signing_session_id.clone(),
             psbt: signing_package_round2.psbt.clone(),
         });
@@ -808,7 +804,7 @@ where
     /// A coordinator processes round 2 signing packages
     pub(crate) async fn coordinator_process_round2(
         &mut self,
-        identifier: Vec<u8>,
+        frost_identifier: &frost::Identifier,
         signing_session_id: FixedBytes<32>,
         psbt: Vec<u8>,
     ) -> Result<(), Error> {
@@ -833,18 +829,18 @@ where
             target: "consensus::authority::signing::coordinator_process_round2",
             "My identifier {:?} and the peers identifier {:?}",
             self.personal_frost_identifier,
-            deserialize_frost_peer_id(identifier.clone())?
+            frost_identifier
         );
 
         // return if the sending identifier is us
-        if self.personal_frost_identifier == deserialize_frost_peer_id(identifier.clone())? {
+        if self.personal_frost_identifier == *frost_identifier {
             info!(target: "consensus::authority::signing::coordinator_process_round2", "identifier is us, this should not happen");
             return Ok(());
         }
 
         // add the transmitted round 2 package data
         if let Err(e) =
-            self.new_round2_signing_package(identifier.clone(), signing_session_id, psbt).await
+            self.new_round2_signing_package(frost_identifier, signing_session_id, psbt).await
         {
             error!(target: "consensus::authority::signing::coordinator_process_round2", "Error adding round 2 signing package {:?}", e);
             self.update_signing_state(session_id, SigningState::Failed).await;

--- a/crates/consensus/authority/src/wallet_state_sync.rs
+++ b/crates/consensus/authority/src/wallet_state_sync.rs
@@ -122,7 +122,9 @@ where
         // try getting the wallet state from the random peer we pinged
         match tokio::time::timeout(Duration::from_secs(60), peer_messages_rx.recv()).await {
             Ok(peer_message) => {
-                if let Some((peer_id, peer_message)) = peer_message {
+                if let Some(message_context) = peer_message {
+                    let peer_message = message_context.message;
+                    let peer_id = message_context.peer_id;
                     info!(target: "consensus::authority::sync_wallet_state", "Received wallet state from peer {:?}", peer_id);
 
                     // Note: we ignore empty messages bc they are peer requests for wallet state

--- a/crates/net/network/src/frost/manager.rs
+++ b/crates/net/network/src/frost/manager.rs
@@ -53,8 +53,6 @@ pub struct PeerData {
     pub direction: Direction,
     /// the frost identifier of the peer
     pub frost_identifier: frost::Identifier,
-    /// Did we receive a peer confirmation message from this peer?
-    pub peer_confirmed: bool,
 }
 
 /// Frost Manager implementation
@@ -211,7 +209,6 @@ impl FrostManager {
                 let peer_data = peers_connections.entry(peer_id).or_insert_with(Vec::new);
                 peer_data.push(PeerData {
                     peer_id,
-                    peer_confirmed: true,
                     direction,
                     peer_commands_tx,
                     frost_identifier: authority_index_to_frost_identifier(

--- a/crates/net/network/src/frost/manager.rs
+++ b/crates/net/network/src/frost/manager.rs
@@ -42,7 +42,7 @@ impl ToFrostManager for FrostHandle {
     }
 }
 
-/// Structure that stores all informattion about a connected peer
+/// Structure that stores all information about a connected peer
 #[derive(Debug, Clone)]
 pub struct PeerData {
     /// peer id

--- a/crates/net/network/src/frost/manager.rs
+++ b/crates/net/network/src/frost/manager.rs
@@ -228,6 +228,15 @@ impl FrostManager {
                     warn!(target: "network::frost::on_network_event", "Received FrostProtocolEvent::PeerMessage message from non-authority peer {:?}", peer_id);
                     return;
                 }
+
+                // Check if the peer is in the peer connections. i.e. we have a valid connection to
+                // the peer. it may be find to address this message on the
+                // application level, but then we cannot respond
+                if !self.peers_connections.contains_key(&peer_id) {
+                    warn!(target: "network::frost::on_network_event", "Received FrostProtocolEvent::PeerMessage message from peer with id = {:?}, but the peer is not in the peer connections", peer_id);
+                    return;
+                }
+
                 for task_forwarder in &self.task_forwarder_txs {
                     if let Err(send_res) = task_forwarder.send((peer_id, response.clone())) {
                         error!(target: "network::frost::on_network_event", "Received FrostProtocolEvent::PeerMessage event from peer with id {}, but could not forward it to task. Error: {:?}", peer_id, send_res);

--- a/crates/net/network/src/frost/manager.rs
+++ b/crates/net/network/src/frost/manager.rs
@@ -55,6 +55,17 @@ pub struct PeerData {
     pub frost_identifier: frost::Identifier,
 }
 
+/// Context for forwarding peer messages to the frost task
+#[derive(Debug, Clone)]
+pub struct PeerMessageContext {
+    /// the peer id
+    pub peer_id: PeerId,
+    /// frost identifier
+    pub frost_identifier: frost::Identifier,
+    /// The message itself
+    pub message: PeerMessageResponse,
+}
+
 /// Frost Manager implementation
 #[derive(Debug)]
 pub struct FrostManager {
@@ -73,7 +84,7 @@ pub struct FrostManager {
     /// total authorities to connect to, including ourselves
     authority_peerid: Vec<PeerId>,
     /// Forwards for message to the frost task
-    task_forwarder_txs: Vec<mpsc::UnboundedSender<(PeerId, PeerMessageResponse)>>,
+    task_forwarder_txs: Vec<mpsc::UnboundedSender<PeerMessageContext>>,
     /// Frost configuration
     config: FrostConfig,
 }
@@ -234,8 +245,15 @@ impl FrostManager {
                     return;
                 }
 
+                let peer_data =
+                    self.peers_connections.get(&peer_id).unwrap().first().expect("checked above");
+
                 for task_forwarder in &self.task_forwarder_txs {
-                    if let Err(send_res) = task_forwarder.send((peer_id, response.clone())) {
+                    if let Err(send_res) = task_forwarder.send(PeerMessageContext {
+                        peer_id,
+                        frost_identifier: peer_data.frost_identifier,
+                        message: response.clone(),
+                    }) {
                         error!(target: "network::frost::on_network_event", "Received FrostProtocolEvent::PeerMessage event from peer with id {}, but could not forward it to task. Error: {:?}", peer_id, send_res);
                     }
                 }
@@ -321,7 +339,7 @@ impl FrostManager {
                 // create channel whereby keeping the sender half and sending to the caller the
                 // receiver
                 let (task_forwarder_txs, frost_task_forwarder_rx) =
-                    mpsc::unbounded_channel::<(PeerId, PeerMessageResponse)>();
+                    mpsc::unbounded_channel::<PeerMessageContext>();
                 self.task_forwarder_txs.push(task_forwarder_txs);
                 // reply to caller
                 if let Err(e) = tx.send(frost_task_forwarder_rx) {
@@ -385,7 +403,7 @@ pub enum FrostCommand {
     /// Get the readily connected peers
     GetAllConnectedPeers(oneshot::Sender<HashMap<PeerId, PeerData>>),
     /// Get a receiver for streaming peer messages
-    GetPeerMessagesStream(oneshot::Sender<mpsc::UnboundedReceiver<(PeerId, PeerMessageResponse)>>),
+    GetPeerMessagesStream(oneshot::Sender<mpsc::UnboundedReceiver<PeerMessageContext>>),
     /// Get wallet state from peer
     GetWalletStateFromPeer,
 }

--- a/crates/net/network/src/frost/messages.rs
+++ b/crates/net/network/src/frost/messages.rs
@@ -7,7 +7,6 @@ use reth_network_peers::PeerId;
 use reth_primitives::{Buf, BufMut, BytesMut};
 
 const MESSAGE_VERSION: usize = 0;
-const UTXO_SET_MESSAGE_VERSION: usize = 0;
 const WALLET_STATE_MESSAGE_VERSION: usize = 0;
 
 /// A structured healthcheck message
@@ -70,28 +69,6 @@ impl SignRequest {
     }
 }
 
-/// A structured utxo set message
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct UtxoRequest {
-    /// The version of the request message
-    pub version: u16,
-    /// utxo set data
-    pub data: Vec<u8>,
-}
-
-impl fmt::Display for UtxoRequest {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Utxo set data Size: {} bytes", self.data.len())
-    }
-}
-
-impl UtxoRequest {
-    /// Constructs a new PBFT Request using a data payload.
-    pub const fn new(data: Vec<u8>) -> Self {
-        Self { version: UTXO_SET_MESSAGE_VERSION as u16, data }
-    }
-}
-
 /// A structured wallet state message
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WalletStateRequest {
@@ -151,14 +128,12 @@ pub enum FrostProtoMessageId {
     SignerRound2SigningPackage = 0x08,
     /// Coordinating node will collect the PSBTs with the partial sigs
     CoordinatorRound2SigningPackage = 0x09,
-    /// Utxo set
-    Utxo = 0x0A,
     /// Healthcheck
-    Healthcheck = 0x0B,
+    Healthcheck = 0x0A,
     /// Round 1 Dkg request message
-    Round1DkgRequest = 0x0C,
+    Round1DkgRequest = 0x0B,
     /// WalletState
-    WalletState = 0x0D,
+    WalletState = 0x0C,
 }
 
 /// Enum defining the frost message kind
@@ -186,8 +161,6 @@ pub enum FrostProtoMessageKind {
     SignerRound2SigningPackage(SignRequest),
     /// Coordinating node will collect the PSBTs with the partial sigs
     CoordinatorRound2SigningPackage(SignRequest),
-    /// Utxo set message
-    Utxo(UtxoRequest),
     /// Health
     Healthcheck(HealthcheckRequest),
     /// Wallet state message
@@ -295,14 +268,6 @@ impl FrostProtoMessage {
         }
     }
 
-    /// Creates a utxo set message
-    pub const fn utxo_message(resource: UtxoRequest) -> Self {
-        Self {
-            message_type: FrostProtoMessageId::Utxo,
-            message: FrostProtoMessageKind::Utxo(resource),
-        }
-    }
-
     /// Creates a wallet state message
     pub const fn wallet_state_message(resource: WalletStateRequest) -> Self {
         Self {
@@ -363,11 +328,6 @@ impl FrostProtoMessage {
                 buf.put_u32_le(resource.psbt.len() as u32); // Use u32 to support larger data sizes
                 buf.put_slice(&resource.psbt);
             }
-            FrostProtoMessageKind::Utxo(resource) => {
-                // serialize the data
-                buf.put_u64_le(resource.data.len() as u64); // Use u64 to support larger data sizes
-                buf.put_slice(&resource.data);
-            }
             FrostProtoMessageKind::Healthcheck(resource) => {
                 // Serialize the sender
                 let sender_bytes = resource.sender.as_slice();
@@ -414,10 +374,9 @@ impl FrostProtoMessage {
             0x07 => FrostProtoMessageId::CoordinatorRound1SigningPackage,
             0x08 => FrostProtoMessageId::SignerRound2SigningPackage,
             0x09 => FrostProtoMessageId::CoordinatorRound2SigningPackage,
-            0x0A => FrostProtoMessageId::Utxo,
-            0x0B => FrostProtoMessageId::Healthcheck,
-            0x0C => FrostProtoMessageId::Round1DkgRequest,
-            0x0D => FrostProtoMessageId::WalletState,
+            0x0A => FrostProtoMessageId::Healthcheck,
+            0x0B => FrostProtoMessageId::Round1DkgRequest,
+            0x0C => FrostProtoMessageId::WalletState,
             _ => return None,
         };
         let message = match message_type {
@@ -558,15 +517,6 @@ impl FrostProtoMessage {
                     psbt,
                 ))
             }
-            FrostProtoMessageId::Utxo => {
-                // utxo
-                let utxo_set_len = u64::from_le_bytes(buf[..8].try_into().unwrap()) as usize;
-                buf.advance(8);
-                let utxo = buf[..utxo_set_len].to_vec();
-                buf.advance(utxo_set_len);
-
-                FrostProtoMessageKind::Utxo(UtxoRequest::new(utxo))
-            }
             FrostProtoMessageId::Healthcheck => {
                 // Deserialize the sender
                 let sender_len = u16::from_le_bytes(buf[..2].try_into().unwrap()) as usize;
@@ -620,7 +570,7 @@ mod tests {
     use super::{
         DkgRequest, FrostProtoMessage, FrostProtoMessageId, FrostProtoMessageKind, SignRequest,
     };
-    use super::{HealthcheckRequest, UtxoRequest, WalletStateRequest};
+    use super::{HealthcheckRequest, WalletStateRequest};
     use itertools::Itertools;
     #[allow(unused_imports)]
     use reth_primitives::SealedBlock;
@@ -717,33 +667,6 @@ mod tests {
             assert_eq!(decoded_peer_id, peer_id, "PeerId does not match");
         } else {
             panic!("Decoded message is not a PongMessage");
-        }
-    }
-
-    #[test]
-    fn test_utxo_encode_decode() {
-        let msg = "foo bar".to_owned();
-        let random_string = msg.bytes().collect_vec();
-
-        let message = FrostProtoMessage {
-            message_type: FrostProtoMessageId::Utxo,
-            message: FrostProtoMessageKind::Utxo(UtxoRequest::new(random_string)),
-        };
-
-        // Encode the message
-        let encoded_bytes = message.encoded();
-
-        // Simulate receiving the encoded bytes and decoding them
-        let mut encoded_bytes_slice: &[u8] = &encoded_bytes;
-        let decoded_message = FrostProtoMessage::decode_message(&mut encoded_bytes_slice)
-            .expect("Failed to decode UtxoMessage");
-
-        // Verify that the decoded message matches the original message
-        if let FrostProtoMessageKind::Utxo(utxo_request) = decoded_message.message {
-            let decoded_message = String::from_utf8(utxo_request.data).unwrap();
-            assert_eq!(decoded_message, msg, "data does not match");
-        } else {
-            panic!("Decoded message is not a UtxoMessage");
         }
     }
 

--- a/crates/net/network/src/frost/messages.rs
+++ b/crates/net/network/src/frost/messages.rs
@@ -38,16 +38,16 @@ impl fmt::Display for HealthcheckRequest {
 pub struct DkgRequest {
     /// The version of the request message
     pub version: u16,
-    /// Frost identifier
-    pub identifier: Vec<u8>,
     /// Frost data
     pub data: Vec<u8>,
+    /// Frost identifier
+    pub identifier: Vec<u8>,
 }
 
 impl DkgRequest {
     /// Constructs a new DKG Request using a frost identifier and a data payload.
-    pub const fn new(identifier: Vec<u8>, data: Vec<u8>) -> Self {
-        Self { version: MESSAGE_VERSION as u16, identifier, data }
+    pub const fn new(data: Vec<u8>, identifier: Vec<u8>) -> Self {
+        Self { version: MESSAGE_VERSION as u16, data, identifier }
     }
 }
 
@@ -56,8 +56,6 @@ impl DkgRequest {
 pub struct SignRequest {
     /// The version of the request message
     pub version: u16,
-    /// Frost identifier
-    pub identifier: Vec<u8>,
     /// Signing session id
     pub signing_session_id: Vec<u8>,
     /// Frost data
@@ -67,8 +65,8 @@ pub struct SignRequest {
 impl SignRequest {
     /// Constructs a new sign Request using a frost identifier, signing session id and a psbt
     /// payload.
-    pub const fn new(identifier: Vec<u8>, signing_session_id: Vec<u8>, psbt: Vec<u8>) -> Self {
-        Self { version: MESSAGE_VERSION as u16, identifier, signing_session_id, psbt }
+    pub const fn new(signing_session_id: Vec<u8>, psbt: Vec<u8>) -> Self {
+        Self { version: MESSAGE_VERSION as u16, signing_session_id, psbt }
     }
 }
 
@@ -358,9 +356,6 @@ impl FrostProtoMessage {
             FrostProtoMessageKind::SignerRound2SigningPackage(resource) |
             FrostProtoMessageKind::CoordinatorRound1SigningPackage(resource) |
             FrostProtoMessageKind::CoordinatorRound2SigningPackage(resource) => {
-                // identifier
-                buf.put_u8(resource.identifier.len() as u8); // Assuming identifier is not too long
-                buf.put_slice(&resource.identifier);
                 // signing session id
                 buf.put_u32_le(resource.signing_session_id.len() as u32); // Use u32 to support larger data sizes
                 buf.put_slice(&resource.signing_session_id);
@@ -438,7 +433,7 @@ impl FrostProtoMessage {
                 let data = buf[..data_len].to_vec();
                 buf.advance(data_len);
 
-                FrostProtoMessageKind::Round1Dkg(DkgRequest::new(identifier, data))
+                FrostProtoMessageKind::Round1Dkg(DkgRequest::new(data, identifier))
             }
             FrostProtoMessageId::Round2Dkg => {
                 let id_len = buf[0] as usize;
@@ -451,7 +446,7 @@ impl FrostProtoMessage {
                 let data = buf[..data_len].to_vec();
                 buf.advance(data_len);
 
-                FrostProtoMessageKind::Round2Dkg(DkgRequest::new(identifier, data))
+                FrostProtoMessageKind::Round2Dkg(DkgRequest::new(data, identifier))
             }
             FrostProtoMessageId::Round1DkgRequest => {
                 let id_len = buf[0] as usize;
@@ -464,7 +459,7 @@ impl FrostProtoMessage {
                 let data = buf[..data_len].to_vec();
                 buf.advance(data_len);
 
-                FrostProtoMessageKind::Round1DkgRequest(DkgRequest::new(identifier, data))
+                FrostProtoMessageKind::Round1DkgRequest(DkgRequest::new(data, identifier))
             }
 
             FrostProtoMessageId::Ping => FrostProtoMessageKind::Ping,
@@ -488,11 +483,6 @@ impl FrostProtoMessage {
                 FrostProtoMessageKind::PongMessage(peer_id)
             }
             FrostProtoMessageId::SignerRound1SigningPackage => {
-                // id
-                let id_len = buf[0] as usize;
-                buf.advance(1);
-                let identifier = buf[..id_len].to_vec();
-                buf.advance(id_len);
                 // Decode signing_session_id as u32
                 let session_id_len = u32::from_le_bytes(
                     buf[..4].try_into().expect("Buffer underflow for session ID length"),
@@ -507,17 +497,11 @@ impl FrostProtoMessage {
                 buf.advance(psbt_len);
 
                 FrostProtoMessageKind::SignerRound1SigningPackage(SignRequest::new(
-                    identifier,
                     signing_session_id,
                     psbt,
                 ))
             }
             FrostProtoMessageId::CoordinatorRound1SigningPackage => {
-                // id
-                let id_len = buf[0] as usize;
-                buf.advance(1);
-                let identifier = buf[..id_len].to_vec();
-                buf.advance(id_len);
                 // Decode signing_session_id as u32
                 let session_id_len = u32::from_le_bytes(
                     buf[..4].try_into().expect("Buffer underflow for session ID length"),
@@ -532,17 +516,11 @@ impl FrostProtoMessage {
                 buf.advance(psbt_len);
 
                 FrostProtoMessageKind::CoordinatorRound1SigningPackage(SignRequest::new(
-                    identifier,
                     signing_session_id,
                     psbt,
                 ))
             }
             FrostProtoMessageId::SignerRound2SigningPackage => {
-                // id
-                let id_len = buf[0] as usize;
-                buf.advance(1);
-                let identifier = buf[..id_len].to_vec();
-                buf.advance(id_len);
                 // Decode signing_session_id as u32
                 let session_id_len = u32::from_le_bytes(
                     buf[..4].try_into().expect("Buffer underflow for session ID length"),
@@ -557,17 +535,11 @@ impl FrostProtoMessage {
                 buf.advance(psbt_len);
 
                 FrostProtoMessageKind::SignerRound2SigningPackage(SignRequest::new(
-                    identifier,
                     signing_session_id,
                     psbt,
                 ))
             }
             FrostProtoMessageId::CoordinatorRound2SigningPackage => {
-                // id
-                let id_len = buf[0] as usize;
-                buf.advance(1);
-                let identifier = buf[..id_len].to_vec();
-                buf.advance(id_len);
                 // Decode signing_session_id as u32
                 let session_id_len = u32::from_le_bytes(
                     buf[..4].try_into().expect("Buffer underflow for session ID length"),
@@ -582,7 +554,6 @@ impl FrostProtoMessage {
                 buf.advance(psbt_len);
 
                 FrostProtoMessageKind::CoordinatorRound2SigningPackage(SignRequest::new(
-                    identifier,
                     signing_session_id,
                     psbt,
                 ))
@@ -681,8 +652,7 @@ mod tests {
 
     #[test]
     fn test_signing_encoding_decoding() {
-        let signing_request =
-            SignRequest::new(vec![1, 2, 3, 4], vec![5, 6, 7, 8, 9], vec![0, 1, 0, 1, 0]);
+        let signing_request = SignRequest::new(vec![5, 6, 7, 8, 9], vec![0, 1, 0, 1, 0]);
 
         let message = FrostProtoMessage {
             message_type: FrostProtoMessageId::SignerRound1SigningPackage,

--- a/crates/net/network/src/frost/mod.rs
+++ b/crates/net/network/src/frost/mod.rs
@@ -45,21 +45,18 @@ impl fmt::Display for PeerMessageResponse {
 pub struct DkgResponse {
     /// The Response Type
     pub response_type: DkgEventResponseType,
-    /// Frost Identifier
-    pub identifier: Vec<u8>,
     /// Frost Data
     pub data: Vec<u8>,
+    /// Frost Identifier
+    /// Note: for signing we do not require this field as we can pull it from peer data when the
+    /// session is established for DKG we do require it as the coordinator sends the round 1
+    /// package on the behalf of the signers
+    pub identifier: Vec<u8>,
 }
 
 impl fmt::Display for DkgResponse {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{} - Identifier Size: {} bytes, Data Size: {} bytes",
-            self.response_type,
-            self.identifier.len(),
-            self.data.len()
-        )
+        write!(f, "{} - bytes, Data Size: {} bytes", self.response_type, self.data.len())
     }
 }
 
@@ -122,8 +119,6 @@ impl fmt::Display for HealthcheckResponse {
 pub struct SigningResponse {
     /// The Response Type
     pub response_type: SigningEventResponseType,
-    /// Frost identifier
-    pub identifier: Vec<u8>,
     /// Signing session id
     pub signing_session_id: Vec<u8>,
     /// Frost data
@@ -134,9 +129,8 @@ impl fmt::Display for SigningResponse {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{} - Identifier Size: {} bytes, Session ID Size: {} bytes, PSBT Size: {} bytes",
+            "{} - bytes, Session ID Size: {} bytes, PSBT Size: {} bytes",
             self.response_type,
-            self.identifier.len(),
             self.signing_session_id.len(),
             self.psbt.len()
         )

--- a/crates/net/network/src/frost/mod.rs
+++ b/crates/net/network/src/frost/mod.rs
@@ -209,39 +209,15 @@ impl fmt::Display for SigningEventResponseType {
     }
 }
 
-/// Frost Protocol Events
+/// All events related to frost events emitted by the network.
+/// These are events that are emitted by the network to the frost manager.
+/// And most likely will be used to update the frost task state.
 #[derive(Debug, Clone)]
 pub enum FrostProtocolEvent {
     /// An emitted event once the connection is established
     ConnectionEstablished {
         #[allow(dead_code)]
         /// the connection direction - we connected to them, or they to us
-        direction: Direction,
-        /// the other peer id
-        peer_id: PeerId,
-        /// the tx sender we send to the other peer to enable it to communicate with us
-        peer_commands_tx: mpsc::UnboundedSender<FrostPeerCommand>,
-    },
-    /// An emitted event once a peer sends a message to another peer
-    PeerMessage {
-        /// The other peer id
-        peer_id: PeerId,
-        /// The message response
-        response: PeerMessageResponse,
-    },
-}
-
-/// All events related to frost events emitted by the network.
-/// These are events that are emitted by the network to the frost manager.
-/// And most likely will be used to update the frost task state.
-#[derive(Debug)]
-pub enum NetworkFrostEvent {
-    /// Represents the event of receiving a list of transactions from a peer.
-    ///
-    /// This indicates transactions that were broadcasted to us from the peer.
-    ConnectionEstablished {
-        #[allow(dead_code)]
-        /// the connection direction - we dialed them, or they dialed us
         direction: Direction,
         /// the other peer id
         peer_id: PeerId,

--- a/crates/net/network/src/frost/protocol.rs
+++ b/crates/net/network/src/frost/protocol.rs
@@ -206,19 +206,19 @@ impl Stream for FrostProtoConnection {
                         let DkgResponse { response_type, identifier, data } = dkg_response;
                         match response_type {
                             DkgEventResponseType::DkgRound1Request => {
-                                let req = DkgRequest::new(identifier, data);
+                                let req = DkgRequest::new(data, identifier);
                                 Poll::Ready(Some(
                                     FrostProtoMessage::round1_dkg_request_message(req).encoded(),
                                 ))
                             }
                             DkgEventResponseType::DkgRound1 => {
-                                let req = DkgRequest::new(identifier, data);
+                                let req = DkgRequest::new(data, identifier);
                                 Poll::Ready(Some(
                                     FrostProtoMessage::round1_dkg_message(req).encoded(),
                                 ))
                             }
                             DkgEventResponseType::DkgRound2 => {
-                                let req = DkgRequest::new(identifier, data);
+                                let req = DkgRequest::new(data, identifier);
                                 Poll::Ready(Some(
                                     FrostProtoMessage::round2_dkg_message(req).encoded(),
                                 ))
@@ -226,17 +226,17 @@ impl Stream for FrostProtoConnection {
                         }
                     }
                     PeerMessageResponse::Signing(signing_response) => {
-                        let SigningResponse { response_type, identifier, signing_session_id, psbt } =
+                        let SigningResponse { response_type, signing_session_id, psbt } =
                             signing_response;
                         match response_type {
                             SigningEventResponseType::SignerRound1SigningPackage => {
-                                let req = SignRequest::new(identifier, signing_session_id, psbt);
+                                let req = SignRequest::new(signing_session_id, psbt);
                                 Poll::Ready(Some(
                                     FrostProtoMessage::round1_signer_package_message(req).encoded(),
                                 ))
                             }
                             SigningEventResponseType::CoordinatorRound1SigningPackage => {
-                                let req = SignRequest::new(identifier, signing_session_id, psbt);
+                                let req = SignRequest::new(signing_session_id, psbt);
                                 Poll::Ready(Some(
                                     FrostProtoMessage::round1_coordinator_signing_package_message(
                                         req,
@@ -245,13 +245,13 @@ impl Stream for FrostProtoConnection {
                                 ))
                             }
                             SigningEventResponseType::SignerRound2SigningPackage => {
-                                let req = SignRequest::new(identifier, signing_session_id, psbt);
+                                let req = SignRequest::new(signing_session_id, psbt);
                                 Poll::Ready(Some(
                                     FrostProtoMessage::round2_signer_package_message(req).encoded(),
                                 ))
                             }
                             SigningEventResponseType::CoordinatorRound2SigningPackage => {
-                                let req = SignRequest::new(identifier, signing_session_id, psbt);
+                                let req = SignRequest::new(signing_session_id, psbt);
                                 Poll::Ready(Some(
                                     FrostProtoMessage::round2_coordinator_signing_package_message(
                                         req,
@@ -357,7 +357,6 @@ impl Stream for FrostProtoConnection {
                 if let Err(e) = protocol_events_tx.send(FrostProtocolEvent::PeerMessage {
                     response: PeerMessageResponse::Signing(SigningResponse {
                         response_type: SigningEventResponseType::SignerRound1SigningPackage,
-                        identifier: data.identifier,
                         signing_session_id: data.signing_session_id,
                         psbt: data.psbt,
                     }),
@@ -370,7 +369,6 @@ impl Stream for FrostProtoConnection {
                 if let Err(e) = protocol_events_tx.send(FrostProtocolEvent::PeerMessage {
                     response: PeerMessageResponse::Signing(SigningResponse {
                         response_type: SigningEventResponseType::CoordinatorRound1SigningPackage,
-                        identifier: data.identifier,
                         signing_session_id: data.signing_session_id,
                         psbt: data.psbt,
                     }),
@@ -383,7 +381,6 @@ impl Stream for FrostProtoConnection {
                 if let Err(e) = protocol_events_tx.send(FrostProtocolEvent::PeerMessage {
                     response: PeerMessageResponse::Signing(SigningResponse {
                         response_type: SigningEventResponseType::SignerRound2SigningPackage,
-                        identifier: data.identifier,
                         signing_session_id: data.signing_session_id,
                         psbt: data.psbt,
                     }),
@@ -396,7 +393,6 @@ impl Stream for FrostProtoConnection {
                 if let Err(e) = protocol_events_tx.send(FrostProtocolEvent::PeerMessage {
                     response: PeerMessageResponse::Signing(SigningResponse {
                         response_type: SigningEventResponseType::CoordinatorRound2SigningPackage,
-                        identifier: data.identifier,
                         signing_session_id: data.signing_session_id,
                         psbt: data.psbt,
                     }),

--- a/crates/net/network/src/frost/protocol.rs
+++ b/crates/net/network/src/frost/protocol.rs
@@ -411,8 +411,6 @@ impl Stream for FrostProtoConnection {
                     peer_id: this.peer_id,
                 });
             }
-            // deprecated: TODO remove
-            FrostProtoMessageKind::Utxo(_data) => {}
         }
 
         Poll::Pending


### PR DESCRIPTION
I was actually mistaken about the original desc. of this ticket. https://github.com/botanix-labs/botanix/issues/773
The peer message is provided in `PeerMessage` by the frost protocol manager. The original peer id is provided in `in_coming` which comes from the network manager. meaning a faulty federation member cannot just inject invalid peer ids. HOWEVER, they can provide whatever frost ids they want. 

I would want to remove the frost id as something the peer can provide in a message and calculate it on the fly.
We have a mapping of peer_id -> auth_pk (sorted list). So we should be able to get the index of the authority pk and calculate the frost id from the index. 

@rwlockbg @scottmillner  Does this make sense to you guys?