### PR TITLE
fix:  enable cometbft - rpc connection before syncing check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,11 +48,15 @@ jobs:
       - name: Install Protobuf Compiler
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - uses: dtolnay/rust-toolchain@clippy
+        with:
+          components: rustfmt, clippy
+          toolchain: 1.85.0
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
           cache-all-crates: true
-      - run: cargo clippy -p reth-authority-consensus -p reth-network -p reth-primitives -p reth-rpc --lib --tests --benches --all-features --locked
+      - run: cargo clippy -p reth-authority-consensus -p reth-network -p reth-primitives -p reth-rpc --lib
+          --tests --benches --all-features --locked
         env:
           RUSTFLAGS: -D warnings
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 version = "1.0.5"
 edition = "2021"
-rust-version = "1.80"
+rust-version = "1.85"
 license = "MIT OR Apache-2.0"
 homepage = "https://paradigmxyz.github.io/reth"
 repository = "https://github.com/paradigmxyz/reth"

--- a/bin/btc-server/src/bin/main.rs
+++ b/bin/btc-server/src/bin/main.rs
@@ -757,7 +757,7 @@ where
                 telemetry.update_signing_error_metrics(
                     self.btc_network,
                     self.config.identifier,
-                    Some(signing_session_id.clone()),
+                    Some(signing_session_id),
                     &SigningRound1Error::AlreadyInSigningSession.to_string(),
                 );
             }
@@ -773,7 +773,7 @@ where
             &self.identifier,
         )
         .await
-        .map_err(|e| SigningError::Round1(e))
+        .map_err(SigningError::Round1)
         .to_status()?;
 
         // Save signing nonces in memory
@@ -828,7 +828,7 @@ where
                 telemetry.update_signing_error_metrics(
                     self.btc_network,
                     self.config.identifier,
-                    Some(signing_session_id.clone()),
+                    Some(signing_session_id),
                     &e.to_string(),
                 );
             }

