### PR TITLE
feat(btc-server): Pending Pegout Filtering & Pruning

### DIFF
--- a/bin/btc-server/src/bin/main.rs
+++ b/bin/btc-server/src/bin/main.rs
@@ -546,6 +546,7 @@ where
         let pegouts = pegouts?;
         let pegouts_refs: Vec<&PegoutRequest> = pegouts.iter().collect();
         self.db.store_pending_pegouts(&pegouts_refs).to_status()?;
+        self.db.prune_pending_pegouts().to_status()?;
         self.db.flush().to_status()?;
         info!("stored pegouts.len(): {:?}", pegouts.len());
 
@@ -968,7 +969,21 @@ where
         }
 
         debug!("Cord Fee rate: {:?}", fee_rate);
-        let pending_pegouts = self.db.get_pending_pegouts().to_status()?;
+
+        // Get pending pegouts that are economically viable. Net-negative
+        // pegouts are kept in the db and might be viable in the future, but
+        // might be pruned earlier if the number of pending pegouts exceeds a
+        // certain threshold.
+        //
+        // See `crate::database::Db::prune_pending_pegouts`.
+        let pending_pegouts = self
+            .db
+            .cord_pending_pegouts(fee_rate)
+            .to_status()?
+            .into_iter()
+            .map(|(pegout, _fee)| pegout)
+            .collect::<Vec<pegout_scheduler::PegoutRequest>>();
+
         if let Some(telemetry) = self.telemetry.as_ref() {
             telemetry.update_pending_pegouts(pending_pegouts.len() as i64);
         }

--- a/bin/btc-server/src/bin/main.rs
+++ b/bin/btc-server/src/bin/main.rs
@@ -961,6 +961,7 @@ where
         let fee_res = self
             .bitcoind_client
             .estimate_smart_fee(1, Some(bitcoincore_rpc::json::EstimateMode::Conservative));
