### PR TITLE
Introduce `ActivationManager` for network upgrade proposals (via CometBFT)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10337,6 +10337,7 @@ dependencies = [
  "reth-trie",
  "reth-trie-db",
  "revm",
+ "secp256k1 0.29.1",
  "strum 0.26.3",
  "tempfile",
  "tokio",

--- a/crates/consensus/authority/src/activation_manager/mod.rs
+++ b/crates/consensus/authority/src/activation_manager/mod.rs
@@ -251,10 +251,7 @@ impl ConditionList {
     /// Returns true only when all conditions are satisfied, indicating
     /// that the network is ready to activate the upgrade.
     pub fn all_passing(&self) -> bool {
-        self.comp_req &&
-            self.aye_approval_req &&
-            self.comp_approval_req &&
-            self.block_height_req
+        self.comp_req && self.aye_approval_req && self.comp_approval_req && self.block_height_req
     }
 }
 

--- a/crates/consensus/authority/src/activation_manager/mod.rs
+++ b/crates/consensus/authority/src/activation_manager/mod.rs
@@ -233,7 +233,7 @@ struct NetworkUpgrade {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ConditionList {
     /// Whether the validator is compliant with the upgrade
-    compliant_req: bool,
+    comp_req: bool,
 
     /// Whether the quorum approval rate for Aye votes has been reached
     aye_approval_req: bool,
@@ -251,7 +251,7 @@ impl ConditionList {
     /// Returns true only when all conditions are satisfied, indicating
     /// that the network is ready to activate the upgrade.
     pub fn all_passing(&self) -> bool {
-        self.compliant_req &&
+        self.comp_req &&
             self.aye_approval_req &&
             self.comp_approval_req &&
             self.block_height_req
@@ -729,7 +729,7 @@ where
         debug_assert!(total_votes >= upgrade.min_validator_count);
 
         let list = ConditionList {
-            compliant_req: upgrade.is_compliant,
+            comp_req: upgrade.is_compliant,
             aye_approval_req: aye_approval >= upgrade.quorum,
             comp_approval_req: comp_approval >= upgrade.quorum,
             block_height_req: block_height >= upgrade.target_height,

--- a/crates/consensus/authority/src/activation_manager/mod.rs
+++ b/crates/consensus/authority/src/activation_manager/mod.rs
@@ -1,0 +1,791 @@
+//! # Activation Manager
+//!
+//! Coordinates and manages network protocol upgrades in the Botanix blockchain.
+//!
+//! The activation manager is responsible for safely transitioning the blockchain
+//! network to new protocol versions without causing chain splits or consensus
+//! failures. It implements a distributed voting and activation mechanism that
+//! allows validators to signal support, prepare for, and eventually activate
+//! upgrades in a coordinated manner.
+//!
+//! ## Overview
+//!
+//! Network upgrades in Botanix follow a two-phase approach:
+//! 1. **Signaling Phase**: Validators vote on upgrade proposals to gauge support
+//! 2. **Compliance Phase**: Validators indicate readiness to process upgraded blocks
+//!
+//! An upgrade activates only when all of the following conditions are met:
+//! - A sufficient percentage of validators have voted "Aye" (meeting the quorum approval rate)
+//! - A sufficient percentage of validators are compliant with the upgrade (meeting the quorum
+//!   approval rate)
+//! - A minimum number of distinct validators have participated in voting
+//! - The current block height has reached or passed the scheduled target height
+//! - The local node is compliant with the upgrade
+//!
+//! ## Integration with CometBFT
+//!
+//! The activation manager integrates with CometBFT's ABCI at three critical points:
+//!
+//! 1. **Block Proposal** (`on_prepare_proposal`): Determines which runtime version to use and
+//!    includes the proposer's vote on pending upgrades.
+//!
+//! 2. **Block Validation** (`on_process_proposal`): Validates incoming block proposals based on
+//!    their version and the current upgrade state.
+//!
+//! 3. **Block Finalization** (`on_finalize_block`): Tracks votes, finalizes blocks, and handles
+//!    version transitions when upgrades are activated.
+//!
+//! ## Configuration Modes
+//!
+//! Nodes can be configured in three modes:
+//!
+//! - **Ignore Upgrades**: Default mode where the node doesn't participate in upgrades and rejects
+//!   blocks with versions other than the current active version.
+//!
+//! - **Signal Only**: The node votes on upgrades but doesn't accept upgraded blocks, allowing
+//!   validators to signal intentions before updating their software.
+//!
+//! - **Accept Upgrades**: The node votes on and accepts upgrades when conditions are met, enabling
+//!   full participation in the upgrade process.
+//!
+//! ## Vote Tracking and Expiration
+//!
+//! The manager tracks votes from validators and calculates support approval rates for:
+//! - Aye votes (percentage of validators voting in favor)
+//! - Compliant validators (percentage of validators ready to upgrade)
+//!
+//! Votes automatically expire after a configured retention period (default: 30 days)
+//! to ensure that upgrade decisions reflect recent consensus rather than outdated votes.
+//!
+//! ## Usage
+//!
+//! Nodes typically start in the "Ignore Upgrades" mode by default. When a potential
+//! upgrade is discussed, validators can switch to "Signal Only" mode to participate in
+//! voting. Once a new node version with upgrade support is released, validators can
+//! switch to "Accept Upgrades" mode to fully participate in the upgrade process.
+
+use crate::comet_bft::non_deterministic_data::NetworkUpgradePayload;
+use reth_provider::{ActivationManagerReaderWriter, ProviderResult};
+use std::sync::{Arc, RwLock};
+
+// Reexports
+pub use reth_db::models::activation_manager::{RuntimeVersion, Vote};
+
+#[cfg(test)]
+mod tests;
+
+/// The minimum required quorum percentage for network upgrades.
+///
+/// This represents the minimum percentage (67%) of validators that must:
+/// 1. Vote "Aye" for an upgrade proposal
+/// 2. Be configured to accept the upgrade
+///
+/// This approval rate ensures a supermajority consensus for any network upgrade,
+/// reducing the risk of chain splits while allowing for a reasonable approval rate
+/// that can be achieved in practice.
+///
+/// The value is set at 67% to align with CometBFT's 2/3 consensus approval rate,
+/// ensuring that network upgrades only activate when they have similar levels
+/// of support as other consensus decisions.
+pub const MIN_QUORUM: usize = 67;
+
+/// The minimum validator count used for calculating approval rates.
+///
+/// This constant sets a minimum denominator when calculating approval rates,
+/// ensuring that upgrades require broad support even when few validators have
+/// explicitly voted. By using this minimum in the denominator, we prevent
+/// scenarios where a small number of active validators could reach the required
+/// approval percentage without true network-wide support.
+pub const MIN_VALIDATOR_COUNT: usize = 3;
+// (TODO lamafab): This should be increased with time as we move towards larger
+// and dynamic federations, eventually.
+
+/// The period (in blocks) for which votes are retained and considered valid.
+///
+/// Votes older than this many blocks are automatically pruned and no longer
+/// count toward quorum calculations. This ensures that upgrade decisions
+/// reflect the current state of the network and prevents old votes from
+/// influencing current decisions.
+///
+/// At an average rate of 12 blocks per minute (5 second blocks), this equals:
+/// - 518,400 blocks
+/// - 43,200 minutes
+/// - 720 hours
+/// - 30 days
+///
+/// This extended retention period allows validators sufficient time to:
+/// 1. Signal support for an upgrade
+/// 2. Update their software to prepare for the upgrade
+/// 3. Switch their configuration to accept the upgrade
+///
+/// While ensuring votes eventually expire if an upgrade does not proceed.
+pub const VOTE_RETENTION_PERIOD: u64 = 518_400;
+
+/// The decision returned by the activation manager during the prepare proposal
+/// phase.
+///
+/// This struct represents the decision made by a validator when preparing a new
+/// block proposal. It contains the runtime version to use for the block, any
+/// vote the validator wishes to include in the proposal, and the current state
+/// of upgrade conditions.
+#[derive(Debug, Clone, PartialEq)]
+pub struct OnPrepareProposalDecision {
+    /// The runtime version that should be used for the block proposal. This
+    /// will be either the active version or an upgrade version if conditions
+    /// are met.
+    pub version: RuntimeVersion,
+
+    /// The validator's vote on a pending upgrade to include in the proposal.
+    /// This is included in the Non-Deterministic Data (NDD) of the block
+    /// proposal. If None, no vote is included in the proposal.
+    pub vote: Option<NetworkUpgradePayload>,
+
+    /// The current state of all upgrade conditions. This is used for diagnostic
+    /// purposes to understand why an upgrade is being proposed or not proposed.
+    pub conditions: Option<ConditionList>,
+}
+
+/// The decision returned by the activation manager when processing a block
+/// proposal.
+///
+/// This enum represents whether a validator should accept or reject a proposed
+/// block based on the runtime version and network upgrade conditions.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum OnProcessProposalDecision {
+    /// Accept and process the block proposal.
+    ///
+    /// This is returned when the block version is valid (either the active
+    /// version or an upgrade version that meets all conditions).
+    Process {
+        /// The runtime version of the block being processed
+        version: RuntimeVersion,
+        /// The current state of all upgrade conditions (for diagnostic
+        /// purposes)
+        conditions: Option<ConditionList>,
+    },
+
+    /// Reject the block proposal.
+    ///
+    /// This is returned when the block version is invalid (not the active
+    /// version and not an upgrade version that meets all conditions).
+    RejectBlock {
+        /// The runtime version of the block being rejected
+        version: RuntimeVersion,
+        /// The current state of all upgrade conditions (for diagnostic purposes)
+        conditions: Option<ConditionList>,
+    },
+}
+
+/// The decision returned by the activation manager when finalizing a block.
+///
+/// This enum represents whether a validator should finalize a block or reject
+/// it as a dead end (meaning the validator cannot continue on this chain).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum OnFinalizeBlockDecision {
+    /// Finalize the block and continue processing the chain.
+    ///
+    /// This is returned for blocks with versions the validator can process.
+    Finalize {
+        /// The runtime version of the block being finalized
+        version: RuntimeVersion,
+    },
+
+    /// Reject the block as a dead end that the validator cannot follow.
+    ///
+    /// This is returned for blocks with versions the validator explicitly
+    /// refuses to support or cannot process. This results in a consensus split.
+    RejectBlockDeadEnd {
+        /// The runtime version of the block being rejected
+        version: RuntimeVersion,
+    },
+}
+
+/// Internal representation of a network upgrade configuration.
+///
+/// This struct holds all the parameters and state related to a pending network
+/// upgrade that a validator is tracking.
+struct NetworkUpgrade {
+    /// The runtime version of the proposed upgrade
+    version: RuntimeVersion,
+
+    /// The percentage approval rate (0-100) that must be reached for both
+    /// Aye votes and compliant validators to activate the upgrade
+    quorum: usize,
+
+    /// The minimum number of distinct validators that must participate
+    /// in voting for the upgrade to be considered valid
+    min_validator_count: usize,
+
+    /// The minimum block height at which the upgrade can activate
+    target_height: u64,
+
+    /// This validator's vote on the upgrade proposal (Aye/Nay)
+    our_vote: Vote,
+
+    /// Whether this validator is compliant with the upgrade
+    is_compliant: bool,
+}
+
+/// A list of boolean flags indicating the status of each upgrade condition.
+///
+/// This struct tracks whether each condition required for a network upgrade is
+/// currently satisfied. It's used for diagnostics and decision making.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ConditionList {
+    /// Whether the validator is compliant with the upgrade
+    compliant_req: bool,
+
+    /// Whether the quorum approval rate for Aye votes has been reached
+    aye_approvals_req: bool,
+
+    /// Whether the quorum approval rate for compliant validators has been reached
+    comp_approval_req: bool,
+
+    /// Whether the current block height is at or above the target height
+    block_height_req: bool,
+}
+
+impl ConditionList {
+    /// Checks if all upgrade conditions are passing.
+    ///
+    /// Returns true only when all conditions are satisfied, indicating
+    /// that the network is ready to activate the upgrade.
+    pub fn all_passing(&self) -> bool {
+        self.compliant_req &&
+            self.aye_approvals_req &&
+            self.comp_approval_req &&
+            self.block_height_req
+    }
+}
+
+/// Builder for constructing an `ActivationManager` with specific configuration.
+///
+/// This builder provides methods to configure how a validator will handle
+/// network upgrades - whether it will ignore them, signal votes without
+/// being compliant, or fully accept upgrades when conditions are met.
+pub struct ActivationManagerBuilder<DB> {
+    /// The database client implementing ActivationManagerReaderWriter
+    client: DB,
+
+    /// The currently active runtime version
+    active_version: RuntimeVersion,
+
+    /// How long votes are retained in blocks before expiring
+    vote_retention_period: u64,
+
+    /// Configuration for a pending network upgrade, if any
+    upgrade: Option<NetworkUpgrade>,
+}
+
+impl<DB> ActivationManagerBuilder<DB>
+where
+    DB: ActivationManagerReaderWriter,
+{
+    /// Creates a new ActivationManagerBuilder with specified database client and active version.
+    ///
+    /// This is the primary constructor for initializing the builder with a storage backend
+    /// and the current active runtime version.
+    ///
+    /// # Parameters
+    /// * `client` - The database client implementing ActivationManagerReaderWriter
+    /// * `active_version` - The currently active runtime version
+    ///
+    /// # Returns
+    /// * A new ActivationManagerBuilder configured with default settings
+    pub fn new(client: DB, active_version: RuntimeVersion) -> Self {
+        ActivationManagerBuilder {
+            client,
+            active_version,
+            vote_retention_period: VOTE_RETENTION_PERIOD,
+            upgrade: None,
+        }
+    }
+
+    /// Sets a custom vote retention period.
+    ///
+    /// This method allows customizing how long votes are retained before
+    /// being pruned. The default is `VOTE_RETENTION_PERIOD` (518,400 blocks).
+    ///
+    /// # Parameters
+    /// * `period` - The number of blocks to retain votes
+    ///
+    /// # Returns
+    /// The builder instance with updated vote retention period.
+    pub fn vote_retention_period(mut self, period: u64) -> Self {
+        self.vote_retention_period = period;
+        self
+    }
+
+    /// Finalizes the builder to create an ActivationManager that ignores
+    /// network upgrades.
+    ///
+    /// This creates a manager that will:
+    /// * Not participate in upgrade voting
+    /// * Not include any NetworkUpgradePayload in proposals
+    /// * Reject any blocks with versions other than the current active version
+    ///
+    /// This is the default operating mode for nodes that are not participating
+    /// in the upgrade process and will result in the node rejecting blocks if
+    /// an upgrade is activated on the network.
+    ///
+    /// # Returns
+    /// * An ActivationManager configured to ignore network upgrades
+    pub fn build_ignore_nework_upgrade(self) -> ActivationManager<DB> {
+        debug_assert!(self.upgrade.is_none());
+        self._finalize()
+    }
+
+    /// Finalizes the builder to create an ActivationManager that signals a vote
+    /// on an upgrade.
+    ///
+    /// This creates a manager that will:
+    /// * Include the specified vote in the NetworkUpgradePayload of proposals
+    /// * Still reject any blocks with the upgrade version (is_compliant = false)
+    /// * Track votes from other validators
+    ///
+    /// This mode allows validators to signal their support or opposition to an
+    /// upgrade before they are ready to accept upgraded blocks.
+    ///
+    /// # Parameters
+    /// * `upgrade_version` - The runtime version of the proposed upgrade
+    /// * `our_vote` - This validator's vote (Aye/Nay) on the upgrade
+    ///
+    /// # Returns
+    /// * An ActivationManager configured to signal a vote on the upgrade
+    ///
+    /// # Panics
+    /// * If the upgrade version is not greater than the active version
+    pub fn build_signal_network_upgrade(
+        mut self,
+        upgrade_version: RuntimeVersion,
+        our_vote: Vote,
+    ) -> ActivationManager<DB> {
+        assert!(self.active_version < upgrade_version);
+
+        #[rustfmt::skip]
+        let upgrade = NetworkUpgrade {
+            version: upgrade_version,
+            quorum: usize::MAX,
+            min_validator_count: usize::MAX,
+            target_height: u64::MAX,
+            our_vote,
+            is_compliant: false, // Reject
+        };
+
+        self.upgrade = Some(upgrade);
+        self._finalize()
+    }
+
+    /// Finalizes the builder to create an ActivationManager that accepts an upgrade when conditions
+    /// are met.
+    ///
+    /// This creates a manager that will:
+    /// * Include the specified vote in the NetworkUpgradePayload of proposals
+    /// * Accept and process blocks with the upgrade version once all conditions are met
+    /// * Track votes from other validators and calculate approval rates
+    /// * Transition to the upgrade version automatically when an upgraded block is finalized
+    ///
+    /// This mode should be used when validators are prepared for an upgrade and have
+    /// the necessary code and migrations in place to handle the new version.
+    ///
+    /// # Parameters
+    /// * `upgrade_version` - The runtime version of the proposed upgrade
+    /// * `quorum` - The percentage approval rate (0-100) that must be reached for activation
+    /// * `min_validator_count` - The minimum validator count used for calculating approval rates
+    /// * `target_height` - The minimum block height at which the upgrade can activate
+    /// * `our_vote` - This validator's vote (Aye/Nay), defaults to Aye if None
+    ///
+    /// # Returns
+    /// * An ActivationManager configured to accept the upgrade when conditions are met
+    ///
+    /// # Panics
+    /// * If the `upgrade_version` is not greater than the active version
+    /// * If the `quorum` is less than `MIN_QUORUM`
+    /// * If the `min_validator_count` is less than `MIN_VALIDATOR_COUNT`
+    #[allow(non_snake_case)]
+    #[rustfmt::skip]
+    pub fn build_COMPLIANT_network_upgrade(
+        mut self,
+        upgrade_version: RuntimeVersion,
+        quorum: usize,
+        min_validator_count: usize,
+        target_height: u64,
+        our_vote: Option<Vote>,
+    ) -> ActivationManager<DB> {
+        assert!(
+            self.active_version < upgrade_version,
+            "upgrade version is older than the active version"
+        );
+
+        assert!(
+            quorum >= MIN_QUORUM,
+            "minimum validator count is less than the minimum required"
+        );
+
+        assert!(
+            min_validator_count >= MIN_VALIDATOR_COUNT,
+            "minimum validator count is less than the minimum required"
+        );
+
+        let upgrade = NetworkUpgrade {
+            version: upgrade_version,
+            quorum,
+            min_validator_count,
+            target_height,
+            our_vote: our_vote.unwrap_or(Vote::Aye),
+            is_compliant: true,
+        };
+
+        self.upgrade = Some(upgrade);
+        self._finalize()
+    }
+
+    fn _finalize(self) -> ActivationManager<DB> {
+        ActivationManager {
+            client: self.client,
+            vote_retention_period: self.vote_retention_period,
+            active_version: Arc::new(RwLock::new(self.active_version)),
+            upgrade: Arc::new(RwLock::new(self.upgrade)),
+        }
+    }
+}
+
+/// Manages network protocol upgrades in the Botanix blockchain.
+///
+/// The `ActivationManager` is responsible for coordinating the network-wide
+/// upgrade process, ensuring that validators can safely transition to new
+/// protocol versions without causing chain splits or consensus failures. It
+/// tracks validator votes, calculates support approval rates, and determines when
+/// proposed upgrades should activate.
+///
+/// This component interfaces with CometBFT's ABCI during three critical phases:
+/// 1. Block proposal preparation (`on_prepare_proposal`)
+/// 2. Block proposal validation (`on_process_proposal`)
+/// 3. Block finalization (`on_finalize_block`)
+///
+/// During each phase, the manager makes appropriate decisions based on the
+/// current upgrade state, validator votes, and configured upgrade conditions.
+///
+/// The manager maintains thread-safe access to the active version and upgrade
+/// state through atomic reference counting and read-write locks, allowing it to
+/// be shared between concurrent contexts.
+#[derive(Clone)]
+pub struct ActivationManager<DB> {
+    /// Database client for persisting and retrieving votes
+    client: DB,
+
+    /// How long (in blocks) votes are retained before expiring
+    vote_retention_period: u64,
+
+    /// The currently active runtime version
+    /// Protected by a read-write lock for thread-safe updates
+    active_version: Arc<RwLock<RuntimeVersion>>,
+
+    /// Configuration for a pending network upgrade, if any
+    /// Protected by a read-write lock for thread-safe updates
+    upgrade: Arc<RwLock<Option<NetworkUpgrade>>>,
+}
+
+impl<DB> ActivationManager<DB>
+where
+    DB: ActivationManagerReaderWriter,
+{
+    /// Prepares a proposal decision based on the current upgrade state.
+    ///
+    /// This method is called during CometBFT's `prepare_proposal` phase to determine:
+    /// 1. Which runtime version to use for the proposed block (active or upgrade)
+    /// 2. Whether to include a vote for a pending network upgrade
+    /// 3. Whether all conditions are met to propose an upgraded block
+    ///
+    /// ## Behavior
+    ///
+    /// - Returns the appropriate block version to propose (active or upgrade)
+    /// - Includes this validator's vote on pending upgrades regardless of decision
+    /// - Proposes an upgraded block only when all upgrade conditions are met:
+    ///   * Validator is compliant with the upgrade
+    ///   * Quorum approval rate for Aye votes is reached
+    ///   * Quorum approval rate for compliant validators is reached
+    ///   * Current block height is at or above the target height
+    ///
+    /// # Parameters
+    /// * `block_height` - The height of the block being proposed
+    ///
+    /// # Returns
+    /// * `OnPrepareProposalDecision` containing:
+    ///   - The version to use (active or upgrade)
+    ///   - Optional vote to include in the proposal
+    ///   - Status of all upgrade conditions
+    pub fn on_prepare_proposal(
+        &self,
+        block_height: u64,
+    ) -> ProviderResult<OnPrepareProposalDecision> {
+        let mut our_vote = None;
+        let mut conditions = None;
+
+        // Check if we're tracking a network upgrade.
+        let maybe_upgrade = self.upgrade.read().expect("poisoned lock");
+        if let Some(upgrade) = maybe_upgrade.as_ref() {
+            assert!(upgrade.quorum >= MIN_QUORUM);
+
+            // Prepare our vote information to be included in the proposal.
+            our_vote = Some(NetworkUpgradePayload {
+                version: upgrade.version,
+                vote: upgrade.our_vote,
+                is_compliant: upgrade.is_compliant,
+            });
+
+            // Process the upgraded block only if ALL conditions are met.
+            let c = self._validate_conditions(upgrade, block_height)?;
+            if c.all_passing() {
+                // Signal that we should create a proposal with the upgraded version
+                return Ok(OnPrepareProposalDecision {
+                    version: upgrade.version,
+                    vote: our_vote,
+                    conditions: Some(c),
+                });
+            }
+
+            conditions = Some(c);
+        }
+
+        // Default case: propose a block with the current active version. We
+        // include our vote (if any) to signal our upgrade intentions, even when
+        // not yet proposing upgraded blocks.
+        let active_version = self.active_version.read().expect("poisoned lock");
+        Ok(OnPrepareProposalDecision { version: *active_version, vote: our_vote, conditions })
+    }
+
+    /// Processes an incoming block proposal, tracking votes and determining if
+    /// it should be accepted.
+    ///
+    /// This method is called during CometBFT's `process_proposal` phase to
+    /// determine whether to accept or reject a block proposal based on its
+    /// version and the current upgrade state.
+    ///
+    /// ## Behavior
+    ///
+    /// - Accepts blocks with the active version
+    /// - Accepts blocks with an upgrade version if the validator is compliant with the upgrade AND
+    ///   all conditions are met
+    /// - Rejects blocks with unknown versions or when conditions aren't met
+    ///
+    /// # Parameters
+    /// * `block_height` - The height of the block being processed
+    /// * `block_version` - The runtime version of the block being processed
+    ///
+    /// # Returns
+    /// * `OnProcessProposalDecision::Process` if the block should be accepted
+    /// * `OnProcessProposalDecision::RejectBlock` if the block should be rejected
+    pub fn on_process_proposal(
+        &self,
+        block_height: u64,
+        block_version: RuntimeVersion,
+    ) -> ProviderResult<OnProcessProposalDecision> {
+        let mut conditions = None;
+
+        // Check if block matches a pending upgrade we're tracking.
+        let maybe_upgrade = self.upgrade.read().expect("poisoned lock");
+        if let Some(upgrade) = maybe_upgrade.as_ref() {
+            let c = self._validate_conditions(upgrade, block_height)?;
+            conditions = Some(c);
+
+            // Process the upgraded block only if ALL conditions are met and if
+            // it matches the upgrade version.
+            if c.all_passing() && block_version == upgrade.version {
+                return Ok(OnProcessProposalDecision::Process {
+                    version: upgrade.version,
+                    conditions,
+                });
+            }
+        }
+
+        // Check if the proposed block uses the currently active runtime version.
+        let active_version = self.active_version.read().expect("poisoned lock");
+        if block_version == *active_version {
+            return Ok(OnProcessProposalDecision::Process { version: *active_version, conditions });
+        }
+
+        Ok(OnProcessProposalDecision::RejectBlock { version: block_version, conditions })
+    }
+
+    /// Finalizes a block and handles potential version transitions.
+    ///
+    /// This method is called during CometBFT's `finalize_block` phase to track
+    /// votes, finalize blocks, and handle version transitions when upgrades are
+    /// activated.
+    ///
+    /// ## Behavior
+    ///
+    /// - Tracks the proposer's vote for network upgrades
+    /// - Accepts any block version during sync (relying on CometBFT's consensus)
+    /// - If an upgraded block is finalized, updates the active version
+    /// - Rejects blocks if explicitly configured to reject that upgrade
+    /// - Cleans up voting data once a version transition occurs
+    /// - DOES NOT recheck quorum or target height during finalization
+    ///
+    /// # Parameters
+    /// * `block_version` - The runtime version of the block being finalized
+    /// * `block_height` - The height of the block being finalized
+    /// * `proposer_address` - The public key of the block proposer
+    /// * `proposer_vote` - The proposer's vote on a network upgrade, if any
+    ///
+    /// # Returns
+    /// * `OnFinalizeBlockDecision::Finalize` if the block should be finalized
+    /// * `OnFinalizeBlockDecision
+    pub fn on_finalize_block(
+        &self,
+        block_version: RuntimeVersion,
+        block_height: u64,
+        proposer_address: secp256k1::PublicKey,
+        proposer_vote: Option<NetworkUpgradePayload>,
+    ) -> ProviderResult<OnFinalizeBlockDecision> {
+        // Track the proposer's vote for upgrade intention, if provided
+        self._track_vote(block_height, proposer_address, proposer_vote)?;
+
+        // NOTE: Upgrade condition checks are deliberately omitted here. These
+        // validations have already occurred during the backing phase in
+        // `on_process_proposal`. When CometBFT finalizes an upgraded block, it
+        // confirms that the required majority of validators have endorsed the
+        // upgrade. Additionally, syncing nodes lack historical context about
+        // previous forks (including migrations and code changes), preventing
+        // them from independently validating past version transitions.
+        // Consequently, any block finalized by CometBFT must be accepted by all
+        // nodes.
+        //
+        // However, nodes can resist future upgrades, and their consequent
+        // behavior is considered undefined.
+
+        let active_version = self.active_version.read().expect("poisoned lock");
+        if block_version <= *active_version {
+            return Ok(OnFinalizeBlockDecision::Finalize { version: block_version });
+        }
+
+        let mut maybe_upgrade = self.upgrade.write().expect("poisoned lock");
+        if let Some(upgrade) = maybe_upgrade.as_ref() {
+            // Future version detected, reject the block; this node is running an
+            // outdated version of this software that cannot handle those finalized
+            // blocks.
+            if block_version != upgrade.version {
+                return Ok(OnFinalizeBlockDecision::RejectBlockDeadEnd { version: block_version });
+            }
+
+            // Prune **all** votes since the decision is now finalized.
+            self.client.remove_upgrading_votes(block_height.saturating_add(1))?;
+
+            // For nodes that are explicitly not accepting this upgrade version,
+            // reject the block and halt further processing.
+            if !upgrade.is_compliant {
+                // Upgrade has been activated; clear pending upgrade.
+                *maybe_upgrade = None;
+
+                return Ok(OnFinalizeBlockDecision::RejectBlockDeadEnd { version: block_version });
+            }
+
+            std::mem::drop(active_version);
+
+            // Upgrade is now active and mandatory for all future block
+            // production. Update our active version and clear the pending
+            // upgrade.
+            let mut active_version = self.active_version.write().expect("poisoned lock");
+            *active_version = upgrade.version;
+            *maybe_upgrade = None;
+
+            return Ok(OnFinalizeBlockDecision::Finalize { version: *active_version });
+        }
+
+        // Future version detected, reject the block; this node is running an
+        // outdated version of this software that cannot handle those finalized
+        // blocks.
+        Ok(OnFinalizeBlockDecision::RejectBlockDeadEnd { version: block_version })
+    }
+
+    /// Validates all conditions required for an upgrade to proceed.
+    ///
+    /// This internal method checks whether all conditions required for a network
+    /// upgrade are currently met, including:
+    /// - Validator is configured to accept the upgrade
+    /// - Quorum approval rate for Aye votes is reached
+    /// - Quorum approval rate for compliant validators is reached
+    /// - Current block height is at or above the target height
+    ///
+    /// # Parameters
+    /// * `upgrade` - The NetworkUpgrade configuration to validate
+    /// * `block_height` - The current block height
+    ///
+    /// # Returns
+    /// * `ConditionList` containing the status of each upgrade condition
+    fn _validate_conditions(
+        &self,
+        upgrade: &NetworkUpgrade,
+        block_height: u64,
+    ) -> ProviderResult<ConditionList> {
+        let (aye_approval, total_votes) =
+            self.client.get_upgrading_approval_rate_ayes(upgrade.min_validator_count)?;
+
+        let (comp_approval, t2) =
+            self.client.get_upgrading_approval_rate_compliance(upgrade.min_validator_count)?;
+
+        debug_assert_eq!(total_votes, t2);
+        debug_assert!(total_votes >= upgrade.min_validator_count);
+
+        let list = ConditionList {
+            compliant_req: upgrade.is_compliant,
+            aye_approvals_req: aye_approval >= upgrade.quorum,
+            comp_approval_req: comp_approval >= upgrade.quorum,
+            block_height_req: block_height >= upgrade.target_height,
+        };
+
+        Ok(list)
+    }
+
+    /// Tracks validator votes for network upgrades.
+    ///
+    /// This internal method processes votes from block proposers and stores them
+    /// in the database if they're relevant to a tracked upgrade. It also prunes
+    /// outdated votes beyond the configured retention period.
+    ///
+    /// ## Behavior
+    ///
+    /// - Stores votes only if they're relevant to a tracked upgrade
+    /// - Updates the database with vote details including block height
+    /// - Prunes outdated votes beyond the configured retention period
+    ///
+    /// # Parameters
+    /// * `block_height` - The height of the block containing the vote
+    /// * `addr` - The public key of the validator casting the vote
+    /// * `vote` - The NetworkUpgradePayload containing the vote details
+    ///
+    /// # Returns
+    /// * `Ok(())` if the vote was successfully processed
+    fn _track_vote(
+        &self,
+        block_height: u64,
+        addr: secp256k1::PublicKey,
+        vote: Option<NetworkUpgradePayload>,
+    ) -> ProviderResult<()> {
+        // If the proposer made a vote...
+        let Some(vote) = vote else {
+            return Ok(());
+        };
+
+        // And we're tracking an upgrade...
+        let maybe_upgrade = self.upgrade.read().expect("poisoned lock");
+        let Some(upgrade) = maybe_upgrade.as_ref() else {
+            return Ok(());
+        };
+
+        // And the proposers' version matches our upgrade version...
+        if vote.version != upgrade.version {
+            return Ok(());
+        }
+
+        // Then track the vote.
+        self.client.update_upgrading_vote(addr, vote.vote, vote.is_compliant, block_height)?;
+
+        // Prune old votes.
+        let prune_below = block_height.saturating_sub(self.vote_retention_period);
+        self.client.remove_upgrading_votes(prune_below)?;
+
+        Ok(())
+    }
+}

--- a/crates/consensus/authority/src/activation_manager/mod.rs
+++ b/crates/consensus/authority/src/activation_manager/mod.rs
@@ -236,7 +236,7 @@ pub struct ConditionList {
     compliant_req: bool,
 
     /// Whether the quorum approval rate for Aye votes has been reached
-    aye_approvals_req: bool,
+    aye_approval_req: bool,
 
     /// Whether the quorum approval rate for compliant validators has been reached
     comp_approval_req: bool,
@@ -252,7 +252,7 @@ impl ConditionList {
     /// that the network is ready to activate the upgrade.
     pub fn all_passing(&self) -> bool {
         self.compliant_req &&
-            self.aye_approvals_req &&
+            self.aye_approval_req &&
             self.comp_approval_req &&
             self.block_height_req
     }
@@ -730,7 +730,7 @@ where
 
         let list = ConditionList {
             compliant_req: upgrade.is_compliant,
-            aye_approvals_req: aye_approval >= upgrade.quorum,
+            aye_approval_req: aye_approval >= upgrade.quorum,
             comp_approval_req: comp_approval >= upgrade.quorum,
             block_height_req: block_height >= upgrade.target_height,
         };

--- a/crates/consensus/authority/src/activation_manager/tests/accept_lagging_validator.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/accept_lagging_validator.rs
@@ -39,7 +39,7 @@ fn activation_manager_accept_lagging_validator() {
         .upgrade_conditions(
             &[ALICE, BOB],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: false,
                 aye_approval_req: false,
                 block_height_req: false,
@@ -70,7 +70,7 @@ fn activation_manager_accept_lagging_validator() {
         .upgrade_conditions(
             &[ALICE, BOB],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: false, // not finalized yet
                 aye_approval_req: false,  // not finalized yet
                 block_height_req: false,
@@ -100,7 +100,7 @@ fn activation_manager_accept_lagging_validator() {
         .upgrade_conditions(
             &[ALICE, BOB],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: true, // IS met!
                 aye_approval_req: true,  // IS met!
                 block_height_req: true,  // IS met!
@@ -141,7 +141,7 @@ fn activation_manager_accept_lagging_validator() {
         .upgrade_conditions(
             &[EVE],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: false,
                 aye_approval_req: false,
                 block_height_req: true, // IS met!

--- a/crates/consensus/authority/src/activation_manager/tests/accept_lagging_validator.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/accept_lagging_validator.rs
@@ -41,7 +41,7 @@ fn activation_manager_accept_lagging_validator() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: false,
-                aye_approvals_req: false,
+                aye_approval_req: false,
                 block_height_req: false,
             },
         )
@@ -72,7 +72,7 @@ fn activation_manager_accept_lagging_validator() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: false, // not finalized yet
-                aye_approvals_req: false, // not finalized yet
+                aye_approval_req: false,  // not finalized yet
                 block_height_req: false,
             },
         )
@@ -102,7 +102,7 @@ fn activation_manager_accept_lagging_validator() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: true, // IS met!
-                aye_approvals_req: true, // IS met!
+                aye_approval_req: true,  // IS met!
                 block_height_req: true,  // IS met!
             },
         )
@@ -143,7 +143,7 @@ fn activation_manager_accept_lagging_validator() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: false,
-                aye_approvals_req: false,
+                aye_approval_req: false,
                 block_height_req: true, // IS met!
             },
         )

--- a/crates/consensus/authority/src/activation_manager/tests/accept_lagging_validator.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/accept_lagging_validator.rs
@@ -53,7 +53,7 @@ fn activation_manager_accept_lagging_validator() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 34,
-                compliance_approval_rate: 34,
+                comp_approval_rate: 34,
             },
         )
         // Eve is not configured.
@@ -83,7 +83,7 @@ fn activation_manager_accept_lagging_validator() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 67,
-                compliance_approval_rate: 67,
+                comp_approval_rate: 67,
             },
         )
         .expectations_empty(&[EVE])
@@ -114,7 +114,7 @@ fn activation_manager_accept_lagging_validator() {
                 finalize_pass: true,
                 // Votes pruned after upgrade
                 aye_approval_rate: 0,
-                compliance_approval_rate: 0,
+                comp_approval_rate: 0,
             },
         )
         // Eve is not configured.
