### PR TITLE
Fix/utxo version deser

### DIFF
--- a/bin/btc-server/src/database/mod.rs
+++ b/bin/btc-server/src/database/mod.rs
@@ -56,6 +56,7 @@ pub struct Utxo {
     pub output: TxOut,
     /// If this is a pegin UTXO, the user's pegin address.
     pub eth_address: Option<[u8; 20]>,
+    #[serde(default)]
     /// The version of the UTXO.
     pub version: u32,
 }

--- a/bin/btc-server/src/database/version.rs
+++ b/bin/btc-server/src/database/version.rs
@@ -3,9 +3,9 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone, Copy, PartialEq)]
 pub enum UtxoVersion {
-    /// Original version with basic spending conditions
+    /// Original version with taproot key spend path
     #[default]
-    V1 = 1,
+    V1 = 0,
 }
 
 impl TryFrom<u32> for UtxoVersion {
@@ -13,7 +13,7 @@ impl TryFrom<u32> for UtxoVersion {
 
     fn try_from(v: u32) -> Result<Self, Self::Error> {
         match v {
-            1 => Ok(UtxoVersion::V1),
+            0 => Ok(UtxoVersion::V1),
             _ => Err(Error::InvalidUTXOVersion(v)),
         }
     }

--- a/bin/btc-server/src/wallet/psbt.rs
+++ b/bin/btc-server/src/wallet/psbt.rs
@@ -14,7 +14,7 @@ use crate::database::version::UtxoVersion;
 const ETH_ADDRESS_KEY_TYPE: u8 = 1;
 const SIGNING_COMMITMENTS_KEY_TYPE: u8 = 2;
 const PARTIAL_SIGNATURE_KEY_TYPE: u8 = 3;
-const VERSION_TYPE: u8 = 4;
+const UTXO_VERSION_TYPE: u8 = 4;
 
 // output keys
 const PEGOUT_ID_KEY_TYPE: u8 = 4;
@@ -37,9 +37,9 @@ lazy_static::lazy_static! {
         key: Vec::new(),
     };
 
-    pub static ref VERSION_TYPE_KEY: ProprietaryKey = ProprietaryKey {
+    pub static ref UTXO_VERSION_TYPE_KEY: ProprietaryKey = ProprietaryKey {
         prefix: PROP_KEY_PREFIX.to_vec(),
-        subtype: VERSION_TYPE,
+        subtype: UTXO_VERSION_TYPE,
         key: Vec::new(),
     };
 }
@@ -66,12 +66,12 @@ pub trait PsbtInputExt: BorrowMut<PsbtInput> {
     fn add_version_to_psbt(&mut self, version: u32) {
         self.borrow_mut()
             .proprietary
-            .insert(VERSION_TYPE_KEY.clone(), (version).to_le_bytes().to_vec());
+            .insert(UTXO_VERSION_TYPE_KEY.clone(), (version).to_le_bytes().to_vec());
     }
 
     /// Gets the version of a UTXO from a PSBT input
     fn get_version_from_psbt_input(&self) -> Option<UtxoVersion> {
-        self.borrow().proprietary.get(&VERSION_TYPE_KEY).and_then(|bytes| {
+        self.borrow().proprietary.get(&UTXO_VERSION_TYPE_KEY).and_then(|bytes| {
             if bytes.len() == 4 {
                 let version = u32::from_le_bytes(bytes.as_slice().try_into().ok()?);
                 UtxoVersion::try_from(version).ok()


### PR DESCRIPTION
https://github.com/botanix-labs/botanix/issues/921
Easy solution here is to just default to 0 for the utxo version if one is not present. Locally tested by creating utxo before the version was added and decoding after. 