### PR TITLE
fix: gossiping bug fixed by always polling new pool imports

### DIFF
--- a/bin/test-suite/src/suite/consensus/frost/error.rs
+++ b/bin/test-suite/src/suite/consensus/frost/error.rs
@@ -26,6 +26,8 @@ pub enum Error {
     ConsensusCheckpoint,
     /// Consensus Encode Error
     ConsensusEncode,
-    /// Gateway Address not available
+    /// Gateway Address Not Available
     GatewayAddressNotAvailable,
+    /// Latest Block Does Not Exist
+    LatestBlockDoesNotExist,
 }

--- a/bin/test-suite/src/suite/consensus/frost/test_mempool_gossip.rs
+++ b/bin/test-suite/src/suite/consensus/frost/test_mempool_gossip.rs
@@ -59,7 +59,7 @@ pub async fn test_mempool_gossip(
                 tx_hashes_set.insert(canon_state_notification.engine_index);
             }
             let syncing_instances = suite.global_context.syncing_instances as usize;
-            if tx_hashes_set.len() == test_fed_members.len() - syncing_instances {
+            if tx_hashes_set.len() == (test_fed_members.len() - syncing_instances) {
                 return Ok(());
             }
         }

--- a/bin/test-suite/src/suite/consensus/mod.rs
+++ b/bin/test-suite/src/suite/consensus/mod.rs
@@ -7,6 +7,7 @@ use crate::{
         btc_server::{spawn_n_btc_server_processes, SpawnedBtcServerProcess},
         events::await_dkg,
     },
+    utils::wait_until_genesis_block_exists,
 };
 use anyhow::Context;
 use async_trait::async_trait;
@@ -31,6 +32,7 @@ use common::{
         SpawnedRpcServerProcess,
     },
 };
+use reth::rpc::api::clients;
 use reth_btc_wallet::bitcoind::{BitcoindClientFactory, BitcoindConfig, BitcoindFactory};
 use reth_db::DatabaseEnv;
 use reth_provider::ProviderFactory;
