### PR TITLE
feat(btc-server): Upper pegout bound & priority by age

### DIFF
--- a/bin/btc-server/src/bin/main.rs
+++ b/bin/btc-server/src/bin/main.rs
@@ -57,6 +57,19 @@ use btcserverlib::{
 
 const JWT_HEADER_KEY: &str = "trace-proto-bin";
 
+/// The upper bound on pegouts in a single transaction. We use a _reasonable_
+/// number based on the following properties:
+///
+/// * Bitcoin's upper bound on a transaction is 100kb
+/// * 32 bytes required for an output (ie. pegout)
+/// * 110 bytes required for an input
+/// * We assume each output has an input
+///   * In practice, it's more likely that an individual input will map to multiple smaller outputs.
+///     But a larger output could also consume multiple inputs.
+///
+/// With a pegout bound of 500, we can conclude: (32 + 110) * 500 = 71_000
+const UPPER_PEGOUT_BOUND: usize = 500;
+
 macro_rules! already_exists {
     ($($arg:tt)*) => {{
         tonic::Status::already_exists(format!($($arg)*))
@@ -968,7 +981,11 @@ where
         }
 
         debug!("Cord Fee rate: {:?}", fee_rate);
-        let pending_pegouts = self.db.get_pending_pegouts().to_status()?;
+
+        // Select up to `UPPER_PEGOUT_BOUND` pegouts, sorted by age in ascending
+        // order. Respectively, the oldest pegouts come first.
+        let pending_pegouts = self.db.coord_pending_pegouts(UPPER_PEGOUT_BOUND).to_status()?;
+
         if let Some(telemetry) = self.telemetry.as_ref() {
             telemetry.update_pending_pegouts(pending_pegouts.len() as i64);
         }

--- a/bin/btc-server/src/bin/main.rs
+++ b/bin/btc-server/src/bin/main.rs
@@ -544,6 +544,7 @@ where
                         e
                     )
                 })?;
