### PR TITLE
fix/pass-error-to-PeginDataError

### DIFF
--- a/crates/primitives/src/botanix/peg_contract.rs
+++ b/crates/primitives/src/botanix/peg_contract.rs
@@ -393,13 +393,13 @@ impl PeginMeta {
 #[derive(Debug, Error)]
 pub enum PeginDataError {
     /// Invalid data format
-    #[error("invalid data format")]
+    #[error("invalid data format: {0}")]
     InvalidFormat(#[from] btcencode::Error),
     /// Invalid pegin proof
-    #[error("invalid pegin proof")]
+    #[error("invalid pegin proof: {0}")]
     Invalid(&'static str),
     /// Invalid public key format
-    #[error("invalid public key format")]
+    #[error("invalid public key format: {0}")]
     InvalidPublicKey(secp256k1::Error),
     /// Invalid bitcoin block height
     #[error("invalid bitcoin block height")]


### PR DESCRIPTION
Realized we weren't actually passing the error message to `PeginDataError` for most variants.
@thobbyAk discovered this when debugging peginv1 proofs, nice catch amigo!