@@ -865,6 +867,7 @@ impl Suite for ConsensusIntegrationTestSuite {
 
         // =================== POA NODES ================== //
         let mut poa_botanix_clients = vec![];
+        let mut client: Option<BotanixEthClient> = None;
         if create_test_config.create_poa_nodes {
             // then generate test fed members poa nodes
             let (mut poa_nodes, tx, edh_authorities_list) = create_poa_nodes(
@@ -938,6 +941,8 @@ impl Suite for ConsensusIntegrationTestSuite {
             assert_eq!(keys.len(), 1);
 
             // update local context
+            // save the first client for later use
+            client = Some(poa_botanix_clients[0].clone());
             self.local_context.poa_processes = Some(spawned_poa_processes);
             self.local_context.poa_nodes = Some(poa_nodes);
             self.local_context.poa_notification = Some(tx);
@@ -1008,6 +1013,11 @@ impl Suite for ConsensusIntegrationTestSuite {
             self.local_context.rpc_nodes = Some(rpc_nodes);
             self.local_context.rpc_notification = Some(tx);
             self.local_context.rpc_eth_providers = Some(rpc_botanix_clients);
+        }
+
+        // wait until the genesis block is created before starting tests that require it
+        if client.is_some() {
+            wait_until_genesis_block_exists(&client.expect("client to exist")).await?
         }
 
         Ok(())

--- a/bin/test-suite/src/utils.rs
+++ b/bin/test-suite/src/utils.rs
@@ -1,6 +1,9 @@
 use crate::{
     it_info_print,
-    suite::consensus::{common::events::GatewayAddressResponse, frost::error::Error},
+    suite::consensus::{
+        common::{botanix_client::BotanixEthClient, events::GatewayAddressResponse},
+        frost::error::Error,
+    },
 };
 use bitcoin::{consensus::Encodable, hash_types::BlockHash, Address, Amount};
 use bitcoincore_rpc::RpcApi;
@@ -156,8 +159,8 @@ pub struct BlockChainInfoRes {
 }
 
 pub fn get_checkpoint_block_hash(bitcoind: &impl RpcApi) -> Result<Vec<u8>, Error> {
-    let deep_tip = bitcoind.call::<BlockChainInfoRes>("getblockchaininfo", &[]).unwrap().blocks -
-        (BOTANIX_TESTNET.parent_confirmation_depth as u64);
+    let deep_tip = bitcoind.call::<BlockChainInfoRes>("getblockchaininfo", &[]).unwrap().blocks
+        - (BOTANIX_TESTNET.parent_confirmation_depth as u64);
     let deep_block_hash = bitcoind.get_block_hash(deep_tip).unwrap();
     let mut checkpoint_block_hash = vec![];
     if let Err(e) = deep_block_hash.consensus_encode(&mut checkpoint_block_hash) {
@@ -202,4 +205,19 @@ where
     }
 
     gateway_address_response.map_err(|_| Error::GatewayAddressNotAvailable)
+}
+
+/// Waits until the genesis block exists.
+pub async fn wait_until_genesis_block_exists(client: &BotanixEthClient) -> Result<(), Error> {
+    while client
+        .get_latest_block()
+        .await
+        .map_err(|_| Error::LatestBlockDoesNotExist)?
+        .number
+        .ok_or(Error::LatestBlockDoesNotExist)?
+        == 0.into()
+    {
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+    Ok(())
 }

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -1240,29 +1240,6 @@ where
         // yield back control to tokio. See `NetworkManager` for more context on the design
         // pattern.
 
-        // Advance pool imports (flush txns to pool).
-        //
-        // Note, this is done in batches. A batch is filled from one `Transactions`
-        // broadcast messages or one `PooledTransactions` response at a time. The
-        // minimum batch size is 1 transaction (and might often be the case with blob
-        // transactions).
-        //
-        // The smallest decodable transaction is an empty legacy transaction, 10 bytes
-        // (2 MiB / 10 bytes > 200k transactions).
-        //
-        // Since transactions aren't validated until they are inserted into the pool,
-        // this can potentially validate >200k transactions. More if the message size
-        // is bigger than the soft limit on a `PooledTransactions` response which is
-        // 2 MiB (`Transactions` broadcast messages is smaller, 128 KiB).
-        let maybe_more_pool_imports = metered_poll_nested_stream_with_budget!(
-            poll_durations.acc_pending_imports,
-            "net::tx",
-            "Batched pool imports stream",
-            DEFAULT_BUDGET_TRY_DRAIN_PENDING_POOL_IMPORTS,
-            this.pool_imports.poll_next_unpin(cx),
-            |batch_results| this.on_batch_import_result(batch_results)
-        );
-
         // Advance network/peer related events (update peers map).
         let maybe_more_network_events = metered_poll_nested_stream_with_budget!(
             poll_durations.acc_network_events,
@@ -1334,6 +1311,29 @@ where
             DEFAULT_BUDGET_TRY_DRAIN_NETWORK_TRANSACTION_EVENTS,
             this.transaction_events.poll_next_unpin(cx),
             |event| this.on_network_tx_event(event),
+        );
+
+        // Advance pool imports (flush txns to pool).
+        //
+        // Note, this is done in batches. A batch is filled from one `Transactions`
+        // broadcast messages or one `PooledTransactions` response at a time. The
+        // minimum batch size is 1 transaction (and might often be the case with blob
+        // transactions).
+        //
+        // The smallest decodable transaction is an empty legacy transaction, 10 bytes
+        // (2 MiB / 10 bytes > 200k transactions).
+        //
+        // Since transactions aren't validated until they are inserted into the pool,
+        // this can potentially validate >200k transactions. More if the message size
+        // is bigger than the soft limit on a `PooledTransactions` response which is
+        // 2 MiB (`Transactions` broadcast messages is smaller, 128 KiB).
+        let maybe_more_pool_imports = metered_poll_nested_stream_with_budget!(
+            poll_durations.acc_pending_imports,
+            "net::tx",
+            "Batched pool imports stream",
+            DEFAULT_BUDGET_TRY_DRAIN_PENDING_POOL_IMPORTS,
+            this.pool_imports.poll_next_unpin(cx),
+            |batch_results| this.on_batch_import_result(batch_results)
         );
 
         // Tries to drain hashes pending fetch cache if the tx manager currently has


### PR DESCRIPTION
When we push to `pool_imports` the import future is never polled thus we only actually import transaction once the `TransactionsManager` is polled next time which might take a while

Solution is to poll `pool_imports` after all actions which might result in new futures being pushed to it