@@ -153,7 +153,7 @@ fn activation_manager_accept_lagging_validator() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 0,
-                compliance_approval_rate: 0,
+                comp_approval_rate: 0,
             },
         )
         // Eve REJECTS the upgrade during the backing phase, but ACCEPTS it
@@ -164,7 +164,7 @@ fn activation_manager_accept_lagging_validator() {
                 process_pass: false, // Reject!
                 finalize_pass: true, // Accept
                 aye_approval_rate: 0,
-                compliance_approval_rate: 0,
+                comp_approval_rate: 0,
             },
         )
         .build_block();
@@ -186,7 +186,7 @@ fn activation_manager_accept_lagging_validator() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 0,
-                compliance_approval_rate: 0,
+                comp_approval_rate: 0,
             },
         )
         .build_blocks_until(21);

--- a/crates/consensus/authority/src/activation_manager/tests/accept_lagging_validator.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/accept_lagging_validator.rs
@@ -1,0 +1,195 @@
+use crate::activation_manager::{
+    tests::utils::{
+        Expectations, UpgradeTestFixture, ACTIVE_VERSION, ALICE, BOB, EVE, UPGRADE_VERSION,
+    },
+    ConditionList,
+};
+use reth_db::models::activation_manager::Vote;
+
+/// Tests that a lagging validator can join the network after an upgrade has
+/// occurred.
+///
+/// This test verifies that:
+/// 1. Two validators (ALICE, BOB) can successfully activate an upgrade when they meet all
+///    conditions
+/// 2. A third validator (EVE) who joins later and is compliant with the upgrade can successfully
+///    process blocks with the new version
+/// 3. The lagging validator correctly rejects upgraded blocks during the `process_proposal` phase
+///    but accepts them during finalize_block phase
+/// 4. After finalizing the first upgraded block, the lagging validator properly updates its active
+///    version and can fully participate in the network
+#[test]
+fn activation_manager_accept_lagging_validator() {
+    let upgrade_height = 2;
+    let required_approval_rate = 67;
+
+    let mut f = UpgradeTestFixture::new(upgrade_height, required_approval_rate)
+        .setup_compliant_validator(ALICE, Vote::Aye)
+        .setup_compliant_validator(BOB, Vote::Aye);
+    // NOTE: Eve is not in the validator set, but will be added later.
+
+    assert_eq!(f.next_height(), 0);
+
+    //
+    // Block 0: Alice proposes and votes.
+    //
+
+    f.start_proposal(ALICE, ACTIVE_VERSION)
+        // Alice and Bob do accept the upgrade.
+        .upgrade_conditions(
+            &[ALICE, BOB],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: false,
+                aye_approvals_req: false,
+                block_height_req: false,
+            },
+        )
+        // Eve is not configured.
+        .upgrade_conditions_empty(&[EVE])
+        .expectations(
+            &[ALICE, BOB],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 34,
+                compliance_approval_rate: 34,
+            },
+        )
+        // Eve is not configured.
+        .expectations_empty(&[EVE])
+        .build_block();
+
+    assert_eq!(f.next_height(), 1);
+
+    //
+    // Block 1: Bob proposes and votes.
+    //
+
+    f.start_proposal(BOB, ACTIVE_VERSION)
+        .upgrade_conditions(
+            &[ALICE, BOB],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: false, // not finalized yet
+                aye_approvals_req: false, // not finalized yet
+                block_height_req: false,
+            },
+        )
+        .upgrade_conditions_empty(&[EVE])
+        .expectations(
+            &[ALICE, BOB],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 67,
+                compliance_approval_rate: 67,
+            },
+        )
+        .expectations_empty(&[EVE])
+        .build_block();
+
+    assert_eq!(f.next_height(), 2);
+    assert_eq!(f.next_height(), upgrade_height);
+
+    //
+    // Block 2: Alice proposes the UPGRADE, all conditions are met!
+    //
+
+    f.start_proposal(ALICE, UPGRADE_VERSION)
+        .upgrade_conditions(
+            &[ALICE, BOB],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: true, // IS met!
+                aye_approvals_req: true, // IS met!
+                block_height_req: true,  // IS met!
+            },
+        )
+        .upgrade_conditions_empty(&[EVE])
+        .expectations(
+            &[ALICE, BOB],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                // Votes pruned after upgrade
+                aye_approval_rate: 0,
+                compliance_approval_rate: 0,
+            },
+        )
+        // Eve is not configured.
+        .expectations_empty(&[EVE])
+        .build_block();
+
+    assert_eq!(f.next_height(), 3);
+
+    //
+    // Eve joins the validator set with a willingness to upgrade.
+    //
+
+    let mut f = f.setup_compliant_validator(EVE, Vote::Aye);
+
+    //
+    // Block 3: Alice builds an UPGRADED block, Eve accepts it because it was
+    // finalized.
+    //
+
+    f.start_proposal(ALICE, UPGRADE_VERSION)
+        // No upgrade is ongoing for Alice and Bob.
+        .upgrade_conditions_empty(&[ALICE, BOB])
+        // Eves' upgrade tracker is still ongoing.
+        .upgrade_conditions(
+            &[EVE],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: false,
+                aye_approvals_req: false,
+                block_height_req: true, // IS met!
+            },
+        )
+        .expectations(
+            &[ALICE, BOB],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 0,
+                compliance_approval_rate: 0,
+            },
+        )
+        // Eve REJECTS the upgrade during the backing phase, but ACCEPTS it
+        // during the finalization phase.
+        .expectations(
+            &[EVE],
+            Expectations {
+                process_pass: false, // Reject!
+                finalize_pass: true, // Accept
+                aye_approval_rate: 0,
+                compliance_approval_rate: 0,
+            },
+        )
+        .build_block();
+
+    assert_eq!(f.next_height(), 4);
+
+    //
+    // Block 4-20: Alice keeps building UPGRADED blocks, Eve keeps accepting.
+    //
+
+    f.start_proposal(ALICE, UPGRADE_VERSION)
+        // No upgrade ongoing.
+        .upgrade_conditions_empty(&[ALICE, BOB, EVE])
+        // Eve now accepts the UPGRADED blocks during the backing and
+        // finalization phase.
+        .expectations(
+            &[ALICE, BOB, EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 0,
+                compliance_approval_rate: 0,
+            },
+        )
+        .build_blocks_until(21);
+
+    assert_eq!(f.next_height(), 21);
+}