+
                 Ok(PegoutRequest {
                     id: PegoutId::from_bytes(&p.pegout_id).map_err(|_| {
                         error!("Failed to parse pegout id: {:?}", p.pegout_id);
@@ -989,6 +990,7 @@ where
         if let Some(telemetry) = self.telemetry.as_ref() {
             telemetry.update_pending_pegouts(pending_pegouts.len() as i64);
         }
+
         let outputs = pending_pegouts
             .iter()
             .map(|p| (TxOut { value: p.value, script_pubkey: p.spk.clone() }, p.id))
@@ -1902,6 +1904,7 @@ mod tests {
         for _ in 0..10 {
             let pegout_id = create_random_pegout_id();
             let spk = random_p2wpkh_script();
+
             pending_pegouts.push(rpc::PendingPegout {
                 pegout_id: pegout_id.as_bytes().to_vec(),
                 spk: spk.clone().as_bytes().to_vec(),

--- a/bin/btc-server/src/database/mod.rs
+++ b/bin/btc-server/src/database/mod.rs
@@ -700,6 +700,23 @@ impl Db {
         Ok(ret)
     }
 
+    /// Returns up to `max` pending pegouts, sorted by age in ascending order.
+    /// Respectively, the oldest pegouts come first.
+    pub fn coord_pending_pegouts(
+        &self,
+        max: usize,
+    ) -> Result<Vec<pegout_scheduler::PegoutRequest>, Error> {
+        let mut pegouts = self.get_pending_pegouts()?;
+        // Always sort by timestamp
+        pegouts.sort_by(|a, b| a.botanix_height.cmp(&b.botanix_height));
+
+        if pegouts.len() < max {
+            return Ok(pegouts)
+        }
+
+        Ok(pegouts.into_iter().take(max).collect())
+    }
+
     /// Removes pending pegouts from the database.
     pub fn remove_pending_pegout(&self, pegout_ids: &[PegoutId]) -> Result<(), Error> {
         for pegout_id in pegout_ids.iter() {
@@ -835,6 +852,57 @@ mod tests {
         assert_eq!(pegout_req.spk, req.spk);
         assert_eq!(pegout_req.value, req.value);
         assert_eq!(pegout_req.botanix_height, req.botanix_height);
+    }
+
+    #[test]
+    fn can_coordinate_pending_pegouts_on_timestamp() {
+        let (db, _temp_dir) = setup_db();
+
+        // Create pegouts with the appropriate timestamps in reverse order;
+        // pegout with id 0 is the newest, while Id 9 is the oldest.
+        //
+        // NOTE: We specifically reverse the order of botanix heights so we can
+        // verify that the returned pegouts are sorted accordingly based on
+        // timestamp, not Id.
+        for i in 0..10 {
+            let pegout_id = PegoutId::new([i as u8; 32], 0);
+            let req = pegout_scheduler::PegoutRequest {
+                id: pegout_id,
+                spk: random_p2wpkh_script(),
+                value: Amount::from_sat(100_000),
+                botanix_height: 50 - i,
+            };
+            db.store_pending_pegout(&req).unwrap();
+        }
+
+        // Coordinate zero pegouts.
+        let pegouts = db.coord_pending_pegouts(0).unwrap();
+        assert!(pegouts.is_empty());
+
+        // Coordinate 4 pegouts which are sorted from oldest to newest; pegout
+        // with Id 9 comes first, followed by Id 8, etc.
+        let pegouts = db.coord_pending_pegouts(4).unwrap();
+        assert_eq!(pegouts.len(), 4);
+
+        for i in 0..4 {
+            let id = 9 - i;
+
+            let pegout_id = PegoutId::new([id as u8; 32], 0);
+            assert_eq!(pegouts[i].id, pegout_id);
+            assert_eq!(pegouts[i].botanix_height, 50 - id as u64);
+        }
+
+        // Coordinate 50 pegouts (only 10 available). Still sorted by timestamp.
+        let pegouts = db.coord_pending_pegouts(50).unwrap();
+        assert_eq!(pegouts.len(), 10);
+
+        for i in 0..10 {
+            let id = 9 - i;
+
+            let pegout_id = PegoutId::new([id as u8; 32], 0);
+            assert_eq!(pegouts[i].id, pegout_id);
+            assert_eq!(pegouts[i].botanix_height, 50 - id as u64);
+        }
     }
 
     #[test]

--- a/bin/btc-server/src/database/mod.rs
+++ b/bin/btc-server/src/database/mod.rs
@@ -966,7 +966,7 @@ mod tests {
     fn can_remove_pending_pegout() {
         let (db, _temp_dir) = setup_db();
 
-        // create a 10 random pegouts
+        // create 10 random pegouts
         for i in 0..10 {
             let pegout_id = PegoutId::new([i as u8; 32], 0);
             let req = pegout_scheduler::PegoutRequest {

--- a/bin/btc-server/src/database/mod.rs
+++ b/bin/btc-server/src/database/mod.rs
@@ -707,7 +707,6 @@ impl Db {
         max: usize,
     ) -> Result<Vec<pegout_scheduler::PegoutRequest>, Error> {
         let mut pegouts = self.get_pending_pegouts()?;
-        // Always sort by timestamp
         pegouts.sort_by(|a, b| a.botanix_height.cmp(&b.botanix_height));
 
         if pegouts.len() < max {
@@ -855,15 +854,15 @@ mod tests {
     }
 
     #[test]
-    fn can_coordinate_pending_pegouts_on_timestamp() {
+    fn can_coordinate_pending_pegouts_based_on_height() {
         let (db, _temp_dir) = setup_db();
 
-        // Create pegouts with the appropriate timestamps in reverse order;
+        // Create pegouts with the appropriate height in reverse order;
         // pegout with id 0 is the newest, while Id 9 is the oldest.
         //
         // NOTE: We specifically reverse the order of botanix heights so we can
         // verify that the returned pegouts are sorted accordingly based on
-        // timestamp, not Id.
+        // height, not Id.
         for i in 0..10 {
             let pegout_id = PegoutId::new([i as u8; 32], 0);
             let req = pegout_scheduler::PegoutRequest {
@@ -892,7 +891,7 @@ mod tests {
             assert_eq!(pegouts[i].botanix_height, 50 - id as u64);
         }
 
-        // Coordinate 50 pegouts (only 10 available). Still sorted by timestamp.
+        // Coordinate 50 pegouts (only 10 available). Still sorted by height.
         let pegouts = db.coord_pending_pegouts(50).unwrap();
         assert_eq!(pegouts.len(), 10);
 


### PR DESCRIPTION
Fixes https://github.com/botanix-labs/botanix/issues/903, replaces https://github.com/botanix-labs/Macbeth/pull/604

**_LATEST -> https://github.com/botanix-labs/Macbeth/pull/609#issuecomment-2711318648_**

## Summary

- ~Added a `created` field to the `pegout_scheduler::PegoutRequest` struct that stores a `SystemTime` timestamp. This design decision makes it consistent with `pegout_scheduler::Tx`~
- ~Updated the protobuf definition to include a timestamp field for pegouts~
- ~Modified the pegout deserialization to support backward compatibility:~
  - ~When reading existing pegouts from the database that lack timestamps, `SystemTime::now()` is used as the default value~
  - ~This ensures seamless compatibility with existing database records~
- Added a new `coord_pending_pegouts` method that:
  - Limits the number of pegouts to process in a single transaction
  - Sorts pegouts by creation time (oldest first) to implement FIFO ordering
- Introduced a 500-pegout upper bound for transactions with proper documentation
- ~Set the pegout creation timestamp to the block's timestamp when generated~

## Testing:

- Added test cases to verify FIFO ordering behavior
- ~Included a backward compatibility test to ensure proper handling of legacy pegout requests~

In the long run, all pending pegouts will contain timestamps, eliminating the need for the backward compatibility mechanism.