### PR TITLE
fix(builder): Removed re-initialized state lock

### DIFF
--- a/crates/consensus/authority/src/builder.rs
+++ b/crates/consensus/authority/src/builder.rs
@@ -279,8 +279,6 @@ where
             state_sync.snapshot_message_format,
         ));
 
-        let snapshot_manager_state_lock =
-            Arc::new(RwLock::new(SnapshotManagerStateLock::default()));
         let snapshot_manager = Some(SnapshotManager::new(
             storage.clone(),
             parser.clone(),


### PR DESCRIPTION
This PR makes both snapshot manager and abci use the same lock instance which is threadsafe and shared between both of them. Previously there were 2 independent ones and the lock did not work properly.