--- a/crates/consensus/authority/src/activation_manager/tests/mod.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/mod.rs
@@ -1,0 +1,156 @@
+use super::*;
+use rand::thread_rng;
+use reth_provider::ProviderResult;
+use secp256k1::generate_keypair;
+use std::{collections::HashMap, sync::Arc};
+
+mod accept_lagging_validator;
+mod reject_ignored_upgrade;
+mod reject_mismatched_vote;
+mod reject_outdated_or_unsupported_version;
+mod utils;
+mod vote_expiration;
+mod vote_majority_nay_compliant_and_reject;
+mod vote_nay_and_accept;
+mod vote_nay_and_reject;
+mod wait_for_compliance;
+
+/// In-Memory database that integrates the `ActivationManagerReaderWriter` trait.
+#[derive(Clone)]
+struct Db {
+    votes: Arc<RwLock<HashMap<secp256k1::PublicKey, VoteEntry>>>,
+}
+
+impl Db {
+    fn new() -> Self {
+        Db { votes: Arc::new(RwLock::new(HashMap::new())) }
+    }
+}
+
+struct VoteEntry {
+    vote: Vote,
+    is_compliant: bool,
+    botanix_height: u64,
+}
+
+impl ActivationManagerReaderWriter for Db {
+    fn update_upgrading_vote(
+        &self,
+        auth: secp256k1::PublicKey,
+        vote: Vote,
+        is_compliant: bool,
+        botanix_height: u64,
+    ) -> ProviderResult<()> {
+        let mut votes = self.votes.write().unwrap();
+
+        #[rustfmt::skip]
+        votes
+            .entry(auth)
+            .and_modify(|e| {
+                e.vote = vote;
+                e.is_compliant = is_compliant;
+                e.botanix_height = botanix_height;
+            })
+            .or_insert(VoteEntry {
+                vote,
+                is_compliant,
+                botanix_height,
+            });
+
+        Ok(())
+    }
+
+    fn get_upgrading_approval_rate_ayes(
+        &self,
+        min_validator_count: usize,
+    ) -> ProviderResult<(usize, usize)> {
+        let votes = self.votes.read().unwrap();
+
+        let total = votes.len().max(min_validator_count);
+        let votes_received = votes.iter().filter(|(_, e)| e.vote == Vote::Aye).count();
+
+        // Calculate percentage (0-100) of votes received
+        let quorum = (votes_received * 100).div_ceil(total);
+
+        Ok((quorum, total))
+    }
+
+    fn get_upgrading_approval_rate_compliance(
+        &self,
+        min_validator_count: usize,
+    ) -> ProviderResult<(usize, usize)> {
+        let votes = self.votes.read().unwrap();
+
+        let total = votes.len().max(min_validator_count);
+        let votes_received = votes.iter().filter(|(_, e)| e.is_compliant).count();
+
+        // Calculate percentage (0-100) of votes received
+        let quorum = (votes_received * 100).div_ceil(total);
+
+        Ok((quorum, total))
+    }
+
+    fn remove_upgrading_votes(&self, botanix_height: u64) -> ProviderResult<usize> {
+        let mut votes = self.votes.write().unwrap();
+
+        let gross_total = votes.len();
+        votes.retain(|_, e| e.botanix_height >= botanix_height);
+
+        Ok(gross_total - votes.len())
+    }
+}
+
+#[test]
+fn activation_manager_basic_db_interface() {
+    let db = Db::new();
+
+    // Generate keypairs
+    let (_, alice) = generate_keypair(&mut thread_rng());
+    let (_, bob) = generate_keypair(&mut thread_rng());
+    let (_, eve) = generate_keypair(&mut thread_rng());
+
+    let min_validator_count = 3;
+
+    // Alice votes Aye, is not compliant
+    db.update_upgrading_vote(alice, Vote::Aye, false, 0).unwrap();
+    let res = db.get_upgrading_approval_rate_ayes(min_validator_count).unwrap();
+    assert_eq!(res, (34, 3));
+    let res = db.get_upgrading_approval_rate_compliance(min_validator_count).unwrap();
+    assert_eq!(res, (0, 3));
+
+    // Bob votes Nay, is not compliant
+    db.update_upgrading_vote(bob, Vote::Nay, false, 0).unwrap();
+    let res = db.get_upgrading_approval_rate_ayes(min_validator_count).unwrap();
+    assert_eq!(res, (34, 3));
+    let res = db.get_upgrading_approval_rate_compliance(min_validator_count).unwrap();
+    assert_eq!(res, (0, 3));
+
+    // Eve votes Aye, IS compliant
+    db.update_upgrading_vote(eve, Vote::Aye, true, 0).unwrap();
+    let res = db.get_upgrading_approval_rate_ayes(min_validator_count).unwrap();
+    assert_eq!(res, (67, 3));
+    let res = db.get_upgrading_approval_rate_compliance(min_validator_count).unwrap();
+    assert_eq!(res, (34, 3));
+
+    // Adjust minimum voter count (ABOVE total votes)
+    let min_validator_count = 5;
+    let res = db.get_upgrading_approval_rate_ayes(min_validator_count).unwrap();
+    assert_eq!(res, (40, 5));
+    let res = db.get_upgrading_approval_rate_compliance(min_validator_count).unwrap();
+    assert_eq!(res, (20, 5));
+
+    // Adjust minimum voter count (BELOW total votes)
+    let min_validator_count = 1;
+    let res = db.get_upgrading_approval_rate_ayes(min_validator_count).unwrap();
+    assert_eq!(res, (67, 3));
+    let res = db.get_upgrading_approval_rate_compliance(min_validator_count).unwrap();
+    assert_eq!(res, (34, 3));
+
+    // Remove votes
+    let res = db.remove_upgrading_votes(1).unwrap();
+    assert_eq!(res, 3);
+    let res = db.get_upgrading_approval_rate_ayes(min_validator_count).unwrap();
+    assert_eq!(res, (0, 1));
+    let res = db.get_upgrading_approval_rate_compliance(min_validator_count).unwrap();
+    assert_eq!(res, (0, 1));
+}

--- a/crates/consensus/authority/src/activation_manager/tests/reject_ignored_upgrade.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/reject_ignored_upgrade.rs
@@ -54,7 +54,7 @@ fn activation_manager_reject_ignored_upgrade() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 34,
-                compliance_approval_rate: 34,
+                comp_approval_rate: 34,
             },
         )
         // Eve DOES NOT participate in voting.
@@ -64,7 +64,7 @@ fn activation_manager_reject_ignored_upgrade() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 0,
-                compliance_approval_rate: 0,
+                comp_approval_rate: 0,
             },
         )
         .build_block();
@@ -92,7 +92,7 @@ fn activation_manager_reject_ignored_upgrade() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 67,
-                compliance_approval_rate: 67,
+                comp_approval_rate: 67,
             },
         )
         .expectations(
@@ -101,7 +101,7 @@ fn activation_manager_reject_ignored_upgrade() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 0,
-                compliance_approval_rate: 0,
+                comp_approval_rate: 0,
             },
         )
         .build_block();
@@ -129,7 +129,7 @@ fn activation_manager_reject_ignored_upgrade() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 67,
-                compliance_approval_rate: 67,
+                comp_approval_rate: 67,
             },
         )
         .expectations(
@@ -138,7 +138,7 @@ fn activation_manager_reject_ignored_upgrade() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 0,
-                compliance_approval_rate: 0,
+                comp_approval_rate: 0,
             },
         )
         .build_block();
@@ -168,7 +168,7 @@ fn activation_manager_reject_ignored_upgrade() {
                 finalize_pass: true,
                 // Votes pruned after upgrade
                 aye_approval_rate: 0,
-                compliance_approval_rate: 0,
+                comp_approval_rate: 0,
             },
         )
         // Eve REJECTS the upgrade.
@@ -178,7 +178,7 @@ fn activation_manager_reject_ignored_upgrade() {
                 process_pass: false,  // Reject!
                 finalize_pass: false, // Reject!
                 aye_approval_rate: 0,
-                compliance_approval_rate: 0,
+                comp_approval_rate: 0,
             },
         )
         .build_block();
@@ -198,7 +198,7 @@ fn activation_manager_reject_ignored_upgrade() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 0,
-                compliance_approval_rate: 0,
+                comp_approval_rate: 0,
             },
         )
         // Eve REJECTS the upgrade.
@@ -208,7 +208,7 @@ fn activation_manager_reject_ignored_upgrade() {
                 process_pass: false,  // Reject!
                 finalize_pass: false, // Reject!
                 aye_approval_rate: 0,
-                compliance_approval_rate: 0,
+                comp_approval_rate: 0,
             },
         )
         .build_blocks_until(21);

--- a/crates/consensus/authority/src/activation_manager/tests/reject_ignored_upgrade.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/reject_ignored_upgrade.rs
@@ -1,0 +1,217 @@
+use crate::activation_manager::{
+    tests::utils::{
+        Expectations, UpgradeTestFixture, ACTIVE_VERSION, ALICE, BOB, EVE, UPGRADE_VERSION,
+    },
+    ConditionList,
+};
+use reth_db::models::activation_manager::Vote;
+
+/// Tests that a validator can reject an upgrade that it ignores.
+///
+/// This test verifies that:
+/// 1. Two validators (ALICE, BOB) vote for and are compliant with the upgrade
+/// 2. A third validator (EVE) ignores the upgrade entirely
+/// 3. When conditions are met (2 validators required, height reached), ALICE proposes upgraded
+///    blocks
+/// 4. EVE consistently rejects these upgraded blocks in both the process_proposal and
+///    finalize_block phases
+/// 5. This leads to a consensus split where ALICE and BOB operate on the upgraded chain while EVE
+///    rejects those blocks as dead ends
+#[test]
+fn activation_manager_reject_ignored_upgrade() {
+    let upgrade_height = 3;
+    let required_approval_rate = 67;
+
+    let mut f = UpgradeTestFixture::new(upgrade_height, required_approval_rate)
+        .setup_compliant_validator(ALICE, Vote::Aye)
+        .setup_compliant_validator(BOB, Vote::Aye)
+        // NOTE: Eve ignores the upgrade.
+        .setup_ignoring_validator(EVE);
+
+    assert_eq!(f.next_height(), 0);
+
+    //
+    // Block 0: Alice proposes and votes.
+    //
+
+    f.start_proposal(ALICE, ACTIVE_VERSION)
+        // Alice and Bob do accept the upgrade.
+        .upgrade_conditions(
+            &[ALICE, BOB],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: false,
+                aye_approvals_req: false,
+                block_height_req: false,
+            },
+        )
+        // Eve DOES NOT accept the upgrade.
+        .upgrade_conditions_empty(&[EVE])
+        // Alice and Bob do participate in voting.
+        .expectations(
+            &[ALICE, BOB],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 34,
+                compliance_approval_rate: 34,
+            },
+        )
+        // Eve DOES NOT participate in voting.
+        .expectations(
+            &[EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 0,
+                compliance_approval_rate: 0,
+            },
+        )
+        .build_block();
+
+    assert_eq!(f.next_height(), 1);
+
+    //
+    // Block 1: Bob proposes and votes.
+    //
+
+    f.start_proposal(BOB, ACTIVE_VERSION)
+        .upgrade_conditions(
+            &[ALICE, BOB],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: false, // not finalized yet
+                aye_approvals_req: false, // not finalized yet
+                block_height_req: false,
+            },
+        )
+        .upgrade_conditions_empty(&[EVE])
+        .expectations(
+            &[ALICE, BOB],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 67,
+                compliance_approval_rate: 67,
+            },
+        )
+        .expectations(
+            &[EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 0,
+                compliance_approval_rate: 0,
+            },
+        )
+        .build_block();
+
+    assert_eq!(f.next_height(), 2);
+
+    //
+    // Block 2: Eve proposes, but DOES NOT participate in voting.
+    //
+
+    f.start_proposal(EVE, ACTIVE_VERSION)
+        .upgrade_conditions(
+            &[ALICE, BOB],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: true, // IS met!
+                aye_approvals_req: true, // IS met!
+                block_height_req: false,
+            },
+        )
+        .upgrade_conditions_empty(&[EVE])
+        .expectations(
+            &[ALICE, BOB],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 67,
+                compliance_approval_rate: 67,
+            },
+        )
+        .expectations(
+            &[EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 0,
+                compliance_approval_rate: 0,
+            },
+        )
+        .build_block();
+
+    assert_eq!(f.next_height(), 3);
+    assert_eq!(f.next_height(), upgrade_height);
+
+    //
+    // Block 3: Alice proposes the UPGRADE, all conditions are met!
+    //
+
+    f.start_proposal(ALICE, UPGRADE_VERSION)
+        .upgrade_conditions(
+            &[ALICE, BOB],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: true, // IS met!
+                aye_approvals_req: true, // IS met!
+                block_height_req: true,  // IS met!
+            },
+        )
+        .upgrade_conditions_empty(&[EVE])
+        .expectations(
+            &[ALICE, BOB],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                // Votes pruned after upgrade
+                aye_approval_rate: 0,
+                compliance_approval_rate: 0,
+            },
+        )
+        // Eve REJECTS the upgrade.
+        .expectations(
+            &[EVE],
+            Expectations {
+                process_pass: false,  // Reject!
+                finalize_pass: false, // Reject!
+                aye_approval_rate: 0,
+                compliance_approval_rate: 0,
+            },
+        )
+        .build_block();
+
+    assert_eq!(f.next_height(), 4);
+
+    //
+    // Block 4-20: Alice keeps building upgraded bocks, Eve keeps rejecting.
+    //
+
+    f.start_proposal(ALICE, UPGRADE_VERSION)
+        // No upgrade ongoing.
+        .upgrade_conditions_empty(&[ALICE, BOB])
+        .expectations(
+            &[ALICE, BOB],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 0,
+                compliance_approval_rate: 0,
+            },
+        )
+        // Eve REJECTS the upgrade.
+        .expectations(
+            &[EVE],
+            Expectations {
+                process_pass: false,  // Reject!
+                finalize_pass: false, // Reject!
+                aye_approval_rate: 0,
+                compliance_approval_rate: 0,
+            },
+        )
+        .build_blocks_until(21);
+
+    assert_eq!(f.next_height(), 21);
+}

--- a/crates/consensus/authority/src/activation_manager/tests/reject_ignored_upgrade.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/reject_ignored_upgrade.rs
@@ -39,7 +39,7 @@ fn activation_manager_reject_ignored_upgrade() {
         .upgrade_conditions(
             &[ALICE, BOB],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: false,
                 aye_approval_req: false,
                 block_height_req: false,
@@ -79,7 +79,7 @@ fn activation_manager_reject_ignored_upgrade() {
         .upgrade_conditions(
             &[ALICE, BOB],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: false, // not finalized yet
                 aye_approval_req: false,  // not finalized yet
                 block_height_req: false,
@@ -116,7 +116,7 @@ fn activation_manager_reject_ignored_upgrade() {
         .upgrade_conditions(
             &[ALICE, BOB],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: true, // IS met!
                 aye_approval_req: true,  // IS met!
                 block_height_req: false,
@@ -154,7 +154,7 @@ fn activation_manager_reject_ignored_upgrade() {
         .upgrade_conditions(
             &[ALICE, BOB],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: true, // IS met!
                 aye_approval_req: true,  // IS met!
                 block_height_req: true,  // IS met!

--- a/crates/consensus/authority/src/activation_manager/tests/reject_ignored_upgrade.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/reject_ignored_upgrade.rs
@@ -41,7 +41,7 @@ fn activation_manager_reject_ignored_upgrade() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: false,
-                aye_approvals_req: false,
+                aye_approval_req: false,
                 block_height_req: false,
             },
         )
@@ -81,7 +81,7 @@ fn activation_manager_reject_ignored_upgrade() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: false, // not finalized yet
-                aye_approvals_req: false, // not finalized yet
+                aye_approval_req: false,  // not finalized yet
                 block_height_req: false,
             },
         )
@@ -118,7 +118,7 @@ fn activation_manager_reject_ignored_upgrade() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: true, // IS met!
-                aye_approvals_req: true, // IS met!
+                aye_approval_req: true,  // IS met!
                 block_height_req: false,
             },
         )
@@ -156,7 +156,7 @@ fn activation_manager_reject_ignored_upgrade() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: true, // IS met!
-                aye_approvals_req: true, // IS met!
+                aye_approval_req: true,  // IS met!
                 block_height_req: true,  // IS met!
             },
         )

--- a/crates/consensus/authority/src/activation_manager/tests/reject_mismatched_vote.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/reject_mismatched_vote.rs
@@ -41,7 +41,7 @@ fn activation_manager_reject_mismatched_vote() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: false,
-                aye_approvals_req: false,
+                aye_approval_req: false,
                 block_height_req: false,
             },
         )
@@ -79,7 +79,7 @@ fn activation_manager_reject_mismatched_vote() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: false,
-                aye_approvals_req: false,
+                aye_approval_req: false,
                 block_height_req: false,
             },
         )
@@ -117,7 +117,7 @@ fn activation_manager_reject_mismatched_vote() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: false,
-                aye_approvals_req: false,
+                aye_approval_req: false,
                 block_height_req: false,
             },
         )
@@ -157,7 +157,7 @@ fn activation_manager_reject_mismatched_vote() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: false,
-                aye_approvals_req: false,
+                aye_approval_req: false,
                 block_height_req: true, // IS met!
             },
         )

--- a/crates/consensus/authority/src/activation_manager/tests/reject_mismatched_vote.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/reject_mismatched_vote.rs
@@ -52,7 +52,7 @@ fn activation_manager_reject_mismatched_vote() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 34,
-                compliance_approval_rate: 34,
+                comp_approval_rate: 34,
             },
         )
         // Eve does not count Alices' vote (different version).
@@ -62,7 +62,7 @@ fn activation_manager_reject_mismatched_vote() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 0,
-                compliance_approval_rate: 0,
+                comp_approval_rate: 0,
             },
         )
         .build_block();
@@ -90,7 +90,7 @@ fn activation_manager_reject_mismatched_vote() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 67,
-                compliance_approval_rate: 67,
+                comp_approval_rate: 67,
             },
         )
         // Eve does not count Bobs' vote (different version).
@@ -100,7 +100,7 @@ fn activation_manager_reject_mismatched_vote() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 0,
-                compliance_approval_rate: 0,
+                comp_approval_rate: 0,
             },
         )
         .build_block();
@@ -128,7 +128,7 @@ fn activation_manager_reject_mismatched_vote() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 67,
-                compliance_approval_rate: 67,
+                comp_approval_rate: 67,
             },
         )
         // Eve counts his own vote
@@ -138,7 +138,7 @@ fn activation_manager_reject_mismatched_vote() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 34,
-                compliance_approval_rate: 34,
+                comp_approval_rate: 34,
             },
         )
         .build_block();
@@ -167,7 +167,7 @@ fn activation_manager_reject_mismatched_vote() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 67,
-                compliance_approval_rate: 67,
+                comp_approval_rate: 67,
             },
         )
         .expectations(
@@ -176,7 +176,7 @@ fn activation_manager_reject_mismatched_vote() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 34,
-                compliance_approval_rate: 34,
+                comp_approval_rate: 34,
             },
         )
         .build_blocks_until(21);