--- a/bin/btc-server/src/util.rs
+++ b/bin/btc-server/src/util.rs
@@ -28,9 +28,9 @@ lazy_static! {
 // Psbt validation flags
 pub(crate) const NO_FLAGS: u8 = 0u8;
 pub(crate) const ROUND1: u8 = 1u8;
-pub(crate) const ROUND1_TRANSITION: u8 = 1u8 << 1 | ROUND1;
-pub(crate) const ROUND2: u8 = 1u8 << 2 | ROUND1_TRANSITION;
-pub(crate) const ROUND2_TRANSITION: u8 = 1u8 << 3 | ROUND1_TRANSITION;
+pub(crate) const ROUND1_TRANSITION: u8 = (1u8 << 1) | ROUND1;
+pub(crate) const ROUND2: u8 = (1u8 << 2) | ROUND1_TRANSITION;
+pub(crate) const ROUND2_TRANSITION: u8 = (1u8 << 3) | ROUND1_TRANSITION;
 
 pub fn btc_per_kb_to_sat_per_vb(btc_per_kb: bitcoin::Amount) -> FeeRate {
     let sats = btc_per_kb.to_sat();

--- a/bin/federation-utils/src/errors.rs
+++ b/bin/federation-utils/src/errors.rs
@@ -42,18 +42,18 @@ pub enum WalletError {
 }
 
 impl From<io::Error> for WalletError {
-    fn from(err: io::Error) -> WalletError {
-        WalletError::IoError(err.to_string())
+    fn from(err: io::Error) -> Self {
+        Self::IoError(err.to_string())
     }
 }
 
 impl From<ProviderError> for WalletError {
-    fn from(err: ProviderError) -> WalletError {
-        WalletError::RpcError(err.to_string())
+    fn from(err: ProviderError) -> Self {
+        Self::RpcError(err.to_string())
     }
 }
 impl From<&str> for WalletError {
-    fn from(message: &str) -> WalletError {
-        WalletError::CustomError(message.to_string())
+    fn from(message: &str) -> Self {
+        Self::CustomError(message.to_string())
     }
 }

--- a/bin/federation-utils/src/handler.rs
+++ b/bin/federation-utils/src/handler.rs
@@ -3,7 +3,7 @@ use crate::{
     config::{get_default_config_path, Config},
     errors::WalletError,
 };
-use base64::decode;
+use base64::Engine;
 use ethers::{prelude::*, types::Transaction};
 use hex::encode as hex_encode;
 use k256::{ecdsa::SigningKey as Secp256k1SigningKey, elliptic_curve::generic_array::GenericArray};
@@ -159,7 +159,9 @@ fn deserialize_secret_key(seceret_path: &str) -> Result<String, WalletError> {
     }
     match parsed_key.priv_key.key_type.as_str() {
         "tendermint/PrivKeySecp256k1" => {
-            let priv_key_bytes = decode(&parsed_key.priv_key.value)
+            let engine = base64::engine::general_purpose::STANDARD;
+            let priv_key_bytes = engine
+                .decode(&parsed_key.priv_key.value)
                 .map_err(|e| WalletError::CustomError(format!("Base64 decode error: {:?}", e)))?;
 
             // Ensure the key is exactly 32 bytes

--- a/bin/federation-utils/src/main.rs
+++ b/bin/federation-utils/src/main.rs
@@ -50,9 +50,7 @@ async fn inner_main() -> Result<(), WalletError> {
                         "Secret key path must be provided via CLI or config".to_string(),
                     )
                 })?;
-            let bal = handle_get_balance(&secret_key_path, provider_url, chain_id)
-                .await
-                .map_err(WalletError::from)?;
+            let bal = handle_get_balance(&secret_key_path, provider_url, chain_id).await?;
             println!("Balance: {:?}", bal);
         }
         Commands::SweepBalance(sweep_balance) => {
@@ -84,8 +82,7 @@ async fn inner_main() -> Result<(), WalletError> {
                 provider_url,
                 &receiver_address.to_string(),
             )
-            .await
-            .map_err(WalletError::from)?;
+            .await?;
 
             println!("Sweep successful: {:?}", sweep);
         }
@@ -97,9 +94,7 @@ async fn inner_main() -> Result<(), WalletError> {
             if tx_hash.is_empty() {
                 return Err(WalletError::CustomError("Tx hash cannot be an empty".to_string()));
             }
-            let tx_info = handle_get_transaction_info(&tx_hash, provider_url, chain_id)
-                .await
-                .map_err(WalletError::from)?;
+            let tx_info = handle_get_transaction_info(&tx_hash, provider_url, chain_id).await?;
 
             println!("Transaction info: {:?}", tx_info);
         }

--- a/bin/reth/src/commands/poa/mod.rs
+++ b/bin/reth/src/commands/poa/mod.rs
@@ -724,6 +724,7 @@ impl<Ext: clap::Args + fmt::Debug> PoaNodeCommand<Ext> {
             .with_host(cometbft_rpc_host);
 
         // Build authority Consensus
+        let (abci_started_tx, abci_started_rx) = tokio::sync::oneshot::channel::<()>();
         let (frost_task, abci_client_builder, snapshot_manager) =
             match AuthorityConsensusBuilder::try_new(
                 Arc::clone(&chain_arc.clone()),
@@ -792,7 +793,7 @@ impl<Ext: clap::Args + fmt::Debug> PoaNodeCommand<Ext> {
             executor.spawn_critical(
                 "Frost Task",
                 Box::pin(async move {
-                    frost_task.expect("frost task exists").start_task().await;
+                    frost_task.expect("frost task exists").start_task(abci_started_rx).await;
                 }),
             );
         }
@@ -888,6 +889,7 @@ impl<Ext: clap::Args + fmt::Debug> PoaNodeCommand<Ext> {
 
             launch_rpc.await?
         };
+        abci_started_tx.send(()).expect("abci started tx");
 
         let (tx, rx) = oneshot::channel();
         executor.spawn_critical(

--- a/crates/consensus/authority/src/frost_task.rs
+++ b/crates/consensus/authority/src/frost_task.rs
@@ -281,7 +281,7 @@ where
             !response.pending_pegouts.is_empty()
     }
 
-    pub async fn start_task(&mut self) {
+    pub async fn start_task(&mut self, mut abci_started_rx: tokio::sync::oneshot::Receiver<()>) {
         // before we start get a proper event receiver
         let (peer_messages_tx, peer_messages_rx) = tokio::sync::oneshot::channel();
         if let Err(e) =
@@ -318,21 +318,28 @@ where
         }
         let mut canon_state_notifs = self.storage.client.subscribe_to_canonical_state();
 
+        let mut abci_started = false;
         loop {
-            // get sync status
-            match self.is_syncing().await {
-                Ok(is_syncing) => {
-                    self.storage.inner.write().await.is_block_syncing = is_syncing;
-                    if is_syncing {
-                        info!(target: "consensus::authority::frost_task::start_task", "Node is syncing, pausing frost task...");
+            // check if abci has started
+            if abci_started_rx.try_recv().is_ok() {
+                abci_started = true;
+            }
+            if abci_started {
+                // get sync status
+                match self.is_syncing().await {
+                    Ok(is_syncing) => {
+                        self.storage.inner.write().await.is_block_syncing = is_syncing;
+                        if is_syncing {
+                            info!(target: "consensus::authority::frost_task::start_task", "Node is syncing, pausing frost task...");
+                            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                            continue;
+                        }
+                    }
+                    Err(e) => {
+                        info!(target: "consensus::authority::frost_task::start_task", "Error getting block sync status {:?}", e);
                         tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                         continue;
                     }
-                }
-                Err(e) => {
-                    info!(target: "consensus::authority::frost_task::start_task", "Error getting block sync status {:?}", e);
-                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-                    continue;
                 }
             }
 

--- a/crates/primitives-traits/Cargo.toml
+++ b/crates/primitives-traits/Cargo.toml
@@ -18,7 +18,6 @@ alloy-genesis = { workspace = true }
 alloy-primitives = { workspace = true }
 alloy-rlp = { workspace = true }
 alloy-rpc-types-eth = { workspace = true, optional = true }
-reth-rpc-types = { workspace = true }
 
 # arbitrary utils
 arbitrary = { workspace = true, features = ["derive"], optional = true }
@@ -31,6 +30,7 @@ modular-bitfield = { workspace = true }
 proptest = { workspace = true, optional = true }
 proptest-arbitrary-interop = { workspace = true, optional = true }
 reth-codecs = { workspace = true }
+reth-rpc-types = { workspace = true }
 revm-primitives = { workspace = true, features = ["serde"] }
 
 # misc

--- a/crates/rpc/rpc-eth-api/Cargo.toml
+++ b/crates/rpc/rpc-eth-api/Cargo.toml
@@ -24,7 +24,6 @@ auto_impl = { workspace = true }
 bitcoin = { workspace = true }
 dyn-clone = { workspace = true }
 futures = { workspace = true }
-serde_json = { workspace = true }
 
 # rpc
 jsonrpsee = { workspace = true, features = ["server", "macros"] }
@@ -49,6 +48,7 @@ revm = { workspace = true }
 revm-inspectors = { workspace = true }
 revm-primitives = { workspace = true, features = ["dev"] }
 secp256k1 = { workspace = true }
+serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 

--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -8,7 +8,8 @@ use crate::helpers::{
 use alloy_dyn_abi::TypedData;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_primitives::{
-    extra_data_header::ExtraDataHeader, transaction::AccessListResult, Address, BlockId, BlockNumberOrTag, Bytes, B256, B64, U256, U64
+    extra_data_header::ExtraDataHeader, transaction::AccessListResult, Address, BlockId,
+    BlockNumberOrTag, Bytes, B256, B64, U256, U64,
 };
 use reth_rpc_server_types::{result::internal_rpc_err, ToRpcResult};
 use reth_rpc_types::{
@@ -423,8 +424,12 @@ where
         if let Some(ref mut rich_block) = block {
             if include_extra_data_header.is_some_and(|v| v) {
                 // Add the header JSON to extra_info
-                let mut extra_data_header = ExtraDataHeader::deserialize(&mut rich_block.header.extra_data.0.to_vec().as_slice())
-                    .map_err(|e| internal_rpc_err(format!("Failed to deserialize extra data header: {}", e)))?;
+                let mut extra_data_header = ExtraDataHeader::deserialize(
+                    &mut rich_block.header.extra_data.0.to_vec().as_slice(),
+                )
+                .map_err(|e| {
+                    internal_rpc_err(format!("Failed to deserialize extra data header: {}", e))
+                })?;
                 let extra_data_header_json = serde_json::to_value(&mut extra_data_header)
                     .map_err(|e| internal_rpc_err(format!("Failed to serialize header: {}", e)))?;
                 rich_block.extra_info.insert("extraDataHeader".to_string(), extra_data_header_json);

--- a/crates/rpc/rpc/src/engine.rs
+++ b/crates/rpc/rpc/src/engine.rs
@@ -88,7 +88,10 @@ where
         full: bool,
         include_extra_data_header: Option<bool>,
     ) -> Result<Option<RichBlock>> {
-        self.eth.block_by_number(number, full, include_extra_data_header).instrument(engine_span!()).await
+        self.eth
+            .block_by_number(number, full, include_extra_data_header)
+            .instrument(engine_span!())
+            .await
     }
 
     /// Handler for: `eth_sendRawTransaction`

--- a/crates/rpc/rpc/src/otterscan.rs
+++ b/crates/rpc/rpc/src/otterscan.rs
@@ -298,8 +298,11 @@ where
         })
         .await?;
 
-        let Some(BlockTransactions::Full(transactions)) =
-            self.eth.block_by_number(num.into(), true, None).await?.map(|block| block.inner.transactions)
+        let Some(BlockTransactions::Full(transactions)) = self
+            .eth
+            .block_by_number(num.into(), true, None)
+            .await?
+            .map(|block| block.inner.transactions)
         else {
             return Err(EthApiError::UnknownBlockNumber.into());
         };

--- a/crates/storage/codecs/derive/src/compact/generator.rs
+++ b/crates/storage/codecs/derive/src/compact/generator.rs
@@ -141,32 +141,30 @@ fn generate_from_compact(fields: &FieldList, ident: &Ident, is_zstd: bool) -> To
     // If the type has compression support, then check the `__zstd` flag. Otherwise, use the default
     // code branch. However, even if it's a type with compression support, not all values are
     // to be compressed (thus the zstd flag). Ideally only the bigger ones.
-    is_zstd
-        .then(|| {
-            let decompressor = format_ident!("{}_DECOMPRESSOR", ident.to_string().to_uppercase());
-            quote! {
-                if flags.__zstd() != 0 {
-                    #decompressor.with(|decompressor| {
-                        let decompressor = &mut decompressor.borrow_mut();
-                        let decompressed = decompressor.decompress(buf);
-                        let mut original_buf = buf;
+    if is_zstd {
+        let decompressor = format_ident!("{}_DECOMPRESSOR", ident.to_string().to_uppercase());
+        quote! {
+            if flags.__zstd() != 0 {
+                #decompressor.with(|decompressor| {
+                    let decompressor = &mut decompressor.borrow_mut();
+                    let decompressed = decompressor.decompress(buf);
+                    let mut original_buf = buf;
 
-                        let mut buf: &[u8] = decompressed;
-                        #(#lines)*
-                        (obj, original_buf)
-                    })
-                } else {
+                    let mut buf: &[u8] = decompressed;
                     #(#lines)*
-                    (obj, buf)
-                }
-            }
-        })
-        .unwrap_or_else(|| {
-            quote! {
+                    (obj, original_buf)
+                })
+            } else {
                 #(#lines)*
                 (obj, buf)
             }
-        })
+        }
+    } else {
+        quote! {
+            #(#lines)*
+            (obj, buf)
+        }
+    }
 }
 
 /// Generates code to implement the `Compact` trait method `from_compact`.

--- a/crates/trie/common/src/proofs.rs
+++ b/crates/trie/common/src/proofs.rs
@@ -155,6 +155,7 @@ impl AccountProof {
     }
 
     /// Verify the storage proofs and account proof against the provided state root.
+    #[allow(clippy::result_large_err)]
     pub fn verify(&self, root: B256) -> Result<(), ProofVerificationError> {
         // Verify storage proofs.
         for storage_proof in &self.storage_proofs {
@@ -207,6 +208,7 @@ impl StorageProof {
     }
 
     /// Verify the proof against the provided storage root.
+    #[allow(clippy::result_large_err)]
     pub fn verify(&self, root: B256) -> Result<(), ProofVerificationError> {
         let expected =
             if self.value.is_zero() { None } else { Some(encode_fixed_size(&self.value).to_vec()) };


### PR DESCRIPTION
This this PR does:

1. This PR resolves the issues raised in [929](https://github.com/botanix-labs/botanix/issues/929). The current implementation allows having the frost task getting notified about abci being started (also reth rpcs) which is the prerequisite for the comet-reth connection. If the latter is not satisfied, the `is_syncing` condition in the frost task would always be failing as there is simply no other way of having reth-comet connected. On the other hand, the frost task loop needs to proceed at least one iteration before we start checking for the syncing condition in order to have the dkg started See here -> https://github.com/botanix-labs/Macbeth/blob/main/bin/reth/src/commands/poa/mod.rs#L800. For this reason I have added a condition that checks in each iteration if the abci has already been started and only when, then we would start checking for syncing on cometbft side. If syncing, the frost task would do empty cycles until sync is complete.

2. I have also fixed some linting stuff acc. to the latest Rust version we are using. We SHOULD USE 1.85 as 1.87 has issues with backwards compat atm and we get compilation errors. I have set this to the pipelines too.

3. I have fixed compilation warnings and errors acc. to v1.85 standards. 