### PR TITLE
chore(abci): error out on txs being recived via `check_tx`

### DIFF
--- a/bin/reth/src/commands/poa/mod.rs
+++ b/bin/reth/src/commands/poa/mod.rs
@@ -799,13 +799,11 @@ impl<Ext: clap::Args + fmt::Debug> PoaNodeCommand<Ext> {
         }
 
         // NOTE: the node will block here until DKG has completed
-        let eth_tx_validator = validator.validator.clone();
         let abci_client_builder = abci_client_builder.expect("abci client builder exists");
         let fut = || async {
             abci_client_builder
                 .start_server(
                     &executor.clone(),
-                    eth_tx_validator.clone(),
                     transaction_pool.clone(),
                     abci_host.to_string(),
                     *abci_port,

--- a/crates/consensus/authority/src/comet_bft/abci.rs
+++ b/crates/consensus/authority/src/comet_bft/abci.rs
@@ -33,7 +33,7 @@ use comet_bft_rpc::HttpCometBFTRpcClientFactory;
 use reth_payload_builder::EthPayloadBuilderAttributes;
 use reth_primitives::{
     botanix::block_with_peg::SealedBlockWithPeg, header_ext::HeaderExt, Address, BlockHash,
-    BlockNumber, BlockWithSenders, SealedBlock, TransactionSigned, B256,
+    BlockNumber, BlockWithSenders, SealedBlock, B256,
 };
 use reth_provider::{
     BlockReaderIdExt, CanonStateNotification, Chain, ProviderError, ProviderFactory,
@@ -42,7 +42,7 @@ use reth_provider::{
 use reth_revm::primitives::FixedBytes;
 use reth_rpc_types::{engine::PayloadAttributes, BlockId};
 use reth_tasks::{TaskExecutor, TaskSpawner};
-use reth_transaction_pool::{EthPooledTransaction, EthTransactionValidator, TransactionPool};
+use reth_transaction_pool::TransactionPool;
 use schnellru::{ByLength, LruMap};
 
 use tendermint_abci::{Application, ServerBuilder};
@@ -258,14 +258,12 @@ where
     pub async fn start_server<Pool: TransactionPool + Clone + 'static>(
         &self,
         task_executor: &impl TaskSpawner,
-        validator: EthTransactionValidator<DB, EthPooledTransaction>,
         tx_pool: Pool,
         abci_host: String,
         abci_port: u16,
     ) -> Result<(), tendermint_abci::Error> {
         let app = ABCIClient::new(
             self.storage.clone(),
-            validator,
             tx_pool,
             self.bitcoin_checkpoint.clone(),
             self.abci_driver_tx.clone(),
@@ -329,7 +327,6 @@ enum PayloadBuilderError {
 #[derive(Clone)]
 pub(crate) struct ABCIClient<EF, BF, DB, Pool> {
     storage: Storage<EF, BF, DB>,
-    validator: EthTransactionValidator<DB, EthPooledTransaction>,
     pool: Pool,
     bitcoin_checkpoint: BitcoinCheckpoint,
     block_cache: Arc<RwLock<LruMap<BlockHash, BlockWithContext>>>,
@@ -363,7 +360,6 @@ where
     #[allow(clippy::too_many_arguments)]
     fn new(
         storage: Storage<EF, BF, DB>,
-        validator: EthTransactionValidator<DB, EthPooledTransaction>,
         pool: Pool,
         bitcoin_checkpoint: BitcoinCheckpoint,
         driver_tx: tokio::sync::mpsc::Sender<ABCIDriverMessage>,
@@ -380,7 +376,6 @@ where
     ) -> Self {
         Self {
             storage,
-            validator,
             pool,
             bitcoin_checkpoint,
             // Saving the last 5 blocks that were proposed
@@ -1100,7 +1095,7 @@ where
         // We are explicitly rejecting transactions that are received from the comet network
         // we expect txs to the submitted to the Reth mempool via Reth RPC, not via the ABCI
         // interface
-        return ResponseCheckTx { code: ERROR, ..Default::default() };
+        ResponseCheckTx { code: ERROR, ..Default::default() }
         // // We are ignore type for now
         // // One of CheckTx_New or CheckTx_Recheck. CheckTx_New is the default and means that a
         // full // check of the tranasaction is required. CheckTx_Recheck types are used
@@ -1593,8 +1588,9 @@ mod tests {
     use reth_revm::primitives::EnvKzgSettings;
     use reth_tasks::TaskManager;
     use reth_transaction_pool::{
-        blobstore::InMemoryBlobStore, test_utils::TransactionGenerator, Pool as RethPool,
-        TransactionOrigin, TransactionPool, TransactionValidationTaskExecutor,
+        blobstore::InMemoryBlobStore, test_utils::TransactionGenerator, EthPooledTransaction,
+        EthTransactionValidator, Pool as RethPool, TransactionOrigin, TransactionPool,
+        TransactionValidationTaskExecutor,
     };
     use std::path::Path;
     use tempfile::tempdir;
@@ -1686,7 +1682,6 @@ mod tests {
 
         ABCIClient::new(
             storage,
-            validator.validator,
             transaction_pool,
             bitcoin_checkpoint,
             driver_tx,

--- a/crates/consensus/authority/src/comet_bft/abci.rs
+++ b/crates/consensus/authority/src/comet_bft/abci.rs
@@ -1097,68 +1097,72 @@ where
     /// docs: https://docs.cometbft.com/v0.38/spec/abci/abci++_methods#checktx
     fn check_tx(&self, request: RequestCheckTx) -> ResponseCheckTx {
         info!("check_tx request: {:?}", request);
-        // We are ignore type for now
-        // One of CheckTx_New or CheckTx_Recheck. CheckTx_New is the default and means that a full
-        // check of the tranasaction is required. CheckTx_Recheck types are used when the mempool is
-        // initiating a normal recheck of a transaction.
-        let _type = request.r#type;
-        let _tx_bytes = request.tx.clone();
-        let hex = match hex::decode(request.tx.clone()) {
-            Ok(hex) => hex, // Proceed with the decoded hex if successful
-            Err(err) => {
-                return ResponseCheckTx {
-                    code: 1,
-                    log: format!("Failed to decode transaction: {}", err),
-                    ..Default::default()
-                };
-            }
-        };
+        // We are explicitly rejecting transactions that are received from the comet network
+        // we expect txs to the submitted to the Reth mempool via Reth RPC, not via the ABCI
+        // interface
+        return ResponseCheckTx { code: ERROR, ..Default::default() };
+        // // We are ignore type for now
+        // // One of CheckTx_New or CheckTx_Recheck. CheckTx_New is the default and means that a
+        // full // check of the tranasaction is required. CheckTx_Recheck types are used
+        // when the mempool is // initiating a normal recheck of a transaction.
+        // let _type = request.r#type;
+        // let _tx_bytes = request.tx.clone();
+        // let hex = match hex::decode(request.tx.clone()) {
+        //     Ok(hex) => hex, // Proceed with the decoded hex if successful
+        //     Err(err) => {
+        //         return ResponseCheckTx {
+        //             code: 1,
+        //             log: format!("Failed to decode transaction: {}", err),
+        //             ..Default::default()
+        //         };
+        //     }
+        // };
 
-        let mut error = (SUCCESS, "Ok");
-        match TransactionSigned::decode_enveloped(&mut hex.as_slice()) {
-            Ok(tx) => {
-                if let Ok(tx_ec_recover) = tx.try_into_ecrecovered() {
-                    let length = tx_ec_recover.length_without_header();
-                    let pool_tx = EthPooledTransaction::new(tx_ec_recover, length);
+        // let mut error = (SUCCESS, "Ok");
+        // match TransactionSigned::decode_enveloped(&mut hex.as_slice()) {
+        //     Ok(tx) => {
+        //         if let Ok(tx_ec_recover) = tx.try_into_ecrecovered() {
+        //             let length = tx_ec_recover.length_without_header();
+        //             let pool_tx = EthPooledTransaction::new(tx_ec_recover, length);
 
-                    let res = self.validator.validate_one(
-                        reth_transaction_pool::TransactionOrigin::External,
-                        pool_tx.clone(),
-                    );
+        //             let res = self.validator.validate_one(
+        //                 reth_transaction_pool::TransactionOrigin::External,
+        //                 pool_tx.clone(),
+        //             );
 
-                    match res {
-                        reth_transaction_pool::TransactionValidationOutcome::Valid {
-                            balance: _,
-                            state_nonce: _,
-                            transaction: _,
-                            propagate: _,
-                        } => {} // Do nothing
-                        reth_transaction_pool::TransactionValidationOutcome::Invalid(_, e) => {
-                            error!("Txinvalid: Error validating transaction: {:?}", e);
-                            error = (ERROR, "Error occurred while validating transaction");
-                        }
-                        reth_transaction_pool::TransactionValidationOutcome::Error(_, e) => {
-                            error!("TxError: Error validating transaction: {:?}", e);
-                            error = (ERROR, "Error occurred while validating transaction");
-                        }
-                    }
-                } else {
-                    error = (ERROR, "Error recovering tx signer. Invalid signature");
-                }
-            }
-            Err(e) => {
-                error!("Error decoding transaction: {:?}", e);
-                error = (ERROR, "Error decoding transaction");
-            }
-        }
+        //             match res {
+        //                 reth_transaction_pool::TransactionValidationOutcome::Valid {
+        //                     balance: _,
+        //                     state_nonce: _,
+        //                     transaction: _,
+        //                     propagate: _,
+        //                 } => {} // Do nothing
+        //                 reth_transaction_pool::TransactionValidationOutcome::Invalid(_, e) => {
+        //                     error!("Txinvalid: Error validating transaction: {:?}", e);
+        //                     error = (ERROR, "Error occurred while validating transaction");
+        //                 }
+        //                 reth_transaction_pool::TransactionValidationOutcome::Error(_, e) => {
+        //                     error!("TxError: Error validating transaction: {:?}", e);
+        //                     error = (ERROR, "Error occurred while validating transaction");
+        //                 }
+        //             }
+        //         } else {
+        //             error = (ERROR, "Error recovering tx signer. Invalid signature");
+        //         }
+        //     }
+        //     Err(e) => {
+        //         error!("Error decoding transaction: {:?}", e);
+        //         error = (ERROR, "Error decoding transaction");
+        //     }
+        // }
 
-        self.metrics.commet_checked_txs.increment(1);
-        ResponseCheckTx {
-            code: error.0,
-            log: error.1.to_string(),
-            info: error.1.to_string(),
-            ..Default::default()
-        }
+        // self.metrics.commet_checked_txs.increment(1);
+        // ResponseCheckTx {
+        //     code: error.0,
+        //     log: error.1.to_string(),
+        //     info: error.1.to_string(),
+        //     ..Default::default()
+        // }
     }
 
     /// docs: https://docs.cometbft.com/v0.38/spec/abci/abci++_methods#prepareproposal

--- a/crates/consensus/authority/src/metrics.rs
+++ b/crates/consensus/authority/src/metrics.rs
@@ -42,9 +42,6 @@ pub struct AuthorityMetrics {
     /// Number of commet prepared proposals
     pub(crate) commet_prepared_proposals: Counter,
 
-    /// Number of commet checked txs
-    pub(crate) commet_checked_txs: Counter,
-
     /// Number of commet processd\ed proposals
     pub(crate) commet_processed_proposals: Counter,
 }


### PR DESCRIPTION
Txs should not be entering and persisting in the cometBFT mempool. On our testnet we "firewall" off the cometRPC but others may not. We expect txs to be entering the reth mempool via RPC, a user can submit a txs via comet's RPC however it will never get included in a block. Validating a tx that will never be in a block set a bad precedence and practice. 

Edit: I left the check tx code commented out in case its useful later. Happy to just remove it as well.