### PR TITLE
fix(state-sync): flags default is false

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -739,7 +739,7 @@ start-poa-server-3:
 	--p2p-secret-key "${NODE_3_DIR}/discovery-secret" \
 	--port 30305 \
 	--abci-port=46658 \
-  --sync.enable_state_sync \
+    --sync.enable_state_sync \
 	--sync.enable_historical_sync
 
 start-non-fed-server-1:

--- a/Makefile
+++ b/Makefile
@@ -668,7 +668,9 @@ start-poa-server-1:
 	--sync.num_snapshots_to_keep 3 \
 	--p2p-secret-key "${NODE_1_DIR}/discovery-secret" \
 	--port 30303 \
-	--abci-port=26658
+	--abci-port=26658 \
+	--sync.enable_state_sync \
+	--sync.enable_historical_sync
 
 start-poa-server-2:
 	cd ./bin/reth && \
@@ -701,7 +703,9 @@ start-poa-server-2:
 	--sync.num_snapshots_to_keep 3 \
 	--p2p-secret-key "${NODE_2_DIR}/discovery-secret" \
 	--port 30304 \
-	--abci-port=36658
+	--abci-port=36658 \
+	--sync.enable_state_sync \
+	--sync.enable_historical_sync
 
 start-poa-server-3:
 	cd ./bin/reth && \
@@ -734,7 +738,9 @@ start-poa-server-3:
 	--sync.num_snapshots_to_keep 3 \
 	--p2p-secret-key "${NODE_3_DIR}/discovery-secret" \
 	--port 30305 \
-	--abci-port=46658
+	--abci-port=46658 \
+  --sync.enable_state_sync \
+	--sync.enable_historical_sync
 
 start-non-fed-server-1:
 	cd ./bin/reth && \
@@ -760,7 +766,9 @@ start-non-fed-server-1:
 	--bitcoind.password "${BITCOIND_PWD}" \
 	--p2p-secret-key "${NON_FED_1_DIR}/discovery-secret" \
 	--port 30306 \
-	--abci-port=56658
+	--abci-port=56658 \
+	--sync.enable_state_sync \
+	--sync.enable_historical_sync \
 
 clean-poa-3:
 	cd ${NODE_3_DIR} && \

--- a/bin/test-suite/src/suite/consensus/common/poa_node.rs
+++ b/bin/test-suite/src/suite/consensus/common/poa_node.rs
@@ -376,6 +376,8 @@ impl FederationMemberTestConfig {
             discovery_secret_path.to_str().context("discovery secret path to exist")?,
             "--abci-port",
             abci_port.as_str(),
+            "--sync.enable_state_sync",
+            "--sync.enable_historical_sync",
         ];
 
         // use botanix chain spec

--- a/bin/test-suite/src/suite/consensus/common/rpc_node.rs
+++ b/bin/test-suite/src/suite/consensus/common/rpc_node.rs
@@ -271,6 +271,8 @@ impl NonFederationMemberTestConfig {
             discovery_port.as_str(),
             "--p2p-secret-key",
             discovery_secret_path.to_str().context("discovery secret path to exist")?,
+            "--sync.enable_state_sync",
+            "--sync.enable_historical_sync",
         ];
 
         Ok(SpawnedRpcServerProcess {

--- a/bin/test-suite/src/suite/consensus/sync/test_state_sync.rs
+++ b/bin/test-suite/src/suite/consensus/sync/test_state_sync.rs
@@ -19,7 +19,7 @@ use crate::{
     },
 };
 
-const MAX_RETRIES: u8 = 5;
+const MAX_RETRIES: u8 = 10;
 const REQUIRED_SNAPSHOTS: usize = 1;
 
 #[allow(clippy::too_many_lines)]

--- a/crates/node/core/src/args/state_sync.rs
+++ b/crates/node/core/src/args/state_sync.rs
@@ -26,7 +26,7 @@ pub struct StateSyncArgs {
 
     /// State sync enabled
     #[arg(
-        default_value_t = true,
+        default_value_t = false,
         long = "sync.enable_state_sync",
         name = "sync.enable_state_sync",
         value_name = "ENABLE_STATE_SYNC"
@@ -35,7 +35,7 @@ pub struct StateSyncArgs {
 
     /// Historical state sync enabled
     #[arg(
-        default_value_t = true,
+        default_value_t = false,
         long = "sync.enable_historical_sync",
         name = "sync.enable_historical_sync",
         value_name = "ENABLE_HISTORICAL_SYNC"


### PR DESCRIPTION
If we set the default to true there's no way to pass false.
The expected type is a boolean and is based on whether the flag is present or not.  So set default to false and pass the flag if you want it true.