--- a/crates/consensus/authority/src/activation_manager/tests/reject_mismatched_vote.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/reject_mismatched_vote.rs
@@ -39,7 +39,7 @@ fn activation_manager_reject_mismatched_vote() {
         .upgrade_conditions(
             &[ALICE, BOB, EVE],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: false,
                 aye_approval_req: false,
                 block_height_req: false,
@@ -77,7 +77,7 @@ fn activation_manager_reject_mismatched_vote() {
         .upgrade_conditions(
             &[ALICE, BOB, EVE],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: false,
                 aye_approval_req: false,
                 block_height_req: false,
@@ -115,7 +115,7 @@ fn activation_manager_reject_mismatched_vote() {
         .upgrade_conditions(
             &[ALICE, BOB, EVE],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: false,
                 aye_approval_req: false,
                 block_height_req: false,
@@ -155,7 +155,7 @@ fn activation_manager_reject_mismatched_vote() {
         .upgrade_conditions(
             &[ALICE, BOB, EVE],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: false,
                 aye_approval_req: false,
                 block_height_req: true, // IS met!

--- a/crates/consensus/authority/src/activation_manager/tests/reject_mismatched_vote.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/reject_mismatched_vote.rs
@@ -1,0 +1,185 @@
+use crate::activation_manager::{
+    tests::utils::{Expectations, UpgradeTestFixture, ACTIVE_VERSION, ALICE, BOB, EVE},
+    ConditionList,
+};
+use reth_db::models::activation_manager::Vote;
+
+/// Tests that validators tracking different upgrade versions don't count each
+/// other's votes.
+///
+/// This test verifies that:
+/// 1. Two validators (ALICE, BOB) vote for and track upgrade version 2.0
+/// 2. A third validator (EVE) votes for a different upgrade version (3.0)
+/// 3. The validators only count votes for their specific tracked version
+/// 4. Even though all validators are voting "Aye", the upgrade doesn't activate because from each
+///    perspective, the minimum quorum requirement is not met
+/// 5. This protects the network from confusion when multiple potential upgrades are being discussed
+#[test]
+fn activation_manager_reject_mismatched_vote() {
+    let upgrade_height = 3;
+    // NOTE: All validators are required to reach the approval rate!
+    let required_approval_rate = 100;
+
+    let mut f = UpgradeTestFixture::new(upgrade_height, required_approval_rate)
+        .setup_compliant_validator(ALICE, Vote::Aye)
+        .setup_compliant_validator(BOB, Vote::Aye)
+        // NOTE: Eve is using the same active version as Alice and Bob, but
+        // tracks a different upgrade; Alice and Bob vote for version 2.0, while
+        // Eve votes for 3.0.
+        .setup_INVALID_compliant_validator(EVE, Vote::Aye);
+
+    assert_eq!(f.next_height(), 0);
+
+    //
+    // Block 0: Alice proposes and votes.
+    //
+
+    f.start_proposal(ALICE, ACTIVE_VERSION)
+        // All validators are do accept the upgrade.
+        .upgrade_conditions(
+            &[ALICE, BOB, EVE],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: false,
+                aye_approvals_req: false,
+                block_height_req: false,
+            },
+        )
+        // Alice and Bob count Alices' vote.
+        .expectations(
+            &[ALICE, BOB],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 34,
+                compliance_approval_rate: 34,
+            },
+        )
+        // Eve does not count Alices' vote (different version).
+        .expectations(
+            &[EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 0,
+                compliance_approval_rate: 0,
+            },
+        )
+        .build_block();
+
+    assert_eq!(f.next_height(), 1);
+
+    //
+    // Block 1: Bob proposes and votes.
+    //
+
+    f.start_proposal(BOB, ACTIVE_VERSION)
+        .upgrade_conditions(
+            &[ALICE, BOB, EVE],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: false,
+                aye_approvals_req: false,
+                block_height_req: false,
+            },
+        )
+        // Alice and Bob count each others votes.
+        .expectations(
+            &[ALICE, BOB],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 67,
+                compliance_approval_rate: 67,
+            },
+        )
+        // Eve does not count Bobs' vote (different version).
+        .expectations(
+            &[EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 0,
+                compliance_approval_rate: 0,
+            },
+        )
+        .build_block();
+
+    assert_eq!(f.next_height(), 2);
+
+    //
+    // Block 2: Eve proposes and votes.
+    //
+
+    f.start_proposal(EVE, ACTIVE_VERSION)
+        .upgrade_conditions(
+            &[ALICE, BOB, EVE],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: false,
+                aye_approvals_req: false,
+                block_height_req: false,
+            },
+        )
+        // Alice and Bob DO NOT count Eves' vote (different version).
+        .expectations(
+            &[ALICE, BOB],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 67,
+                compliance_approval_rate: 67,
+            },
+        )
+        // Eve counts his own vote
+        .expectations(
+            &[EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 34,
+                compliance_approval_rate: 34,
+            },
+        )
+        .build_block();
+
+    assert_eq!(f.next_height(), 3);
+    assert_eq!(f.next_height(), upgrade_height);
+
+    //
+    // Block 3-20: Alice keeps building, but the upgrade never happens
+    // (100% quorum requirement).
+    //
+
+    f.start_proposal(ALICE, ACTIVE_VERSION)
+        .upgrade_conditions(
+            &[ALICE, BOB, EVE],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: false,
+                aye_approvals_req: false,
+                block_height_req: true, // IS met!
+            },
+        )
+        .expectations(
+            &[ALICE, BOB],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 67,
+                compliance_approval_rate: 67,
+            },
+        )
+        .expectations(
+            &[EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 34,
+                compliance_approval_rate: 34,
+            },
+        )
+        .build_blocks_until(21);
+
+    assert_eq!(f.next_height(), 21);
+}

--- a/crates/consensus/authority/src/activation_manager/tests/reject_outdated_or_unsupported_version.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/reject_outdated_or_unsupported_version.rs
@@ -41,7 +41,7 @@ fn activation_manager_reject_outdated_or_unsupported_version() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: false,
-                aye_approvals_req: false,
+                aye_approval_req: false,
                 block_height_req: false,
             },
         )
@@ -68,7 +68,7 @@ fn activation_manager_reject_outdated_or_unsupported_version() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: false, // not finalized yet
-                aye_approvals_req: false, // not finalized yet
+                aye_approval_req: false,  // not finalized yet
                 block_height_req: false,
             },
         )
@@ -95,7 +95,7 @@ fn activation_manager_reject_outdated_or_unsupported_version() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: true, // IS met!
-                aye_approvals_req: true, // IS met!
+                aye_approval_req: true,  // IS met!
                 block_height_req: false,
             },
         )
@@ -123,7 +123,7 @@ fn activation_manager_reject_outdated_or_unsupported_version() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: true, // IS met!
-                aye_approvals_req: true, // IS met!
+                aye_approval_req: true,  // IS met!
                 block_height_req: true,  // IS met!
             },
         )

--- a/crates/consensus/authority/src/activation_manager/tests/reject_outdated_or_unsupported_version.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/reject_outdated_or_unsupported_version.rs
@@ -1,0 +1,216 @@
+use crate::activation_manager::{
+    tests::utils::{
+        Expectations, UpgradeTestFixture, ACTIVE_VERSION, ALICE, BOB, EVE, UPGRADE_VERSION,
+    },
+    ConditionList,
+};
+use reth_db::models::activation_manager::Vote;
+
+/// Tests that validators reject blocks with outdated or unsupported versions.
+///
+/// This test verifies that:
+/// 1. All validators successfully activate an upgrade to version 2.0
+/// 2. EVE is then reset to use the previous version (1.0)
+/// 3. When EVE proposes blocks with the outdated version:
+///    - ALICE and BOB reject these blocks during process_proposal but accept them during
+///      finalize_block
+///    - This behavior allows historical sync while preventing outdated block production
+/// 4. When ALICE proposes blocks with the upgraded version:
+///    - EVE rejects these blocks during both process_proposal and finalize_block
+///    - This creates a consensus split where EVE cannot follow the upgraded chain
+#[test]
+fn activation_manager_reject_outdated_or_unsupported_version() {
+    let upgrade_height = 3;
+    let required_approval_rate = 67;
+
+    let mut f = UpgradeTestFixture::new(upgrade_height, required_approval_rate)
+        .setup_compliant_validator(ALICE, Vote::Aye)
+        .setup_compliant_validator(BOB, Vote::Aye)
+        .setup_compliant_validator(EVE, Vote::Aye);
+
+    assert_eq!(f.next_height(), 0);
+
+    //
+    // Block 0: Alice proposes and votes.
+    //
+
+    f.start_proposal(ALICE, ACTIVE_VERSION)
+        // All validators do accept the upgrade.
+        .upgrade_conditions(
+            &[ALICE, BOB, EVE],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: false,
+                aye_approvals_req: false,
+                block_height_req: false,
+            },
+        )
+        .expectations(
+            &[ALICE, BOB, EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 34,
+                compliance_approval_rate: 34,
+            },
+        )
+        .build_block();
+
+    assert_eq!(f.next_height(), 1);
+
+    //
+    // Block 1: Bob proposes and votes.
+    //
+
+    f.start_proposal(BOB, ACTIVE_VERSION)
+        .upgrade_conditions(
+            &[ALICE, BOB, EVE],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: false, // not finalized yet
+                aye_approvals_req: false, // not finalized yet
+                block_height_req: false,
+            },
+        )
+        .expectations(
+            &[ALICE, BOB, EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 67,
+                compliance_approval_rate: 67,
+            },
+        )
+        .build_block();
+
+    assert_eq!(f.next_height(), 2);
+
+    //
+    // Block 2: Eve proposes and votes.
+    //
+
+    f.start_proposal(EVE, ACTIVE_VERSION)
+        .upgrade_conditions(
+            &[ALICE, BOB, EVE],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: true, // IS met!
+                aye_approvals_req: true, // IS met!
+                block_height_req: false,
+            },
+        )
+        .expectations(
+            &[ALICE, BOB, EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 100,
+                compliance_approval_rate: 100,
+            },
+        )
+        .build_block();
+
+    assert_eq!(f.next_height(), 3);
+    assert_eq!(f.next_height(), upgrade_height);
+
+    //
+    // Block 3: Alice proposes the UPGRADE, all conditions are met!
+    //
+
+    f.start_proposal(ALICE, UPGRADE_VERSION)
+        .upgrade_conditions(
+            &[ALICE, BOB, EVE],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: true, // IS met!
+                aye_approvals_req: true, // IS met!
+                block_height_req: true,  // IS met!
+            },
+        )
+        .expectations(
+            &[ALICE, BOB, EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                // Votes pruned after upgrade
+                aye_approval_rate: 0,
+                compliance_approval_rate: 0,
+            },
+        )
+        .build_block();
+
+    assert_eq!(f.next_height(), 4);
+
+    //
+    // RESET Eve with the previous, outdated version. Do note that Alice and Bob
+    // do still accept the outdated blocks during finalization, but they do not
+    // back outdated blocks.
+    //
+    assert!(ACTIVE_VERSION < UPGRADE_VERSION);
+    let mut f = f.setup_ignoring_validator(EVE);
+
+    //
+    // Block 4-20: Eve keeps building OUTDATED bocks, Alice and Bob keep
+    // finalizing.
+    //
+
+    f.start_proposal(EVE, ACTIVE_VERSION)
+        // No upgrade ongoing.
+        .upgrade_conditions_empty(&[ALICE, BOB, EVE])
+        // Alice and Bob REJECT the outdated block during the backing phase, but
+        // will accept it during the finalization phase.
+        .expectations(
+            &[ALICE, BOB],
+            Expectations {
+                process_pass: false, // Reject!
+                finalize_pass: true, // Accept
+                aye_approval_rate: 0,
+                compliance_approval_rate: 0,
+            },
+        )
+        // Eve (producer) accepts the outdated block.
+        .expectations(
+            &[EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 0,
+                compliance_approval_rate: 0,
+            },
+        )
+        .build_blocks_until(21);
+
+    assert_eq!(f.next_height(), 21);
+
+    //
+    // Block 21-40: Alice keeps building UPGRADED blocks, Eve keeps rejecting.
+    //
+
+    f.start_proposal(ALICE, UPGRADE_VERSION)
+        .upgrade_conditions_empty(&[ALICE, BOB, EVE])
+        // Alice and Bob accept the upgraded blocks.
+        .expectations(
+            &[ALICE, BOB],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 0,
+                compliance_approval_rate: 0,
+            },
+        )
+        // Eve REJECTS the upgraded blocks, both during the backing and
+        // finalization phase. Note that Eve is not configured to accept the
+        // upgrade.
+        .expectations(
+            &[EVE],
+            Expectations {
+                process_pass: false,  // Reject!
+                finalize_pass: false, // Reject!
+                aye_approval_rate: 0,
+                compliance_approval_rate: 0,
+            },
+        )
+        .build_blocks_until(41);
+
+    assert_eq!(f.next_height(), 41);
+}

--- a/crates/consensus/authority/src/activation_manager/tests/reject_outdated_or_unsupported_version.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/reject_outdated_or_unsupported_version.rs
@@ -39,7 +39,7 @@ fn activation_manager_reject_outdated_or_unsupported_version() {
         .upgrade_conditions(
             &[ALICE, BOB, EVE],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: false,
                 aye_approval_req: false,
                 block_height_req: false,
@@ -66,7 +66,7 @@ fn activation_manager_reject_outdated_or_unsupported_version() {
         .upgrade_conditions(
             &[ALICE, BOB, EVE],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: false, // not finalized yet
                 aye_approval_req: false,  // not finalized yet
                 block_height_req: false,
@@ -93,7 +93,7 @@ fn activation_manager_reject_outdated_or_unsupported_version() {
         .upgrade_conditions(
             &[ALICE, BOB, EVE],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: true, // IS met!
                 aye_approval_req: true,  // IS met!
                 block_height_req: false,
@@ -121,7 +121,7 @@ fn activation_manager_reject_outdated_or_unsupported_version() {
         .upgrade_conditions(
             &[ALICE, BOB, EVE],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: true, // IS met!
                 aye_approval_req: true,  // IS met!
                 block_height_req: true,  // IS met!

--- a/crates/consensus/authority/src/activation_manager/tests/reject_outdated_or_unsupported_version.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/reject_outdated_or_unsupported_version.rs
@@ -51,7 +51,7 @@ fn activation_manager_reject_outdated_or_unsupported_version() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 34,
-                compliance_approval_rate: 34,
+                comp_approval_rate: 34,
             },
         )
         .build_block();
@@ -78,7 +78,7 @@ fn activation_manager_reject_outdated_or_unsupported_version() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 67,
-                compliance_approval_rate: 67,
+                comp_approval_rate: 67,
             },
         )
         .build_block();
@@ -105,7 +105,7 @@ fn activation_manager_reject_outdated_or_unsupported_version() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 100,
-                compliance_approval_rate: 100,
+                comp_approval_rate: 100,
             },
         )
         .build_block();
@@ -134,7 +134,7 @@ fn activation_manager_reject_outdated_or_unsupported_version() {
                 finalize_pass: true,
                 // Votes pruned after upgrade
                 aye_approval_rate: 0,
-                compliance_approval_rate: 0,
+                comp_approval_rate: 0,
             },
         )
         .build_block();
@@ -165,7 +165,7 @@ fn activation_manager_reject_outdated_or_unsupported_version() {
                 process_pass: false, // Reject!
                 finalize_pass: true, // Accept
                 aye_approval_rate: 0,
-                compliance_approval_rate: 0,
+                comp_approval_rate: 0,
             },
         )
         // Eve (producer) accepts the outdated block.
@@ -175,7 +175,7 @@ fn activation_manager_reject_outdated_or_unsupported_version() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 0,
-                compliance_approval_rate: 0,
+                comp_approval_rate: 0,
             },
         )
         .build_blocks_until(21);
@@ -195,7 +195,7 @@ fn activation_manager_reject_outdated_or_unsupported_version() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 0,
-                compliance_approval_rate: 0,
+                comp_approval_rate: 0,
             },
         )
         // Eve REJECTS the upgraded blocks, both during the backing and
@@ -207,7 +207,7 @@ fn activation_manager_reject_outdated_or_unsupported_version() {
                 process_pass: false,  // Reject!
                 finalize_pass: false, // Reject!
                 aye_approval_rate: 0,
-                compliance_approval_rate: 0,
+                comp_approval_rate: 0,
             },
         )
         .build_blocks_until(41);

