### PR TITLE
feat(workflows): add binary release workflow wip

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -1,0 +1,113 @@
+name: Binary Release
+
+on:
+  push:
+    tags:
+      - v*
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  extract-version:
+    name: extract version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract version
+        run: echo "VERSION=$(echo ${GITHUB_REF#refs/tags/})" >> $GITHUB_OUTPUT
+        id: extract_version
+    outputs:
+      VERSION: ${{ steps.extract_version.outputs.VERSION }}
+  
+  build:
+    name: build release
+    runs-on: ${{ matrix.configs.os }}
+    needs: extract-version
+    strategy:
+      matrix:
+        configs:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-24.04
+            profile: maxperf
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04
+            profile: maxperf
+          - target: x86_64-apple-darwin
+            os: macos-13
+            profile: maxperf
+          - target: aarch64-apple-darwin
+            os: macos-14
+            profile: maxperf
+          - target: x86_64-pc-windows-gnu
+            os: ubuntu-24.04
+            profile: maxperf
+        build:
+          - command: build
+            binary: reth
+          - command: build-btc-server
+            binary: btc-server
+    steps:
+        - uses: actions/checkout@v4
+        - uses: rui314/setup-mold@v1
+        - uses: dtolnay/rust-toolchain@stable
+          with:
+            target: ${{ matrix.configs.target }}
+        - name: Install cross main
+          id: cross_main
+          run: |
+            cargo install cross --git https://github.com/cross-rs/cross
+        - uses: Swatinem/rust-cache@v2
+          with:
+            cache-on-failure: true
+        - name: Apple M1 setup
+          if: matrix.configs.target == 'aarch64-apple-darwin'
+          run: |
+            echo "SDKROOT=$(xcrun -sdk macosx --show-sdk-path)" >> $GITHUB_ENV
+            echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx --show-sdk-platform-version)" >> $GITHUB_ENV
+        - name: Build Reth Binary
+          run: make PROFILE=${{ matrix.configs.profile }} ${{ matrix.build.command }}-${{ matrix.configs.target }}
+        - name: Build Bitcoin Server
+          run: make PROFILE=${{ matrix.configs.profile }} ${{ matrix.build.command }}-${{ matrix.configs.target }}
+        - name: Move Binary to Artifacts
+          run: |
+            mkdir -p artifacts
+            [[ "${{ matrix.configs.target }}" == *windows* ]] && ext=".exe"
+            mv "target/${{ matrix.configs.target }}/${{ matrix.configs.profile }}/${{ matrix.build.binary }}${ext}" ./artifacts
+
+        - name: gcloud auth
+          id: 'auth'
+          uses: google-github-actions/auth@v2
+          with: 
+            workload_identity_provider: projects/1091390741689/locations/global/workloadIdentityPools/github-pool/providers/github-provider
+            service_account: github-actions-sa@botanix-391913.iam.gserviceaccount.com
+        
+        - name: gcloud setup
+          uses: google-github-actions/setup-gcloud@v2
+          with:
+            project_id: botanix-391913
+
+        - name: Sign Binary with GCP KMS
+          run: |
+            cd artifacts
+            tar -cvf ${{ matrix.build.binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}.tar.gz ${{ matrix.build.binary }}*
+            gcloud kms asymmetric-sign \
+                --version=1 \
+                --key=projects/botanix-391913/locations/global/keyRings/botanix-keyring/cryptoKeys/botanix-artifact-registry-key/cryptoKeyVersions/1 \
+                --keyring=projects/botanix-391913/locations/global/keyRings/botanix-keyring \
+                --location=global \
+                --input-file=./${{ matrix.build.binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}.tar.gz \
+                --signature-file=./${{ matrix.build.binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}.tar.gz.sig
+            mv *tar.gz* ..
+            
+        - name: Upload Artifacts
+          uses: actions/upload-artifact@v4
+          with:
+            name: ${{ matrix.build.binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}.tar.gz
+            path: ${{ matrix.build.binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}.tar.gz
+
+        - name: Upload Signature
+          uses: actions/upload-artifact@v4
+          with:
+            name: ${{ matrix.build.binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}.tar.gz.sig
+            path: ${{ matrix.build.binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}.tar.gz.sig
+            

--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -4,12 +4,20 @@ on:
   push:
     tags:
       - v*
-  pull_request:
-    branches:
-      - main
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release'
+        required: true
+        default: 'latest'
+      engineer:
+        description: 'Engineer to release'
+        required: true
+        default: 'botanix'
 
 jobs:
   extract-version:
+    if: github.event_name != 'workflow_dispatch'
     name: extract version
     runs-on: ubuntu-latest
     steps:
@@ -23,7 +31,6 @@ jobs:
     name: build release
     runs-on: 
       group: macbeth
-    needs: extract-version
     permissions:
       contents: read
       id-token: write
@@ -106,4 +113,20 @@ jobs:
           with:
             name: ${{ matrix.build.binary }}-${{ matrix.configs.target }}.tar.gz.sha256sum
             path: ${{ matrix.build.binary }}-${{ matrix.configs.target }}.tar.gz.sha256sum
-            
+
+        - name: Upload Binary to GCP Artifact Storage
+          run: | 
+            VERSION="${{ github.event.inputs.version || github.ref_name }}"
+            gcloud storage cp ${{ matrix.build.binary }}-${{ matrix.configs.target }}.tar.gz.sha256sum gs://botanix-artifact-registry/releases/${{ matrix.build.binary }}/${VERSION}/
+            gcloud storage cp ${{ matrix.build.binary }}-${{ matrix.configs.target }}.tar.gz gs://botanix-artifact-registry/releases/${{ matrix.build.binary }}/${VERSION}/
+
+            # Set Content-Type and Cache-Control headers
+            gsutil setmeta -h "Cache-Control:public, max-age=3600" gs://botanix-artifact-registry/releases/${{ matrix.build.binary }}/${VERSION}/${{ matrix.build.binary }}-${{ matrix.configs.target }}.tar.gz.sha256sum
+            gsutil setmeta -h "Cache-Control:public, max-age=3600" gs://botanix-artifact-registry/releases/${{ matrix.build.binary }}/${VERSION}/${{ matrix.build.binary }}-${{ matrix.configs.target }}.tar.gz
+
+            echo "Binary uploaded to:"
+            echo "https://storage.googleapis.com/botanix-artifact-registry/releases/${{ matrix.build.binary }}/${VERSION}/${{ matrix.build.binary }}-${{ matrix.configs.target }}.tar.gz"
+            echo "https://storage.googleapis.com/botanix-artifact-registry/releases/${{ matrix.build.binary }}/${VERSION}/${{ matrix.build.binary }}-${{ matrix.configs.target }}.tar.gz.sha256sum"
+
+
+  

--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -21,8 +21,12 @@ jobs:
   
   build:
     name: build release
-    runs-on: ${{ matrix.configs.os }}
+    runs-on: 
+      group: macbeth
     needs: extract-version
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       matrix:
         configs:
@@ -47,23 +51,35 @@ jobs:
           id: cross_main
           run: |
             cargo install cross --git https://github.com/cross-rs/cross
+
+        - name: Install protoc
+          run: |
+            sudo apt-get update
+            sudo apt-get install -y protobuf-compiler
+
         - uses: Swatinem/rust-cache@v2
           with:
             cache-on-failure: true
         - name: Build Reth Binary
-          run: make PROFILE=${{ matrix.configs.profile }} ${{ matrix.build.command }}-${{ matrix.configs.target }}
-        - name: Build Bitcoin Server
-          run: make PROFILE=${{ matrix.configs.profile }} ${{ matrix.build.command }}-${{ matrix.configs.target }}
+          run: make PROFILE=${{ matrix.configs.profile }} build-${{ matrix.configs.target }}
+
+        - name: Build Bitcoin Server Binary
+          run: |
+            cross build --package btc-server --bin btc-server --target ${{ matrix.configs.target }} --release
+
         - name: Move Binary to Artifacts
           run: |
             mkdir -p artifacts
             [[ "${{ matrix.configs.target }}" == *windows* ]] && ext=".exe"
-            mv "target/${{ matrix.configs.target }}/${{ matrix.configs.profile }}/${{ matrix.build.binary }}${ext}" ./artifacts
+            mv "target/${{ matrix.configs.target }}/${{ matrix.configs.profile }}/reth${ext}" ./artifacts
+            mv "target/${{ matrix.configs.target }}/release/btc-server${ext}" ./artifacts
+
 
         - name: gcloud auth
           id: 'auth'
           uses: google-github-actions/auth@v2
           with: 
+            project_id: botanix-391913
             workload_identity_provider: projects/1091390741689/locations/global/workloadIdentityPools/github-pool/providers/github-provider
             service_account: github-actions-sa@botanix-391913.iam.gserviceaccount.com
         
@@ -72,28 +88,22 @@ jobs:
           with:
             project_id: botanix-391913
 
-        - name: Sign Binary with GCP KMS
+        - name: Create sha256sum
           run: |
             cd artifacts
-            tar -cvf ${{ matrix.build.binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}.tar.gz ${{ matrix.build.binary }}*
-            gcloud kms asymmetric-sign \
-                --version=1 \
-                --key=projects/botanix-391913/locations/global/keyRings/botanix-keyring/cryptoKeys/botanix-artifact-registry-key/cryptoKeyVersions/1 \
-                --keyring=projects/botanix-391913/locations/global/keyRings/botanix-keyring \
-                --location=global \
-                --input-file=./${{ matrix.build.binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}.tar.gz \
-                --signature-file=./${{ matrix.build.binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}.tar.gz.sig
-            mv *tar.gz* ..
+            tar -cvf ${{ matrix.build.binary }}-${{ matrix.configs.target }}.tar.gz ${{ matrix.build.binary }}*
+            sha256sum ${{ matrix.build.binary }}-${{ matrix.configs.target }}.tar.gz > ${{ matrix.build.binary }}-${{ matrix.configs.target }}.tar.gz.sha256sum
+            mv ${{ matrix.build.binary }}-${{ matrix.configs.target }}.tar.gz ${{ matrix.build.binary }}-${{ matrix.configs.target }}.tar.gz.sha256sum ..
             
         - name: Upload Artifacts
           uses: actions/upload-artifact@v4
           with:
-            name: ${{ matrix.build.binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}.tar.gz
-            path: ${{ matrix.build.binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}.tar.gz
+            name: ${{ matrix.build.binary }}-${{ matrix.configs.target }}.tar.gz
+            path: ${{ matrix.build.binary }}-${{ matrix.configs.target }}.tar.gz
 
         - name: Upload Signature
           uses: actions/upload-artifact@v4
           with:
-            name: ${{ matrix.build.binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}.tar.gz.sig
-            path: ${{ matrix.build.binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}.tar.gz.sig
+            name: ${{ matrix.build.binary }}-${{ matrix.configs.target }}.tar.gz.sha256sum
+            path: ${{ matrix.build.binary }}-${{ matrix.configs.target }}.tar.gz.sha256sum
             

--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -32,15 +32,6 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04
             profile: maxperf
-          - target: x86_64-apple-darwin
-            os: macos-13
-            profile: maxperf
-          - target: aarch64-apple-darwin
-            os: macos-14
-            profile: maxperf
-          - target: x86_64-pc-windows-gnu
-            os: ubuntu-24.04
-            profile: maxperf
         build:
           - command: build
             binary: reth
@@ -59,11 +50,6 @@ jobs:
         - uses: Swatinem/rust-cache@v2
           with:
             cache-on-failure: true
-        - name: Apple M1 setup
-          if: matrix.configs.target == 'aarch64-apple-darwin'
-          run: |
-            echo "SDKROOT=$(xcrun -sdk macosx --show-sdk-path)" >> $GITHUB_ENV
-            echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx --show-sdk-platform-version)" >> $GITHUB_ENV
         - name: Build Reth Binary
           run: make PROFILE=${{ matrix.configs.profile }} ${{ matrix.build.command }}-${{ matrix.configs.target }}
         - name: Build Bitcoin Server

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,7 +1,7 @@
 [build]
 pre-build = [
     # rust-bindgen dependencies: llvm-dev libclang-dev (>= 5.0) clang (>= 5.0)
-    "apt-get update && apt-get install --assume-yes --no-install-recommends llvm-dev libclang-6.0-dev clang-6.0",
+    "apt-get update && apt-get install --assume-yes --no-install-recommends build-essential llvm-dev protobuf-compiler gcc pkg-config libprotobuf-dev libclang-6.0-dev clang-6.0",
 ]
 
 [build.env]

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ install: ## Build and install the reth binary under `~/.cargo/bin`.
 .PHONY: install-btc-server
 install-btc-server: ## Build and install the btc-server binary under `~/.cargo/bin`.
 	cargo install --path bin/btc-server --bin btc-server --force --locked \
-		--features $(FEATURES)" \
+		--features "$(FEATURES)" \
 		--profile "$(PROFILE)" \
 		$(CARGO_INSTALL_EXTRA_FLAGS)
 

--- a/Makefile
+++ b/Makefile
@@ -55,9 +55,9 @@ install: ## Build and install the reth binary under `~/.cargo/bin`.
 		--profile "$(PROFILE)" \
 		$(CARGO_INSTALL_EXTRA_FLAGS)
 
-.PHONY: install-op
-install-op: ## Build and install the op-reth binary under `~/.cargo/bin`.
-	cargo install --path bin/reth --bin op-reth --force --locked \
+.PHONY: install-btc-server
+install-btc-server: ## Build and install the btc-server binary under `~/.cargo/bin`.
+	cargo install --path bin/btc-server --bin btc-server --force --locked \
 		--features $(FEATURES)" \
 		--profile "$(PROFILE)" \
 		$(CARGO_INSTALL_EXTRA_FLAGS)
@@ -109,9 +109,10 @@ build-%:
 	RUSTFLAGS="-C link-arg=-lgcc -Clink-arg=-static-libgcc" \
 		cross build --bin reth --target $* --features "$(FEATURES)" --profile "$(PROFILE)"
 
-op-build-%:
+
+build-btc-server-%:
 	RUSTFLAGS="-C link-arg=-lgcc -Clink-arg=-static-libgcc" \
-		cross build --bin op-reth --target $* --features $(FEATURES)" --profile "$(PROFILE)"
+		cross build --bin btc-server --target $* --features $(FEATURES)" --profile "$(PROFILE)"
 
 # Unfortunately we can't easily use cross to build for Darwin because of licensing issues.
 # If we wanted to, we would need to build a custom Docker image with the SDK available.
@@ -123,10 +124,10 @@ build-x86_64-apple-darwin:
 	$(MAKE) build-native-x86_64-apple-darwin
 build-aarch64-apple-darwin:
 	$(MAKE) build-native-aarch64-apple-darwin
-op-build-x86_64-apple-darwin:
-	$(MAKE) op-build-native-x86_64-apple-darwin
-op-build-aarch64-apple-darwin:
-	$(MAKE) op-build-native-aarch64-apple-darwin
+build-btc-server-x86_64-apple-darwin:
+	$(MAKE) build-btc-server-native-x86_64-apple-darwin
+build-btc-server-aarch64-apple-darwin:
+	$(MAKE) build-btc-server-native-aarch64-apple-darwin
 
 # Create a `.tar.gz` containing a binary for a specific target.
 define tarball_release_binary

--- a/Makefile
+++ b/Makefile
@@ -111,8 +111,7 @@ build-%:
 
 
 build-btc-server-%:
-	RUSTFLAGS="-C link-arg=-lgcc -Clink-arg=-static-libgcc" \
-		cross build --bin btc-server --target $* --features $(FEATURES)" --profile "$(PROFILE)"
+		cross build --package btc-server --bin btc-server --target $* --release"
 
 # Unfortunately we can't easily use cross to build for Darwin because of licensing issues.
 # If we wanted to, we would need to build a custom Docker image with the SDK available.

--- a/bin/botanix-up/.gitignore
+++ b/bin/botanix-up/.gitignore
@@ -1,2 +1,3 @@
 # Botanix up default output directory
 output/
+CometBFT-*


### PR DESCRIPTION
# Binary Release GH Workflow for Cross-Platform Deployment

## Overview
This PR implements a new GHA workflow that enables us to publish versioned binary releases alongside our existing Docker artefact releases. This allows our builders and rpc providers to deploy nodes directly on bare metal servers or virtual machines without requiring any container orchestration.

## Why Is This Needed??
While our Docker-compose based deployment works well in containerised environments, there exist the tendency to get requests from node operators and developers to provide native binaries for:

1. Air-gapped environments where pulling Docker images is restricted
2. Self-hosted scenarios with limited resources


## Implementation Details

### New GitHub Actions Workflow
Added a new workflow file `.github/workflows/binary-release.yml` that:
- Triggers on tags matching the pattern `v*` (parallel to our Docker releases)
- Builds binaries for multiple targets:
  - Linux (amd64, arm64)
  - macOS (amd64, arm64)
  - Windows (amd64)
- Automatically creates GitHub Releases with the compiled binaries
- Signs binaries with our gcloud kms key

### Integration with Existing Processes
- Maintained compatibility with our semantic versioning approach
- Ensures binary and Docker releases share the same version tagging convention


## Considerations and Limitations
- Each platform-specific binary requires separate verification by our CI pipeline, potentially increasing release times

## Future Enhancements
- Implement a self-updater for binaries similar to what we have for Docker deployments
- Update our release documentation to include binary installation instructions
- Integrate with package managers (apt, brew, etc.) for easier installation
- Attach comprehensive release notes

## Breaking Changes
None. This is an additive feature that doesn't affect existing Docker-based deployments.
