### PR TITLE
Feature(eth-rpc): Allow eth_getBlockByNumber to optionally include edh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10158,6 +10158,7 @@ dependencies = [
  "proptest-arbitrary-interop",
  "rand 0.8.5",
  "reth-codecs",
+ "reth-rpc-types",
  "revm-primitives",
  "roaring",
  "secp256k1 0.29.1",
@@ -10471,6 +10472,7 @@ dependencies = [
  "revm-inspectors",
  "revm-primitives",
  "secp256k1 0.29.1",
+ "serde_json",
  "tokio",
  "tracing",
 ]

--- a/crates/primitives-traits/Cargo.toml
+++ b/crates/primitives-traits/Cargo.toml
@@ -18,6 +18,7 @@ alloy-genesis = { workspace = true }
 alloy-primitives = { workspace = true }
 alloy-rlp = { workspace = true }
 alloy-rpc-types-eth = { workspace = true, optional = true }
+reth-rpc-types = { workspace = true }
 
 # arbitrary utils
 arbitrary = { workspace = true, features = ["derive"], optional = true }

--- a/crates/primitives-traits/src/alloy_compat.rs
+++ b/crates/primitives-traits/src/alloy_compat.rs
@@ -1,5 +1,6 @@
 use super::Header;
-use alloy_rpc_types_eth::{ConversionError, Header as RpcHeader};
+use alloy_rpc_types_eth::ConversionError;
+use reth_rpc_types::Header as RpcHeader;
 
 impl TryFrom<RpcHeader> for Header {
     type Error = ConversionError;

--- a/crates/primitives/src/extra_data_header.rs
+++ b/crates/primitives/src/extra_data_header.rs
@@ -6,6 +6,7 @@ use bitcoin::{
     hashes::Hash,
 };
 use revm_primitives::Address;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 /// The version of the extra data header
@@ -19,7 +20,7 @@ pub const CHAIN_VERSION: u32 = 0;
 /// bitcoin_block_hash ... )` This sighash excludes the authority signature field.
 /// Use `encode_into_without_signature` to serialize the extradata header with out the signature
 /// field Note: the order of the struct properties is important for serialization/deserialization
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ExtraDataHeader {
     /// The version of the extra data header
     pub version: u32,

--- a/crates/rpc/rpc-api/src/engine.rs
+++ b/crates/rpc/rpc-api/src/engine.rs
@@ -257,6 +257,7 @@ pub trait EngineEthApi {
         &self,
         number: BlockNumberOrTag,
         full: bool,
+        include_extra_data_header: Option<bool>,
     ) -> RpcResult<Option<RichBlock>>;
 
     /// Sends signed transaction, returning its hash.

--- a/crates/rpc/rpc-builder/tests/it/http.rs
+++ b/crates/rpc/rpc-builder/tests/it/http.rs
@@ -183,7 +183,7 @@ where
     EthApiClient::transaction_count(client, address, None).await.unwrap();
     EthApiClient::storage_at(client, address, U256::default().into(), None).await.unwrap();
     EthApiClient::block_by_hash(client, hash, false).await.unwrap();
-    EthApiClient::block_by_number(client, block_number, false).await.unwrap();
+    EthApiClient::block_by_number(client, block_number, false, None).await.unwrap();
     EthApiClient::block_transaction_count_by_number(client, block_number).await.unwrap();
     EthApiClient::block_transaction_count_by_hash(client, hash).await.unwrap();
     EthApiClient::block_uncles_count_by_hash(client, hash).await.unwrap();

--- a/crates/rpc/rpc-eth-api/Cargo.toml
+++ b/crates/rpc/rpc-eth-api/Cargo.toml
@@ -24,6 +24,7 @@ auto_impl = { workspace = true }
 bitcoin = { workspace = true }
 dyn-clone = { workspace = true }
 futures = { workspace = true }
+serde_json = { workspace = true }
 
 # rpc
 jsonrpsee = { workspace = true, features = ["server", "macros"] }

--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -8,7 +8,7 @@ use crate::helpers::{
 use alloy_dyn_abi::TypedData;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_primitives::{
-    transaction::AccessListResult, Address, BlockId, BlockNumberOrTag, Bytes, B256, B64, U256, U64,
+    extra_data_header::ExtraDataHeader, transaction::AccessListResult, Address, BlockId, BlockNumberOrTag, Bytes, B256, B64, U256, U64
 };
 use reth_rpc_server_types::{result::internal_rpc_err, ToRpcResult};
 use reth_rpc_types::{
@@ -67,6 +67,7 @@ pub trait EthApi {
         &self,
         number: BlockNumberOrTag,
         full: bool,
+        include_extra_data_header: Option<bool>,
     ) -> RpcResult<Option<RichBlock>>;
 
     /// Returns the number of transactions in a block from a block matching the given block hash.
@@ -414,9 +415,25 @@ where
         &self,
         number: BlockNumberOrTag,
         full: bool,
+        include_extra_data_header: Option<bool>,
     ) -> RpcResult<Option<RichBlock>> {
         trace!(target: "rpc::eth", ?number, ?full, "Serving eth_getBlockByNumber");
-        Ok(EthBlocks::rpc_block(self, number.into(), full).await?)
+        let mut block = EthBlocks::rpc_block(self, number.into(), full).await?;
+
+        if let Some(ref mut rich_block) = block {
+            if include_extra_data_header.is_some_and(|v| v) {
+                // Add the header JSON to extra_info
+                let mut extra_data_header = ExtraDataHeader::deserialize(&mut rich_block.header.extra_data.0.to_vec().as_slice())
+                    .map_err(|e| internal_rpc_err(format!("Failed to deserialize extra data header: {}", e)))?;
+                let extra_data_header_json = serde_json::to_value(&mut extra_data_header)
+                    .map_err(|e| internal_rpc_err(format!("Failed to serialize header: {}", e)))?;
+                rich_block.extra_info.insert("extraDataHeader".to_string(), extra_data_header_json);
+            }
+
+            return Ok(Some(rich_block.clone()));
+        }
+
+        Ok(block)
     }
 
     /// Handler for: `eth_getGatewayAddress`

--- a/crates/rpc/rpc-testing-util/src/debug.rs
+++ b/crates/rpc/rpc-testing-util/src/debug.rs
@@ -101,7 +101,7 @@ where
     {
         let block = match block.into() {
             BlockId::Hash(hash) => self.block_by_hash(hash.block_hash, false).await,
-            BlockId::Number(tag) => self.block_by_number(tag, false).await,
+            BlockId::Number(tag) => self.block_by_number(tag, false, None).await,
         }?
         .ok_or_else(|| RpcError::Custom("block not found".to_string()))?;
         let hashes = block.transactions.hashes().map(|tx| (tx, opts.clone())).collect::<Vec<_>>();

--- a/crates/rpc/rpc/src/engine.rs
+++ b/crates/rpc/rpc/src/engine.rs
@@ -86,8 +86,9 @@ where
         &self,
         number: BlockNumberOrTag,
         full: bool,
+        include_extra_data_header: Option<bool>,
     ) -> Result<Option<RichBlock>> {
-        self.eth.block_by_number(number, full).instrument(engine_span!()).await
+        self.eth.block_by_number(number, full, include_extra_data_header).instrument(engine_span!()).await
     }
 
     /// Handler for: `eth_sendRawTransaction`

--- a/crates/rpc/rpc/src/otterscan.rs
+++ b/crates/rpc/rpc/src/otterscan.rs
@@ -155,7 +155,7 @@ where
 
     /// Handler for `ots_getBlockDetails`
     async fn get_block_details(&self, block_number: u64) -> RpcResult<BlockDetails> {
-        let block = self.eth.block_by_number(block_number.into(), true);
+        let block = self.eth.block_by_number(block_number.into(), true, None);
         let receipts = self.eth.block_receipts(block_number.into());
         let (block, receipts) = futures::try_join!(block, receipts)?;
         self.block_details(block, receipts)
@@ -177,7 +177,7 @@ where
         page_size: usize,
     ) -> RpcResult<OtsBlockTransactions> {
         // retrieve full block and its receipts
-        let block = self.eth.block_by_number(block_number.into(), true);
+        let block = self.eth.block_by_number(block_number.into(), true, None);
         let receipts = self.eth.block_receipts(block_number.into());
         let (block, receipts) = futures::try_join!(block, receipts)?;
 
@@ -299,7 +299,7 @@ where
         .await?;
 
         let Some(BlockTransactions::Full(transactions)) =
-            self.eth.block_by_number(num.into(), true).await?.map(|block| block.inner.transactions)
+            self.eth.block_by_number(num.into(), true, None).await?.map(|block| block.inner.transactions)
         else {
             return Err(EthApiError::UnknownBlockNumber.into());
         };


### PR DESCRIPTION
Part of https://github.com/botanix-labs/botanix/issues/909

The motive of this PR is to allow sidecar access to the header data of L2 blocks when requested. The header info contains the block hash and the block number. Both will be used when looking for an optimal L2 block as part of pegin proof v1.