### PR TITLE
Refactor(Pegins): Improve pegin versioning ergonomics

### DIFF
--- a/bin/test-suite/src/suite/consensus/frost/test_batch_pegins.rs
+++ b/bin/test-suite/src/suite/consensus/frost/test_batch_pegins.rs
@@ -10,7 +10,7 @@ use ethers::{
 use reth_primitives::{
     botanix::{
         mint_validation::MINT_TOPIC,
-        peg_contract::{PeginData, PeginMeta, PeginMetaV0, PeginMetaV1},
+        peg_contract::{PeginData, PeginMeta, PeginMetaV1, PeginMetaTrait},
         utils::AmountExt,
     },
     B256,
@@ -43,29 +43,35 @@ fn create_pegin_meta(
     pmt: PartialMerkleTree,
     headers: Vec<bitcoin::block::Header>,
     reference_hash: Option<B256>,
-) -> PeginMeta {
+) -> Box<dyn PeginMetaTrait> {
     match version {
-        PEGIN_META_VERSION_V0 => PeginMeta::V0(PeginMetaV0 {
-            version: PEGIN_META_VERSION_V0,
-            outpoint: bitcoin::OutPoint::new(pegin_tx.compute_txid(), vout as u32),
-            address: eth_account,
-            aggregate_publickey: agg_pk,
-            tx: pegin_tx.clone(),
-            merkle_proof: pmt,
-            block_headers: headers,
-        }),
-        PEGIN_META_VERSION_V1 => PeginMeta::V1(PeginMetaV1 {
-            inner: PeginMetaV0 {
-                version: PEGIN_META_VERSION_V1,
+        PEGIN_META_VERSION_V0 => {
+            let meta = PeginMeta {
+                version: PEGIN_META_VERSION_V0,
                 outpoint: bitcoin::OutPoint::new(pegin_tx.compute_txid(), vout as u32),
                 address: eth_account,
-                aggregate_publickey: agg_pk,
+                aggregate_public_key: agg_pk,
                 tx: pegin_tx.clone(),
                 merkle_proof: pmt,
                 block_headers: headers,
-            },
-            ref_block_hash: reference_hash.unwrap(),
-        }),
+            };
+            Box::new(meta) as Box<dyn PeginMetaTrait>
+        },
+        PEGIN_META_VERSION_V1 => {
+            let meta = PeginMetaV1 {
+                inner: PeginMeta {
+                    version: PEGIN_META_VERSION_V1,
+                    outpoint: bitcoin::OutPoint::new(pegin_tx.compute_txid(), vout as u32),
+                    address: eth_account,
+                    aggregate_public_key: agg_pk,
+                    tx: pegin_tx.clone(),
+                    merkle_proof: pmt,
+                    block_headers: headers,
+                },
+                ref_block_hash: reference_hash.unwrap(),
+            };
+            Box::new(meta) as Box<dyn PeginMetaTrait>
+        },
         _ => panic!("unsupported version"),
     }
 }
@@ -223,7 +229,7 @@ pub async fn batch_pegins(
             None
         };
 
-        let meta = create_pegin_meta(
+        let meta = vec![create_pegin_meta(
             version,
             &pegin_tx,
             vout,
@@ -232,18 +238,17 @@ pub async fn batch_pegins(
             pmt,
             headers.clone(),
             reference_hash,
-        );
+        )];
 
         // validate the pegin data first offchain before submitting
         let pegin_data = PeginData {
             account: Address::from_slice(eth_address.as_bytes()),
             amount,
             bitcoin_block_height: bitcoin_block_height as u32,
-            meta: vec![meta.clone()],
         };
 
-        pegin_data.validate(&checkpoint, &agg_pk).expect("pegin data should be valid!");
-        pegins.push(pegin_data);
+        meta[0].validate(&checkpoint, &agg_pk, pegin_data.clone()).expect("pegin data should be valid!");
+        pegins.push((pegin_data, meta));
     }
 
     // mint all the pegins
@@ -258,13 +263,13 @@ pub async fn batch_pegins(
     let mut nonce = provider.nonce().await;
     for (_, pegin) in pegins.iter().enumerate() {
         // There is only one pegin that needs to be serialized
-        let serialized_pegin_meta = pegin.meta[0].serialize().unwrap();
+        let serialized_pegin_meta = pegin.1[0].serialize().unwrap();
         let metadata = ethers::core::types::Bytes::from(serialized_pegin_meta.clone());
         let tx_hash = provider
             .non_confirmed_mint(
-                ethers::core::types::Address::from_slice(pegin.account.as_slice()),
-                pegin.amount,
-                pegin.bitcoin_block_height,
+                ethers::core::types::Address::from_slice(pegin.0.account.as_ref()),
+                pegin.0.amount,
+                pegin.0.bitcoin_block_height,
                 metadata,
                 refund_address,
                 nonce,
@@ -295,7 +300,7 @@ pub async fn batch_pegins(
     tokio::time::sleep(Duration::from_secs(5)).await;
     // Ensure each eth address has a non zero balance
     for (_, pegin) in pegins.iter().enumerate() {
-        let eth_address_balance = provider.get_botanix_balance(pegin.account).await;
+        let eth_address_balance = provider.get_botanix_balance(pegin.0.account).await;
         assert!(!eth_address_balance.expect("get balance").is_zero());
     }
 
@@ -315,7 +320,7 @@ pub async fn batch_pegins(
         let utxo = utxos.iter().find(|utxo| {
             bitcoin::Txid::from_slice(utxo.outpoint.as_ref().unwrap().txid.as_slice())
                 .expect("valid txid") ==
-                pegin.meta[0].tx().compute_txid()
+                pegin.1[0].as_any().downcast_ref::<PeginMeta>().unwrap().tx.compute_txid()
         });
         assert!(utxo.is_some());
     }

--- a/bin/test-suite/src/suite/consensus/frost/test_frost_e2e.rs
+++ b/bin/test-suite/src/suite/consensus/frost/test_frost_e2e.rs
@@ -9,7 +9,7 @@ use ethers::{
 };
 use reth_primitives::botanix::{
     mint_validation::{BURN_TOPIC, MINT_TOPIC},
-    peg_contract::{PeginData, PeginMeta, PeginMetaV0, PegoutData},
+    peg_contract::{PeginData, PeginMeta, PeginMetaTrait, PegoutData, PEGIN_META_VERSION_V0},
     utils::AmountExt,
 };
 
@@ -140,25 +140,24 @@ pub async fn frost_e2e_stable(
 
     // create pegin meta
     let bitcoin_block_height = conf_block_info.height;
-    let meta = PeginMeta::V0(PeginMetaV0 {
-        version: 0,
-        outpoint: bitcoin::OutPoint::new(pegin_tx.compute_txid(), vout as u32),
-        address: eth_account,
-        aggregate_publickey: secp256k1::PublicKey::from_str(
-            gateway_address_response.aggregate_public_key.as_str(),
-        )
-        .expect("valid public key"),
-        tx: pegin_tx.clone(),
-        merkle_proof: pmt,
-        block_headers: headers,
-    });
+    let meta = vec![PeginMeta {
+            version: PEGIN_META_VERSION_V0,
+            outpoint: bitcoin::OutPoint::new(pegin_tx.compute_txid(), vout as u32),
+            address: eth_account,
+            aggregate_public_key: secp256k1::PublicKey::from_str(
+                gateway_address_response.aggregate_public_key.as_str(),
+            )
+            .expect("valid public key"),
+            tx: pegin_tx.clone(),
+            merkle_proof: pmt,
+            block_headers: headers,
+        }];
 
     // validate the pegin data first offchain before submitting
     let pegin_data = PeginData {
         account: Address::from_slice(eth_destination.as_bytes()),
         amount,
         bitcoin_block_height: bitcoin_block_height as u32,
-        meta: vec![meta.clone()],
     };
     let checkpoint = {
         let tip = bitcoind_rpc.get_block_count().unwrap();
@@ -166,11 +165,12 @@ pub async fn frost_e2e_stable(
         let hash = bitcoind_rpc.get_block_hash(height).unwrap();
         (bitcoind_rpc.get_block_header(&hash).unwrap(), height as u32)
     };
-    pegin_data
+    meta[0]
         .validate(
             &checkpoint,
             &secp256k1::PublicKey::from_str(gateway_address_response.aggregate_public_key.as_str())
                 .unwrap(),
+            pegin_data
         )
         .expect("pegin data should be valid!");
     it_info_print!("Pegindata successfully validated");
@@ -178,9 +178,9 @@ pub async fn frost_e2e_stable(
     // send the pegin transactions to all fed members
     it_info_print!(
         "Sending pegin tx: block headers=",
-        meta.block_headers().iter().map(|h| h.block_hash()).collect::<Vec<_>>()
+        meta[0].block_headers.iter().map(|h| h.block_hash()).collect::<Vec<_>>()
     );
-    let serialized_pegin_meta = meta.serialize().unwrap();
+    let serialized_pegin_meta = meta[0].serialize().unwrap();
     it_info_print!("Serialized pegin meta: ", hex::encode(serialized_pegin_meta.clone()));
     let mint_contract = mint_contract_instances
         .first()

--- a/bin/test-suite/src/suite/consensus/frost/test_frost_e2e_signing_disconnect.rs
+++ b/bin/test-suite/src/suite/consensus/frost/test_frost_e2e_signing_disconnect.rs
@@ -10,7 +10,7 @@ use ethers::{
 use reth_primitives::{
     botanix::{
         mint_validation::{BURN_TOPIC, MINT_TOPIC},
-        peg_contract::{PeginMeta, PeginMetaV0, PEGIN_META_VERSION_V0},
+        peg_contract::{PeginMeta, PeginMetaTrait, PEGIN_META_VERSION_V0},
         utils::AmountExt,
     },
     Address,
@@ -141,23 +141,23 @@ pub async fn frost_e2e_failed_signing_disconnect(
 
     // create pegin meta
     let bitcoin_block_height = conf_block_info.height;
-    let meta = PeginMeta::V0(PeginMetaV0 {
+    let meta = PeginMeta {
         version: PEGIN_META_VERSION_V0,
         outpoint: bitcoin::OutPoint::new(pegin_tx.compute_txid(), vout as u32),
         address: eth_account,
-        aggregate_publickey: secp256k1::PublicKey::from_str(
+        aggregate_public_key: secp256k1::PublicKey::from_str(
             gateway_address_response.aggregate_public_key.as_str(),
         )
         .expect("valid public key"),
         tx: pegin_tx.clone(),
         merkle_proof: pmt,
         block_headers: headers,
-    });
+    };
 
     // send the pegin transactions to all fed members
     it_info_print!(
         "Sending pegin tx: block headers",
-        meta.block_headers().iter().map(|h| h.block_hash()).collect::<Vec<_>>()
+        meta.block_headers.iter().map(|h| h.block_hash()).collect::<Vec<_>>()
     );
     let serialized_pegin_meta = meta.serialize().unwrap();
     it_info_print!("Serialized pegin meta: ", hex::encode(serialized_pegin_meta.clone()));

--- a/bin/test-suite/src/suite/consensus/invalid_transactions/test_invalid_pegin.rs
+++ b/bin/test-suite/src/suite/consensus/invalid_transactions/test_invalid_pegin.rs
@@ -5,9 +5,7 @@ use bitcoincore_rpc::RpcApi;
 use ethers::{prelude::Provider, providers::Http};
 use reth_primitives::{
     botanix::{
-        peg_contract::{
-            PeginMeta, PeginMetaV0, PeginMetaV1, PEGIN_META_VERSION_V0, PEGIN_META_VERSION_V1,
-        },
+        peg_contract::{PeginMeta, PeginMetaTrait, PeginMetaV1, PEGIN_META_VERSION_V0, PEGIN_META_VERSION_V1},
         utils::AmountExt,
     },
     Address, B256,
@@ -137,18 +135,18 @@ pub async fn invalid_pegin(
 
     // create invalid pegin meta with empty headers list
     let bitcoin_block_height = conf_block_info.height;
-    let meta = PeginMeta::V0(PeginMetaV0 {
+    let meta = PeginMeta {
         version: PEGIN_META_VERSION_V0,
         outpoint: bitcoin::OutPoint::new(pegin_tx.compute_txid(), vout as u32),
         address: eth_account.clone(),
-        aggregate_publickey: secp256k1::PublicKey::from_str(
+        aggregate_public_key: secp256k1::PublicKey::from_str(
             gateway_address_response.aggregate_public_key.as_str(),
         )
         .expect("valid public key"),
         tx: pegin_tx.clone(),
         merkle_proof: pmt,
         block_headers: vec![],
-    });
+    };
 
     // send the pegin transactions to all fed members
     let serialized_pegin_meta = meta.serialize().unwrap();
@@ -211,18 +209,18 @@ pub async fn invalid_pegin(
     let pmt = PartialMerkleTree::from_txids(&[txid], &[true]);
 
     let bitcoin_block_height = conf_block_info.height;
-    let meta = PeginMeta::V0(PeginMetaV0 {
+    let meta = PeginMeta {
         version: PEGIN_META_VERSION_V0,
         outpoint: bitcoin::OutPoint::new(pegin_tx.compute_txid(), vout as u32),
         address: eth_account.clone(),
-        aggregate_publickey: secp256k1::PublicKey::from_str(
+        aggregate_public_key: secp256k1::PublicKey::from_str(
             gateway_address_response.aggregate_public_key.as_str(),
         )
         .expect("valid public key"),
         tx: pegin_tx.clone(),
         merkle_proof: pmt.clone(),
         block_headers: headers.clone(),
-    });
+    };
 
     // send the pegin transactions to all fed members
     let serialized_pegin_meta = meta.serialize().unwrap();
@@ -277,12 +275,12 @@ pub async fn invalid_pegin(
     assert!(nonce_after > nonce_before);
 
     // create invalid pegin meta with invalid reference hash for v1
-    let meta = PeginMeta::V1(PeginMetaV1 {
-        inner: PeginMetaV0 {
+    let meta = PeginMetaV1 {
+        inner: PeginMeta {
             version: PEGIN_META_VERSION_V1,
             outpoint: bitcoin::OutPoint::new(pegin_tx.compute_txid(), vout as u32),
             address: eth_account.clone(),
-            aggregate_publickey: secp256k1::PublicKey::from_str(
+            aggregate_public_key: secp256k1::PublicKey::from_str(
                 gateway_address_response.aggregate_public_key.as_str(),
             )
             .expect("valid public key"),
@@ -291,7 +289,7 @@ pub async fn invalid_pegin(
             block_headers: headers,
         },
         ref_block_hash: B256::from_slice(&[0; 32]),
-    });
+    };
 
     let serialized_pegin_meta = meta.serialize().unwrap();
     let metadata = ethers::core::types::Bytes::from(serialized_pegin_meta.clone());

--- a/crates/botanix-cli/src/main.rs
+++ b/crates/botanix-cli/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use clap::{Parser, Subcommand};
-use reth_primitives::botanix::peg_contract::PeginMeta;
+use reth_primitives::botanix::peg_contract::deserialize_meta;
 
 #[derive(Debug, Parser)]
 #[command(version, about)]
@@ -25,7 +25,7 @@ fn inner_main() -> Result<(), anyhow::Error> {
         App::PeginProof(cmd) => match cmd {
             PeginProof::Inspect { proof } => {
                 let bytes = hex::decode(&proof).context("invalid hex")?;
-                let meta = PeginMeta::deserialize(&bytes).context("invalid proof format")?;
+                let meta = deserialize_meta(&bytes).context("Invalid proof format");
                 println!("{:#?}", meta);
             }
         },
@@ -44,7 +44,6 @@ mod tests {
     use super::*;
     use assert_matches::assert_matches;
     use clap::CommandFactory;
-    use reth_primitives::botanix::peg_contract::PeginMeta;
     use std::{ffi::OsString, str::FromStr};
 
     // Helper function to parse command line arguments

--- a/crates/chain-state/src/notifications.rs
+++ b/crates/chain-state/src/notifications.rs
@@ -4,7 +4,7 @@ use auto_impl::auto_impl;
 use derive_more::{Deref, DerefMut};
 use reth_execution_types::{BlockReceipts, Chain};
 use reth_primitives::{
-    botanix::peg_contract::{PeginMeta, PegoutWithId},
+    botanix::peg_contract::{EssentialPeginData, PegoutWithId},
     SealedBlockWithSenders, SealedHeader,
 };
 use std::{
@@ -77,7 +77,7 @@ pub enum CanonStateNotification {
         /// The newly added chain segment.
         new: Arc<Chain>,
         /// Pegins
-        pegins: Option<Vec<PeginMeta>>,
+        pegins: Option<Vec<EssentialPeginData>>,
         /// Pegouts
         pegouts: Option<Vec<PegoutWithId>>,
     },

--- a/crates/consensus/authority/src/comet_bft/abci.rs
+++ b/crates/consensus/authority/src/comet_bft/abci.rs
@@ -1535,7 +1535,7 @@ where
                         let pegins = sealed_block_with_peg
                             .pegins()
                             .iter()
-                            .flat_map(|p| p.meta.clone())
+                            .flat_map(|(_, meta)| meta.clone())
                             .collect::<Vec<_>>();
                         let pegouts = sealed_block_with_peg.pegouts().to_vec();
 

--- a/crates/consensus/authority/src/frost_task.rs
+++ b/crates/consensus/authority/src/frost_task.rs
@@ -372,7 +372,7 @@ where
 
                         let pegins = pegins
                             .as_ref()
-                            .map_or_else(Vec::new, |pegins| get_utxos_from_pegin_meta(pegins));
+                            .map_or_else(Vec::new, |pegins| get_utxos_from_pegin_meta(pegins.to_vec()));
 
                         // convert pegouts into correct format
                         let pending_pegouts = pegouts.as_ref().map_or_else(Vec::new, |pegouts| {

--- a/crates/consensus/authority/src/utils.rs
+++ b/crates/consensus/authority/src/utils.rs
@@ -17,7 +17,7 @@ use reth_network::{NetworkHandle, NetworkInfo};
 use reth_primitives::{
     botanix::{
         mint_validation::{try_parse_burn_event, BURN_TOPIC, MINT_CONTRACT_ADDRESS, MINT_TOPIC},
-        peg_contract::{PeginMeta, PegoutData, PegoutWithId},
+        peg_contract::{EssentialPeginData, PegoutData, PegoutWithId},
     },
     constants::EPOCH_LENGTH,
     Bloom, BloomInput,
@@ -115,11 +115,11 @@ pub(crate) async fn get_psbt<BtcServerClient: BtcServerExtendedApi + Clone>(
     btc_server.get_psbt(req).await
 }
 
-pub(crate) fn get_utxos_from_pegin_meta(pegins: &[PeginMeta]) -> Vec<Utxo> {
+pub(crate) fn get_utxos_from_pegin_meta(pegins: Vec<EssentialPeginData>) -> Vec<Utxo> {
     if pegins.is_empty() {
         return vec![];
     }
-    pegins.iter().map(utxo_from_pegin_meta).collect()
+    pegins.iter().map(|pegin_meta| utxo_from_pegin_meta(pegin_meta.clone())).collect()
 }
 
 pub(crate) fn get_pending_pegouts_from_pegout_data(
@@ -140,20 +140,21 @@ pub(crate) fn get_pending_pegouts_from_pegout_data(
         .collect::<Vec<_>>()
 }
 
-fn utxo_from_pegin_meta(pegin_meta: &PeginMeta) -> Utxo {
-    let tx_out =
-        pegin_meta.tx().output.get(pegin_meta.outpoint().vout as usize).expect("valid vout");
+fn utxo_from_pegin_meta(pegin_meta: EssentialPeginData) -> Utxo {
+
+    let pegin_tx = pegin_meta.tx;
+    let tx_out = pegin_tx.output.get(pegin_meta.outpoint.vout as usize).expect("valid vout");
     let serialized_script_pub_key = bitcoin::consensus::serialize(&tx_out.script_pubkey);
     Utxo {
         outpoint: Some(client::OutPoint {
-            txid: bitcoin::consensus::serialize(&pegin_meta.outpoint().txid),
-            vout: pegin_meta.outpoint().vout,
+            txid: bitcoin::consensus::serialize(&pegin_meta.outpoint.txid),
+            vout: pegin_meta.outpoint.vout,
         }),
         output: Some(TxOut {
             script_pubkey: Some(ScriptBuf { script: serialized_script_pub_key }),
             value: tx_out.value.to_sat(),
         }),
-        eth_address: hex::encode(pegin_meta.address()),
+        eth_address: hex::encode(pegin_meta.address),
     }
 }
 

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -34,7 +34,7 @@ use reth_primitives::{
         mint_validation::{
             try_parse_burn_event, try_parse_mint_event, MintContractError, MINT_CONTRACT_ADDRESS,
         },
-        peg_contract::{PeginData, PegoutWithId},
+        peg_contract::{EssentialPeginData, PeginData, PeginMeta, PeginMetaV1, PegoutWithId},
     },
     header_ext::HeaderExt,
     Address, BlockNumber, BlockWithSenders, EthereumHardfork, Header, Receipt, Request, TxHash,
@@ -58,6 +58,9 @@ use revm_primitives::{
 use alloc::{boxed::Box, sync::Arc, vec, vec::Vec};
 #[cfg(feature = "std")]
 use std::sync::Arc;
+
+/// Result type for mint contract checks, containing validated pegin and pegout data
+pub type MintContractCheckResult = (Vec<(PeginData, Vec<EssentialPeginData>)>, Vec<PegoutWithId>);
 
 /// Provides executors to execute regular ethereum blocks
 #[derive(Debug, Clone)]
@@ -163,7 +166,7 @@ struct EthExecuteOutput {
     requests: Vec<Request>,
     gas_used: u64,
     total_block_fees: u128,
-    pegins: Vec<PeginData>,
+    pegins: Vec<(PeginData, Vec<EssentialPeginData>)>,
     pegouts: Vec<PegoutWithId>,
 }
 
@@ -237,8 +240,8 @@ where
         let mut receipts = Vec::with_capacity(block.body.len());
 
         for (sender, transaction) in block.transactions_with_sender() {
-            // The sum of the transaction’s gas limit, Tg, and the gas utilized in this block prior,
-            // must be no greater than the block’s gasLimit.
+            // The sum of the transaction's gas limit, Tg, and the gas utilized in this block prior,
+            // must be no greater than the block's gasLimit.
             let block_available_gas = block.header.gas_limit - cumulative_gas_used;
             if transaction.gas_limit() > block_available_gas {
                 return Err(BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas {
@@ -429,7 +432,7 @@ where
         botanix_consensus_pkg: &BotanixConsensusPackage,
         tx_hash: TxHash,
         provider: ProviderFactory<RethDB>,
-    ) -> Result<(Vec<PeginData>, Vec<PegoutWithId>), MintContractError> {
+    ) -> Result<MintContractCheckResult, MintContractError> {
         let consensus_pkg = botanix_consensus_pkg;
         let btc_network = consensus_pkg.btc_network;
 
@@ -437,9 +440,9 @@ where
         let mut pegins = vec![];
         let mut pegouts = vec![];
         for log in result.logs() {
-            let pegin_data = match try_parse_mint_event(log)? {
-                None => continue,
-                Some(p) => p,
+            let (pegin_data, pegin_meta) = match try_parse_mint_event(log)? {
+                (Some(p),Some(m)) => (p, m),
+                _ => continue,
             };
 
             // Get the reference block hash from the pegin metadata.
@@ -447,40 +450,43 @@ where
             // by using a bitcoin checkpoint that is close to the pegin block height.
             // The reference block hash is only provided for version v1.
             let mut bitcoin_checkpoint = consensus_pkg.bitcoin_checkpoint;
-            for meta in pegin_data.clone().meta {
-                match (meta.version(), meta.ref_block_hash()) {
-                    (1, None) => {
+            for meta in &pegin_meta {
+                bitcoin_checkpoint = if meta.as_any().downcast_ref::<PeginMeta>().is_some() {
+                    consensus_pkg.bitcoin_checkpoint
+                } else if let Some(meta_v1) = meta.as_any().downcast_ref::<PeginMetaV1>() {
+                    if let Some(block) = provider
+                        .find_block_by_hash(meta_v1.ref_block_hash, reth_provider::BlockSource::Any)
+                        .map_err(|_| MintContractError::InvalidPeginData {
+                            error: "Reference block hash not found".to_string(),
+                            revert_address: pegin_data.account,
+                            revert_amount: pegin_data.amount,
+                        })? {
+                        let header = block.header;
+                        let package = header
+                            .botanix_consensus_package(
+                                self.bitcoin_network,
+                                self.bitcoind_factory.clone(),
+                            )
+                            .map_err(|_| MintContractError::InvalidPeginData {
+                                error: "Failed to get botanix consensus package".to_string(),
+                                revert_address: pegin_data.account,
+                                revert_amount: pegin_data.amount,
+                            })?;
+                        package.bitcoin_checkpoint
+                    } else {
                         return Err(MintContractError::InvalidPeginData {
-                            error: "Reference block hash cannot be found".to_string(),
+                            error: "Reference block cannot be found".to_string(),
                             revert_address: pegin_data.account,
                             revert_amount: pegin_data.amount,
                         })
                     }
-                    (1, Some(hash)) => {
-                        if let Some(block) = provider
-                            .find_block_by_hash(hash, reth_provider::BlockSource::Any)
-                            .map_err(|_| MintContractError::InvalidPeginData {
-                                error: "Reference block hash not found".to_string(),
-                                revert_address: pegin_data.account,
-                                revert_amount: pegin_data.amount,
-                            })?
-                        {
-                            let header = block.header;
-                            let package = header
-                                .botanix_consensus_package(
-                                    self.bitcoin_network,
-                                    self.bitcoind_factory.clone(),
-                                )
-                                .map_err(|_| MintContractError::InvalidPeginData {
-                                    error: "Failed to get botanix consensus package".to_string(),
-                                    revert_address: pegin_data.account,
-                                    revert_amount: pegin_data.amount,
-                                })?;
-                            bitcoin_checkpoint = package.bitcoin_checkpoint;
-                        }
-                    }
-                    _ => {}
-                }
+                } else {
+                    return Err(MintContractError::InvalidPeginData {
+                        error: "Invalid meta".to_string(),
+                        revert_address: pegin_data.account,
+                        revert_amount: pegin_data.amount,
+                    })
+                };
             }
 
             // the pegin height must be equal or less than the required block depth (checkpoint)
@@ -495,30 +501,37 @@ where
                 });
             }
             let aggregate_public_key = consensus_pkg.aggregate_public_key;
-            match pegin_data.validate(&bitcoin_checkpoint, &aggregate_public_key) {
-                Ok(aggregate_value) => {
-                    if pegin_data.amount >= aggregate_value {
+            let mut aggregate_value = ethers::types::U256::from_str_radix("0", 10).expect("valid amount");
+            let mut pegin_meta_essential = vec![];
+            for meta in &pegin_meta {
+                match meta.validate(&bitcoin_checkpoint, &aggregate_public_key, pegin_data.clone() ) {
+                    Ok(value) => {
+                        aggregate_value += value;
+                    },
+                    Err(e) => {
                         return Err(MintContractError::InvalidPeginData {
-                            error: format!(
-                                "pegin amount should be less than aggregate value: \
-                                    pegin aggregate value: {}; pegin amount: {}",
-                                aggregate_value, pegin_data.amount,
-                            ),
+                            error: format!("pegin validation failed: {}", e),
                             revert_address: pegin_data.account,
                             revert_amount: pegin_data.amount,
                         });
-                    }
+                    },
                 }
-                Err(e) => {
-                    return Err(MintContractError::InvalidPeginData {
-                        error: format!("pegin validation failed: {}", e),
-                        revert_address: pegin_data.account,
-                        revert_amount: pegin_data.amount,
-                    });
-                }
+                pegin_meta_essential.push(meta.to_essential());
+            };
+
+            if pegin_data.amount >= aggregate_value {
+                return Err(MintContractError::InvalidPeginData {
+                    error: format!(
+                        "pegin amount should be less than aggregate value: \
+                            pegin aggregate value: {}; pegin amount: {}",
+                        aggregate_value, pegin_data.amount,
+                    ),
+                    revert_address: pegin_data.account,
+                    revert_amount: pegin_data.amount,
+                });
             }
 
-            pegins.push(pegin_data);
+            pegins.push((pegin_data, pegin_meta_essential));
         }
 
         // Check pegouts

--- a/crates/evm/execution-types/src/execute.rs
+++ b/crates/evm/execution-types/src/execute.rs
@@ -1,5 +1,5 @@
 use reth_primitives::{
-    botanix::peg_contract::{PeginData, PegoutWithId},
+    botanix::peg_contract::{EssentialPeginData, PeginData, PegoutWithId},
     Request, U256,
 };
 use revm::db::BundleState;
@@ -44,7 +44,7 @@ pub struct BlockExecutionOutput<T> {
     /// Total block fees
     pub total_block_fees: u128,
     /// Pegins
-    pub pegins: Vec<PeginData>,
+    pub pegins: Vec<(PeginData, Vec<EssentialPeginData>)>,
     /// Pegouts
     pub pegouts: Vec<PegoutWithId>,
 }

--- a/crates/primitives/src/botanix/block_with_peg.rs
+++ b/crates/primitives/src/botanix/block_with_peg.rs
@@ -1,4 +1,4 @@
-use super::peg_contract::{PeginData, PegoutWithId};
+use super::peg_contract::{EssentialPeginData, PeginData, PegoutWithId};
 use crate::SealedBlockWithSenders;
 
 /// Sealed block with pegin and pegout data
@@ -7,7 +7,7 @@ pub struct SealedBlockWithPeg {
     /// Sealed block with senders
     block: SealedBlockWithSenders,
     /// Pegins
-    pegins: Vec<PeginData>,
+    pegins: Vec<(PeginData, Vec<EssentialPeginData>)>,
     /// Pegouts
     pegouts: Vec<PegoutWithId>,
 }
@@ -16,7 +16,7 @@ impl SealedBlockWithPeg {
     /// Create a new `SealedBlockWithPeg`
     pub const fn new(
         block: SealedBlockWithSenders,
-        pegins: Vec<PeginData>,
+        pegins: Vec<(PeginData, Vec<EssentialPeginData>)>,
         pegouts: Vec<PegoutWithId>,
     ) -> Self {
         Self { block, pegins, pegouts }
@@ -28,7 +28,7 @@ impl SealedBlockWithPeg {
     }
 
     /// Pegins
-    pub fn pegins(&self) -> &[PeginData] {
+    pub fn pegins(&self) -> &[(PeginData, Vec<EssentialPeginData>)] {
         self.pegins.as_slice()
     }
 

--- a/crates/primitives/src/botanix/mint_validation.rs
+++ b/crates/primitives/src/botanix/mint_validation.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 
 use crate::{
     botanix::{
-        peg_contract::{PeginData, PeginDataError, PeginMeta, PegoutData, PegoutDataError},
+        peg_contract::{PeginData, PeginDataError, PegoutData, PegoutDataError, PeginMetaTrait, deserialize_meta},
         utils::AmountExt,
     },
     keccak256, Address, B256,
@@ -22,6 +22,9 @@ lazy_static::lazy_static! {
     /// address of the mint contract
     pub static ref MINT_CONTRACT_ADDRESS: Address = Address::from_str("0x0Ea320990B44236A0cEd0ecC0Fd2b2df33071e78").unwrap();
 }
+
+/// Data returned from a mint event, containing optional pegin data and metadata
+pub type MintEventData = (Option<PeginData>, Option<Vec<Box<dyn PeginMetaTrait>>>);
 
 /// Two types of events that can be emitted by the mint contract.
 #[derive(Debug)]
@@ -138,21 +141,21 @@ fn topic_to_address(t: B256) -> Option<Address> {
 /// returns [Ok(None)] if it's not a [Mint] event.
 pub fn try_parse_mint_event(
     log: &revm_primitives::Log,
-) -> Result<Option<PeginData>, ParseMintEventError> {
+) -> Result<MintEventData, ParseMintEventError> {
     if log.address != *MINT_CONTRACT_ADDRESS {
         info!("Log address is not mint contract address");
-        return Ok(None);
+        return Ok((None, None));
     }
 
     let topics = log.topics();
     if topics.is_empty() {
         // NB I don't think this is possible but just be safe.
         info!("Log has no topics");
-        return Ok(None);
+        return Ok((None, None));
     }
     if topics[0] != *MINT_TOPIC {
         info!("Log topic is not mint topic");
-        return Ok(None);
+        return Ok((None, None));
     }
 
     // So we have a mint event
@@ -197,23 +200,21 @@ pub fn try_parse_mint_event(
         let mut proofs = Vec::new();
         let mut offset = 0;
         while offset < meta_bytes.len() {
-            let (proof, proof_size) =
-                PeginMeta::deserialize(&meta_bytes[offset..]).map_err(|e| {
-                    let err = ParseMintEventError::InvalidPeginData {
-                        error: e,
-                        revert_address: destination,
-                        revert_amount: amount,
-                    };
-                    error!("Failed to parse pegin meta: {:?}", err);
-                    err
-                })?;
+            let (proof, proof_size) = deserialize_meta(&meta_bytes[offset..]).map_err(|e| {
+                ParseMintEventError::InvalidPeginData {
+                    error: e,
+                    revert_address: destination,
+                    revert_amount: amount,
+                }
+            })?;
+                
             proofs.push(proof);
             offset += proof_size;
         }
         proofs
     };
 
-    Ok(Some(PeginData { account: destination, amount, bitcoin_block_height, meta }))
+    Ok((Some(PeginData { account: destination, amount, bitcoin_block_height}), Some(meta)))
 }
 
 /// Parse the given log for a [Burn] event.
@@ -291,6 +292,7 @@ mod test {
     use revm_primitives::{hex, Bytes, Log, LogData};
 
     use super::*;
+    use crate::botanix::peg_contract::deserialize_meta;
 
     #[test]
     fn mint_topic() {
@@ -330,7 +332,7 @@ mod test {
         assert_eq!(nonce, 1000u64);
 
         let meta_bytes = decoded_params.get(2).unwrap().clone().into_bytes().unwrap();
-        let meta = PeginMeta::deserialize(meta_bytes.as_slice());
+        let meta = deserialize_meta(meta_bytes.as_slice());
         assert!(meta.is_ok());
     }
 

--- a/crates/primitives/src/botanix/peg_contract.rs
+++ b/crates/primitives/src/botanix/peg_contract.rs
@@ -1,3 +1,4 @@
+use core::fmt::Debug;
 use std::str::FromStr;
 
 use crate::{botanix::utils::AmountExt, Address};
@@ -10,7 +11,6 @@ use bitcoin::{
     },
     constants::COINBASE_MATURITY,
     merkle_tree::PartialMerkleTree,
-    TxOut,
 };
 use btcserverlib::{
     pegout_id::PegoutId,
@@ -37,119 +37,109 @@ pub struct PeginData {
     pub amount: U256,
     /// Bitcoin block height the pegin is confirmed in
     pub bitcoin_block_height: u32,
-    /// Pegin metadata
-    pub meta: Vec<PeginMeta>,
 }
 
-impl PeginData {
-    /// Validates multiple pegin proofs against the current bitcoin block hash
-    /// Returns the aggregate value of all the pegin amounts
-    pub fn validate(
-        &self,
-        bitcoin_commitment: &(bitcoin::block::Header, u32),
-        aggregate_pk: &secp256k1::PublicKey,
-    ) -> Result<U256, PeginDataError> {
-        // the aggregate value from all the pegin proofs
-        let mut aggregate_value = U256::from_str_radix("0", 10).expect("valid amount");
-        let commit_hash = bitcoin_commitment.0.block_hash();
-        for pegin in &self.meta {
-            let pegin = match pegin {
-                PeginMeta::V0(meta) => {
-                    if meta.version != PEGIN_META_VERSION_V0 {
-                        return Err(PeginDataError::Invalid(
-                            "invalid meta version: only accepting version 0",
-                        ));
-                    }
-                    meta
-                }
-                PeginMeta::V1(meta) => {
-                    if meta.inner.version != PEGIN_META_VERSION_V1 {
-                        return Err(PeginDataError::Invalid(
-                            "invalid meta version: only accepting version 1",
-                        ));
-                    }
-                    &meta.inner
-                }
+/// Deserializes pegin metadata from bytes
+/// 
+/// Returns a boxed trait object implementing `PeginMetaTrait` and the number of bytes consumed
+pub fn deserialize_meta(mut bytes: &[u8]) -> Result<(Box<dyn PeginMetaTrait>, usize), PeginDataError> {
+    let proofs_size = bytes.len();
+    let meta = PeginMeta {
+        version: <u32>::consensus_decode(&mut bytes)?,
+        outpoint: Decodable::consensus_decode(&mut bytes)?,
+        address: {
+            let mut address_slice = [0u8; 20];
+            bytes.read_slice(&mut address_slice)?;
+            Address::from_slice(&address_slice)
+        },
+        aggregate_public_key: {
+            // compressed schnorr public key
+            let mut pk_bytes = [0u8; 33];
+            bytes.read_slice(&mut pk_bytes)?;
+            PublicKey::from_slice(&pk_bytes).map_err(PeginDataError::InvalidPublicKey)?
+        },
+        block_headers: {
+            let len = btcencode::VarInt::consensus_decode(&mut bytes)?.0;
+            let mut ret = Vec::with_capacity(len as usize);
+            for _ in 0..len {
+                ret.push(Decodable::consensus_decode(&mut bytes)?);
+            }
+
+            ret
+        },
+        merkle_proof: PartialMerkleTree::consensus_decode(&mut bytes)?,
+        tx: Decodable::consensus_decode(&mut bytes)?,
+    };
+    match meta.version {
+        PEGIN_META_VERSION_V0 => Ok((Box::new(meta) as Box<dyn PeginMetaTrait>, proofs_size - bytes.len())),
+        PEGIN_META_VERSION_V1 => {
+            let meta_v1 = PeginMetaV1 {
+                inner: meta,
+                ref_block_hash: {
+                    let mut hash = [0u8; 32];
+                    bytes.read_slice(&mut hash)?;
+                    B256::from_slice(&hash)
+                },
             };
-
-            // pegin block headers list should contain the commitment header
-            if !pegin.block_headers.iter().any(|h| h.block_hash() == commit_hash) {
-                return Err(PeginDataError::Invalid("recent block hash mismatch"));
-            }
-
-            // Then let's validate the merkle proof.
-            let merkle = &pegin.merkle_proof;
-            let mut txids = Vec::with_capacity(1);
-            let mut idxs = Vec::with_capacity(1);
-            let root = merkle.extract_matches(&mut txids, &mut idxs).unwrap();
-            if !txids.contains(&pegin.outpoint.txid) {
-                return Err(PeginDataError::Invalid("invalid merkle proof: inclusion"));
-            }
-            // And check that the merkle proof is indeed for the first header provided.
-            if pegin.block_headers[0].merkle_root != root {
-                return Err(PeginDataError::Invalid("merkle proof and block header mismatch"));
-            }
-
-            // then check that the merkle proof was indeed for the pegin tx
-            if pegin.tx.compute_txid() != pegin.outpoint.txid {
-                return Err(PeginDataError::Invalid("invalid tx or outpoint: txid"));
-            }
-            if pegin.tx.output.len() < pegin.outpoint.vout as usize {
-                return Err(PeginDataError::Invalid("invalid tx or outpoint: output idx"));
-            }
-
-            let encoded_pk = aggregate_pk.serialize();
-            let vk = frost::VerifyingKey::deserialize(&encoded_pk)
-                .map_err(PeginDataError::FrostError)?;
-            let tpk = generate_tweaked_public_key(&vk, &self.account.into())
-                .map_err(|_e| PeginDataError::InvalidTweak())?;
-            let gateway_script = generate_taproot_scriptpubkey(&tpk);
-
-            let output = &pegin.tx.output[pegin.outpoint.vout as usize];
-            if gateway_script != output.script_pubkey {
-                return Err(PeginDataError::Invalid("invalid script pubkey"));
-            }
-
-            let output_value = bitcoin::Amount::from_sat(output.value.to_sat()).to_wei();
-            aggregate_value += output_value;
-
-            // check that the user provided an actual valid block header sequence
-            let mut iter = pegin.block_headers.iter().peekable();
-            while let Some(header) = iter.next() {
-                if let Some(next) = iter.peek() {
-                    if next.prev_blockhash != header.block_hash() {
-                        return Err(PeginDataError::Invalid("invalid block header sequence"));
-                    }
-                }
-            }
-
-            // calculate pegin txs block depth
-            let diff = pegin
-                .block_headers
-                .iter()
-                .rev()
-                .skip_while(|h| h.block_hash() != commit_hash)
-                .count() -
-                1; // minus one for the commitment itself
-                   // the latest block height minus the position of the user block in the list is the
-                   // height of the user block
-            if bitcoin_commitment.1 - (diff as u32) != self.bitcoin_block_height {
-                return Err(PeginDataError::InvalidBitcoinBlockHeight);
-            }
-
-            // If any of the inputs are coinbase and the tx is not coinbase, return an error
-            if pegin.tx.is_coinbase() && (diff as u32) < COINBASE_MATURITY {
-                return Err(PeginDataError::Invalid("spending non-mature coinbase"));
-            }
-        }
-
-        Ok(aggregate_value)
+            Ok((Box::new(meta_v1) as Box<dyn PeginMetaTrait>, proofs_size - bytes.len()))
+        },
+        _ => {
+            Err(PeginDataError::Invalid("Invalid meta format"))
+        },
     }
 }
 
+/// Trait for handling pegin metadata operations including serialization,
+/// deserialization, and validation of Bitcoin pegins.
+pub trait PeginMetaTrait: Debug + 'static + Send + Sync {
+    /// Serialize a pegin meta
+    fn serialize(&self) -> Result<Vec<u8>, PeginDataError>;
+
+    /// Validates a pegin proof against the current bitcoin block hash
+    /// Returns the value of the pegin
+    fn validate(
+        &self,
+        bitcoin_commitment: &(bitcoin::block::Header, u32),
+        aggregate_pk: &secp256k1::PublicKey,
+        pegin_data: PeginData,
+    ) -> Result<U256, PeginDataError>;
+
+    /// Converts the complete pegin metadata to a minimal essential representation
+    /// containing only the data needed for transaction records
+    fn to_essential(&self) -> EssentialPeginData;
+
+    /// For equality comparison - returns true if self equals other
+    fn clone_box(&self) -> Box<dyn PeginMetaTrait>;
+
+    /// For equality comparison
+    fn equals(&self, other: &dyn PeginMetaTrait) -> bool;
+    
+    /// Type tag for type identification (simple integer instead of `TypeId`)
+    fn type_tag(&self) -> u32;
+
+    /// Returns a reference to the trait object as a type-erased `&dyn Any`
+    /// This allows for downcasting to concrete types with `downcast_ref`
+    fn as_any(&self) -> &dyn std::any::Any;
+}
+
+impl Clone for Box<dyn PeginMetaTrait> {
+    fn clone(&self) -> Self {
+        self.clone_box()
+    }
+}
+
+impl PartialEq for Box<dyn PeginMetaTrait> {
+    fn eq(&self, other: &Self) -> bool {
+        // Objects are equal if they have the same type tag and the equals method returns true
+        self.type_tag() == other.type_tag() && self.equals(other.as_ref())
+    }
+}
+
+impl Eq for Box<dyn PeginMetaTrait> {}
+
 /// Pegin metadata structure
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PeginMetaV0 {
+pub struct PeginMeta {
     /// Version of the pegin metadata
     pub version: u32,
     /// Merkle proof for the pegin tx
@@ -159,7 +149,7 @@ pub struct PeginMetaV0 {
     /// final destination address of the pegin
     pub address: Address,
     /// Aggregate public key the funds were sent to
-    pub aggregate_publickey: secp256k1::PublicKey,
+    pub aggregate_public_key: secp256k1::PublicKey,
     /// Bitcoin block headers starting with the block the pegin is confirmed in,
     /// going up until at least the mainchain commitment or beyond.
     /// NB We need to allow to go beyond because between the user crafting the tx and
@@ -169,14 +159,13 @@ pub struct PeginMetaV0 {
     pub tx: bitcoin::Transaction,
 }
 
-impl PeginMetaV0 {
-    /// Serialize a pegin meta
-    pub fn serialize(&self) -> Result<Vec<u8>, PeginDataError> {
+impl PeginMetaTrait for PeginMeta {
+    fn serialize(&self) -> Result<Vec<u8>, PeginDataError> {
         let mut bytes = Vec::new();
         self.version.consensus_encode(&mut bytes)?;
         self.outpoint.consensus_encode(&mut bytes)?;
         bytes.extend_from_slice(self.address.0.as_slice());
-        bytes.extend_from_slice(&self.aggregate_publickey.serialize());
+        bytes.extend_from_slice(&self.aggregate_public_key.serialize());
         btcencode::VarInt(self.block_headers.len() as u64).consensus_encode(&mut bytes)?;
         for header in &self.block_headers {
             header.consensus_encode(&mut bytes)?;
@@ -187,48 +176,127 @@ impl PeginMetaV0 {
         Ok(bytes)
     }
 
-    /// Deserialize a pegin meta
-    pub fn deserialize(mut bytes: &[u8]) -> Result<(Self, usize), PeginDataError> {
-        // bytes is a list of proofs
-        let proofs_size = bytes.len();
-        Ok((
-            Self {
-                version: <u32>::consensus_decode(&mut bytes)?,
-                outpoint: Decodable::consensus_decode(&mut bytes)?,
-                address: {
-                    let mut address_slice = [0u8; 20];
-                    bytes.read_slice(&mut address_slice)?;
-                    Address::from_slice(&address_slice)
-                },
-                aggregate_publickey: {
-                    // compressed schnorr public key
-                    let mut pk_bytes = [0u8; 33];
-                    bytes.read_slice(&mut pk_bytes)?;
-                    PublicKey::from_slice(&pk_bytes).map_err(PeginDataError::InvalidPublicKey)?
-                },
-                block_headers: {
-                    let len = btcencode::VarInt::consensus_decode(&mut bytes)?.0;
-                    let mut ret = Vec::with_capacity(len as usize);
-                    for _ in 0..len {
-                        ret.push(Decodable::consensus_decode(&mut bytes)?);
-                    }
+    fn validate(
+        &self,
+        bitcoin_commitment: &(bitcoin::block::Header, u32),
+        aggregate_pk: &secp256k1::PublicKey,
+        pegin_data: PeginData,
+    ) -> Result<U256, PeginDataError> {
+        let commit_hash = bitcoin_commitment.0.block_hash();
 
-                    ret
-                },
-                merkle_proof: PartialMerkleTree::consensus_decode(&mut bytes)?,
-                tx: Decodable::consensus_decode(&mut bytes)?,
-            },
-            // list of proofs size - bytes left = proof size
-            proofs_size - bytes.len(),
-        ))
+        // pegin block headers list should contain the commitment header
+        if !&self.block_headers.iter().any(|h| h.block_hash() == commit_hash) {
+            return Err(PeginDataError::Invalid("recent block hash mismatch"));
+        }
+
+        // Then let's validate the merkle proof.
+        let merkle = &self.merkle_proof;
+        let mut txids = Vec::with_capacity(1);
+        let mut idxs = Vec::with_capacity(1);
+        let root = merkle.extract_matches(&mut txids, &mut idxs).unwrap();
+        if !txids.contains(&self.outpoint.txid) {
+            return Err(PeginDataError::Invalid("invalid merkle proof: inclusion"));
+        }
+
+        // And check that the merkle proof is indeed for the first header provided.
+        if self.block_headers[0].merkle_root != root {
+            return Err(PeginDataError::Invalid("merkle proof and block header mismatch"));
+        }
+
+        // then check that the merkle proof was indeed for the pegin tx
+        if self.tx.compute_txid() != self.outpoint.txid {
+            return Err(PeginDataError::Invalid("invalid tx or outpoint: txid"));
+        }
+
+        if self.tx.output.len() < self.outpoint.vout as usize {
+            return Err(PeginDataError::Invalid("invalid tx or outpoint: output idx"));
+        }
+
+        let encoded_pk = aggregate_pk.serialize();
+        let vk = frost::VerifyingKey::deserialize(&encoded_pk)
+            .map_err(PeginDataError::FrostError)?;
+        let tpk = generate_tweaked_public_key(&vk, &pegin_data.account.into())
+            .map_err(|_e| PeginDataError::InvalidTweak())?;
+        let gateway_script = generate_taproot_scriptpubkey(&tpk);
+
+        let output = &self.tx.output[self.outpoint.vout as usize];
+        if gateway_script != output.script_pubkey {
+            return Err(PeginDataError::Invalid("invalid script pubkey"));
+        }
+
+        let output_value = bitcoin::Amount::from_sat(output.value.to_sat()).to_wei();
+
+        // check that the user provided an actual valid block header sequence
+        let headers = &self.block_headers;
+        let mut iter = headers.iter().peekable();
+        while let Some(header) = iter.next() {
+            if let Some(next) = iter.peek() {
+                if next.prev_blockhash != header.block_hash() {
+                    return Err(PeginDataError::Invalid("invalid block header sequence"));
+                }
+            }
+        }
+
+        // calculate pegin txs block depth
+        let diff = self
+            .block_headers
+            .iter()
+            .rev()
+            .skip_while(|h| h.block_hash() != commit_hash)
+            .count() -
+            1; // minus one for the commitment itself
+            // the latest block height minus the position of the user block in the list is the
+            // height of the user block
+        if bitcoin_commitment.1 - (diff as u32) != pegin_data.bitcoin_block_height {
+            return Err(PeginDataError::InvalidBitcoinBlockHeight);
+        }
+
+        // If any of the inputs are coinbase and the tx is not coinbase, return an error
+        if self.tx.is_coinbase() && (diff as u32) < COINBASE_MATURITY {
+            return Err(PeginDataError::Invalid("spending non-mature coinbase"));
+        }
+
+        Ok(output_value)
     }
 
-    /// Get the txout for the pegin
-    pub fn txout(&self) -> &TxOut {
-        self.tx
-            .output
-            .get(self.outpoint.vout as usize)
-            .expect("we check on creation that vout exists")
+    fn to_essential(&self) -> EssentialPeginData {
+        EssentialPeginData {
+            outpoint: self.outpoint,
+            address: self.address,
+            tx: self.tx.clone(),
+        }
+    }
+
+    fn clone_box(&self) -> Box<dyn PeginMetaTrait> {
+        Box::new(self.clone())
+    }
+
+    fn equals(&self, other: &dyn PeginMetaTrait) -> bool {
+        // Only compare if the other object has the same type tag
+        if other.type_tag() != self.type_tag() {
+            return false;
+        }
+
+        if let Some(other) = other.as_any().downcast_ref::<Self>() {
+            self.version == other.version &&
+            self.address == other.address &&
+            self.aggregate_public_key == other.aggregate_public_key &&
+            self.merkle_proof == other.merkle_proof &&
+            self.block_headers == other.block_headers &&
+            self.tx == other.tx &&
+            self.outpoint == other.outpoint
+        } else {
+            false
+        }
+    }
+    
+    fn type_tag(&self) -> u32 {
+        // A unique identifier for this type
+        PEGIN_META_VERSION_V0
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
 }
 
@@ -236,148 +304,72 @@ impl PeginMetaV0 {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PeginMetaV1 {
     /// Inner V0 pegin metadata
-    pub inner: PeginMetaV0,
+    pub inner: PeginMeta,
     /// Reference block hash
     pub ref_block_hash: B256,
 }
 
-impl PeginMetaV1 {
-    /// Serialize a pegin meta
-    pub fn serialize(&self) -> Result<Vec<u8>, PeginDataError> {
+impl PeginMetaTrait for PeginMetaV1 {
+    fn serialize(&self) -> Result<Vec<u8>, PeginDataError> {
         let mut bytes = self.inner.serialize()?;
         self.ref_block_hash.consensus_encode(&mut bytes)?;
         Ok(bytes)
     }
 
-    /// Deserialize a pegin meta
-    pub fn deserialize(mut bytes: &[u8]) -> Result<(Self, usize), PeginDataError> {
-        // bytes is a list of proofs
-        let proofs_size = bytes.len();
-        let (inner, inner_size) = PeginMetaV0::deserialize(bytes)?;
-        bytes = &bytes[inner_size..];
-
-        let ref_block_hash = {
-            let mut hash = [0u8; 32];
-            bytes.read_slice(&mut hash)?;
-            B256::from_slice(&hash)
-        };
-        Ok((Self { inner, ref_block_hash }, proofs_size - bytes.len()))
+    fn validate(
+        &self,
+        bitcoin_commitment: &(bitcoin::block::Header, u32),
+        aggregate_pk: &secp256k1::PublicKey,
+        pegin_data: PeginData,
+    ) -> Result<U256, PeginDataError> {
+        self.inner.validate(bitcoin_commitment, aggregate_pk, pegin_data)
     }
 
-    /// Get the txout for the pegin
-    pub fn txout(&self) -> &TxOut {
-        self.inner.txout()
+    fn to_essential(&self) -> EssentialPeginData {
+        EssentialPeginData {
+            outpoint: self.inner.outpoint,
+            address: self.inner.address,
+            tx: self.inner.tx.clone(),
+        }
+    }
+
+    fn clone_box(&self) -> Box<dyn PeginMetaTrait> {
+        Box::new(self.clone())
+    }
+
+    fn equals(&self, other: &dyn PeginMetaTrait) -> bool {
+        // Only compare if the other object has the same type tag
+        if other.type_tag() != self.type_tag() {
+            return false;
+        }
+
+        if let Some(other) = other.as_any().downcast_ref::<Self>() {
+            self.inner.equals(&other.inner) &&
+            self.ref_block_hash == other.ref_block_hash
+        } else {
+            false
+        }
+    }
+    
+    fn type_tag(&self) -> u32 {
+        // A unique identifier for this type
+        PEGIN_META_VERSION_V1
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
 }
 
-/// Pegin metadata enum that can hold different versions of pegin metadata
+/// Essential pegin data
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum PeginMeta {
-    /// Version 0 of pegin metadata
-    V0(PeginMetaV0),
-    /// Version 1 of pegin metadata with reference block hash
-    V1(PeginMetaV1),
-}
-
-impl PeginMeta {
-    /// Serialize the pegin metadata to bytes
-    pub fn serialize(&self) -> Result<Vec<u8>, PeginDataError> {
-        match self {
-            Self::V0(meta) => meta.serialize(),
-            Self::V1(meta) => meta.serialize(),
-        }
-    }
-
-    /// Deserialize bytes into pegin metadata
-    pub fn deserialize(bytes: &[u8]) -> Result<(Self, usize), PeginDataError> {
-        // Read the version first
-        let mut bytes_clone = bytes;
-        let version = u32::consensus_decode(&mut bytes_clone)?;
-
-        match version {
-            PEGIN_META_VERSION_V0 => {
-                let (meta, size) = PeginMetaV0::deserialize(bytes)?;
-                Ok((Self::V0(meta), size))
-            }
-            PEGIN_META_VERSION_V1 => {
-                let (meta, size) = PeginMetaV1::deserialize(bytes)?;
-                Ok((Self::V1(meta), size))
-            }
-            _ => Err(PeginDataError::Invalid("Invalid pegin meta version")),
-        }
-    }
-
-    /// Get the version of the pegin metadata
-    pub const fn version(&self) -> u32 {
-        match self {
-            Self::V0(meta) => meta.version,
-            Self::V1(meta) => meta.inner.version,
-        }
-    }
-
-    /// Get the merkle proof from the pegin metadata
-    pub const fn merkle_proof(&self) -> &PartialMerkleTree {
-        match self {
-            Self::V0(meta) => &meta.merkle_proof,
-            Self::V1(meta) => &meta.inner.merkle_proof,
-        }
-    }
-
-    /// Get the outpoint from the pegin metadata
-    pub const fn outpoint(&self) -> &bitcoin::OutPoint {
-        match self {
-            Self::V0(meta) => &meta.outpoint,
-            Self::V1(meta) => &meta.inner.outpoint,
-        }
-    }
-
-    /// Get the address from the pegin metadata
-    pub const fn address(&self) -> Address {
-        match self {
-            Self::V0(meta) => meta.address,
-            Self::V1(meta) => meta.inner.address,
-        }
-    }
-
-    /// Get the aggregate public key from the pegin metadata
-    pub const fn aggregate_publickey(&self) -> secp256k1::PublicKey {
-        match self {
-            Self::V0(meta) => meta.aggregate_publickey,
-            Self::V1(meta) => meta.inner.aggregate_publickey,
-        }
-    }
-
-    /// Get the block headers from the pegin metadata
-    pub const fn block_headers(&self) -> &Vec<Header> {
-        match self {
-            Self::V0(meta) => &meta.block_headers,
-            Self::V1(meta) => &meta.inner.block_headers,
-        }
-    }
-
-    /// Get the transaction from the pegin metadata
-    pub const fn tx(&self) -> &bitcoin::Transaction {
-        match self {
-            Self::V0(meta) => &meta.tx,
-            Self::V1(meta) => &meta.inner.tx,
-        }
-    }
-
-    /// Get the reference block hash from the pegin metadata (V1 only)
-    pub const fn ref_block_hash(&self) -> Option<B256> {
-        match self {
-            Self::V0(_) => None,
-            Self::V1(meta) => Some(meta.ref_block_hash),
-        }
-    }
-
-    /// Get the transaction output from the pegin metadata
-    pub fn txout(&self) -> &TxOut {
-        match self {
-            Self::V0(meta) => meta.txout(),
-            Self::V1(meta) => meta.inner.txout(),
-        }
-    }
+pub struct EssentialPeginData {
+    /// Outpoint of the pegin transaction
+    pub outpoint: bitcoin::OutPoint,
+    /// The complete pegin transaction
+    pub tx: bitcoin::Transaction,
+    /// Destination address for the pegin
+    pub address: Address,
 }
 
 /// Error type for pegin data
@@ -477,14 +469,14 @@ mod tests {
     use revm_primitives::hex;
     use secp256k1::PublicKey;
 
-    fn create_test_pegin_meta_v0() -> PeginMetaV0 {
+    fn create_test_pegin_meta() -> PeginMeta {
         let txid = Txid::all_zeros();
-        PeginMetaV0 {
+        PeginMeta {
             version: PEGIN_META_VERSION_V0,
             merkle_proof: PartialMerkleTree::from_txids(&[txid], &[true]),
             outpoint: OutPoint { txid, vout: 0 },
             address: Address::from_str("0xa65812bac44dadb79c3e4930dbd98d5a75376b2a").unwrap(),
-            aggregate_publickey: PublicKey::from_str(
+            aggregate_public_key: PublicKey::from_str(
                 "0376698beebe8ee5c74d8cc50ab84ac301ee8f10af6f28d0ffd6adf4d6d3b9b762",
             )
             .unwrap(),
@@ -514,21 +506,25 @@ mod tests {
     }
 
     fn create_test_pegin_meta_v1() -> PeginMetaV1 {
-        let inner = create_test_pegin_meta_v0();
-
-        PeginMetaV1 { inner, ref_block_hash: B256::from_slice(&[0; 32]) }
+        let inner = create_test_pegin_meta();
+        
+        PeginMetaV1 {
+            inner,
+            ref_block_hash: B256::from_slice(&[0; 32]),
+        }
     }
 
     #[test]
     fn serialize_pegin_metadata_v0() {
-        let pegin_metadata = create_test_pegin_meta_v0();
+        let pegin_metadata = create_test_pegin_meta();
 
         let serialized = pegin_metadata.serialize().unwrap();
-        let (deserialized, size) = PeginMetaV0::deserialize(&serialized).unwrap();
+        let (deserialized, size) = deserialize_meta(&serialized).unwrap();
+        let deserialized = deserialized.as_any().downcast_ref::<PeginMeta>().unwrap();
         assert_eq!(pegin_metadata.version, deserialized.version);
         assert_eq!(pegin_metadata.outpoint, deserialized.outpoint);
         assert_eq!(pegin_metadata.address, deserialized.address);
-        assert_eq!(pegin_metadata.aggregate_publickey, deserialized.aggregate_publickey);
+        assert_eq!(pegin_metadata.aggregate_public_key, deserialized.aggregate_public_key);
         assert_eq!(pegin_metadata.block_headers.len(), deserialized.block_headers.len());
         assert_eq!(pegin_metadata.tx, deserialized.tx);
         assert_eq!(
@@ -542,13 +538,14 @@ mod tests {
     fn serialize_pegin_metadata_v1() {
         let pegin_metadata = create_test_pegin_meta_v1();
         let serialized = pegin_metadata.serialize().unwrap();
-        let (deserialized, size) = PeginMetaV1::deserialize(&serialized).unwrap();
+        let (deserialized, size) = deserialize_meta(&serialized).unwrap();
+        let deserialized = deserialized.as_any().downcast_ref::<PeginMetaV1>().unwrap();
         assert_eq!(pegin_metadata.inner.version, deserialized.inner.version);
         assert_eq!(pegin_metadata.inner.outpoint, deserialized.inner.outpoint);
         assert_eq!(pegin_metadata.inner.address, deserialized.inner.address);
         assert_eq!(
-            pegin_metadata.inner.aggregate_publickey,
-            deserialized.inner.aggregate_publickey
+            pegin_metadata.inner.aggregate_public_key,
+            deserialized.inner.aggregate_public_key
         );
         assert_eq!(
             pegin_metadata.inner.block_headers.len(),
@@ -567,7 +564,8 @@ mod tests {
     fn deserialize_pegin_metadata_v0() {
         // Proof generated by side-car service
         let pegin_metadata_vec = hex::decode("000000002e5523bcd1b329e8a1a66b7d31719e94a33483eae77f5a677e6634d84ce55f470000000014194f42f33a9b3d5fe9e7ba8501be24d00b07b50376698beebe8ee5c74d8cc50ab84ac301ee8f10af6f28d0ffd6adf4d6d3b9b762010080732aa97865f6b4be36ba861d397401e956d23e129940bb8a03000000000000000000b0d5ec7a0f49793b896db8f4a2cb4ec37e6b2dbd8e90e23d23f860abc9a76b70f1d2ba6494380517307685f90e00000005ce88336dc1340fed95a5f334a536b459d9af3aa3f44eb7b64de3a75e01812f021403c7f4a599f74775069cd3e3e589456fd672037ee1c2c9570f6776fb2e864a3e06d4e3858fdfa9f987053290aac66ef9b7c28fcaf3d3d64724d65a5fc11a2365557cde0d0e465dbfa1f2730617416133b2347ca5170fc1c0dd86f019356acf331d671f862a2841476864ef8639511b9e6f29c25b3c150680b626f9c185be81022f000100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000").unwrap();
-        let (meta, size) = PeginMetaV0::deserialize(pegin_metadata_vec.as_slice()).unwrap();
+        let (meta, size) = deserialize_meta(pegin_metadata_vec.as_slice()).unwrap();
+        let meta = meta.as_any().downcast_ref::<PeginMeta>().unwrap();
         println!("meta {:?}", meta);
         println!("meta usize {:?}", size);
         assert_eq!(meta.version, PEGIN_META_VERSION_V0);
@@ -577,7 +575,7 @@ mod tests {
             hex::decode("14194f42f33a9b3d5fe9e7ba8501be24d00b07b5").unwrap()
         );
         assert_eq!(
-            meta.aggregate_publickey,
+            meta.aggregate_public_key,
             PublicKey::from_str(
                 "0376698beebe8ee5c74d8cc50ab84ac301ee8f10af6f28d0ffd6adf4d6d3b9b762"
             )
@@ -595,7 +593,8 @@ mod tests {
         // Add ref_block_hash (32 bytes of zeros) to the end
         pegin_metadata_vec.extend_from_slice(&[0; 32]);
 
-        let (meta, size) = PeginMetaV1::deserialize(pegin_metadata_vec.as_slice()).unwrap();
+        let (meta, size) = deserialize_meta(pegin_metadata_vec.as_slice()).unwrap();
+        let meta = meta.as_any().downcast_ref::<PeginMetaV1>().unwrap();
         println!("meta {:?}", meta);
         println!("meta usize {:?}", size);
 
@@ -606,7 +605,7 @@ mod tests {
             hex::decode("14194f42f33a9b3d5fe9e7ba8501be24d00b07b5").unwrap()
         );
         assert_eq!(
-            meta.inner.aggregate_publickey,
+            meta.inner.aggregate_public_key,
             PublicKey::from_str(
                 "0376698beebe8ee5c74d8cc50ab84ac301ee8f10af6f28d0ffd6adf4d6d3b9b762"
             )
@@ -698,17 +697,17 @@ mod tests {
         version: Option<u32>,
         block_headers: Option<Vec<Header>>,
         pk: &secp256k1::PublicKey,
-    ) -> PeginData {
+    ) -> (PeginData, Vec<PeginMeta>) {
         let header_metadata = create_header_metadata(None, pk);
         let destination_address =
             Address::from_str("0xa65812bac44dadb79c3e4930dbd98d5a75376b2a").unwrap();
 
-        let meta = PeginMetaV0 {
+        let meta = PeginMeta {
             version: version.unwrap_or_default(),
             merkle_proof: header_metadata.merkle_proof,
             outpoint: header_metadata.outpoint,
             address: destination_address,
-            aggregate_publickey: *pk,
+            aggregate_public_key: *pk,
             block_headers: if let Some(block_headers) = block_headers {
                 block_headers
             } else {
@@ -717,13 +716,15 @@ mod tests {
             tx: header_metadata.tx,
         };
 
-        PeginData {
-            account: destination_address,
-            // 100 sats converted to wei
-            amount: U256::from_str_radix("1000000000000", 10).unwrap(),
-            bitcoin_block_height: 1_u32,
-            meta: vec![PeginMeta::V0(meta)],
-        }
+        (
+            PeginData {
+                account: destination_address,
+                // 100 sats converted to wei
+                amount: U256::from_str_radix("1000000000000", 10).unwrap(),
+                bitcoin_block_height: 1_u32,
+            },
+            vec![meta]
+        )
     }
 
     fn random_pk() -> secp256k1::PublicKey {
@@ -735,165 +736,122 @@ mod tests {
     #[test]
     fn validate_pegin_data() {
         let pk = random_pk();
-        let pegin_data = pegin_data_setup(None, None, &pk);
-        let header = pegin_data.meta.first().unwrap().block_headers().first().unwrap();
+        let (pegin_data, pegin_meta) = pegin_data_setup(None, None, &pk);
+        let header = pegin_meta[0].block_headers[0];
 
-        let aggregate_amount = pegin_data.validate(&(*header, 1_u32), &pk).expect("valid");
+        let aggregate_amount = pegin_meta[0].validate(&(header, 1_u32), &pk, pegin_data.clone()).expect("valid");
         assert_eq!(aggregate_amount, pegin_data.amount);
-    }
-
-    #[test]
-    #[should_panic(expected = "invalid meta version: only accepting version 0")]
-    fn validate_pegin_data_with_incorrect_version() {
-        let pk = random_pk();
-        let pegin_data = pegin_data_setup(Some(1_u32), None, &pk);
-        let header = pegin_data.meta.first().unwrap().block_headers().first().unwrap();
-
-        pegin_data.validate(&(*header, 1_u32), &pk).unwrap();
     }
 
     #[test]
     #[should_panic(expected = "recent block hash mismatch")]
     fn validate_pegin_data_without_headers() {
         let pk = random_pk();
-        let pegin_data = pegin_data_setup(None, Some(Vec::new()), &pk);
+        let (pegin_data, pegin_meta) = pegin_data_setup(None, Some(Vec::new()), &pk);
         let header = create_header_metadata(None, &pk).header;
 
-        pegin_data.validate(&(header, 1_u32), &pk).unwrap();
+        pegin_meta[0].validate(&(header, 1_u32), &pk, pegin_data).unwrap();
     }
 
     #[test]
     #[should_panic(expected = "recent block hash mismatch")]
     fn validate_pegin_data_with_incorrect_block_hash() {
         let pk = random_pk();
-        let pegin_data = pegin_data_setup(None, None, &pk);
+        let (pegin_data, pegin_meta) = pegin_data_setup(None, None, &pk);
         let header = create_header_metadata(Some(1_u32), &pk).header;
 
-        pegin_data.validate(&(header, 1_u32), &pk).unwrap();
+        pegin_meta[0].validate(&(header, 1_u32), &pk, pegin_data).unwrap();
     }
 
     #[test]
     #[should_panic(expected = "invalid merkle proof: inclusion")]
     fn validate_pegin_data_with_invalid_merkle_proof() {
         let pk = random_pk();
-        let mut pegin_data = pegin_data_setup(None, None, &pk);
-        let header = *pegin_data.meta.first_mut().unwrap().block_headers().first().unwrap();
+        let (pegin_data, mut pegin_meta) = pegin_data_setup(None, None, &pk);
+        let header = pegin_meta[0].block_headers[0];
 
         let different_txid = bitcoin::Txid::all_zeros();
         let different_txids = vec![different_txid];
         let matches = vec![true];
 
-        match pegin_data.meta.first_mut().unwrap() {
-            PeginMeta::V0(meta) => {
-                meta.merkle_proof = PartialMerkleTree::from_txids(&different_txids, &matches)
-            }
-            PeginMeta::V1(meta) => {
-                meta.inner.merkle_proof = PartialMerkleTree::from_txids(&different_txids, &matches)
-            }
-        };
+        pegin_meta[0].merkle_proof = PartialMerkleTree::from_txids(&different_txids, &matches);
 
-        pegin_data.validate(&(header, 1_u32), &pk).unwrap();
+        pegin_meta[0].validate(&(header, 1_u32), &pk, pegin_data).unwrap();
     }
 
     #[test]
     #[should_panic(expected = "invalid merkle proof: inclusion")]
     fn validate_pegin_data_with_invalid_outpoint() {
         let pk = random_pk();
-        let mut pegin_data = pegin_data_setup(None, None, &pk);
-        let header = *pegin_data.meta.first_mut().unwrap().block_headers().first().unwrap();
+        let (pegin_data, mut pegin_meta) = pegin_data_setup(None, None, &pk);
+        let header = pegin_meta[0].block_headers[0];
 
-        match pegin_data.meta.first_mut().unwrap() {
-            PeginMeta::V0(meta) => meta.outpoint.txid = bitcoin::Txid::all_zeros(),
-            PeginMeta::V1(meta) => meta.inner.outpoint.txid = bitcoin::Txid::all_zeros(),
-        };
+        pegin_meta[0].outpoint.txid = bitcoin::Txid::all_zeros();
 
-        pegin_data.validate(&(header, 1_u32), &pk).unwrap();
+        pegin_meta[0].validate(&(header, 1_u32), &pk, pegin_data).unwrap();
     }
 
     #[test]
     #[should_panic(expected = "merkle proof and block header mismatch")]
     fn validate_pegin_data_with_mismatched_merkle_root() {
         let pk = random_pk();
-        let mut pegin_data = pegin_data_setup(None, None, &pk);
+        let (pegin_data, mut pegin_meta) = pegin_data_setup(None, None, &pk);
 
-        match pegin_data.meta.first_mut().unwrap() {
-            PeginMeta::V0(meta) => meta.block_headers[0].merkle_root = TxMerkleNode::all_zeros(),
-            PeginMeta::V1(meta) => {
-                meta.inner.block_headers[0].merkle_root = TxMerkleNode::all_zeros()
-            }
-        };
+        pegin_meta[0].block_headers[0].merkle_root = TxMerkleNode::all_zeros();
 
-        let header = *pegin_data.meta.first_mut().unwrap().block_headers().first().unwrap();
-        pegin_data.validate(&(header, 1_u32), &pk).unwrap();
+        let header = pegin_meta[0].block_headers[0];
+        pegin_meta[0].validate(&(header, 1_u32), &pk, pegin_data).unwrap();
     }
 
     #[test]
     #[should_panic(expected = "merkle proof and block header mismatch")]
     fn validate_pegin_data_with_same_txid_different_root() {
         let pk = random_pk();
-        let mut pegin_data = pegin_data_setup(None, None, &pk);
-        let header = *pegin_data.meta.first_mut().unwrap().block_headers().first().unwrap();
+        let (pegin_data, mut pegin_meta) = pegin_data_setup(None, None, &pk);
+        let header = pegin_meta[0].block_headers[0];
 
-        let original_txid = pegin_data.meta.first_mut().unwrap().outpoint().txid;
+        let original_txid = pegin_meta[0].outpoint.txid;
 
         let txids = vec![original_txid];
         let matches = vec![true];
-        match pegin_data.meta.first_mut().unwrap() {
-            PeginMeta::V0(meta) => {
-                meta.merkle_proof = PartialMerkleTree::from_txids(&txids, &matches)
-            }
-            PeginMeta::V1(meta) => {
-                meta.inner.merkle_proof = PartialMerkleTree::from_txids(&txids, &matches)
-            }
-        };
+        pegin_meta[0].merkle_proof = PartialMerkleTree::from_txids(&txids, &matches);
 
-        pegin_data.validate(&(header, 1_u32), &pk).unwrap();
+        pegin_meta[0].validate(&(header, 1_u32), &pk, pegin_data).unwrap();
     }
 
     #[test]
     #[should_panic(expected = "invalid tx or outpoint: txid")]
     fn validate_pegin_data_with_invalid_tx() {
         let pk = random_pk();
-        let mut pegin_data = pegin_data_setup(None, None, &pk);
-        let header = *pegin_data.meta.first_mut().unwrap().block_headers().first().unwrap();
+        let (pegin_data, mut pegin_meta) = pegin_data_setup(None, None, &pk);
+        let header = pegin_meta[0].block_headers[0];
 
-        match pegin_data.meta.first_mut().unwrap() {
-            PeginMeta::V0(meta) => meta.tx.version = bitcoin::transaction::Version(999),
-            PeginMeta::V1(meta) => meta.inner.tx.version = bitcoin::transaction::Version(999),
-        };
+        pegin_meta[0].tx.version = bitcoin::transaction::Version(999);
 
-        pegin_data.validate(&(header, 1_u32), &pk).unwrap();
+        pegin_meta[0].validate(&(header, 1_u32), &pk, pegin_data).unwrap();
     }
 
     #[test]
     #[should_panic(expected = "invalid tx or outpoint: output idx")]
     fn validate_pegin_data_with_invalid_outpoint_vout() {
         let pk = random_pk();
-        let mut pegin_data = pegin_data_setup(None, None, &pk);
-        let header = *pegin_data.meta.first_mut().unwrap().block_headers().first().unwrap();
+        let (pegin_data, mut pegin_meta) = pegin_data_setup(None, None, &pk);
+        let header = pegin_meta[0].block_headers[0];
 
-        match pegin_data.meta.first_mut().unwrap() {
-            PeginMeta::V0(meta) => meta.outpoint.vout = 2,
-            PeginMeta::V1(meta) => meta.inner.outpoint.vout = 2,
-        };
+        pegin_meta[0].outpoint.vout = 2;
 
-        pegin_data.validate(&(header, 1_u32), &pk).unwrap();
+        pegin_meta[0].validate(&(header, 1_u32), &pk, pegin_data).unwrap();
     }
 
     #[test]
     #[should_panic(expected = "invalid script pubkey")]
     fn validate_pegin_data_with_invalid_script_pubkey() {
         let pk = random_pk();
-        let mut pegin_data = pegin_data_setup(None, None, &pk);
+        let (pegin_data, mut pegin_meta) = pegin_data_setup(None, None, &pk);
 
-        match pegin_data.meta.first_mut().unwrap() {
-            PeginMeta::V0(meta) => meta.tx.output[0].script_pubkey = bitcoin::ScriptBuf::new(),
-            PeginMeta::V1(meta) => {
-                meta.inner.tx.output[0].script_pubkey = bitcoin::ScriptBuf::new()
-            }
-        };
+        pegin_meta[0].tx.output[0].script_pubkey = bitcoin::ScriptBuf::new();
 
-        let new_txid = pegin_data.meta.first_mut().unwrap().tx().compute_txid();
+        let new_txid = pegin_meta[0].tx.compute_txid();
 
         let txids = vec![new_txid];
         let matches = vec![true];
@@ -903,53 +861,44 @@ mod tests {
         let mut idxs = Vec::with_capacity(1);
         let root = merkle_proof.extract_matches(&mut txids, &mut idxs).unwrap();
 
-        match pegin_data.meta.first_mut().unwrap() {
-            PeginMeta::V0(meta) => {
-                meta.block_headers[0].merkle_root = root;
-                meta.merkle_proof = merkle_proof;
-                meta.outpoint.txid = new_txid;
-            }
-            PeginMeta::V1(meta) => {
-                meta.inner.block_headers[0].merkle_root = root;
-                meta.inner.merkle_proof = merkle_proof;
-                meta.inner.outpoint.txid = new_txid;
-            }
-        }
+        pegin_meta[0].block_headers[0].merkle_root = root;
+        pegin_meta[0].merkle_proof = merkle_proof;
+        pegin_meta[0].outpoint.txid = new_txid;
+        
 
-        let modified_header =
-            *pegin_data.meta.first_mut().unwrap().block_headers().first().unwrap();
-        pegin_data.validate(&(modified_header, 1_u32), &pk).unwrap();
+        let modified_header = pegin_meta[0].block_headers[0];
+        pegin_meta[0].validate(&(modified_header, 1_u32), &pk, pegin_data).unwrap();
     }
 
     #[test]
     #[should_panic(expected = "invalid script pubkey")]
     fn validate_pegin_data_with_different_account() {
         let pk = random_pk();
-        let mut pegin_data = pegin_data_setup(None, None, &pk);
-        let header = *pegin_data.meta.first_mut().unwrap().block_headers().first().unwrap();
+        let (mut pegin_data, pegin_meta) = pegin_data_setup(None, None, &pk);
+        let header = pegin_meta[0].block_headers[0];
 
         pegin_data.account = Address::with_last_byte(1);
 
-        pegin_data.validate(&(header, 1_u32), &pk).unwrap();
+        pegin_meta[0].validate(&(header, 1_u32), &pk, pegin_data).unwrap();
     }
 
     #[test]
     #[should_panic(expected = "invalid script pubkey")]
     fn validate_pegin_data_with_different_pubkey() {
         let pk = random_pk();
-        let pegin_data = pegin_data_setup(None, None, &pk);
-        let header = *pegin_data.meta.first().unwrap().block_headers().first().unwrap();
+        let (pegin_data, pegin_meta) = pegin_data_setup(None, None, &pk);
+        let header = pegin_meta[0].block_headers[0];
         let different_pk = random_pk();
 
-        pegin_data.validate(&(header, 1_u32), &different_pk).unwrap();
+        pegin_meta[0].validate(&(header, 1_u32), &different_pk, pegin_data).unwrap();
     }
 
     #[test]
     #[should_panic(expected = "invalid block header sequence")]
     fn validate_pegin_data_with_invalid_block_sequence() {
         let pk = random_pk();
-        let mut pegin_data = pegin_data_setup(None, None, &pk);
-        let header = *pegin_data.meta.first().unwrap().block_headers().first().unwrap();
+        let (pegin_data, mut pegin_meta) = pegin_data_setup(None, None, &pk);
+        let header = pegin_meta[0].block_headers[0];
 
         let second_header = bitcoin::block::Header {
             version: header.version,
@@ -959,26 +908,19 @@ mod tests {
             bits: header.bits,
             nonce: header.nonce,
         };
-        match pegin_data.meta.first_mut().unwrap() {
-            PeginMeta::V0(meta) => {
-                meta.block_headers.push(second_header);
-                meta.block_headers[1].prev_blockhash = bitcoin::BlockHash::all_zeros();
-            }
-            PeginMeta::V1(meta) => {
-                meta.inner.block_headers.push(second_header);
-                meta.inner.block_headers[1].prev_blockhash = bitcoin::BlockHash::all_zeros();
-            }
-        };
 
-        pegin_data.validate(&(header, 1_u32), &pk).unwrap();
+        pegin_meta[0].block_headers.push(second_header);
+        pegin_meta[0].block_headers[1].prev_blockhash = bitcoin::BlockHash::all_zeros();
+        
+        pegin_meta[0].validate(&(header, 1_u32), &pk, pegin_data).unwrap();
     }
 
     #[test]
     #[should_panic(expected = "invalid block header sequence")]
     fn validate_pegin_data_with_broken_block_chain_in_middle() {
         let pk = random_pk();
-        let mut pegin_data = pegin_data_setup(None, None, &pk);
-        let first_header = *pegin_data.meta.first_mut().unwrap().block_headers().first().unwrap();
+        let (pegin_data, mut pegin_meta) = pegin_data_setup(None, None, &pk);
+        let first_header = pegin_meta[0].block_headers[0];
 
         let second_header = bitcoin::block::Header {
             version: first_header.version,
@@ -998,30 +940,22 @@ mod tests {
             nonce: first_header.nonce,
         };
 
-        match pegin_data.meta.first_mut().unwrap() {
-            PeginMeta::V0(meta) => {
-                meta.block_headers.push(second_header);
-                meta.block_headers.push(third_header);
-            }
-            PeginMeta::V1(meta) => {
-                meta.inner.block_headers.push(second_header);
-                meta.inner.block_headers.push(third_header);
-            }
-        }
+        pegin_meta[0].block_headers.push(second_header);
+        pegin_meta[0].block_headers.push(third_header);
 
-        pegin_data.validate(&(first_header, 1_u32), &pk).unwrap();
+        pegin_meta[0].validate(&(first_header, 1_u32), &pk, pegin_data).unwrap();
     }
 
     #[test]
     fn validate_pegin_data_with_invalid_block_height() {
         let pk = random_pk();
-        let mut pegin_data = pegin_data_setup(None, None, &pk);
-        let header = *pegin_data.meta.first_mut().unwrap().block_headers().first().unwrap();
+        let (mut pegin_data, pegin_meta) = pegin_data_setup(None, None, &pk);
+        let header = pegin_meta[0].block_headers[0];
 
         pegin_data.bitcoin_block_height = 999;
 
         assert!(matches!(
-            pegin_data.validate(&(header, 1_u32), &pk),
+            pegin_meta[0].validate(&(header, 1_u32), &pk, pegin_data),
             Err(PeginDataError::InvalidBitcoinBlockHeight)
         ));
     }
@@ -1072,15 +1006,15 @@ mod tests {
             nonce: 0_u32,
         };
 
-        let meta = PeginMetaV0 {
+        let meta = vec![PeginMeta {
             version: PEGIN_META_VERSION_V0,
             merkle_proof: merkle_proof.clone(),
             outpoint,
             address: destination_address,
-            aggregate_publickey: pk,
+            aggregate_public_key: pk,
             block_headers: vec![header],
             tx: tx.clone(),
-        };
+        }];
 
         let amount = U256::from_str_radix("1000000000000", 10).unwrap();
 
@@ -1088,10 +1022,9 @@ mod tests {
             account: destination_address,
             amount,
             bitcoin_block_height: 1_u32,
-            meta: vec![PeginMeta::V0(meta)],
         };
 
-        let res = pegin_data.validate(&(header, 1_u32), &pk).unwrap_err();
+        let res = meta[0].validate(&(header, 1_u32), &pk, pegin_data).unwrap_err();
         assert!(matches!(res, PeginDataError::Invalid("spending non-mature coinbase")));
 
         // Create a chain of 100 blocks with the coinbase tx in the last 100 blocks
@@ -1102,24 +1035,23 @@ mod tests {
             headers.push(header);
         }
 
-        let meta = PeginMetaV0 {
+        let meta = vec![PeginMeta {
             version: PEGIN_META_VERSION_V0,
             merkle_proof,
             outpoint,
             address: destination_address,
-            aggregate_publickey: pk,
+            aggregate_public_key: pk,
             block_headers: headers.clone(),
             tx,
-        };
+        }];
 
         let pegin_data = PeginData {
             account: destination_address,
             amount,
             bitcoin_block_height: 0_u32,
-            meta: vec![PeginMeta::V0(meta)],
         };
 
-        let res = pegin_data.validate(&(headers[100], 100_u32), &pk).unwrap();
+        let res = meta[0].validate(&(headers[100], 100_u32), &pk, pegin_data).unwrap();
         assert_eq!(res, amount);
     }
 }


### PR DESCRIPTION
This PR improves the ergonomics of the Pegin version design as well as decouple `PeginMeta` from `PeginData` as the latter is not likely to have future versions. Currently, we have an enum managing the two versions. This PR changes to use a trait to this management so that we need to do minimal code changes in the future when we have new versions. 

This is the fix for https://github.com/botanix-labs/botanix/issues/931