+
         let mut fee_rate = self.fall_back_fee_rate;
         if let Ok(fee) = fee_res {
             if let Some(f) = fee.fee_rate {
@@ -987,6 +988,7 @@ where
         if let Some(telemetry) = self.telemetry.as_ref() {
             telemetry.update_pending_pegouts(pending_pegouts.len() as i64);
         }
+
         let outputs = pending_pegouts
             .iter()
             .map(|p| (TxOut { value: p.value, script_pubkey: p.spk.clone() }, p.id))

--- a/bin/btc-server/src/coordinator/mod.rs
+++ b/bin/btc-server/src/coordinator/mod.rs
@@ -91,15 +91,6 @@ pub async fn make_tx(
     min_signers: u16,
     tracked_txs: Vec<Tx>,
 ) -> Result<Psbt, CoordinatorError> {
-    // TODO: re-enable this check
-    // Ensure we are above the minimum relay fee rate
-    // let mut fee_rate = fee_rate;
-    // let mut fee_rate = FeeRate::from_sat_per_vb_unchecked()
-    // let min_relay_fee_rate = FeeRate::from_sat_per_vb_unchecked(MIN_RELAY_FEE_RATE_SAT_VB);
-    // if fee_rate < min_relay_fee_rate {
-    //     fee_rate = min_relay_fee_rate;
-    // }
-
     // collect all database utxos in a hashmap
     let utxos: HashMap<OutPoint, Utxo> =
         db.iter_utxos().try_fold(HashMap::new(), |mut map, r| {

--- a/bin/btc-server/src/coordinator/mod.rs
+++ b/bin/btc-server/src/coordinator/mod.rs
@@ -119,6 +119,7 @@ pub async fn make_tx(
             .iter()
             .flat_map(|tx| tx.pegout_requests.iter().map(|p| p.id))
             .collect::<HashSet<_>>();
+
         println!("tracked_pegout_request_ids = {:?}", tracked_pegout_request_ids);
 
         // Collect all pegout ids being retried.
@@ -134,6 +135,7 @@ pub async fn make_tx(
             .filter(|tx| tx.pegout_requests.iter().any(|p| matching_pegouts_ids.contains(&&p.id)))
             .map(|tx| tx.inputs().next().ok_or_else(|| CoordinatorError::NoConflictingInputs))
             .collect();
+
         let matching_tracked_inputs = matching_tracked_inputs?;
 
         // get the utxo for each matching tracked input

--- a/bin/btc-server/src/database/mod.rs
+++ b/bin/btc-server/src/database/mod.rs
@@ -1009,6 +1009,96 @@ mod tests {
     }
 
     #[test]
+    fn can_prune_pegouts_by_count() {
+        let (db, _temp_dir) = setup_db();
+
+        // create a 10 random pegouts
+        for i in 0..10 {
+            let pegout_id = PegoutId::new([i as u8; 32], 0);
+            let req = pegout_scheduler::PegoutRequest {
+                id: pegout_id,
+                spk: random_p2wpkh_script(),
+                value: Amount::from_sat(10_000 * (i as u64 + 1)),
+                botanix_height: 1,
+            };
+            db.store_pending_pegout(&req).unwrap();
+        }
+
+        // Retain ten pegouts (all).
+        db.do_prune_pending_pegouts(10).unwrap();
+        let pegouts = db.get_pending_pegouts().unwrap();
+        assert_eq!(pegouts.len(), 10);
+        assert_eq!(pegouts[0].value, Amount::from_sat(10_000));
+        assert_eq!(pegouts[9].value, Amount::from_sat(100_000));
+
+        // Retain four pegouts.
+        db.do_prune_pending_pegouts(4).unwrap();
+        let pegouts = db.get_pending_pegouts().unwrap();
+        assert_eq!(pegouts.len(), 4);
+        assert_eq!(pegouts[0].value, Amount::from_sat(70_000));
+        assert_eq!(pegouts[3].value, Amount::from_sat(100_000));
+
+        // Retain zero pegouts (none).
+        db.do_prune_pending_pegouts(0).unwrap();
+        let pegouts = db.get_pending_pegouts().unwrap();
+        assert!(pegouts.is_empty());
+    }
+
+    #[test]
+    fn can_coordinate_pegout_efficiency() {
+        let (db, _temp_dir) = setup_db();
+
+        let txouts = [
+            TxOut {
+                value: Amount::from_sat(1_000),
+                script_pubkey: ScriptBuf::from_bytes(vec![0; 20]),
+            },
+            TxOut {
+                value: Amount::from_sat(1_000),
+                script_pubkey: ScriptBuf::from_bytes(vec![0; 30]),
+            },
+            TxOut {
+                value: Amount::from_sat(1_000),
+                script_pubkey: ScriptBuf::from_bytes(vec![0; 40]),
+            },
+        ];
+
+        for i in 0..3 {
+            let pegout_id = PegoutId::new([i as u8; 32], 0);
+            let req = pegout_scheduler::PegoutRequest {
+                id: pegout_id,
+                spk: txouts[i].script_pubkey.clone(),
+                value: txouts[i].value,
+                botanix_height: 1,
+            };
+            db.store_pending_pegout(&req).unwrap();
+        }
+
+        // Fee is low, all pegouts can be processed.
+        let fee_rate = FeeRate::from_sat_per_vb_unchecked(1);
+        let pegouts = db.cord_pending_pegouts(fee_rate).unwrap();
+        assert_eq!(pegouts.len(), 3);
+        assert_eq!(pegouts[0].0.spk, txouts[0].script_pubkey);
+        assert_eq!(pegouts[0].1, Amount::from_sat(100)); // est. fee for pegout
+        assert_eq!(pegouts[1].0.spk, txouts[1].script_pubkey);
+        assert_eq!(pegouts[1].1, Amount::from_sat(110)); // est. fee for pegout
+        assert_eq!(pegouts[2].0.spk, txouts[2].script_pubkey);
+        assert_eq!(pegouts[2].1, Amount::from_sat(120)); // est. fee for pegout
+
+        // Fee is medium, only the first pegout can be processed.
+        let fee_rate = FeeRate::from_sat_per_vb_unchecked(10);
+        let pegouts = db.cord_pending_pegouts(fee_rate).unwrap();
+        assert_eq!(pegouts.len(), 1);
+        assert_eq!(pegouts[0].0.spk, txouts[0].script_pubkey);
+        assert_eq!(pegouts[0].1, Amount::from_sat(1_000)); // est. fee for pegout
+
+        // Fee is high, no pegouts can be processed.
+        let fee_rate = FeeRate::from_sat_per_vb_unchecked(20);
+        let pegouts = db.cord_pending_pegouts(fee_rate).unwrap();
+        assert!(pegouts.is_empty());
+    }
+
+    #[test]
     fn from_db_utxo_to_rpc_utxo() {
         let tx = create_tx(1, 1, None);
         let utxo = Utxo::new(

--- a/bin/btc-server/src/database/mod.rs
+++ b/bin/btc-server/src/database/mod.rs
@@ -718,7 +718,7 @@ impl Db {
     ) -> Result<Vec<(pegout_scheduler::PegoutRequest, Amount)>, Error> {
         let pegouts = self.get_pending_pegouts()?;
 
-        if pegouts.len() == 0 {
+        if pegouts.is_empty() {
             return Ok(vec![]);
         }
 

--- a/bin/btc-server/src/database/mod.rs
+++ b/bin/btc-server/src/database/mod.rs
@@ -10,7 +10,7 @@ use bitcoin::{
     consensus::encode::Encodable,
     hashes::{sha256, Hash},
     psbt::Psbt,
-    Amount, BlockHash, OutPoint, ScriptBuf, TxOut, Txid,
+    Amount, BlockHash, FeeRate, OutPoint, ScriptBuf, TxOut, Txid,
 };
 use client::SigningStatus;
 use frost_secp256k1_tr as frost;
@@ -22,6 +22,8 @@ pub mod error;
 pub mod version;
 pub use error::Error;
 use version::UtxoVersion;
+
+const MAX_PENDING_PEGOUTS: usize = 10_000;
 
 /// sled tree id for the utxos tree.
 const TREE_UTXOS: &[u8; 5] = b"utxos";
@@ -698,6 +700,93 @@ impl Db {
             ret.push(tx);
         }
         Ok(ret)
+    }
+
+    /// Get all economically viable pegouts based on the given fee rate,
+    /// returning the pegouts with their corresponding individual fee estimates.
+    ///
+    /// Each pegout's fee is calculated considering:
+    ///   1. The output's own size in vbytes
+    ///   2. A fair portion of transaction overhead
+    ///   3. A generous estimate for input costs, assuming one input per pegout
+    ///
+    /// Pegouts where the value is less than the estimated fee are filtered out,
+    /// but remain in the database until they either become viable or get pruned.
+    pub fn cord_pending_pegouts(
+        &self,
+        fee_rate: FeeRate,
+    ) -> Result<Vec<(pegout_scheduler::PegoutRequest, Amount)>, Error> {
+        let pegouts = self.get_pending_pegouts()?;
+
+        if pegouts.len() == 0 {
+            return Ok(vec![]);
+        }
+
+        // NOTE(lamafab): We use a simple and conservative fee estimation model
+        // here. Ideally, this should be intertwined with the actual UTXO
+        // maintenance and input selection mechanism in the long run.
+
+        // Base transaction overhead distributed across the pegout batch size.
+        // We assume that most/all pegouts will be selected.
+        const VB_TX_OVERHEAD: u64 = 10; // version + locktime + varint counts
+        let avg_header_vb = (VB_TX_OVERHEAD / (pegouts.len() as u64)).max(1);
+
+        // Assuming one input per pegout. In practice, inputs can be shared
+        // across outputs.
+        const VB_INPUT_OVERHEAD: u64 = 68; // ~P2WPKH input
+
+        let mut pegouts = pegouts
+            .into_iter()
+            .map(|pegout| {
+                // Output size in vbytes
+                let output_vb = pegout.txout().weight().to_vbytes_ceil();
+
+                // Total vbytes allocated to this pegout
+                let total_vb = avg_header_vb + VB_INPUT_OVERHEAD + output_vb;
+
+                // Calculate estimated fee for individual pegout
+                let fee = fee_rate.fee_vb(total_vb).unwrap();
+
+                (pegout, fee)
+            })
+            .collect::<Vec<(pegout_scheduler::PegoutRequest, Amount)>>();
+
+        // We only process pegouts that are economically viable.
+        pegouts.retain(|(pegout, fee)| &pegout.value >= fee);
+
+        Ok(pegouts)
+    }
+
+    /// Prune pending pegouts once [`MAX_PENDING_PEGOUTS`] is reached. Pegouts
+    /// with higher values are retained.
+    pub fn prune_pending_pegouts(&self) -> Result<(), Error> {
+        self.do_prune_pending_pegouts(MAX_PENDING_PEGOUTS)
+    }
+
+    /// Prune pending pegouts once `retain_amt` is reached. Pegouts
+    /// with higher values are retained.
+    fn do_prune_pending_pegouts(&self, retain_amt: usize) -> Result<(), Error> {
+        // sled doc:
+        // > Beware: performs a full O(n) scan under the hood.
+        let pegout_count = self.pending_pegouts.iter().count();
+
+        if pegout_count <= retain_amt {
+            return Ok(());
+        }
+
+        let mut pegouts = self.get_pending_pegouts()?;
+
+        // Sort descending by value.
+        pegouts.sort_by(|a, b| b.value.cmp(&a.value));
+
+        // Only once the number of pegouts exceeds the limit, we start removing
+        // the ones with the lowest value.
+        let to_remove = pegouts.split_off(retain_amt);
+        for pegout in to_remove {
+            self.pending_pegouts.remove(pegout.id.as_bytes())?;
+        }
+
+        Ok(())
     }
 
     /// Removes pending pegouts from the database.


### PR DESCRIPTION
This is my (second) attempt to fix issue https://github.com/botanix-labs/botanix/issues/903; I tried to keep it as simple as possible without introducing steep changes and not requiring us to change the UTXO selection mechanism, which would be high-risk and not something we'd want to do shortly before the audit. All of this will change anyway once we move toward a dynamic and federated validator model. Essentially, this introduces two new methods to the `btc-server` database API: one to only select economically viable pegouts, and another method to prune pegouts after exceeding a certain amount.

This is first opened as a **Draft to discuss** whether this proposal is a good way to implement the desired outcome.

## Summary
This PR adds two key features to improve pegout handling:

* **Economical pegout filtering**: Only process pegouts where the value exceeds the estimated transaction fee, preventing net-negative transfers that would cost more in fees than they're worth.
* **Pegout pruning**: Automatically prune pending pegouts when their number exceeds a threshold (10,000), prioritizing higher-value transfers.

## Implementation details

* Added `cord_pending_pegouts()` method to filter economically viable pegouts based on current fee rates
* Implemented `prune_pending_pegouts()` to remove low-value pegouts when count exceeds threshold
* Modified `get_psbt` workflow (for coordinator) to check economic viability before processing
* Added pruning call when receiving new pending pegouts from consensus
* Added basic fee calculation estimates:
	1. The output's own size in vbytes
	2. A fair portion of transaction overhead
	3. A generous estimate for input costs, assuming one input per pegout

## Further Thoughts

After studying this section of the codebasefor a while:

1. In the long run we need to think about proper UTXO management and consolidation, and calculate precise fee requirements for pegouts based on that. As noted earlier, this depends on how the dynamic federation model will look like in the near future.
2. The database would benefit from a proper querying language; we often load **all** pegouts into memory for processing when single-lookup or queries would be more appropriate. Most damningly, we load all pegouts every single time a new pegout is stored in order to calculate the updated Merkle root!