--- a/crates/consensus/authority/src/activation_manager/tests/utils.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/utils.rs
@@ -1,0 +1,521 @@
+use super::Db;
+use crate::activation_manager::{
+    ActivationManager, ActivationManagerBuilder, ConditionList, OnFinalizeBlockDecision,
+    OnPrepareProposalDecision, OnProcessProposalDecision, VOTE_RETENTION_PERIOD,
+};
+use reth_db::models::activation_manager::{RuntimeVersion, Vote};
+use reth_provider::ActivationManagerReaderWriter;
+use secp256k1::{generate_keypair, rand::thread_rng};
+
+/// Index for the ALICE validator in the test fixture
+pub(super) const ALICE: usize = 0;
+/// Index for the BOB validator in the test fixture
+pub(super) const BOB: usize = 1;
+/// Index for the EVE validator in the test fixture
+pub(super) const EVE: usize = 2;
+
+// Runtime version constants for tests
+/// The default active runtime version used in tests (1.0)
+pub(super) const ACTIVE_VERSION: RuntimeVersion = RuntimeVersion::new(1, 0);
+/// The default upgrade runtime version used in tests (2.0)
+pub(super) const UPGRADE_VERSION: RuntimeVersion = RuntimeVersion::new(2, 0);
+/// An alternative version used for testing mismatched version scenarios (3.0)
+pub(super) const INVALID_VERSION: RuntimeVersion = RuntimeVersion::new(3, 0);
+
+/// Stores vote details for a validator in the test environment.
+///
+/// This structure holds information about a validator's vote on an upgrade
+/// proposal, including which version they're voting on, their vote (Aye/Nay),
+/// and whether they're ready to accept the upgrade.
+struct VoteDetails {
+    /// The runtime version that the validator is voting on
+    version: RuntimeVersion,
+    /// The validator's vote (Aye/Nay)
+    vote: Vote,
+    /// Whether the validator is ready to accept the upgrade
+    is_compliant: bool,
+}
+
+/// Main test fixture for network upgrade scenarios.
+///
+/// This fixture manages the state for multiple validators in upgrade testing
+/// scenarios, including their identities, databases, activation managers,
+/// and voting status. It provides methods to configure validators with
+/// different upgrade behaviors and to advance the simulation through blocks.
+pub(super) struct UpgradeTestFixture {
+    /// The block height at which the upgrade should activate (if conditions are met)
+    upgrade_height: u64,
+    /// The percentage approval rate (0-100) required for upgrade activation
+    required_approval_rate: usize,
+    /// The minimum number of distinct validators required to participate in voting
+    min_validator_count: usize,
+
+    /// The current block height in the simulation
+    block_height: u64,
+    /// How long votes are retained before expiring (in blocks)
+    vote_retention_period: u64,
+
+    /// The public keys representing each validator's identity
+    addrs: [secp256k1::PublicKey; 3],
+    /// In-memory databases for each validator
+    dbs: [Db; 3],
+    /// The activation manager instances for each validator
+    managers: [Option<ActivationManager<Db>>; 3],
+    /// Expected votes to be included in block proposals for each validator
+    expected_votes: [Option<VoteDetails>; 3],
+}
+
+impl UpgradeTestFixture {
+    /// Creates a new `UpgradeTestFixture` with the specified upgrade parameters.
+    ///
+    /// Initializes a test environment with three validators (ALICE, BOB, EVE) and
+    /// configures the upgrade parameters to be used throughout the tests.
+    ///
+    /// # Parameters
+    /// * `upgrade_height` - The block height at which the upgrade should activate
+    /// * `approval_rate` - The percentage approval rate (0-100) required for upgrade activation
+    /// * `min_validator_count` - The minimum number of validators that must participate
+    ///
+    /// # Returns
+    /// * A new `UpgradeTestFixture` with default values and generated validator keys
+    pub(super) fn new(upgrade_height: u64, approval_rate: usize) -> Self {
+        // Generate keypairs
+        let (_, alice_addr) = generate_keypair(&mut thread_rng());
+        let (_, bob_addr) = generate_keypair(&mut thread_rng());
+        let (_, eve_addr) = generate_keypair(&mut thread_rng());
+
+        Self {
+            upgrade_height,
+            required_approval_rate: approval_rate,
+            min_validator_count: 3,
+            block_height: 0,
+            vote_retention_period: VOTE_RETENTION_PERIOD,
+            addrs: [alice_addr, bob_addr, eve_addr],
+            dbs: [Db::new(), Db::new(), Db::new()],
+            managers: [None, None, None],
+            expected_votes: [None, None, None],
+        }
+    }
+
+    /// Sets a custom vote retention period for the test.
+    ///
+    /// Allows configuring how long votes are retained before expiring during the test.
+    /// This is useful for testing vote expiration scenarios with a shorter period.
+    ///
+    /// # Parameters
+    /// * `vote_retention_period` - How long votes are retained (in blocks)
+    ///
+    /// # Returns
+    /// * The fixture with the updated vote retention period
+    pub(super) fn vote_retention_period(mut self, vote_retention_period: u64) -> Self {
+        self.vote_retention_period = vote_retention_period;
+        self
+    }
+
+    /// Configures a validator to ignore network upgrades.
+    ///
+    /// Sets up the specified validator to not participate in upgrade voting and
+    /// to reject any blocks with versions other than the current active version.
+    ///
+    /// # Parameters
+    /// * `validator` - The index of the validator to configure (ALICE, BOB, or EVE)
+    ///
+    /// # Returns
+    /// * The fixture with the configured validator
+    pub(super) fn setup_ignoring_validator(mut self, validator: usize) -> Self {
+        let db = self.dbs[validator].clone();
+
+        let manager = ActivationManagerBuilder::new(db, ACTIVE_VERSION)
+            .vote_retention_period(self.vote_retention_period)
+            .build_ignore_nework_upgrade();
+
+        self.managers[validator] = Some(manager);
+        self.expected_votes[validator] = None;
+
+        self
+    }
+
+    /// Configures a validator to signal a vote without accepting the upgrade.
+    ///
+    /// Sets up the specified validator to include their vote in block proposals
+    /// but to reject blocks with the upgraded version.
+    ///
+    /// # Parameters
+    /// * `validator` - The index of the validator to configure (ALICE, BOB, or EVE)
+    /// * `vote` - The validator's vote (Aye/Nay)
+    ///
+    /// # Returns
+    /// * The fixture with the configured validator
+    pub(super) fn setup_signaling_validator(mut self, validator: usize, vote: Vote) -> Self {
+        let db = self.dbs[validator].clone();
+
+        let manager = ActivationManagerBuilder::new(db, ACTIVE_VERSION)
+            .vote_retention_period(self.vote_retention_period)
+            .build_signal_network_upgrade(UPGRADE_VERSION, vote);
+
+        self.managers[validator] = Some(manager);
+        self.expected_votes[validator] =
+            Some(VoteDetails { version: UPGRADE_VERSION, vote, is_compliant: false });
+
+        self
+    }
+
+    /// Configures a validator to accept the standard upgrade version.
+    ///
+    /// Sets up the specified validator to both vote for and accept the upgrade
+    /// when all conditions are met.
+    ///
+    /// # Parameters
+    /// * `validator` - The index of the validator to configure (ALICE, BOB, or EVE)
+    /// * `vote` - The validator's vote (Aye/Nay)
+    ///
+    /// # Returns
+    /// * The fixture with the configured validator
+    pub(super) fn setup_compliant_validator(self, validator: usize, vote: Vote) -> Self {
+        self._do_setup_compliant_validator(validator, vote, UPGRADE_VERSION)
+    }
+
+    /// Configures a validator to accept an invalid upgrade version.
+    ///
+    /// Sets up the specified validator to both vote for and accept an alternative
+    /// upgrade version (3.0). This is used to test how validators handle mismatched
+    /// upgrade versions.
+    ///
+    /// # Parameters
+    /// * `validator` - The index of the validator to configure (ALICE, BOB, or EVE)
+    /// * `vote` - The validator's vote (Aye/Nay)
+    ///
+    /// # Returns
+    /// * The fixture with the configured validator
+    #[allow(non_snake_case)]
+    pub(super) fn setup_INVALID_compliant_validator(self, validator: usize, vote: Vote) -> Self {
+        self._do_setup_compliant_validator(validator, vote, INVALID_VERSION)
+    }
+
+    /// Internal method to set up a validator to accept a specific upgrade version.
+    ///
+    /// Configures the validator with the specified parameters and creates an
+    /// ActivationManager that will accept the upgrade when conditions are met.
+    ///
+    /// # Parameters
+    /// * `validator` - The index of the validator to configure
+    /// * `vote` - The validator's vote (Aye/Nay)
+    /// * `upgrade_version` - The version to track and accept
+    ///
+    /// # Returns
+    /// * The fixture with the configured validator
+    fn _do_setup_compliant_validator(
+        mut self,
+        validator: usize,
+        vote: Vote,
+        upgrade_version: RuntimeVersion,
+    ) -> Self {
+        let db = self.dbs[validator].clone();
+
+        let manager = ActivationManagerBuilder::new(db, ACTIVE_VERSION)
+            .vote_retention_period(self.vote_retention_period)
+            .build_COMPLIANT_network_upgrade(
+                upgrade_version,
+                self.required_approval_rate,
+                self.min_validator_count,
+                self.upgrade_height,
+                Some(vote),
+            );
+
+        self.managers[validator] = Some(manager);
+        self.expected_votes[validator] =
+            Some(VoteDetails { version: upgrade_version, vote, is_compliant: true });
+
+        self
+    }
+
+    /// Returns the current block height in the test simulation.
+    ///
+    /// # Returns
+    /// * The current block height
+    pub(super) fn next_height(&self) -> u64 {
+        self.block_height
+    }
+
+    /// Starts a block proposal process for testing.
+    ///
+    /// Creates a ProposingTestFixture that will simulate the process of a validator
+    /// proposing a block with the specified version.
+    ///
+    /// # Parameters
+    /// * `validator` - The index of the validator who will propose the block
+    /// * `version` - The runtime version to propose for the block
+    ///
+    /// # Returns
+    /// * A ProposingTestFixture for building and testing the block
+    pub(super) fn start_proposal(
+        &mut self,
+        validator: usize,
+        version: RuntimeVersion,
+    ) -> ProposingTestFixture<'_> {
+        ProposingTestFixture {
+            i: self,
+            proposer_index: validator,
+            expected_proposal_version: version,
+            expectations: [None, None, None],
+            expected_conditions: [None, None, None],
+        }
+    }
+}
+
+/// Expectations for a validator's behavior during block processing.
+///
+/// This structure defines the expected outcomes when a validator processes
+/// a block proposal, including whether they should accept or reject it,
+/// and the expected voting statistics after processing.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(super) struct Expectations {
+    /// Whether the validator should accept the block during `process_proposal`
+    pub(super) process_pass: bool,
+    /// Whether the validator should accept the block during `finalize_block`
+    pub(super) finalize_pass: bool,
+    /// The expected percentage (0-100) of Aye votes
+    pub(super) aye_approval_rate: usize,
+    /// The expected percentage (0-100) of compliant validators
+    pub(super) compliance_approval_rate: usize,
+}
+
+/// Fixture for testing the block proposal and validation flow.
+///
+/// This structure builds on the main UpgradeTestFixture to test specific
+/// block proposal scenarios. It allows setting expectations for each validator's
+/// behavior and conducts the simulation of proposing, processing, and
+/// finalizing blocks.
+pub(super) struct ProposingTestFixture<'a> {
+    i: &'a mut UpgradeTestFixture,
+
+    /// The index of the validator proposing the current block
+    proposer_index: usize,
+    /// The runtime version expected in the proposal
+    expected_proposal_version: RuntimeVersion,
+
+    /// Expectations for each validator's behavior when processing the block
+    expectations: [Option<Expectations>; 3],
+    /// Expected upgrade conditions for each validator
+    expected_conditions: [Option<ConditionList>; 3],
+}
+
+impl ProposingTestFixture<'_> {
+    /// Sets the expected upgrade conditions for specified validators.
+    ///
+    /// Configures the test to expect the specified conditions when validators
+    /// process the proposed block.
+    ///
+    /// # Parameters
+    /// * `vals` - Array of validator indices to configure expectations for
+    /// * `conditions` - The conditions to expect
+    ///
+    /// # Returns
+    /// * The fixture with updated expectations
+    pub(super) fn upgrade_conditions(mut self, vals: &[usize], conditions: ConditionList) -> Self {
+        for v in vals {
+            self.expected_conditions[*v] = Some(conditions);
+        }
+        self
+    }
+
+    /// Clears the expected upgrade conditions for specified validators.
+    ///
+    /// Configures the test to expect no upgrade conditions when validators
+    /// process the proposed block.
+    ///
+    /// # Parameters
+    /// * `vals` - Array of validator indices to clear expectations for
+    ///
+    /// # Returns
+    /// * The fixture with updated expectations
+    pub(super) fn upgrade_conditions_empty(mut self, vals: &[usize]) -> Self {
+        for v in vals {
+            self.expected_conditions[*v] = None;
+        }
+        self
+    }
+
+    /// Sets the behavior expectations for specified validators.
+    ///
+    /// Configures the test to expect certain behaviors and outcomes when
+    /// validators process the proposed block.
+    ///
+    /// # Parameters
+    /// * `vals` - Array of validator indices to configure expectations for
+    /// * `expectations` - The behavior and outcomes to expect
+    ///
+    /// # Returns
+    /// * The fixture with updated expectations
+    pub(super) fn expectations(mut self, vals: &[usize], expectations: Expectations) -> Self {
+        for v in vals {
+            self.expectations[*v] = Some(expectations);
+        }
+        self
+    }
+
+    /// Clears the behavior expectations for specified validators.
+    ///
+    /// Configures the test to expect no specific behaviors when validators
+    /// process the proposed block.
+    ///
+    /// # Parameters
+    /// * `vals` - Array of validator indices to clear expectations for
+    ///
+    /// # Returns
+    /// * The fixture with updated expectations
+    pub(super) fn expectations_empty(mut self, vals: &[usize]) -> Self {
+        for v in vals {
+            self.expectations[*v] = None;
+        }
+        self
+    }
+
+    /// Builds a single block and advances the test simulation.
+    ///
+    /// Simulates the full process of proposing, processing, and finalizing a block
+    /// and verifies that all validators behave according to expectations.
+    pub(super) fn build_block(mut self) {
+        self.do_build_block();
+    }
+
+    /// Builds multiple blocks until reaching the target height.
+    ///
+    /// Repeatedly builds blocks and advances the simulation until the
+    /// specified block height is reached.
+    ///
+    /// # Parameters
+    /// * `target_height` - The block height to build up to
+    pub(super) fn build_blocks_until(mut self, target_height: u64) {
+        while self.i.block_height < target_height {
+            self.do_build_block();
+        }
+    }
+
+    /// Internal method to simulate the full block building process.
+    ///
+    /// This method:
+    /// 1. Has the proposer prepare a block proposal
+    /// 2. Has each validator process the proposal
+    /// 3. Has each validator finalize the block
+    /// 4. Verifies that all validators behave according to expectations
+    /// 5. Advances the block height
+    fn do_build_block(&mut self) {
+        dbg!(self.i.block_height);
+
+        let proposer = self.i.managers[self.proposer_index].as_mut().unwrap();
+        let proposer_addr = &self.i.addrs[self.proposer_index];
+
+        // Proposer builds the block
+        let OnPrepareProposalDecision {
+            version: proposer_version,
+            vote: proposer_vote,
+            conditions: proposer_conditions,
+        } = proposer.on_prepare_proposal(self.i.block_height).unwrap();
+
+        // Verify proposed version
+        assert_eq!(proposer_version, self.expected_proposal_version, "proposed different version");
+
+        // Verify proposer's vote
+        if let Some(p) = &proposer_vote {
+            let e = self.i.expected_votes[self.proposer_index].as_ref().unwrap();
+            assert_eq!(p.version, e.version, "voted for different version");
+            assert_eq!(p.vote, e.vote, "voted with different vote");
+            assert_eq!(p.is_compliant, e.is_compliant, "voted with different compliance");
+        }
+
+        // Verify proposer's conditions
+        let expected_cond = self.expected_conditions[self.proposer_index].as_ref();
+        assert_eq!(
+            proposer_conditions.as_ref(),
+            expected_cond,
+            "proposed with different conditions"
+        );
+
+        // Each party processes and finalizes the block
+        for (i, (manager, db)) in self.i.managers.iter_mut().zip(self.i.dbs.iter()).enumerate() {
+            let auth_idx = i;
+            dbg!(auth_idx);
+
+            let Some(manager) = manager.as_mut() else {
+                assert!(
+                    self.expectations[i].is_none(),
+                    "expected expectations for non-existent manager"
+                );
+                assert!(
+                    self.expected_conditions[i].is_none(),
+                    "expected conditions for non-existent manager"
+                );
+
+                continue;
+            };
+
+            let expect = self.expectations[i].as_ref().expect("expected expectations for manager");
+            let expected_cond = self.expected_conditions[i].as_ref();
+
+            // COMET-BFT: Process the proposal.
+            let decision =
+                manager.on_process_proposal(self.i.block_height, proposer_version).unwrap();
+
+            match decision {
+                OnProcessProposalDecision::Process { version, conditions } => {
+                    assert!(expect.process_pass, "expected process pass");
+                    assert_eq!(version, proposer_version, "processed different version");
+                    assert_eq!(
+                        conditions.as_ref(),
+                        expected_cond,
+                        "processed with different conditions"
+                    );
+                }
+                OnProcessProposalDecision::RejectBlock { version, conditions } => {
+                    assert!(!expect.process_pass, "expected process fail");
+                    assert_eq!(version, proposer_version, "processed different version");
+                    assert_eq!(
+                        conditions.as_ref(),
+                        expected_cond,
+                        "processed with different conditions"
+                    );
+                }
+            }
+
+            // COMET-BFT: Finalize the proposal.
+            let decision = manager
+                .on_finalize_block(
+                    proposer_version,
+                    self.i.block_height,
+                    *proposer_addr,
+                    proposer_vote.clone(),
+                )
+                .unwrap();
+
+            match decision {
+                OnFinalizeBlockDecision::Finalize { version } => {
+                    assert!(expect.finalize_pass, "expected finalize pass");
+                    assert_eq!(version, proposer_version, "finalized different version");
+                }
+                OnFinalizeBlockDecision::RejectBlockDeadEnd { version } => {
+                    assert!(!expect.finalize_pass, "expected finalize fail");
+                    assert_eq!(version, proposer_version, "(none-)finalized different version");
+                }
+            }
+
+            // Verify approval rates
+            let (ayes, votes) =
+                db.get_upgrading_approval_rate_ayes(self.i.min_validator_count).unwrap();
+
+            let (compliance, v2) =
+                db.get_upgrading_approval_rate_compliance(self.i.min_validator_count).unwrap();
+
+            assert_eq!(votes, v2);
+            assert!(votes >= self.i.min_validator_count, "voter count does not meet minimum");
+
+            assert_eq!(ayes, expect.aye_approval_rate, "ayes approval_rate mismatch");
+            assert_eq!(
+                compliance, expect.compliance_approval_rate,
+                "compliant approval_rate mismatch"
+            );
+        }
+
+        self.i.block_height += 1;
+    }
+}

--- a/crates/consensus/authority/src/activation_manager/tests/utils.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/utils.rs
@@ -277,7 +277,7 @@ pub(super) struct Expectations {
     /// The expected percentage (0-100) of Aye votes
     pub(super) aye_approval_rate: usize,
     /// The expected percentage (0-100) of compliant validators
-    pub(super) compliance_approval_rate: usize,
+    pub(super) comp_approval_rate: usize,
 }
 
 /// Fixture for testing the block proposal and validation flow.
@@ -510,10 +510,7 @@ impl ProposingTestFixture<'_> {
             assert!(votes >= self.i.min_validator_count, "voter count does not meet minimum");
 
             assert_eq!(ayes, expect.aye_approval_rate, "ayes approval_rate mismatch");
-            assert_eq!(
-                compliance, expect.compliance_approval_rate,
-                "compliant approval_rate mismatch"
-            );
+            assert_eq!(compliance, expect.comp_approval_rate, "compliant approval_rate mismatch");
         }
 
         self.i.block_height += 1;

--- a/crates/consensus/authority/src/activation_manager/tests/vote_expiration.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/vote_expiration.rs
@@ -1,0 +1,256 @@
+use crate::activation_manager::{
+    tests::utils::{Expectations, UpgradeTestFixture, ACTIVE_VERSION, ALICE, BOB, EVE},
+    ConditionList,
+};
+use reth_db::models::activation_manager::Vote;
+
+/// Tests that votes expire after the retention period and are no longer counted.
+///
+/// This test verifies that:
+/// 1. All validators vote for and are willing to accept an upgrade
+/// 2. With a reduced vote retention period of 10 blocks, votes begin to expire
+/// 3. By block 12, BOB's vote (cast in block 1) expires and is no longer counted
+/// 4. By block 13, EVE's vote (cast in block 2) also expires
+/// 5. Even when the target height is reached, the upgrade doesn't activate because expired votes
+///    reduce the validator count below the minimum requirement
+/// 6. This ensures that upgrade decisions reflect recent consensus rather than outdated votes
+#[test]
+fn activation_manager_vote_expiration() {
+    let upgrade_height = 20;
+    let required_approval_rate = 67;
+    let vote_retention_period = 10;
+
+    let mut f = UpgradeTestFixture::new(upgrade_height, required_approval_rate)
+        // NOTE: Setup the vote retention period.
+        .vote_retention_period(vote_retention_period)
+        .setup_compliant_validator(ALICE, Vote::Aye)
+        .setup_compliant_validator(BOB, Vote::Aye)
+        .setup_compliant_validator(EVE, Vote::Aye);
+
+    assert_eq!(f.next_height(), 0);
+
+    //
+    // Block 0: Alice proposes and votes.
+    //
+
+    f.start_proposal(ALICE, ACTIVE_VERSION)
+        // All validators do accept the upgrade.
+        .upgrade_conditions(
+            &[ALICE, BOB, EVE],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: false,
+                aye_approvals_req: false,
+                block_height_req: false,
+            },
+        )
+        .expectations(
+            &[ALICE, BOB, EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 34,
+                compliance_approval_rate: 34,
+            },
+        )
+        .build_block();
+
+    assert_eq!(f.next_height(), 1);
+
+    //
+    // Block 1: Bob proposes and votes.
+    //
+
+    f.start_proposal(BOB, ACTIVE_VERSION)
+        .upgrade_conditions(
+            &[ALICE, BOB, EVE],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: false, // not finalized yet
+                aye_approvals_req: false, // not finalized yet
+                block_height_req: false,
+            },
+        )
+        .expectations(
+            &[ALICE, BOB, EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 67,
+                compliance_approval_rate: 67,
+            },
+        )
+        .build_block();
+
+    assert_eq!(f.next_height(), 2);
+
+    //
+    // Block 2: Eve proposes and votes.
+    //
+
+    f.start_proposal(EVE, ACTIVE_VERSION)
+        .upgrade_conditions(
+            &[ALICE, BOB, EVE],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: true, // IS met!
+                aye_approvals_req: true, // IS met!
+                block_height_req: false,
+            },
+        )
+        .expectations(
+            &[ALICE, BOB, EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 100,
+                compliance_approval_rate: 100,
+            },
+        )
+        .build_block();
+
+    assert_eq!(f.next_height(), 3);
+    assert_eq!(vote_retention_period, 10);
+    assert_eq!(upgrade_height, 20);
+
+    //
+    // Block 3-11: Alice keeps building, meanwhile Bob's and Eve's votes
+    // approach the expiration target.
+    //
+
+    f.start_proposal(ALICE, ACTIVE_VERSION)
+        .upgrade_conditions(
+            &[ALICE, BOB, EVE],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: true, // IS met!
+                aye_approvals_req: true, // IS met!
+                block_height_req: false, // IS NOT met!
+            },
+        )
+        .expectations(
+            &[ALICE, BOB, EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 100,
+                compliance_approval_rate: 100,
+            },
+        )
+        .build_blocks_until(12);
+
+    assert_eq!(f.next_height(), 12);
+
+    //
+    // Block 12: Alice builds the block; Bob voted last in block 2, his vote
+    // EXPIRED!
+    //
+
+    f.start_proposal(ALICE, ACTIVE_VERSION)
+        .upgrade_conditions(
+            &[ALICE, BOB, EVE],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: true,
+                aye_approvals_req: true,
+                block_height_req: false,
+            },
+        )
+        .expectations(
+            &[ALICE, BOB, EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                // NOTE: Bob's vote expired!
+                aye_approval_rate: 67,
+                compliance_approval_rate: 67,
+            },
+        )
+        .build_block();
+
+    assert_eq!(f.next_height(), 13);
+
+    //
+    // Block 13: Alice builds the block, Eve voted last in block 3, his vote
+    // EXPIRED!
+    //
+
+    f.start_proposal(ALICE, ACTIVE_VERSION)
+        .upgrade_conditions(
+            &[ALICE, BOB, EVE],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: true, // not finalized yet
+                aye_approvals_req: true, // not finalized yet
+                block_height_req: false,
+            },
+        )
+        .expectations(
+            &[ALICE, BOB, EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                // NOTE: Eve's vote expired!
+                aye_approval_rate: 34,
+                compliance_approval_rate: 34,
+            },
+        )
+        .build_block();
+
+    assert_eq!(f.next_height(), 14);
+
+    //
+    // Block 14-19: Alice keeps building right before the height of the upgrade.
+    //
+
+    f.start_proposal(ALICE, ACTIVE_VERSION)
+        .upgrade_conditions(
+            &[ALICE, BOB, EVE],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: false, // IS NOT me!
+                aye_approvals_req: false, // IS NOT met!
+                block_height_req: false,  // IS NOT met!
+            },
+        )
+        .expectations(
+            &[ALICE, BOB, EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 34,
+                compliance_approval_rate: 34,
+            },
+        )
+        .build_blocks_until(20);
+
+    assert_eq!(f.next_height(), 20);
+    assert_eq!(upgrade_height, 20);
+
+    //
+    // Block 20-30: Alice keeps building, but the upgrade never happens.
+    //
+
+    f.start_proposal(ALICE, ACTIVE_VERSION)
+        .upgrade_conditions(
+            &[ALICE, BOB, EVE],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: false,
+                aye_approvals_req: false,
+                block_height_req: true, // IS met!
+            },
+        )
+        .expectations(
+            &[ALICE, BOB, EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 34,
+                compliance_approval_rate: 34,
+            },
+        )
+        .build_blocks_until(31);
+
+    assert_eq!(f.next_height(), 31);
+}

