### PR TITLE
fix(btc-server): only validate outputs up to upper bound

### DIFF
--- a/bin/btc-server/src/bin/main.rs
+++ b/bin/btc-server/src/bin/main.rs
@@ -29,6 +29,7 @@ use btcserverlib::{
     util::{
         btc_per_kb_to_sat_per_vb, deserialize_frost_peer_id, get_available_utxos,
         get_pegin_confirmation_depth, parse_eth_address, parse_signing_session_id, ParsingError,
+        UPPER_PEGOUT_BOUND
     },
     wallet::{
         self,
@@ -56,19 +57,6 @@ use btcserverlib::{
 };
 
 const JWT_HEADER_KEY: &str = "trace-proto-bin";
-
-/// The upper bound on pegouts in a single transaction. We use a _reasonable_
-/// number based on the following properties:
-///
-/// * Bitcoin's upper bound on a transaction is 100kb
-/// * 32 bytes required for an output (ie. pegout)
-/// * 110 bytes required for an input
-/// * We assume each output has an input
-///   * In practice, it's more likely that an individual input will map to multiple smaller outputs.
-///     But a larger output could also consume multiple inputs.
-///
-/// With a pegout bound of 500, we can conclude: (32 + 110) * 500 = 71_000
-const UPPER_PEGOUT_BOUND: usize = 500;
 
 macro_rules! already_exists {
     ($($arg:tt)*) => {{

--- a/bin/btc-server/src/bin/main.rs
+++ b/bin/btc-server/src/bin/main.rs
@@ -29,7 +29,7 @@ use btcserverlib::{
     util::{
         btc_per_kb_to_sat_per_vb, deserialize_frost_peer_id, get_available_utxos,
         get_pegin_confirmation_depth, parse_eth_address, parse_signing_session_id, ParsingError,
-        UPPER_PEGOUT_BOUND
+        UPPER_PEGOUT_BOUND,
     },
     wallet::{
         self,
@@ -849,6 +849,7 @@ where
 
         // We just signed for all pending pegouts lets start tracking them
         if cfg!(feature = "conflicting_input") {
+            info!("get_round2_signing_package: removing pending pegouts");
             let pending_pegouts = self.db.get_pending_pegouts().to_status()?;
             let pending_pegout_ids =
                 pending_pegouts.iter().map(|p| p.id).collect::<Vec<PegoutId>>();
@@ -912,7 +913,7 @@ where
 
         // If the coordinator participated in signing they have already tracked the tx
         // however, if the coordinator did not participate in signing they need to track the
-        // tx now
+        // tx now.
         let pending_pegouts = self.db.get_pending_pegouts().to_status()?;
         let pegout_ids = psbt
             .pegout_ids()
@@ -1191,8 +1192,8 @@ where
             .as_ref()
             .ok_or(DKGError::MissingRound1DkgPayload)
             .to_status()?
-            .1 ==
-            dkg_round1
+            .1
+            == dkg_round1
         {
             return Err(badarg!("Cannot add own round1 dkg package"));
         }
@@ -1280,7 +1281,9 @@ where
                 // We only continue with part 2 if and only if ALL participants have
                 // submitted their round 1 packages
                 if (round1_packages.len() as u16) < self.max_signers - 1 {
-                    return Err(badarg!("not all participants have submitted their round 1 packages yet"));
+                    return Err(badarg!(
+                        "not all participants have submitted their round 1 packages yet"
+                    ));
                 }
 
                 let (round2_secret_package, round2_packages) =

--- a/bin/btc-server/src/util.rs
+++ b/bin/btc-server/src/util.rs
@@ -248,7 +248,7 @@ pub fn validate_psbt(
         return Err(ValidatePSBTError::NoOutputs);
     }
 
-    validate_outputs(psbt, db)?;
+    validate_outputs(psbt, db, flags & ROUND2 == ROUND2)?;
 
     // Sanity fee checks
     let fee = match psbt.fee() {
@@ -387,7 +387,11 @@ pub enum ValidateOutputsError {
 
 /// Check all pending pegouts are being settled in this tx
 /// and additional outputs are change outputs
-pub(crate) fn validate_outputs(psbt: &Psbt, db: &database::Db) -> Result<(), ValidateOutputsError> {
+pub(crate) fn validate_outputs(
+    psbt: &Psbt,
+    db: &database::Db,
+    is_round_2: bool,
+) -> Result<(), ValidateOutputsError> {
     // check aggregated public key exists
     let public_key_package =
         db.get_public_key_package()?.ok_or(ValidateOutputsError::MissingKeyPackage)?;
@@ -415,9 +419,13 @@ pub(crate) fn validate_outputs(psbt: &Psbt, db: &database::Db) -> Result<(), Val
     }
 
     // check psbt pegout exists in pending pegouts list
-    for psbt_pegout_id in psbt_pegout_ids.iter() {
-        if !pending_pegout_ids.contains(psbt_pegout_id) {
-            return Err(ValidateOutputsError::MissingPsbtPegout(*psbt_pegout_id));
+    // if round 2 flag, then we are at the end of the round and signers have already cleared the pending pegouts included
+    // in the psbt and tracked the tx
+    if !is_round_2 {
+        for psbt_pegout_id in psbt_pegout_ids.iter() {
+            if !pending_pegout_ids.contains(psbt_pegout_id) {
+                return Err(ValidateOutputsError::MissingPsbtPegout(*psbt_pegout_id));
+            }
         }
     }
 

--- a/bin/btc-server/src/util.rs
+++ b/bin/btc-server/src/util.rs
@@ -12,7 +12,7 @@ use bitcoin::{
 use frost_secp256k1_tr as frost;
 use lazy_static::lazy_static;
 use log::info;
-use std::{cmp::min, collections::{HashMap, HashSet}};
+use std::collections::{HashMap, HashSet};
 
 use crate::{
     database::{self, Db, Utxo},
@@ -392,7 +392,8 @@ pub(crate) fn validate_outputs(psbt: &Psbt, db: &database::Db) -> Result<(), Val
     let public_key_package =
         db.get_public_key_package()?.ok_or(ValidateOutputsError::MissingKeyPackage)?;
 
-    let pending_pegouts = db.get_pending_pegouts()?;
+    // use coord_pending_pegouts since this is what the coordinator uses when creating the psbt
+    let pending_pegouts = db.coord_pending_pegouts(UPPER_PEGOUT_BOUND)?;
     let pending_pegout_ids = pending_pegouts.iter().map(|p| p.id).collect::<Vec<PegoutId>>();
 
     let mut psbt_pegout_ids: Vec<PegoutId> = Vec::with_capacity(psbt.outputs.len());
@@ -413,12 +414,10 @@ pub(crate) fn validate_outputs(psbt: &Psbt, db: &database::Db) -> Result<(), Val
         return Err(ValidateOutputsError::DuplicateOutputs);
     }
 
-    // only enforce up to max number of pegouts
-    for pegout_id in
-        pending_pegout_ids.iter().take(min(pending_pegout_ids.len(), UPPER_PEGOUT_BOUND))
-    {
-        if !psbt_pegout_ids.contains(pegout_id) {
-            return Err(ValidateOutputsError::MissingPsbtPegout(*pegout_id));
+    // check psbt pegout exists in pending pegouts list
+    for psbt_pegout_id in psbt_pegout_ids.iter() {
+        if !pending_pegout_ids.contains(psbt_pegout_id) {
+            return Err(ValidateOutputsError::MissingPsbtPegout(*psbt_pegout_id));
         }
     }
 
@@ -614,9 +613,9 @@ mod tests {
                 .unwrap_or_default()
         });
 
-        let diff = total_inputs.checked_sub(total_outputs).unwrap_or_default().to_sat() /
-            psbt.unsigned_tx.output.len() as u64 +
-            100;
+        let diff = total_inputs.checked_sub(total_outputs).unwrap_or_default().to_sat()
+            / psbt.unsigned_tx.output.len() as u64
+            + 100;
 
         // increase each output accordingly to cause negative fee
         for output in psbt.unsigned_tx.output.iter_mut() {

--- a/bin/btc-server/src/util.rs
+++ b/bin/btc-server/src/util.rs
@@ -12,7 +12,7 @@ use bitcoin::{
 use frost_secp256k1_tr as frost;
 use lazy_static::lazy_static;
 use log::info;
-use std::collections::{HashMap, HashSet};
+use std::{cmp::min, collections::{HashMap, HashSet}};
 
 use crate::{
     database::{self, Db, Utxo},
@@ -31,6 +31,19 @@ pub(crate) const ROUND1: u8 = 1u8;
 pub(crate) const ROUND1_TRANSITION: u8 = (1u8 << 1) | ROUND1;
 pub(crate) const ROUND2: u8 = (1u8 << 2) | ROUND1_TRANSITION;
 pub(crate) const ROUND2_TRANSITION: u8 = (1u8 << 3) | ROUND1_TRANSITION;
+
+/// The upper bound on pegouts in a single transaction. We use a _reasonable_
+/// number based on the following properties:
+///
+/// * Bitcoin's upper bound on a transaction is 100kb
+/// * 32 bytes required for an output (ie. pegout)
+/// * 110 bytes required for an input
+/// * We assume each output has an input
+///   * In practice, it's more likely that an individual input will map to multiple smaller outputs.
+///     But a larger output could also consume multiple inputs.
+///
+/// With a pegout bound of 500, we can conclude: (32 + 110) * 500 = 71_000
+pub const UPPER_PEGOUT_BOUND: usize = 500;
 
 pub fn btc_per_kb_to_sat_per_vb(btc_per_kb: bitcoin::Amount) -> FeeRate {
     let sats = btc_per_kb.to_sat();
@@ -400,7 +413,10 @@ pub(crate) fn validate_outputs(psbt: &Psbt, db: &database::Db) -> Result<(), Val
         return Err(ValidateOutputsError::DuplicateOutputs);
     }
 
-    for pegout_id in pending_pegout_ids.iter() {
+    // only enforce up to max number of pegouts
+    for pegout_id in
+        pending_pegout_ids.iter().take(min(pending_pegout_ids.len(), UPPER_PEGOUT_BOUND))
+    {
         if !psbt_pegout_ids.contains(pegout_id) {
             return Err(ValidateOutputsError::MissingPsbtPegout(*pegout_id));
         }


### PR DESCRIPTION
Changing the validation logic to only enforce that a psbt pegout exists in the pending pegouts list. Not that all pending pegouts need to be in the psbt.  This is overly restrictive and all pegouts will eventually get processed if there's more than the upper bound allowed in a single pegout.