### PR TITLE
fix(btc-server): set bitcoin pegin confirmation depth to 18

### DIFF
--- a/bin/btc-server/src/util.rs
+++ b/bin/btc-server/src/util.rs
@@ -58,7 +58,8 @@ pub fn btc_per_kb_to_sat_per_vb(btc_per_kb: bitcoin::Amount) -> FeeRate {
 
 pub fn get_pegin_confirmation_depth(network: bitcoin::Network) -> u32 {
     match network {
-        bitcoin::Network::Regtest | bitcoin::Network::Signet | bitcoin::Network::Bitcoin => 1,
+        bitcoin::Network::Regtest | bitcoin::Network::Signet => 1,
+        bitcoin::Network::Bitcoin => 18,
         _ => panic!("Unsupported network"),
     }
 }


### PR DESCRIPTION
Sets btc-server pegin confirmation depth to 18