### PR TITLE
Botanix up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2166,6 +2166,7 @@ dependencies = [
  "clap",
  "hex",
  "rand 0.8.5",
+ "reth-node-core",
  "secp256k1 0.29.1",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2159,6 +2159,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "botanix-up"
+version = "1.0.5"
+dependencies = [
+ "anyhow",
+ "clap",
+ "hex",
+ "rand 0.8.5",
+ "secp256k1 0.29.1",
+ "serde",
+ "serde_json",
+ "test-suite",
+ "tokio",
+ "toml",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "boyer-moore-magiclen"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ exclude = [".github/"]
 resolver = "2"
 
 members = [
+    "bin/botanix-up",
     "bin/btc-server",
     "bin/federation-utils",
     "bin/reth-bench/",

--- a/bin/botanix-up/.gitignore
+++ b/bin/botanix-up/.gitignore
@@ -1,0 +1,2 @@
+# Botanix up default output directory
+output/

--- a/bin/botanix-up/Cargo.toml
+++ b/bin/botanix-up/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "botanix-up"
+version = { workspace = true }
+edition = { workspace = true }
+rust-version = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+exclude = { workspace = true }
+
+[[bin]]
+name = "botanix-up"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1.0.95"
+clap = { version = "4", features = ["derive"] }
+hex = "0.4.3"
+rand = { workspace = true }
+secp256k1 = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+test-suite = { path = "../test-suite" }
+tokio = { version = "1.43.0", features = ["full"] }
+toml = { workspace = true }
+tracing = { workspace = true }
+url = { workspace = true }
+[lints]
+workspace = true

--- a/bin/botanix-up/Cargo.toml
+++ b/bin/botanix-up/Cargo.toml
@@ -17,6 +17,7 @@ anyhow = "1.0.95"
 clap = { version = "4", features = ["derive"] }
 hex = "0.4.3"
 rand = { workspace = true }
+reth-node-core = { workspace = true }
 secp256k1 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/bin/botanix-up/src/cli.rs
+++ b/bin/botanix-up/src/cli.rs
@@ -1,0 +1,51 @@
+use anyhow::Result;
+use clap::Parser;
+#[derive(Parser, Debug)]
+#[command(name = "Botanix Up")]
+pub(crate) struct Cli {
+    /// Config.toml path (default path is home directory)
+    #[arg(short = 'o', long)]
+    pub output_path: Option<String>,
+
+    /// numbers of nodes
+    #[arg(short = 'n', long)]
+    pub(crate) num_nodes: u16,
+
+    /// multisig min signers
+    #[arg(short = 'm', long)]
+    pub(crate) multisig_min_signers: u16,
+
+    /// multisig max signers
+    #[arg(short = 't', long)]
+    pub(crate) multisig_max_signers: u16,
+}
+
+impl Cli {
+    pub(crate) fn validate(&self) -> Result<()> {
+        if self.num_nodes == 0 {
+            return Err(anyhow::anyhow!("Number of nodes must be greater than 0"));
+        }
+
+        if self.multisig_max_signers == 0 {
+            return Err(anyhow::anyhow!("Max signers must be greater than 0"));
+        }
+
+        if self.multisig_min_signers == 0 {
+            return Err(anyhow::anyhow!("Min signers must be greater than 0"));
+        }
+
+        if self.multisig_min_signers > self.num_nodes || self.multisig_max_signers > self.num_nodes
+        {
+            return Err(anyhow::anyhow!(
+                "Min signers and max signers must be less than or equal to the number of nodes"
+            ));
+        }
+
+        if self.multisig_max_signers < self.multisig_min_signers {
+            return Err(anyhow::anyhow!(
+                "Max signers must be greater than or equal to the min signers"
+            ));
+        }
+        Ok(())
+    }
+}

--- a/bin/botanix-up/src/main.rs
+++ b/bin/botanix-up/src/main.rs
@@ -6,13 +6,20 @@ use crate::comet_node::{get_enode, TestSignal};
 use anyhow::{Context, Result as AnyResult};
 use clap::Parser;
 use cli::Cli;
+use reth_node_core::{
+    args::{FedMemberPubKey, FederationTomlConfig},
+    primitives::Address,
+};
+use secp256k1::SECP256K1;
 use std::{
     fs,
+    io::Write,
     path::{Path, PathBuf},
 };
 use test_suite::suite::consensus::common::{
     comet_node::{self, updated_genesis_file, GenesisValidator, PrivValidator},
-    poa_node::ABCI_PORT_BASE,
+    poa_node::{ABCI_PORT_BASE, DISCOVERY_PORT_BASE},
+    MINTING_CONTRACT_BYTECODE,
 };
 use tokio::{self, sync::broadcast::channel};
 
@@ -29,7 +36,7 @@ async fn create_cometbft_nodes(num_nodes: u16, output_path: PathBuf) -> AnyResul
 
         let node_path = cometbft_path.join(format!("node-{}", i));
         std::fs::create_dir_all(&node_path)?;
-        let (exit_status, stdout, stderr) = comet_node::init_cometbft_node(i, &node_path).await?;
+        let (exit_status, _stdout, stderr) = comet_node::init_cometbft_node(i, &node_path).await?;
         if !exit_status.success() {
             return Err(anyhow::anyhow!(
                 "CometBFT node failed to initialize: {:?} {:?}",
@@ -100,6 +107,60 @@ async fn create_cometbft_nodes(num_nodes: u16, output_path: PathBuf) -> AnyResul
     Ok(())
 }
 
+async fn create_poa_nodes(num_nodes: u16, output_path: PathBuf) -> AnyResult<()> {
+    let random_fee_recipient = Address::random();
+    let poa_path = output_path.join("poa");
+    // Create the output directory
+    std::fs::create_dir_all(&poa_path)?;
+    let mut fed_pks = vec![];
+
+    for i in 0..num_nodes {
+        // Create data dir for the node
+        let node_path = poa_path.join(format!("node-{}", i));
+        std::fs::create_dir_all(&node_path)?;
+        // Create the secret key
+        let sk = secp256k1::SecretKey::new(&mut rand::thread_rng());
+        let pk = sk.public_key(SECP256K1);
+
+        // Write the discovery secret key
+        let discovery_secret_path = Path::new(&node_path).join("discovery-secret");
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open(discovery_secret_path.clone())
+            .context("discovery secret file cannot be created/opened")?;
+        let _ = file
+            .write_all(&sk.display_secret().to_string().as_bytes())
+            .context("error writing secret key to file")?;
+
+        let addrs = format!("127.0.0.1:{}", DISCOVERY_PORT_BASE + 1000 * i);
+        fed_pks.push(FedMemberPubKey { key: pk.to_string(), socket_addr: addrs });
+
+        // Lastly we need to create the jwt secret key
+        let jwt_secret_path = Path::new(&node_path).join("bjwt.hex");
+        let jwt_sk = secp256k1::SecretKey::new(&mut rand::thread_rng());
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open(jwt_secret_path.clone())
+            .context("jwt secret file cannot be created/opened")?;
+        let _ = file
+            .write_all(&jwt_sk.display_secret().to_string().as_bytes())
+            .context("error writing jwt secret key to file")?;
+    }
+
+    let federation_config = FederationTomlConfig {
+        federation_member_public_key: fed_pks,
+        botanix_fee_recipient: random_fee_recipient.to_string(),
+        minting_contract_bytecode: String::from(MINTING_CONTRACT_BYTECODE),
+    };
+
+    let federation_config_path = Path::new(&poa_path).join("federation.toml");
+    federation_config.write_to_path(&federation_config_path)?;
+
+    Ok(())
+}
+
 async fn inner_main() -> AnyResult<()> {
     let cli = Cli::parse();
     // Basic sanity checks
@@ -112,8 +173,8 @@ async fn inner_main() -> AnyResult<()> {
     // Create the output directory
     std::fs::create_dir_all(&output_path)?;
 
-    // Create the cometbft nodes
-    create_cometbft_nodes(cli.num_nodes, output_path).await?;
+    create_cometbft_nodes(cli.num_nodes, output_path.clone()).await?;
+    create_poa_nodes(cli.num_nodes, output_path.clone()).await?;
 
     // Create the output directory
     Ok(())

--- a/bin/botanix-up/src/main.rs
+++ b/bin/botanix-up/src/main.rs
@@ -1,0 +1,126 @@
+//! This binary is meant to setup a testnet botanix federation in one command.
+//! All the configs and binaries will be setup at a output location of your choice.
+
+mod cli;
+use crate::comet_node::{get_enode, TestSignal};
+use anyhow::{Context, Result as AnyResult};
+use clap::Parser;
+use cli::Cli;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+use test_suite::suite::consensus::common::{
+    comet_node::{self, updated_genesis_file, GenesisValidator, PrivValidator},
+    poa_node::ABCI_PORT_BASE,
+};
+use tokio::{self, sync::broadcast::channel};
+
+async fn create_cometbft_nodes(num_nodes: u16, output_path: PathBuf) -> AnyResult<()> {
+    let mut cometbft_nodes = Vec::new();
+    let cometbft_path = output_path.join("cometbft");
+    // Create the output directory
+    std::fs::create_dir_all(&cometbft_path)?;
+    // Create the nodes
+    for i in 0..num_nodes {
+        let cometbft_proxy_app_port = ABCI_PORT_BASE + 1000 * i;
+        let cometbft_rpc_app_port = cometbft_proxy_app_port - 1;
+        let cometbft_p2p_app_port = cometbft_rpc_app_port - 1;
+
+        let node_path = cometbft_path.join(format!("node-{}", i));
+        std::fs::create_dir_all(&node_path)?;
+        let (exit_status, stdout, stderr) = comet_node::init_cometbft_node(i, &node_path).await?;
+        if !exit_status.success() {
+            return Err(anyhow::anyhow!(
+                "CometBFT node failed to initialize: {:?} {:?}",
+                exit_status,
+                stderr
+            ));
+        }
+        // read priv_validator_key.json file
+        let priv_validator_key_file =
+            Path::new(&node_path).join("config").join("priv_validator_key.json");
+        let validator =
+            serde_json::from_str::<PrivValidator>(&fs::read_to_string(priv_validator_key_file)?)
+                .context("Error reading priv_validator_key.json file")?;
+
+        // get enode
+        let (exit_status, stdout, stderr) =
+            get_enode(i, &node_path).await.context("Error getting enode")?;
+        if !exit_status.success() {
+            tracing::error!(
+                "CometBFT enode failed to be obtained: {:?} {:?} {:?}",
+                exit_status,
+                stdout,
+                stderr
+            );
+            return Err(anyhow::anyhow!(
+                "CometBFT enode failed to be obtained: {:?} {:?}",
+                exit_status,
+                stderr
+            ));
+        }
+        let output_parts = stdout.split("\n").filter(|x| !x.is_empty()).collect::<Vec<&str>>();
+        let enode = output_parts[output_parts.len() - 1].trim().to_string();
+        tracing::info!("CometBFT enode: {:?}", enode);
+
+        // prepare test signal
+        let (test_signal_tx, _test_signal_rx) = channel::<TestSignal>(10);
+
+        // create the cometbft node
+        let cometbft_node = comet_node::CometBftNodeConfig::new(
+            i,
+            validator,
+            enode,
+            cometbft_proxy_app_port,
+            cometbft_rpc_app_port,
+            cometbft_p2p_app_port,
+            test_signal_tx,
+            node_path,
+            false,
+        )
+        .await?;
+        cometbft_nodes.push(cometbft_node);
+    }
+
+    let genesis_validators = cometbft_nodes
+        .iter()
+        .map(|c| GenesisValidator::from(&c.validator))
+        .collect::<Vec<GenesisValidator>>();
+
+    // Update all the configs with the other peer's information
+    for i in 0..num_nodes {
+        let node_path = cometbft_path.join(format!("node-{}", i));
+        let cometbft_node = cometbft_nodes[i as usize].clone();
+        updated_genesis_file(&node_path, genesis_validators.clone())
+            .expect("Error updating genesis file");
+        comet_node::update_config_toml(&cometbft_node).expect("Error updating config toml file");
+    }
+
+    Ok(())
+}
+
+async fn inner_main() -> AnyResult<()> {
+    let cli = Cli::parse();
+    // Basic sanity checks
+    cli.validate()?;
+    let output_path = PathBuf::from(
+        cli.output_path.unwrap_or(std::env::current_dir()?.to_str().unwrap().to_string()),
+    ).join("output");
+    println!("Output path: {:?}", output_path);
+
+    // Create the output directory
+    std::fs::create_dir_all(&output_path)?;
+
+    // Create the cometbft nodes
+    create_cometbft_nodes(cli.num_nodes, output_path).await?;
+
+    // Create the output directory
+    Ok(())
+}
+#[tokio::main]
+async fn main() {
+    if let Err(e) = inner_main().await {
+        eprintln!("ERROR: {}", e);
+    }
+}

--- a/bin/test-suite/src/suite/consensus/common/comet_node.rs
+++ b/bin/test-suite/src/suite/consensus/common/comet_node.rs
@@ -172,7 +172,7 @@ impl CometBftNodeConfig {
     }
 }
 
-async fn get_cometbft_version(
+pub async fn get_cometbft_version(
     index: u16,
     working_directory: &PathBuf,
 ) -> anyhow::Result<(ExitStatus, String, String)> {
@@ -185,7 +185,7 @@ async fn get_cometbft_version(
     Ok((exit_status, stdout, stderr))
 }
 
-async fn init_cometbft_node(
+pub async fn init_cometbft_node(
     index: u16,
     working_directory: &PathBuf,
 ) -> anyhow::Result<(ExitStatus, String, String)> {
@@ -199,7 +199,7 @@ async fn init_cometbft_node(
     Ok((exit_status, stdout, stderr))
 }
 
-async fn get_enode(
+pub async fn get_enode(
     index: u16,
     working_directory: &PathBuf,
 ) -> anyhow::Result<(ExitStatus, String, String)> {
@@ -213,7 +213,7 @@ async fn get_enode(
     Ok((exit_status, stdout, stderr))
 }
 
-fn updated_genesis_file(
+pub fn updated_genesis_file(
     working_directory: &PathBuf,
     all_validators: Vec<GenesisValidator>,
 ) -> anyhow::Result<()> {
@@ -263,7 +263,7 @@ fn updated_genesis_file(
     Ok(())
 }
 
-fn update_config_toml(cometbft_node: &CometBftNodeConfig) -> anyhow::Result<()> {
+pub fn update_config_toml(cometbft_node: &CometBftNodeConfig) -> anyhow::Result<()> {
     let config_file =
         Path::new(&cometbft_node.working_directory).join("config").join("config.toml");
     let mut toml: toml::Value = toml::from_str(&fs::read_to_string(&config_file)?)

--- a/bin/test-suite/src/suite/consensus/mod.rs
+++ b/bin/test-suite/src/suite/consensus/mod.rs
@@ -46,7 +46,7 @@ use std::{
 use tonic::transport::Channel;
 use tracing::info;
 // scopes
-mod common;
+pub mod common;
 pub mod frost;
 mod invalid_transactions;
 mod rpc_node;


### PR DESCRIPTION
Introducing a new binary, Botanix up. The goal of this binary is to easily auto generate the cometbft binaries for new testnet deployments, local dev setup and setting up new devs. The configs are all setup using existing test suite utils. Feature requested by @birozuru  for the new federation setup

Example run in the bin/botanix-up dir:

`cargo run --num-nodes 2 --multisig-min-signers 2 --multisig-max-signers 2`

```
.
├── Cargo.toml
├── cometbft
│   ├── node-0
│   │   ├── config
│   │   │   ├── config.toml
│   │   │   ├── genesis.json
│   │   │   ├── node_key.json
│   │   │   └── priv_validator_key.json
│   │   └── data
│   │       └── priv_validator_state.json
│   └── node-1
│       ├── config
│       │   ├── config.toml
│       │   ├── genesis.json
│       │   ├── node_key.json
│       │   └── priv_validator_key.json
│       └── data
│           └── priv_validator_state.json
├── poa
│   ├── federation.toml
│   ├── node-0
│   │   ├── bjwt.hex
│   │   └── discovery-secret
│   └── node-1
│       ├── bjwt.hex
│       └── discovery-secret
└── src
    ├── cli.rs
    └── main.rs

```