### PR TITLE
test(int-tests): don't load wallet and generate blocks in tests

### DIFF
--- a/bin/test-suite/src/suite/consensus/frost/test_batch_pegins.rs
+++ b/bin/test-suite/src/suite/consensus/frost/test_batch_pegins.rs
@@ -19,10 +19,10 @@ use reth_primitives::Address;
 use crate::{
     it_info_print,
     suite::consensus::{
-        common::events::{await_botanix_event, GatewayAddressResponse, BITCOIND_WALLET_NAME},
+        common::events::{await_botanix_event, GatewayAddressResponse},
         ConsensusIntegrationTestSuite,
     },
-    utils::{generate_blocks, MIN_BLOCKS_COINBASE_MATURE},
+    utils::generate_blocks,
 };
 
 const NUM_PEGINS: u16 = 5;
@@ -35,19 +35,6 @@ pub async fn batch_pegins(
     let pegin_conf_depth = BOTANIX_TESTNET.parent_confirmation_depth;
     it_info_print!("Pegin Confirmation Depth", pegin_conf_depth);
     let bitcoind_rpc = suite.global_context.bitcoind_rpc();
-
-    // Load up the bitcoin wallet and generate some blocks
-    for wallet in bitcoind_rpc.list_wallets().unwrap() {
-        it_info_print!("#UNLOADING WALLET?", &wallet);
-        let _ = bitcoind_rpc.unload_wallet(Some(&wallet));
-    }
-    let create_res = bitcoind_rpc.create_wallet(BITCOIND_WALLET_NAME, None, None, None, None);
-    if create_res.is_err() {
-        // wallet already exists, load wallet
-        let _ = bitcoind_rpc.load_wallet(BITCOIND_WALLET_NAME);
-    }
-    // generate > 100 blocks so coinbase utxos can be spent from the wallet
-    generate_blocks(&bitcoind_rpc, MIN_BLOCKS_COINBASE_MATURE).await;
     tokio::time::sleep(Duration::from_secs(5)).await;
 
     let test_fed_members = suite

--- a/bin/test-suite/src/suite/consensus/frost/test_frost_e2e.rs
+++ b/bin/test-suite/src/suite/consensus/frost/test_frost_e2e.rs
@@ -19,10 +19,10 @@ use reth_primitives::Address;
 use crate::{
     it_info_print,
     suite::consensus::{
-        common::events::{await_botanix_event, GatewayAddressResponse, BITCOIND_WALLET_NAME},
+        common::events::{await_botanix_event, GatewayAddressResponse},
         ConsensusIntegrationTestSuite,
     },
-    utils::{generate_blocks, MIN_BLOCKS_COINBASE_MATURE},
+    utils::generate_blocks,
 };
 
 #[allow(clippy::too_many_lines)]
@@ -35,20 +35,6 @@ pub async fn frost_e2e_stable(
     // Set up regtest connection
     // config is hardcoded to only work with regtest
     let bitcoind_rpc = suite.global_context.bitcoind_rpc();
-
-    // Load up the bitcoin wallet and generate some blocks
-    for wallet in bitcoind_rpc.list_wallets().unwrap() {
-        it_info_print!("#UNLOADING WALLET?", &wallet);
-        let _ = bitcoind_rpc.unload_wallet(Some(&wallet));
-    }
-    let create_res = bitcoind_rpc.create_wallet(BITCOIND_WALLET_NAME, None, None, None, None);
-    if create_res.is_err() {
-        // wallet already exists
-        // load wallet
-        let _ = bitcoind_rpc.load_wallet(BITCOIND_WALLET_NAME);
-    }
-    // generate > 100 blocks so coinbase utxos can be spent from the wallet
-    generate_blocks(&bitcoind_rpc, MIN_BLOCKS_COINBASE_MATURE).await;
     tokio::time::sleep(Duration::from_secs(5)).await;
 
     let test_fed_members = suite

--- a/bin/test-suite/src/suite/consensus/frost/test_frost_e2e_signing_disconnect.rs
+++ b/bin/test-suite/src/suite/consensus/frost/test_frost_e2e_signing_disconnect.rs
@@ -35,20 +35,6 @@ pub async fn frost_e2e_failed_signing_disconnect(
 ) -> anyhow::Result<(), super::error::Error> {
     let pegin_conf_depth = 6; //TODO(stevenroose) set this from chain constant?
     let bitcoind_rpc = suite.global_context.bitcoind_rpc();
-
-    // Load up the bitcoin wallet and generate some blocks
-    for wallet in bitcoind_rpc.list_wallets().unwrap() {
-        it_info_print!("#UNLOADING WALLET?", &wallet);
-        let _ = bitcoind_rpc.unload_wallet(Some(&wallet));
-    }
-    let create_res = bitcoind_rpc.create_wallet(BITCOIND_WALLET_NAME, None, None, None, None);
-    if create_res.is_err() {
-        // wallet already exists
-        // load wallet
-        let _ = bitcoind_rpc.load_wallet(BITCOIND_WALLET_NAME);
-    }
-    // generate > 100 blocks so coinbase utxos can be spent from the wallet
-    generate_blocks(&bitcoind_rpc, MIN_BLOCKS_COINBASE_MATURE).await;
     tokio::time::sleep(Duration::from_secs(5)).await;
 
     let test_fed_members = suite

--- a/bin/test-suite/src/suite/consensus/invalid_transactions/test_invalid_pegin.rs
+++ b/bin/test-suite/src/suite/consensus/invalid_transactions/test_invalid_pegin.rs
@@ -9,11 +9,8 @@ use reth_primitives::Address;
 
 use crate::{
     it_info_print,
-    suite::consensus::{
-        common::events::{GatewayAddressResponse, BITCOIND_WALLET_NAME},
-        ConsensusIntegrationTestSuite,
-    },
-    utils::{generate_blocks, MIN_BLOCKS_COINBASE_MATURE},
+    suite::consensus::{common::events::GatewayAddressResponse, ConsensusIntegrationTestSuite},
+    utils::generate_blocks,
 };
 
 #[allow(clippy::too_many_lines)]
@@ -25,22 +22,6 @@ pub async fn invalid_pegin(
     // Set up regtest connection
     // config is hardcoded to only work with regtest
     let bitcoind_rpc = suite.global_context.bitcoind_rpc();
-
-    // Load up the bitcoin wallet and generate some blocks
-    for wallet in bitcoind_rpc.list_wallets().unwrap() {
-        it_info_print!("#UNLOADING WALLET?", &wallet);
-        let _ = bitcoind_rpc.unload_wallet(Some(&wallet));
-    }
-    let create_res = bitcoind_rpc.create_wallet(BITCOIND_WALLET_NAME, None, None, None, None);
-    if create_res.is_err() {
-        // wallet already exists
-        // load wallet
-        let _ = bitcoind_rpc.load_wallet(BITCOIND_WALLET_NAME);
-    }
-    let _address =
-        bitcoind_rpc.get_new_address(None, None).expect("get new address").assume_checked();
-    // generate > 100 blocks so coinbase utxos can be spent from the wallet
-    generate_blocks(&bitcoind_rpc, MIN_BLOCKS_COINBASE_MATURE).await;
     tokio::time::sleep(Duration::from_secs(5)).await;
 
     let test_fed_members = suite


### PR DESCRIPTION
We don't need to load the test wallet and generate blocks inside the tests bc this is done during the setup before each test.  This should reduce the time the test-suite runs a bit.