--- a/crates/consensus/authority/src/activation_manager/tests/vote_expiration.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/vote_expiration.rs
@@ -40,7 +40,7 @@ fn activation_manager_vote_expiration() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: false,
-                aye_approvals_req: false,
+                aye_approval_req: false,
                 block_height_req: false,
             },
         )
@@ -67,7 +67,7 @@ fn activation_manager_vote_expiration() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: false, // not finalized yet
-                aye_approvals_req: false, // not finalized yet
+                aye_approval_req: false,  // not finalized yet
                 block_height_req: false,
             },
         )
@@ -94,7 +94,7 @@ fn activation_manager_vote_expiration() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: true, // IS met!
-                aye_approvals_req: true, // IS met!
+                aye_approval_req: true,  // IS met!
                 block_height_req: false,
             },
         )
@@ -124,7 +124,7 @@ fn activation_manager_vote_expiration() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: true, // IS met!
-                aye_approvals_req: true, // IS met!
+                aye_approval_req: true,  // IS met!
                 block_height_req: false, // IS NOT met!
             },
         )
@@ -152,7 +152,7 @@ fn activation_manager_vote_expiration() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: true,
-                aye_approvals_req: true,
+                aye_approval_req: true,
                 block_height_req: false,
             },
         )
@@ -181,7 +181,7 @@ fn activation_manager_vote_expiration() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: true, // not finalized yet
-                aye_approvals_req: true, // not finalized yet
+                aye_approval_req: true,  // not finalized yet
                 block_height_req: false,
             },
         )
@@ -209,7 +209,7 @@ fn activation_manager_vote_expiration() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: false, // IS NOT me!
-                aye_approvals_req: false, // IS NOT met!
+                aye_approval_req: false,  // IS NOT met!
                 block_height_req: false,  // IS NOT met!
             },
         )
@@ -237,7 +237,7 @@ fn activation_manager_vote_expiration() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: false,
-                aye_approvals_req: false,
+                aye_approval_req: false,
                 block_height_req: true, // IS met!
             },
         )

--- a/crates/consensus/authority/src/activation_manager/tests/vote_expiration.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/vote_expiration.rs
@@ -50,7 +50,7 @@ fn activation_manager_vote_expiration() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 34,
-                compliance_approval_rate: 34,
+                comp_approval_rate: 34,
             },
         )
         .build_block();
@@ -77,7 +77,7 @@ fn activation_manager_vote_expiration() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 67,
-                compliance_approval_rate: 67,
+                comp_approval_rate: 67,
             },
         )
         .build_block();
@@ -104,7 +104,7 @@ fn activation_manager_vote_expiration() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 100,
-                compliance_approval_rate: 100,
+                comp_approval_rate: 100,
             },
         )
         .build_block();
@@ -134,7 +134,7 @@ fn activation_manager_vote_expiration() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 100,
-                compliance_approval_rate: 100,
+                comp_approval_rate: 100,
             },
         )
         .build_blocks_until(12);
@@ -163,7 +163,7 @@ fn activation_manager_vote_expiration() {
                 finalize_pass: true,
                 // NOTE: Bob's vote expired!
                 aye_approval_rate: 67,
-                compliance_approval_rate: 67,
+                comp_approval_rate: 67,
             },
         )
         .build_block();
@@ -192,7 +192,7 @@ fn activation_manager_vote_expiration() {
                 finalize_pass: true,
                 // NOTE: Eve's vote expired!
                 aye_approval_rate: 34,
-                compliance_approval_rate: 34,
+                comp_approval_rate: 34,
             },
         )
         .build_block();
@@ -219,7 +219,7 @@ fn activation_manager_vote_expiration() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 34,
-                compliance_approval_rate: 34,
+                comp_approval_rate: 34,
             },
         )
         .build_blocks_until(20);
@@ -247,7 +247,7 @@ fn activation_manager_vote_expiration() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 34,
-                compliance_approval_rate: 34,
+                comp_approval_rate: 34,
             },
         )
         .build_blocks_until(31);

--- a/crates/consensus/authority/src/activation_manager/tests/vote_expiration.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/vote_expiration.rs
@@ -38,7 +38,7 @@ fn activation_manager_vote_expiration() {
         .upgrade_conditions(
             &[ALICE, BOB, EVE],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: false,
                 aye_approval_req: false,
                 block_height_req: false,
@@ -65,7 +65,7 @@ fn activation_manager_vote_expiration() {
         .upgrade_conditions(
             &[ALICE, BOB, EVE],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: false, // not finalized yet
                 aye_approval_req: false,  // not finalized yet
                 block_height_req: false,
@@ -92,7 +92,7 @@ fn activation_manager_vote_expiration() {
         .upgrade_conditions(
             &[ALICE, BOB, EVE],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: true, // IS met!
                 aye_approval_req: true,  // IS met!
                 block_height_req: false,
@@ -122,7 +122,7 @@ fn activation_manager_vote_expiration() {
         .upgrade_conditions(
             &[ALICE, BOB, EVE],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: true, // IS met!
                 aye_approval_req: true,  // IS met!
                 block_height_req: false, // IS NOT met!
@@ -150,7 +150,7 @@ fn activation_manager_vote_expiration() {
         .upgrade_conditions(
             &[ALICE, BOB, EVE],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: true,
                 aye_approval_req: true,
                 block_height_req: false,
@@ -179,7 +179,7 @@ fn activation_manager_vote_expiration() {
         .upgrade_conditions(
             &[ALICE, BOB, EVE],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: true, // not finalized yet
                 aye_approval_req: true,  // not finalized yet
                 block_height_req: false,
@@ -207,7 +207,7 @@ fn activation_manager_vote_expiration() {
         .upgrade_conditions(
             &[ALICE, BOB, EVE],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: false, // IS NOT me!
                 aye_approval_req: false,  // IS NOT met!
                 block_height_req: false,  // IS NOT met!
@@ -235,7 +235,7 @@ fn activation_manager_vote_expiration() {
         .upgrade_conditions(
             &[ALICE, BOB, EVE],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: false,
                 aye_approval_req: false,
                 block_height_req: true, // IS met!

--- a/crates/consensus/authority/src/activation_manager/tests/vote_majority_nay_compliant_and_reject.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/vote_majority_nay_compliant_and_reject.rs
@@ -50,7 +50,7 @@ fn activation_manager_vote_majority_nay_compliant_and_reject() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 34,
-                compliance_approval_rate: 34,
+                comp_approval_rate: 34,
             },
         )
         .build_block();
@@ -77,7 +77,7 @@ fn activation_manager_vote_majority_nay_compliant_and_reject() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 34,
-                compliance_approval_rate: 67,
+                comp_approval_rate: 67,
             },
         )
         .build_block();
@@ -104,7 +104,7 @@ fn activation_manager_vote_majority_nay_compliant_and_reject() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 34,
-                compliance_approval_rate: 100,
+                comp_approval_rate: 100,
             },
         )
         .build_block();
@@ -132,7 +132,7 @@ fn activation_manager_vote_majority_nay_compliant_and_reject() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 34,
-                compliance_approval_rate: 100,
+                comp_approval_rate: 100,
             },
         )
         .build_blocks_until(21);

--- a/crates/consensus/authority/src/activation_manager/tests/vote_majority_nay_compliant_and_reject.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/vote_majority_nay_compliant_and_reject.rs
@@ -1,0 +1,141 @@
+use crate::activation_manager::{
+    tests::utils::{Expectations, UpgradeTestFixture, ACTIVE_VERSION, ALICE, BOB, EVE},
+    ConditionList,
+};
+use reth_db::models::activation_manager::Vote;
+
+/// Tests that an upgrade is rejected when most validators vote Nay despite
+/// sufficient compliance.
+///
+/// This test verifies that:
+/// 1. All validators are configured to accept an upgrade (is_compliant = true)
+/// 2. ALICE votes Aye, but BOB and EVE vote Nay
+/// 3. Despite having 100% of validators being compliant with the upgrade, it does not activate
+///    because the Aye vote approval_rate (only 34%) is below the required quorum
+/// 4. This demonstrates that both acceptance and explicit Aye votes are required for an upgrade to
+///    activate
+#[test]
+fn activation_manager_vote_majority_nay_compliant_and_reject() {
+    let upgrade_height = 3;
+    let required_approval_rate = 67;
+
+    // NOTE: While the majority of validators are willing to upgrade, the
+    // upgrade does not happen since the explicit Aye-votes are are still in the
+    // minority.
+    let mut f = UpgradeTestFixture::new(upgrade_height, required_approval_rate)
+        .setup_compliant_validator(ALICE, Vote::Aye)
+        .setup_compliant_validator(BOB, Vote::Nay)
+        .setup_compliant_validator(EVE, Vote::Nay);
+
+    assert_eq!(f.next_height(), 0);
+
+    //
+    // Block 0: Alice proposes and votes Aye.
+    //
+
+    f.start_proposal(ALICE, ACTIVE_VERSION)
+        // All validators do accept the upgrade.
+        .upgrade_conditions(
+            &[ALICE, BOB, EVE],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: false,
+                aye_approvals_req: false,
+                block_height_req: false,
+            },
+        )
+        .expectations(
+            &[ALICE, BOB, EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 34,
+                compliance_approval_rate: 34,
+            },
+        )
+        .build_block();
+
+    assert_eq!(f.next_height(), 1);
+
+    //
+    // Block 1: Bob proposes and votes Nay, but is willing to upgrade.
+    //
+
+    f.start_proposal(BOB, ACTIVE_VERSION)
+        .upgrade_conditions(
+            &[ALICE, BOB, EVE],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: false, // not finalized yet
+                aye_approvals_req: false,
+                block_height_req: false,
+            },
+        )
+        .expectations(
+            &[ALICE, BOB, EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 34,
+                compliance_approval_rate: 67,
+            },
+        )
+        .build_block();
+
+    assert_eq!(f.next_height(), 2);
+
+    //
+    // Block 2: Eve proposes and votes Nay, but is willing to upgrade.
+    //
+
+    f.start_proposal(EVE, ACTIVE_VERSION)
+        .upgrade_conditions(
+            &[ALICE, BOB, EVE],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: true, // IS met!
+                aye_approvals_req: false,
+                block_height_req: false,
+            },
+        )
+        .expectations(
+            &[ALICE, BOB, EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 34,
+                compliance_approval_rate: 100,
+            },
+        )
+        .build_block();
+
+    assert_eq!(f.next_height(), 3);
+    assert_eq!(f.next_height(), upgrade_height);
+
+    //
+    // Block 3-20: Alice keeps building, but the upgrade never happens.
+    //
+
+    f.start_proposal(ALICE, ACTIVE_VERSION)
+        .upgrade_conditions(
+            &[ALICE, BOB, EVE],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: true,
+                aye_approvals_req: false, // IS NOT met!
+                block_height_req: true,
+            },
+        )
+        .expectations(
+            &[ALICE, BOB, EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 34,
+                compliance_approval_rate: 100,
+            },
+        )
+        .build_blocks_until(21);
+
+    assert_eq!(f.next_height(), 21);
+}

--- a/crates/consensus/authority/src/activation_manager/tests/vote_majority_nay_compliant_and_reject.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/vote_majority_nay_compliant_and_reject.rs
@@ -38,7 +38,7 @@ fn activation_manager_vote_majority_nay_compliant_and_reject() {
         .upgrade_conditions(
             &[ALICE, BOB, EVE],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: false,
                 aye_approval_req: false,
                 block_height_req: false,
@@ -65,7 +65,7 @@ fn activation_manager_vote_majority_nay_compliant_and_reject() {
         .upgrade_conditions(
             &[ALICE, BOB, EVE],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: false, // not finalized yet
                 aye_approval_req: false,
                 block_height_req: false,
@@ -92,7 +92,7 @@ fn activation_manager_vote_majority_nay_compliant_and_reject() {
         .upgrade_conditions(
             &[ALICE, BOB, EVE],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: true, // IS met!
                 aye_approval_req: false,
                 block_height_req: false,
@@ -120,7 +120,7 @@ fn activation_manager_vote_majority_nay_compliant_and_reject() {
         .upgrade_conditions(
             &[ALICE, BOB, EVE],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: true,
                 aye_approval_req: false, // IS NOT met!
                 block_height_req: true,

--- a/crates/consensus/authority/src/activation_manager/tests/vote_majority_nay_compliant_and_reject.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/vote_majority_nay_compliant_and_reject.rs
@@ -40,7 +40,7 @@ fn activation_manager_vote_majority_nay_compliant_and_reject() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: false,
-                aye_approvals_req: false,
+                aye_approval_req: false,
                 block_height_req: false,
             },
         )
@@ -67,7 +67,7 @@ fn activation_manager_vote_majority_nay_compliant_and_reject() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: false, // not finalized yet
-                aye_approvals_req: false,
+                aye_approval_req: false,
                 block_height_req: false,
             },
         )
@@ -94,7 +94,7 @@ fn activation_manager_vote_majority_nay_compliant_and_reject() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: true, // IS met!
-                aye_approvals_req: false,
+                aye_approval_req: false,
                 block_height_req: false,
             },
         )
@@ -122,7 +122,7 @@ fn activation_manager_vote_majority_nay_compliant_and_reject() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: true,
-                aye_approvals_req: false, // IS NOT met!
+                aye_approval_req: false, // IS NOT met!
                 block_height_req: true,
             },
         )

--- a/crates/consensus/authority/src/activation_manager/tests/vote_nay_and_accept.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/vote_nay_and_accept.rs
@@ -51,7 +51,7 @@ fn activation_manager_vote_nay_and_accept() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 34,
-                compliance_approval_rate: 34,
+                comp_approval_rate: 34,
             },
         )
         .build_block();
@@ -78,7 +78,7 @@ fn activation_manager_vote_nay_and_accept() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 67,
-                compliance_approval_rate: 67,
+                comp_approval_rate: 67,
             },
         )
         .build_block();
@@ -106,7 +106,7 @@ fn activation_manager_vote_nay_and_accept() {
                 finalize_pass: true,
                 // NOTE: Eve: votes Nay, but is compliant
                 aye_approval_rate: 67,
-                compliance_approval_rate: 100,
+                comp_approval_rate: 100,
             },
         )
         .build_block();
@@ -135,7 +135,7 @@ fn activation_manager_vote_nay_and_accept() {
                 finalize_pass: true,
                 // Votes pruned after upgrade
                 aye_approval_rate: 0,
-                compliance_approval_rate: 0,
+                comp_approval_rate: 0,
             },
         )
         .build_block();
@@ -155,7 +155,7 @@ fn activation_manager_vote_nay_and_accept() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 0,
-                compliance_approval_rate: 0,
+                comp_approval_rate: 0,
             },
         )
         .build_blocks_until(21);

--- a/crates/consensus/authority/src/activation_manager/tests/vote_nay_and_accept.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/vote_nay_and_accept.rs
@@ -1,0 +1,164 @@
+use crate::activation_manager::{
+    tests::utils::{
+        Expectations, UpgradeTestFixture, ACTIVE_VERSION, ALICE, BOB, EVE, UPGRADE_VERSION,
+    },
+    ConditionList,
+};
+use reth_db::models::activation_manager::Vote;
+
+/// Tests that an upgrade activates even with a validator voting Nay but
+/// accepting.
+///
+/// This test verifies that:
+/// 1. Two validators (ALICE, BOB) vote Aye for an upgrade
+/// 2. One validator (EVE) votes Nay but is configured to accept the upgrade
+/// 3. The upgrade still activates because:
+///    - All validators are accepting the upgrade (100% acceptance)
+///    - Aye votes reach 67%, meeting the quorum requirement
+/// 4. After activation, all validators, including EVE, process blocks with the new version
+/// 5. This shows that validators can signal disagreement while still accepting majority decisions
+#[test]
+fn activation_manager_vote_nay_and_accept() {
+    let upgrade_height = 3;
+    let required_approval_rate = 67;
+
+    let mut f = UpgradeTestFixture::new(upgrade_height, required_approval_rate)
+        .setup_compliant_validator(ALICE, Vote::Aye)
+        .setup_compliant_validator(BOB, Vote::Aye)
+        // NOTE: Eve votes Nay, but accepts the upgrade.
+        .setup_compliant_validator(EVE, Vote::Nay);
+
+    assert_eq!(f.next_height(), 0);
+
+    //
+    // Block 0: Alice proposes and votes Aye.
+    //
+
+    f.start_proposal(ALICE, ACTIVE_VERSION)
+        // All validators do accept the upgrade.
+        .upgrade_conditions(
+            &[ALICE, BOB, EVE],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: false,
+                aye_approvals_req: false,
+                block_height_req: false,
+            },
+        )
+        .expectations(
+            &[ALICE, BOB, EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 34,
+                compliance_approval_rate: 34,
+            },
+        )
+        .build_block();
+
+    assert_eq!(f.next_height(), 1);
+
+    //
+    // Block 1: Bob proposes and votes Aye.
+    //
+
+    f.start_proposal(BOB, ACTIVE_VERSION)
+        .upgrade_conditions(
+            &[ALICE, BOB, EVE],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: false, // not finalized yet
+                aye_approvals_req: false, // not finalized yet
+                block_height_req: false,
+            },
+        )
+        .expectations(
+            &[ALICE, BOB, EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 67,
+                compliance_approval_rate: 67,
+            },
+        )
+        .build_block();
+
+    assert_eq!(f.next_height(), 2);
+
+    //
+    // Block 2: Eve proposes and votes NAY, but accepts the upgrade.
+    //
+
+    f.start_proposal(EVE, ACTIVE_VERSION)
+        .upgrade_conditions(
+            &[ALICE, BOB, EVE],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: true, // IS met!
+                aye_approvals_req: true, // IS met!
+                block_height_req: false,
+            },
+        )
+        .expectations(
+            &[ALICE, BOB, EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                // NOTE: Eve: votes Nay, but is compliant
+                aye_approval_rate: 67,
+                compliance_approval_rate: 100,
+            },
+        )
+        .build_block();
+
+    assert_eq!(f.next_height(), 3);
+    assert_eq!(f.next_height(), upgrade_height);
+
+    //
+    // Block 3: Alice proposes the UPGRADE, all conditions are met!
+    //
+
+    f.start_proposal(ALICE, UPGRADE_VERSION)
+        .upgrade_conditions(
+            &[ALICE, BOB, EVE],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: true, // IS met!
+                aye_approvals_req: true, // IS met!
+                block_height_req: true,  // IS met!
+            },
+        )
+        .expectations(
+            &[ALICE, BOB, EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                // Votes pruned after upgrade
+                aye_approval_rate: 0,
+                compliance_approval_rate: 0,
+            },
+        )
+        .build_block();
+
+    assert_eq!(f.next_height(), 4);
+
+    //
+    // Block 4-20: Alice keeps building UPGRADED blocks, everyone accepts.
+    //
+
+    f.start_proposal(ALICE, UPGRADE_VERSION)
+        // No upgrade ongoing.
+        .upgrade_conditions_empty(&[ALICE, BOB, EVE])
+        .expectations(
+            &[ALICE, BOB, EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 0,
+                compliance_approval_rate: 0,
+            },
+        )
+        .build_blocks_until(21);
+
+    assert_eq!(f.next_height(), 21);
+}

