### PR TITLE
fix(primitives): Handle errors in `PeginMeta` serialization

### DIFF
--- a/bin/test-suite/src/suite/consensus/frost/test_batch_pegins.rs
+++ b/bin/test-suite/src/suite/consensus/frost/test_batch_pegins.rs
@@ -207,7 +207,7 @@ pub async fn batch_pegins(
     let mut nonce = provider.nonce().await;
     for (_, pegin) in pegins.iter().enumerate() {
         // There is only one pegin that needs to be serialized
-        let serialized_pegin_meta = pegin.meta[0].serialize();
+        let serialized_pegin_meta = pegin.meta[0].serialize().unwrap();
         let metadata = ethers::core::types::Bytes::from(serialized_pegin_meta.clone());
         let tx_hash = provider
             .non_confirmed_mint(

--- a/bin/test-suite/src/suite/consensus/frost/test_frost_e2e.rs
+++ b/bin/test-suite/src/suite/consensus/frost/test_frost_e2e.rs
@@ -180,7 +180,7 @@ pub async fn frost_e2e_stable(
         "Sending pegin tx: block headers=",
         meta.block_headers.iter().map(|h| h.block_hash()).collect::<Vec<_>>()
     );
-    let serialized_pegin_meta = meta.serialize();
+    let serialized_pegin_meta = meta.serialize().unwrap();
     it_info_print!("Serialized pegin meta: ", hex::encode(serialized_pegin_meta.clone()));
     let mint_contract = mint_contract_instances
         .first()

--- a/bin/test-suite/src/suite/consensus/frost/test_frost_e2e_signing_disconnect.rs
+++ b/bin/test-suite/src/suite/consensus/frost/test_frost_e2e_signing_disconnect.rs
@@ -159,7 +159,7 @@ pub async fn frost_e2e_failed_signing_disconnect(
         "Sending pegin tx: block headers",
         meta.block_headers.iter().map(|h| h.block_hash()).collect::<Vec<_>>()
     );
-    let serialized_pegin_meta = meta.serialize();
+    let serialized_pegin_meta = meta.serialize().unwrap();
     it_info_print!("Serialized pegin meta: ", hex::encode(serialized_pegin_meta.clone()));
 
     let mint_contract = mint_contract_instances

--- a/bin/test-suite/src/suite/consensus/invalid_transactions/test_invalid_pegin.rs
+++ b/bin/test-suite/src/suite/consensus/invalid_transactions/test_invalid_pegin.rs
@@ -145,7 +145,7 @@ pub async fn invalid_pegin(
     };
 
     // send the pegin transactions to all fed members
-    let serialized_pegin_meta = meta.serialize();
+    let serialized_pegin_meta = meta.serialize().unwrap();
     it_info_print!("Serialized pegin meta: ", hex::encode(serialized_pegin_meta.clone()));
     let botanix_eth_client = mint_contract_instances
         .first()
@@ -219,7 +219,7 @@ pub async fn invalid_pegin(
     };
 
     // send the pegin transactions to all fed members
-    let serialized_pegin_meta = meta.serialize();
+    let serialized_pegin_meta = meta.serialize().unwrap();
     it_info_print!("Serialized pegin meta: ", hex::encode(serialized_pegin_meta.clone()));
     let botanix_eth_client = mint_contract_instances
         .first()

--- a/crates/primitives/src/botanix/peg_contract.rs
+++ b/crates/primitives/src/botanix/peg_contract.rs
@@ -243,7 +243,7 @@ impl From<bitcoin::io::Error> for PeginDataError {
     fn from(err: bitcoin::io::Error) -> Self {
         // `bitcoin::io::Error` is converted to
         // `bitcoin::consensus::encode::Error::Io(_)`
-        PeginDataError::InvalidFormat(err.into())
+        Self::InvalidFormat(err.into())
     }
 }
 

--- a/crates/primitives/src/botanix/peg_contract.rs
+++ b/crates/primitives/src/botanix/peg_contract.rs
@@ -154,20 +154,20 @@ pub struct PeginMeta {
 
 impl PeginMeta {
     /// Serialize a pegin meta
-    pub fn serialize(&self) -> Vec<u8> {
+    pub fn serialize(&self) -> Result<Vec<u8>, PeginDataError> {
         let mut bytes = Vec::new();
-        self.version.consensus_encode(&mut bytes).unwrap();
-        self.outpoint.consensus_encode(&mut bytes).unwrap();
+        self.version.consensus_encode(&mut bytes)?;
+        self.outpoint.consensus_encode(&mut bytes)?;
         bytes.extend_from_slice(self.address.0.as_slice());
         bytes.extend_from_slice(&self.aggregate_publickey.serialize());
-        btcencode::VarInt(self.block_headers.len() as u64).consensus_encode(&mut bytes).unwrap();
+        btcencode::VarInt(self.block_headers.len() as u64).consensus_encode(&mut bytes)?;
         for header in &self.block_headers {
-            header.consensus_encode(&mut bytes).unwrap();
+            header.consensus_encode(&mut bytes)?;
         }
-        self.merkle_proof.consensus_encode(&mut bytes).unwrap();
-        self.tx.consensus_encode(&mut bytes).unwrap();
+        self.merkle_proof.consensus_encode(&mut bytes)?;
+        self.tx.consensus_encode(&mut bytes)?;
 
-        bytes
+        Ok(bytes)
     }
 
     /// Deserialize a pegin meta

--- a/crates/primitives/src/botanix/peg_contract.rs
+++ b/crates/primitives/src/botanix/peg_contract.rs
@@ -239,6 +239,14 @@ pub enum PeginDataError {
     FrostError(frost::Error),
 }
 
+impl From<bitcoin::io::Error> for PeginDataError {
+    fn from(err: bitcoin::io::Error) -> Self {
+        // `bitcoin::io::Error` is converted to
+        // `bitcoin::consensus::encode::Error::Io(_)`
+        PeginDataError::InvalidFormat(err.into())
+    }
+}
+
 /// Error type for pegout data
 #[derive(Debug, Error)]
 pub enum PegoutDataError {

--- a/crates/primitives/src/botanix/peg_contract.rs
+++ b/crates/primitives/src/botanix/peg_contract.rs
@@ -350,7 +350,7 @@ mod tests {
             },
         };
 
-        let serialized = pegin_metadata.serialize();
+        let serialized = pegin_metadata.serialize().unwrap();
         let (deserialized, size) = PeginMeta::deserialize(&serialized).unwrap();
         assert_eq!(pegin_metadata.version, deserialized.version);
         assert_eq!(pegin_metadata.outpoint, deserialized.outpoint);


### PR DESCRIPTION
Fixes https://github.com/botanix-labs/botanix/issues/930

Quite straight forward. All unwraps happen in tests.