--- a/crates/consensus/authority/src/activation_manager/tests/vote_nay_and_accept.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/vote_nay_and_accept.rs
@@ -39,7 +39,7 @@ fn activation_manager_vote_nay_and_accept() {
         .upgrade_conditions(
             &[ALICE, BOB, EVE],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: false,
                 aye_approval_req: false,
                 block_height_req: false,
@@ -66,7 +66,7 @@ fn activation_manager_vote_nay_and_accept() {
         .upgrade_conditions(
             &[ALICE, BOB, EVE],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: false, // not finalized yet
                 aye_approval_req: false,  // not finalized yet
                 block_height_req: false,
@@ -93,7 +93,7 @@ fn activation_manager_vote_nay_and_accept() {
         .upgrade_conditions(
             &[ALICE, BOB, EVE],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: true, // IS met!
                 aye_approval_req: true,  // IS met!
                 block_height_req: false,
@@ -122,7 +122,7 @@ fn activation_manager_vote_nay_and_accept() {
         .upgrade_conditions(
             &[ALICE, BOB, EVE],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: true, // IS met!
                 aye_approval_req: true,  // IS met!
                 block_height_req: true,  // IS met!

--- a/crates/consensus/authority/src/activation_manager/tests/vote_nay_and_accept.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/vote_nay_and_accept.rs
@@ -41,7 +41,7 @@ fn activation_manager_vote_nay_and_accept() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: false,
-                aye_approvals_req: false,
+                aye_approval_req: false,
                 block_height_req: false,
             },
         )
@@ -68,7 +68,7 @@ fn activation_manager_vote_nay_and_accept() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: false, // not finalized yet
-                aye_approvals_req: false, // not finalized yet
+                aye_approval_req: false,  // not finalized yet
                 block_height_req: false,
             },
         )
@@ -95,7 +95,7 @@ fn activation_manager_vote_nay_and_accept() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: true, // IS met!
-                aye_approvals_req: true, // IS met!
+                aye_approval_req: true,  // IS met!
                 block_height_req: false,
             },
         )
@@ -124,7 +124,7 @@ fn activation_manager_vote_nay_and_accept() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: true, // IS met!
-                aye_approvals_req: true, // IS met!
+                aye_approval_req: true,  // IS met!
                 block_height_req: true,  // IS met!
             },
         )

--- a/crates/consensus/authority/src/activation_manager/tests/vote_nay_and_reject.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/vote_nay_and_reject.rs
@@ -60,7 +60,7 @@ fn activation_manager_vote_nay_and_reject() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 34,
-                compliance_approval_rate: 34,
+                comp_approval_rate: 34,
             },
         )
         .build_block();
@@ -97,7 +97,7 @@ fn activation_manager_vote_nay_and_reject() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 67,
-                compliance_approval_rate: 67,
+                comp_approval_rate: 67,
             },
         )
         .build_block();
@@ -136,7 +136,7 @@ fn activation_manager_vote_nay_and_reject() {
                 finalize_pass: true,
                 // NOTE: Eve: votes Nay and rejects.
                 aye_approval_rate: 67,
-                compliance_approval_rate: 67,
+                comp_approval_rate: 67,
             },
         )
         .build_block();
@@ -178,7 +178,7 @@ fn activation_manager_vote_nay_and_reject() {
                 finalize_pass: true,
                 // Votes pruned after upgrade
                 aye_approval_rate: 0,
-                compliance_approval_rate: 0,
+                comp_approval_rate: 0,
             },
         )
         // Eve REJECTS the upgrade.
@@ -189,7 +189,7 @@ fn activation_manager_vote_nay_and_reject() {
                 finalize_pass: false, // Reject!
                 // Votes pruned after upgrade
                 aye_approval_rate: 0,
-                compliance_approval_rate: 0,
+                comp_approval_rate: 0,
             },
         )
         .build_block();
@@ -209,7 +209,7 @@ fn activation_manager_vote_nay_and_reject() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 0,
-                compliance_approval_rate: 0,
+                comp_approval_rate: 0,
             },
         )
         // Eve REJECTS the upgrade.
@@ -219,7 +219,7 @@ fn activation_manager_vote_nay_and_reject() {
                 process_pass: false,  // Reject!
                 finalize_pass: false, // Reject!
                 aye_approval_rate: 0,
-                compliance_approval_rate: 0,
+                comp_approval_rate: 0,
             },
         )
         .build_blocks_until(21);

--- a/crates/consensus/authority/src/activation_manager/tests/vote_nay_and_reject.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/vote_nay_and_reject.rs
@@ -1,0 +1,228 @@
+use crate::activation_manager::{
+    tests::utils::{
+        Expectations, UpgradeTestFixture, ACTIVE_VERSION, ALICE, BOB, EVE, UPGRADE_VERSION,
+    },
+    ConditionList,
+};
+use reth_db::models::activation_manager::Vote;
+
+/// Tests that a validator can vote Nay and reject an upgrade.
+///
+/// This test verifies that:
+/// 1. Two validators (ALICE, BOB) vote Aye and are willing to accept an upgrade
+/// 2. One validator (EVE) votes Nay and is configured to reject the upgrade (is_compliant = false)
+/// 3. When conditions are met, ALICE proposes upgraded blocks
+/// 4. EVE consistently rejects these upgraded blocks in both process_proposal and finalize_block
+///    phases
+/// 5. This leads to a consensus split where ALICE and BOB operate on the upgraded chain while EVE
+///    rejects those blocks as dead ends
+#[test]
+fn activation_manager_vote_nay_and_reject() {
+    let upgrade_height = 3;
+    let required_approval_rate = 67;
+
+    let mut f = UpgradeTestFixture::new(upgrade_height, required_approval_rate)
+        .setup_compliant_validator(ALICE, Vote::Aye)
+        .setup_compliant_validator(BOB, Vote::Aye)
+        // NOTE: Eve votes Nay, and rejects the upgrade if all conditions are met.
+        .setup_signaling_validator(EVE, Vote::Nay);
+
+    assert_eq!(f.next_height(), 0);
+
+    //
+    // Block 0: Alice proposes and votes Aye.
+    //
+
+    f.start_proposal(ALICE, ACTIVE_VERSION)
+        // Alice and Bob do accept the upgrade.
+        .upgrade_conditions(
+            &[ALICE, BOB],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: false,
+                aye_approvals_req: false,
+                block_height_req: false,
+            },
+        )
+        // Eve DOES NOT accept the upgrade.
+        .upgrade_conditions(
+            &[EVE],
+            ConditionList {
+                compliant_req: false, // IS NOT met!
+                comp_approval_req: false,
+                aye_approvals_req: false,
+                block_height_req: false,
+            },
+        )
+        .expectations(
+            &[ALICE, BOB, EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 34,
+                compliance_approval_rate: 34,
+            },
+        )
+        .build_block();
+
+    assert_eq!(f.next_height(), 1);
+
+    //
+    // Block 1: Bob proposes and votes Aye.
+    //
+
+    f.start_proposal(BOB, ACTIVE_VERSION)
+        .upgrade_conditions(
+            &[ALICE, BOB],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: false, // not finalized yet
+                aye_approvals_req: false, // not finalized yet
+                block_height_req: false,
+            },
+        )
+        // Eve DOES NOT accept the upgrade.
+        .upgrade_conditions(
+            &[EVE],
+            ConditionList {
+                compliant_req: false,
+                comp_approval_req: false,
+                aye_approvals_req: false,
+                block_height_req: false,
+            },
+        )
+        .expectations(
+            &[ALICE, BOB, EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 67,
+                compliance_approval_rate: 67,
+            },
+        )
+        .build_block();
+
+    assert_eq!(f.next_height(), 2);
+
+    //
+    // Block 2: Eve proposes and votes NAY, and rejects the upgrade.
+    //
+
+    f.start_proposal(EVE, ACTIVE_VERSION)
+        .upgrade_conditions(
+            &[ALICE, BOB],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: true, // IS met!
+                aye_approvals_req: true, // IS met!
+                block_height_req: false,
+            },
+        )
+        .upgrade_conditions(
+            &[EVE],
+            ConditionList {
+                compliant_req: false,
+                // NOTE: rejecting validators simply use `u64::MAX` as the
+                // approval_rate.
+                comp_approval_req: false,
+                aye_approvals_req: false,
+                block_height_req: false,
+            },
+        )
+        .expectations(
+            &[ALICE, BOB, EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                // NOTE: Eve: votes Nay and rejects.
+                aye_approval_rate: 67,
+                compliance_approval_rate: 67,
+            },
+        )
+        .build_block();
+
+    assert_eq!(f.next_height(), 3);
+    assert_eq!(f.next_height(), upgrade_height);
+
+    //
+    // Block 3: Alice proposes the UPGRADE, all conditions are met!
+    //
+
+    f.start_proposal(ALICE, UPGRADE_VERSION)
+        .upgrade_conditions(
+            &[ALICE, BOB],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: true, // IS met!
+                aye_approvals_req: true, // IS met!
+                block_height_req: true,  // IS met!
+            },
+        )
+        // Eve DOES NOT accept the upgrade.
+        //
+        // NOTE: rejecting validators simply use `u64::MAX` as the minimum
+        // validator requirement and target height.
+        .upgrade_conditions(
+            &[EVE],
+            ConditionList {
+                compliant_req: false,
+                comp_approval_req: false, // IS NOT met!
+                aye_approvals_req: false, // IS NOT met!
+                block_height_req: false,  // IS NOT met!
+            },
+        )
+        .expectations(
+            &[ALICE, BOB],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                // Votes pruned after upgrade
+                aye_approval_rate: 0,
+                compliance_approval_rate: 0,
+            },
+        )
+        // Eve REJECTS the upgrade.
+        .expectations(
+            &[EVE],
+            Expectations {
+                process_pass: false,  // Reject!
+                finalize_pass: false, // Reject!
+                // Votes pruned after upgrade
+                aye_approval_rate: 0,
+                compliance_approval_rate: 0,
+            },
+        )
+        .build_block();
+
+    assert_eq!(f.next_height(), 4);
+
+    //
+    // Block 4-20: Alice keeps building upgraded bocks, Eve keeps rejecting.
+    //
+
+    f.start_proposal(ALICE, UPGRADE_VERSION)
+        // No upgrade ongoing.
+        .upgrade_conditions_empty(&[ALICE, BOB, EVE])
+        .expectations(
+            &[ALICE, BOB],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 0,
+                compliance_approval_rate: 0,
+            },
+        )
+        // Eve REJECTS the upgrade.
+        .expectations(
+            &[EVE],
+            Expectations {
+                process_pass: false,  // Reject!
+                finalize_pass: false, // Reject!
+                aye_approval_rate: 0,
+                compliance_approval_rate: 0,
+            },
+        )
+        .build_blocks_until(21);
+
+    assert_eq!(f.next_height(), 21);
+}

--- a/crates/consensus/authority/src/activation_manager/tests/vote_nay_and_reject.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/vote_nay_and_reject.rs
@@ -38,7 +38,7 @@ fn activation_manager_vote_nay_and_reject() {
         .upgrade_conditions(
             &[ALICE, BOB],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: false,
                 aye_approval_req: false,
                 block_height_req: false,
@@ -48,7 +48,7 @@ fn activation_manager_vote_nay_and_reject() {
         .upgrade_conditions(
             &[EVE],
             ConditionList {
-                compliant_req: false, // IS NOT met!
+                comp_req: false, // IS NOT met!
                 comp_approval_req: false,
                 aye_approval_req: false,
                 block_height_req: false,
@@ -75,7 +75,7 @@ fn activation_manager_vote_nay_and_reject() {
         .upgrade_conditions(
             &[ALICE, BOB],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: false, // not finalized yet
                 aye_approval_req: false,  // not finalized yet
                 block_height_req: false,
@@ -85,7 +85,7 @@ fn activation_manager_vote_nay_and_reject() {
         .upgrade_conditions(
             &[EVE],
             ConditionList {
-                compliant_req: false,
+                comp_req: false,
                 comp_approval_req: false,
                 aye_approval_req: false,
                 block_height_req: false,
@@ -112,7 +112,7 @@ fn activation_manager_vote_nay_and_reject() {
         .upgrade_conditions(
             &[ALICE, BOB],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: true, // IS met!
                 aye_approval_req: true,  // IS met!
                 block_height_req: false,
@@ -121,7 +121,7 @@ fn activation_manager_vote_nay_and_reject() {
         .upgrade_conditions(
             &[EVE],
             ConditionList {
-                compliant_req: false,
+                comp_req: false,
                 // NOTE: rejecting validators simply use `u64::MAX` as the
                 // approval_rate.
                 comp_approval_req: false,
@@ -152,7 +152,7 @@ fn activation_manager_vote_nay_and_reject() {
         .upgrade_conditions(
             &[ALICE, BOB],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: true, // IS met!
                 aye_approval_req: true,  // IS met!
                 block_height_req: true,  // IS met!
@@ -165,7 +165,7 @@ fn activation_manager_vote_nay_and_reject() {
         .upgrade_conditions(
             &[EVE],
             ConditionList {
-                compliant_req: false,
+                comp_req: false,
                 comp_approval_req: false, // IS NOT met!
                 aye_approval_req: false,  // IS NOT met!
                 block_height_req: false,  // IS NOT met!

--- a/crates/consensus/authority/src/activation_manager/tests/vote_nay_and_reject.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/vote_nay_and_reject.rs
@@ -40,7 +40,7 @@ fn activation_manager_vote_nay_and_reject() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: false,
-                aye_approvals_req: false,
+                aye_approval_req: false,
                 block_height_req: false,
             },
         )
@@ -50,7 +50,7 @@ fn activation_manager_vote_nay_and_reject() {
             ConditionList {
                 compliant_req: false, // IS NOT met!
                 comp_approval_req: false,
-                aye_approvals_req: false,
+                aye_approval_req: false,
                 block_height_req: false,
             },
         )
@@ -77,7 +77,7 @@ fn activation_manager_vote_nay_and_reject() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: false, // not finalized yet
-                aye_approvals_req: false, // not finalized yet
+                aye_approval_req: false,  // not finalized yet
                 block_height_req: false,
             },
         )
@@ -87,7 +87,7 @@ fn activation_manager_vote_nay_and_reject() {
             ConditionList {
                 compliant_req: false,
                 comp_approval_req: false,
-                aye_approvals_req: false,
+                aye_approval_req: false,
                 block_height_req: false,
             },
         )
@@ -114,7 +114,7 @@ fn activation_manager_vote_nay_and_reject() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: true, // IS met!
-                aye_approvals_req: true, // IS met!
+                aye_approval_req: true,  // IS met!
                 block_height_req: false,
             },
         )
@@ -125,7 +125,7 @@ fn activation_manager_vote_nay_and_reject() {
                 // NOTE: rejecting validators simply use `u64::MAX` as the
                 // approval_rate.
                 comp_approval_req: false,
-                aye_approvals_req: false,
+                aye_approval_req: false,
                 block_height_req: false,
             },
         )
@@ -154,7 +154,7 @@ fn activation_manager_vote_nay_and_reject() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: true, // IS met!
-                aye_approvals_req: true, // IS met!
+                aye_approval_req: true,  // IS met!
                 block_height_req: true,  // IS met!
             },
         )
@@ -167,7 +167,7 @@ fn activation_manager_vote_nay_and_reject() {
             ConditionList {
                 compliant_req: false,
                 comp_approval_req: false, // IS NOT met!
-                aye_approvals_req: false, // IS NOT met!
+                aye_approval_req: false,  // IS NOT met!
                 block_height_req: false,  // IS NOT met!
             },
         )

--- a/crates/consensus/authority/src/activation_manager/tests/wait_for_compliance.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/wait_for_compliance.rs
@@ -1,0 +1,231 @@
+use crate::activation_manager::{
+    tests::utils::{
+        Expectations, UpgradeTestFixture, ACTIVE_VERSION, ALICE, BOB, EVE, UPGRADE_VERSION,
+    },
+    ConditionList,
+};
+use reth_db::models::activation_manager::Vote;
+
+/// Tests the upgrade flow where validators first signal support, then later accept.
+///
+/// This test verifies that:
+/// 1. All validators initially signal Aye votes but are not ready to accept the upgrade
+/// 2. Despite unanimous Aye votes, the upgrade doesn't activate because no validators are compliant
+///    (is_compliant = false)
+/// 3. After all validators update to accept the upgrade and additional voting occurs:
+///    - By block 5, all conditions are met (100% Aye votes, 100% acceptance, target height reached)
+///    - EVE proposes the first upgraded block which is accepted by all
+/// 4. This demonstrates the two-phase upgrade process where validators can signal support before
+///    they're technically ready to handle the upgrade
+#[test]
+fn activation_manager_wait_for_compliance() {
+    let upgrade_height = 3;
+    let required_approval_rate = 67;
+
+    // NOTE: All validators signal their support for the upgrade, but none are
+    // ready to handle/accept it yet.
+    let mut f = UpgradeTestFixture::new(upgrade_height, required_approval_rate)
+        .setup_signaling_validator(ALICE, Vote::Aye)
+        .setup_signaling_validator(BOB, Vote::Aye)
+        .setup_signaling_validator(EVE, Vote::Aye);
+
+    assert_eq!(f.next_height(), 0);
+
+    //
+    // Block 0: Alice proposes and votes Aye.
+    //
+
+    f.start_proposal(ALICE, ACTIVE_VERSION)
+        // None of the validators are ready to accept the upgrade.
+        .upgrade_conditions(
+            &[ALICE, BOB, EVE],
+            ConditionList {
+                compliant_req: false,
+                comp_approval_req: false,
+                aye_approvals_req: false,
+                block_height_req: false,
+            },
+        )
+        .expectations(
+            &[ALICE, BOB, EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 34,
+                compliance_approval_rate: 0,
+            },
+        )
+        .build_block();
+
+    assert_eq!(f.next_height(), 1);
+
+    //
+    // Block 1: Bob proposes and votes Aye.
+    //
+
+    f.start_proposal(BOB, ACTIVE_VERSION)
+        .upgrade_conditions(
+            &[ALICE, BOB, EVE],
+            ConditionList {
+                compliant_req: false,
+                // NOTE: signaling validators simply use `u64::MAX` as the
+                // approval_rate.
+                comp_approval_req: false,
+                aye_approvals_req: false,
+                block_height_req: false,
+            },
+        )
+        .expectations(
+            &[ALICE, BOB, EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 67,
+                compliance_approval_rate: 0,
+            },
+        )
+        .build_block();
+
+    assert_eq!(f.next_height(), 2);
+
+    //
+    // Block 2: Eve proposes and votes Aye.
+    //
+
+    f.start_proposal(EVE, ACTIVE_VERSION)
+        .upgrade_conditions(
+            &[ALICE, BOB, EVE],
+            ConditionList {
+                compliant_req: false,
+                // NOTE: signaling validators simply use `u64::MAX` as the
+                // approval_rate.
+                comp_approval_req: false,
+                aye_approvals_req: false,
+                block_height_req: false,
+            },
+        )
+        .expectations(
+            &[ALICE, BOB, EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 100,
+                compliance_approval_rate: 0,
+            },
+        )
+        .build_block();
+
+    assert_eq!(f.next_height(), 3);
+    assert_eq!(f.next_height(), upgrade_height);
+
+    //
+    // All validators update their software and are now ready to ACCEPT the upgrade.
+    //
+
+    let mut f = f
+        .setup_compliant_validator(ALICE, Vote::Aye)
+        .setup_compliant_validator(BOB, Vote::Aye)
+        .setup_compliant_validator(EVE, Vote::Aye);
+
+    //
+    // Block 3: Alice proposes and votes Aye.
+    //
+
+    f.start_proposal(ALICE, ACTIVE_VERSION)
+        .upgrade_conditions(
+            &[ALICE, BOB, EVE],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: false,
+                aye_approvals_req: true, // IS met!
+                block_height_req: true,  // IS met!
+            },
+        )
+        .expectations(
+            &[ALICE, BOB, EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 100,
+                compliance_approval_rate: 34,
+            },
+        )
+        .build_block();
+
+    assert_eq!(f.next_height(), 4);
+
+    //
+    // Block 4: Bob proposes and votes Aye.
+    //
+
+    f.start_proposal(BOB, ACTIVE_VERSION)
+        .upgrade_conditions(
+            &[ALICE, BOB, EVE],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: false, // not finalized yet
+                aye_approvals_req: true,
+                block_height_req: true,
+            },
+        )
+        .expectations(
+            &[ALICE, BOB, EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 100,
+                compliance_approval_rate: 67,
+            },
+        )
+        .build_block();
+
+    assert_eq!(f.next_height(), 5);
+
+    //
+    // Block 5: Eve proposes the UPGRADE, all conditions are met!
+    //
+
+    f.start_proposal(EVE, UPGRADE_VERSION)
+        .upgrade_conditions(
+            &[ALICE, BOB, EVE],
+            ConditionList {
+                compliant_req: true,
+                comp_approval_req: true, // IS met!
+                aye_approvals_req: true, // IS met!
+                block_height_req: true,
+            },
+        )
+        .expectations(
+            &[ALICE, BOB, EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                // Votes pruned after upgrade
+                aye_approval_rate: 0,
+                compliance_approval_rate: 0,
+            },
+        )
+        .build_block();
+
+    assert_eq!(f.next_height(), 6);
+
+    //
+    // Block 6-20: Alice keeps building upgraded bocks, all validators accept.
+    //
+
+    f.start_proposal(ALICE, UPGRADE_VERSION)
+        // No upgrade ongoing.
+        .upgrade_conditions_empty(&[ALICE, BOB, EVE])
+        .expectations(
+            &[ALICE, BOB, EVE],
+            Expectations {
+                process_pass: true,
+                finalize_pass: true,
+                aye_approval_rate: 0,
+                compliance_approval_rate: 0,
+            },
+        )
+        .build_blocks_until(21);
+
+    assert_eq!(f.next_height(), 21);
+}

--- a/crates/consensus/authority/src/activation_manager/tests/wait_for_compliance.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/wait_for_compliance.rs
@@ -42,7 +42,7 @@ fn activation_manager_wait_for_compliance() {
             ConditionList {
                 compliant_req: false,
                 comp_approval_req: false,
-                aye_approvals_req: false,
+                aye_approval_req: false,
                 block_height_req: false,
             },
         )
@@ -71,7 +71,7 @@ fn activation_manager_wait_for_compliance() {
                 // NOTE: signaling validators simply use `u64::MAX` as the
                 // approval_rate.
                 comp_approval_req: false,
-                aye_approvals_req: false,
+                aye_approval_req: false,
                 block_height_req: false,
             },
         )
@@ -100,7 +100,7 @@ fn activation_manager_wait_for_compliance() {
                 // NOTE: signaling validators simply use `u64::MAX` as the
                 // approval_rate.
                 comp_approval_req: false,
-                aye_approvals_req: false,
+                aye_approval_req: false,
                 block_height_req: false,
             },
         )
@@ -137,8 +137,8 @@ fn activation_manager_wait_for_compliance() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: false,
-                aye_approvals_req: true, // IS met!
-                block_height_req: true,  // IS met!
+                aye_approval_req: true, // IS met!
+                block_height_req: true, // IS met!
             },
         )
         .expectations(
@@ -164,7 +164,7 @@ fn activation_manager_wait_for_compliance() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: false, // not finalized yet
-                aye_approvals_req: true,
+                aye_approval_req: true,
                 block_height_req: true,
             },
         )
@@ -191,7 +191,7 @@ fn activation_manager_wait_for_compliance() {
             ConditionList {
                 compliant_req: true,
                 comp_approval_req: true, // IS met!
-                aye_approvals_req: true, // IS met!
+                aye_approval_req: true,  // IS met!
                 block_height_req: true,
             },
         )

--- a/crates/consensus/authority/src/activation_manager/tests/wait_for_compliance.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/wait_for_compliance.rs
@@ -40,7 +40,7 @@ fn activation_manager_wait_for_compliance() {
         .upgrade_conditions(
             &[ALICE, BOB, EVE],
             ConditionList {
-                compliant_req: false,
+                comp_req: false,
                 comp_approval_req: false,
                 aye_approval_req: false,
                 block_height_req: false,
@@ -67,7 +67,7 @@ fn activation_manager_wait_for_compliance() {
         .upgrade_conditions(
             &[ALICE, BOB, EVE],
             ConditionList {
-                compliant_req: false,
+                comp_req: false,
                 // NOTE: signaling validators simply use `u64::MAX` as the
                 // approval_rate.
                 comp_approval_req: false,
@@ -96,7 +96,7 @@ fn activation_manager_wait_for_compliance() {
         .upgrade_conditions(
             &[ALICE, BOB, EVE],
             ConditionList {
-                compliant_req: false,
+                comp_req: false,
                 // NOTE: signaling validators simply use `u64::MAX` as the
                 // approval_rate.
                 comp_approval_req: false,
@@ -135,7 +135,7 @@ fn activation_manager_wait_for_compliance() {
         .upgrade_conditions(
             &[ALICE, BOB, EVE],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: false,
                 aye_approval_req: true, // IS met!
                 block_height_req: true, // IS met!
@@ -162,7 +162,7 @@ fn activation_manager_wait_for_compliance() {
         .upgrade_conditions(
             &[ALICE, BOB, EVE],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: false, // not finalized yet
                 aye_approval_req: true,
                 block_height_req: true,
@@ -189,7 +189,7 @@ fn activation_manager_wait_for_compliance() {
         .upgrade_conditions(
             &[ALICE, BOB, EVE],
             ConditionList {
-                compliant_req: true,
+                comp_req: true,
                 comp_approval_req: true, // IS met!
                 aye_approval_req: true,  // IS met!
                 block_height_req: true,

--- a/crates/consensus/authority/src/activation_manager/tests/wait_for_compliance.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/wait_for_compliance.rs
@@ -52,7 +52,7 @@ fn activation_manager_wait_for_compliance() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 34,
-                compliance_approval_rate: 0,
+                comp_approval_rate: 0,
             },
         )
         .build_block();
@@ -81,7 +81,7 @@ fn activation_manager_wait_for_compliance() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 67,
-                compliance_approval_rate: 0,
+                comp_approval_rate: 0,
             },
         )
         .build_block();
@@ -110,7 +110,7 @@ fn activation_manager_wait_for_compliance() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 100,
-                compliance_approval_rate: 0,
+                comp_approval_rate: 0,
             },
         )
         .build_block();
@@ -147,7 +147,7 @@ fn activation_manager_wait_for_compliance() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 100,
-                compliance_approval_rate: 34,
+                comp_approval_rate: 34,
             },
         )
         .build_block();
@@ -174,7 +174,7 @@ fn activation_manager_wait_for_compliance() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 100,
-                compliance_approval_rate: 67,
+                comp_approval_rate: 67,
             },
         )
         .build_block();
@@ -202,7 +202,7 @@ fn activation_manager_wait_for_compliance() {
                 finalize_pass: true,
                 // Votes pruned after upgrade
                 aye_approval_rate: 0,
-                compliance_approval_rate: 0,
+                comp_approval_rate: 0,
             },
         )
         .build_block();
@@ -222,7 +222,7 @@ fn activation_manager_wait_for_compliance() {
                 process_pass: true,
                 finalize_pass: true,
                 aye_approval_rate: 0,
-                compliance_approval_rate: 0,
+                comp_approval_rate: 0,
             },
         )
         .build_blocks_until(21);

--- a/crates/consensus/authority/src/comet_bft/non_deterministic_data.rs
+++ b/crates/consensus/authority/src/comet_bft/non_deterministic_data.rs
@@ -1,5 +1,5 @@
+use crate::activation_manager;
 use bitcoin::consensus::encode::{self, Decodable, Encodable};
-
 use std::io;
 use thiserror::Error;
 
@@ -67,6 +67,29 @@ impl NonDeterministicData {
 
         Ok(Self { version, bitcoin_block_hash, aggregated_public_key })
     }
+}
+
+/// Represents a validator's stance on a network upgrade proposal.
+///
+/// This payload is included in each block's non-deterministic data when a node is
+/// configured to participate in the network upgrade voting process. It communicates
+/// the validator's current position on a specific upgrade version.
+///
+/// # Fields
+///
+/// * `version` - The specific runtime version that this vote applies to.
+///
+/// * `vote` - The validator's explicit opinion on the upgrade (Aye/Nay/Absent).
+///
+/// * `is_compliant` - Indicates whether the validator is technically ready to process blocks with
+///   the upgrade version. When `true`, the validator has the necessary software version and
+///   configuration to handle the upgrade. This can be independent of the vote - a validator may
+///   vote `Nay` but still be prepared to follow the network if the upgrade is adopted.
+#[derive(Debug, Clone, PartialEq)]
+pub struct NetworkUpgradePayload {
+    pub version: activation_manager::RuntimeVersion,
+    pub vote: activation_manager::Vote,
+    pub is_compliant: bool,
 }
 
 #[cfg(test)]

--- a/crates/consensus/authority/src/lib.rs
+++ b/crates/consensus/authority/src/lib.rs
@@ -45,6 +45,7 @@ mod builder;
 pub mod comet_bft;
 
 pub use comet_bft::light_client::LightCBFTClientBuilder;
+pub mod activation_manager;
 mod dkg;
 mod excecution_utils;
 mod frost_task;

--- a/crates/storage/db-api/src/models/activation_manager.rs
+++ b/crates/storage/db-api/src/models/activation_manager.rs
@@ -95,11 +95,11 @@ pub struct MinorVersion(pub u16);
 
 #[test]
 fn runtime_version_ordering() {
-    let v0_0 = RuntimeVersion::from(0, 0);
-    let v0_1 = RuntimeVersion::from(0, 1);
-    let v0_10 = RuntimeVersion::from(0, 10);
-    let v1_0 = RuntimeVersion::from(1, 0);
-    let v2_0 = RuntimeVersion::from(2, 0);
+    let v0_0 = RuntimeVersion::new(0, 0);
+    let v0_1 = RuntimeVersion::new(0, 1);
+    let v0_10 = RuntimeVersion::new(0, 10);
+    let v1_0 = RuntimeVersion::new(1, 0);
+    let v2_0 = RuntimeVersion::new(2, 0);
 
     assert_eq!(v0_0, v0_0);
     assert_eq!(v0_1, v0_1);

--- a/crates/storage/db-api/src/models/activation_manager.rs
+++ b/crates/storage/db-api/src/models/activation_manager.rs
@@ -1,0 +1,119 @@
+//! Activation manager models for network upgrades and voting.
+
+use reth_codecs::{add_arbitrary_tests, Compact};
+use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
+
+/// Represents a validator's vote on a network upgrade proposal.
+///
+/// Validators can explicitly vote in favor of an upgrade (`Aye`),
+/// against an upgrade (`Nay`), or can abstain from voting (`Absent`).
+///
+/// Votes are included in block proposals via the `NetworkUpgradePayload`
+/// in the Non-Deterministic Data (NDD) transaction. These votes are then
+/// tracked by the activation manager to calculate support thresholds.
+///
+/// The default vote is `Nay`, indicating that validators must explicitly
+/// opt-in to upgrades rather than being opted-in by default.
+#[derive(Default, Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Compact)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(compact)]
+pub enum Vote {
+    /// Vote in favor of the upgrade. An `Aye` vote contributes to the signaling
+    /// threshold calculations.
+    Aye,
+
+    /// Vote against the upgrade. A `Nay` vote allows validators to signal
+    /// opposition while still being counted in voting statistics.
+    Nay,
+
+    /// Explicit abstention from voting. An `Absent` vote functions the same as
+    /// `Nay` in quorum calculations, but communicates the validator's intent to
+    /// abstain rather than actively oppose the upgrade. It still counts as
+    /// participation in the voting process.
+    #[default]
+    Absent,
+}
+
+/// Represents a protocol version in the Botanix blockchain.
+///
+/// A runtime version consists of two components:
+/// - Major version (`0`): Incremented for hard fork or breaking changes
+/// - Minor version (`1`): Incremented for non-breaking changes
+///
+/// Runtime versions are comparable, with lexicographic ordering:
+/// - First compare major versions
+/// - If major versions are equal, compare minor versions
+///
+/// This ordered relationship is crucial for the upgrade process, as it ensures that:
+/// 1. Nodes can determine whether a version is an upgrade or downgrade
+/// 2. The activation manager can enforce one-way upgrade progression
+/// 3. Historical blocks during sync can be validated against appropriate version thresholds
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RuntimeVersion(
+    /// Major version component, incremented for breaking changes (hard fork)
+    pub MajorVersion,
+    /// Minor version component, incremented for non-breaking changes (soft fork)
+    pub MinorVersion,
+);
+
+impl RuntimeVersion {
+    /// Creates a new runtime version from major and minor components.
+    pub const fn new(major: u16, minor: u16) -> Self {
+        Self(MajorVersion(major), MinorVersion(minor))
+    }
+}
+
+impl PartialOrd for RuntimeVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for RuntimeVersion {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.0.cmp(&other.0) {
+            Ordering::Equal => self.1.cmp(&other.1),
+            ordering => ordering,
+        }
+    }
+}
+
+impl From<(u16, u16)> for RuntimeVersion {
+    fn from((major, minor): (u16, u16)) -> Self {
+        Self::new(major, minor)
+    }
+}
+
+/// Represents a major version component of a runtime version.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct MajorVersion(pub u16);
+
+/// Represents a minor version component of a runtime version.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct MinorVersion(pub u16);
+
+#[test]
+fn runtime_version_ordering() {
+    let v0_0 = RuntimeVersion::from(0, 0);
+    let v0_1 = RuntimeVersion::from(0, 1);
+    let v0_10 = RuntimeVersion::from(0, 10);
+    let v1_0 = RuntimeVersion::from(1, 0);
+    let v2_0 = RuntimeVersion::from(2, 0);
+
+    assert_eq!(v0_0, v0_0);
+    assert_eq!(v0_1, v0_1);
+    assert_eq!(v0_10, v0_10);
+    assert_eq!(v1_0, v1_0);
+    assert_eq!(v2_0, v2_0);
+
+    assert!(v0_0 < v0_1);
+    assert!(v0_1 < v0_10);
+    assert!(v0_10 < v1_0);
+    assert!(v1_0 < v2_0);
+
+    assert!(v2_0 > v1_0);
+    assert!(v1_0 > v0_10);
+    assert!(v0_10 > v0_1);
+    assert!(v0_1 > v0_0);
+}

--- a/crates/storage/db-api/src/models/mod.rs
+++ b/crates/storage/db-api/src/models/mod.rs
@@ -12,6 +12,7 @@ use reth_trie_common::{StoredNibbles, StoredNibblesSubKey, *};
 use serde::{Deserialize, Serialize};
 
 pub mod accounts;
+pub mod activation_manager;
 pub mod blocks;
 pub mod chunks;
 pub mod client_version;
@@ -20,6 +21,7 @@ pub mod sharded_key;
 pub mod storage_sharded_key;
 
 pub use accounts::*;
+pub use activation_manager::{RuntimeVersion, Vote};
 pub use blocks::*;
 pub use chunks::*;
 pub use client_version::ClientVersion;

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -52,6 +52,9 @@ reth-storage-errors = { workspace = true }
 reth-trie = { workspace = true, features = ["metrics"] }
 reth-trie-db = { workspace = true, features = ["metrics"] }
 revm = { workspace = true }
+
+## crypto
+secp256k1 = { workspace = true, features = ["global-context", "rand-std", "recovery"] }
 strum = { workspace = true }
 
 # async

--- a/crates/storage/provider/src/traits/activation_manager.rs
+++ b/crates/storage/provider/src/traits/activation_manager.rs
@@ -1,0 +1,96 @@
+use reth_db::models::activation_manager::Vote;
+use reth_errors::ProviderResult;
+
+/// Provides read and write operations for managing network upgrade votes and approval rates.
+///
+/// This trait provides functionality to track validators' votes on network upgrades,
+/// calculate voting approval rates, and manage vote retention across blocks.
+///
+/// Implementations should maintain persistence of votes between blocks and handle
+/// the removal of expired votes.
+#[auto_impl::auto_impl(&, Arc, Box)]
+pub trait ActivationManagerReaderWriter: Send + Sync {
+    /// Records or updates a validator's vote for a network upgrade.
+    ///
+    /// This method stores a validator's vote and acceptance status for a network upgrade
+    /// at the given block height. If the validator has previously voted, their vote
+    /// will be updated to the new values.
+    ///
+    /// # Parameters
+    /// * `auth` - The public key identifying the validator
+    /// * `vote` - The validator's vote (Aye or Nay)
+    /// * `is_compliant` - Whether the validator is ready to accept the upgrade
+    /// * `botanix_height` - The block height at which the vote was cast
+    ///
+    /// # Returns
+    /// * `Ok(())` if the vote was successfully recorded
+    /// * `Err` if there was an error recording the vote
+    fn update_upgrading_vote(
+        &self,
+        auth: secp256k1::PublicKey,
+        vote: Vote,
+        is_compliant: bool,
+        botanix_height: u64,
+    ) -> ProviderResult<()>;
+
+    /// Calculates the approval rate of validators signaling support (voting Aye) for an upgrade.
+    ///
+    /// This method calculates the percentage of validators voting "Aye" out of the total
+    /// number of validators who have cast votes, regardless of their compliance status.
+    ///
+    /// The formula used is: `(aye_votes * 100 + total_votes - 1) / total_votes`
+    /// This implements ceiling division to round up to the nearest percentage point.
+    ///
+    /// # Parameters
+    /// * `min_validator_count` - The minimum number of validators required to calculate the
+    ///   approval rate. `total_votes` is be set to this value if the total number of votes is less
+    ///   than this.
+    ///
+    /// # Returns
+    /// * `Ok((approval_rate, total_votes))` where:
+    ///   - `approval_rate` is the percentage (0-100) of Aye votes
+    ///   - `total_votes` is the number of distinct validators who have voted
+    /// * `Err` if there was an error calculating the approval rate
+    fn get_upgrading_approval_rate_ayes(
+        &self,
+        min_validator_count: usize,
+    ) -> ProviderResult<(usize, usize)>;
+
+    /// Calculates the approval rate of validators compliant with the upgrade.
+    ///
+    /// This method calculates the percentage of validators who are compliant
+    /// with the upgrade out of the total number of validators who have cast
+    /// votes, regardless of whether they voted Aye or Nay.
+    ///
+    /// The formula used is: `(compliant_votes * 100 + total_votes - 1) / total_votes`
+    /// This implements ceiling division to round up to the nearest percentage point.
+    ///
+    /// # Parameters
+    /// * `min_validator_count` - The minimum number of validators required to calculate the
+    ///   approval rate. `total_votes` is be set to this value if the total number of votes is less
+    ///   than this.
+    ///
+    /// # Returns
+    /// * `Ok((approval_rate, total_votes))` where:
+    ///   - `approval_rate` is the percentage (0-100) of accepting validators
+    ///   - `total_votes` is the number of distinct validators who have voted
+    /// * `Err` if there was an error calculating the approval
+    fn get_upgrading_approval_rate_compliance(
+        &self,
+        min_validator_count: usize,
+    ) -> ProviderResult<(usize, usize)>;
+
+    /// Removes votes for blocks below the specified height.
+    ///
+    /// This method implements vote expiration by removing all votes that were
+    /// recorded at block heights lower than the specified height. This ensures
+    /// that only recent votes within the retention period are considered.
+    ///
+    /// # Parameters
+    /// * `botanix_height` - Remove all votes recorded at heights lower than this
+    ///
+    /// # Returns
+    /// * `Ok(count)` - The number of votes that were removed
+    /// * `Err` if there was an error removing votes
+    fn remove_upgrading_votes(&self, botanix_height: u64) -> ProviderResult<usize>;
+}

--- a/crates/storage/provider/src/traits/mod.rs
+++ b/crates/storage/provider/src/traits/mod.rs
@@ -9,6 +9,9 @@ pub use reth_evm::provider::EvmEnvProvider;
 mod block;
 pub use block::*;
 
+mod activation_manager;
+pub use activation_manager::ActivationManagerReaderWriter;
+
 mod snapshot;
 pub use snapshot::*;
 


### PR DESCRIPTION
This PR introduces a standalone `ActivationManager` which implements our proposed [Network Upgrade specification](https://github.com/botanix-labs/Macbeth/pull/611#issuecomment-3644142962).

Early feedback on the specification and enforcement logic is appreciated.

***

**EDIT (2025-03-20)**: Comments and recommendations have been addressed, **ready to merge**!

Changes:
* Renamed `threshold` to `approval_rate`
* Renamed `accepting` to `is_compliant`
* Wrapped major/minor version indicators in new-types
  * respectively: `RuntimeVersion { MajorVersion(u16), MinorVersion(u16) }`
* Adjusted approval rate formula calculations; instead of checking `min_validator_count` independently, it's now part of calculation itself. Respectively:

```rust
        let total = votes.len().max(min_validator_count);
        let votes_received = votes.iter().filter(|(_, e)| e.vote == Vote::Aye).count();

        // Calculate percentage (0-100) of votes received
        let quorum = (votes_received * 100).div_ceil(total);
```

This means that if we for example require at least three votes and we have one Aye vote, we calculate `approval_vote = 34` and can just check `approval_vote >= 67` - instead of having to do `approval_vote >= 67 && votes_len >= 3`. 

**EDIT (2025-03-17)**: PR is out of Draft and now ready for review!

Unit test coverage -> https://github.com/botanix-labs/Macbeth/pull/611#issuecomment-2729803006

**EDIT (2025-03-14)**: Completed comprehensive unit test suite:

*  Case: Vote Aye and wait for acceptance threshold
*  Case: Vote Aye but votes expire after sampling period; upgrade does not pass
*  Case: Vote Nay but still accept upgrade when conditions are met
*  Case: Vote Nay and refuse to upgrade (explicit fork)
*  Case: Ignore upgrade completely (implicit fork)
*  Case: Majority votes Nay but is willing to accept; upgrade does not pass
*  Case: Properly handle version transitions at exact target height
*  Case: Reject outdated version
*  Case: Reject unsupported (future) version
*  Case: Upgrade never passes due to insufficient conditions
*  Case: Lagging validator can catch-up (sync) with finalized upgrade
*  Case: Validators ignore votes on mismatched upgrade versions 

Migrated and expanded all test cases using the improved testing structures! I'll add more documentation and do some final cleanups, and then we're done. I will convert this from a Draft to a PR when appropriate.