### PR TITLE
Fix(Pegins): Return an error to invalidate pegin v1 with invalid ref block hash

### DIFF
--- a/bin/test-suite/src/suite/consensus/invalid_transactions/test_invalid_pegin.rs
+++ b/bin/test-suite/src/suite/consensus/invalid_transactions/test_invalid_pegin.rs
@@ -35,11 +35,30 @@ async fn generate_invalid_pegin_metas(
     headers: Vec<Header>,
     provider: Provider<Http>,
 ) -> Vec<(Vec<PeginMeta>, &'static str)> {
-    let mut invalid_pegin_meta_cases = Vec::new();
-
     // Destructure pegin data for easier access
     let (pegin_tx1, vout1, pmt1) = pegin1_data;
     let (pegin_tx2, vout2, pmt2) = pegin2_data;
+    
+    let mut invalid_pegin_meta_cases = Vec::new();
+
+    // Create invalid pegin meta with invalid reference hash for v1
+    let invalid_ref_hash_meta = vec![PeginMeta::V1(PeginMetaV1 {
+        inner: PeginMetaV0 {
+            version: PEGIN_META_VERSION_V1,
+            outpoint: bitcoin::OutPoint::new(pegin_tx1.compute_txid(), vout1),
+            address: eth_account.clone(),
+            aggregate_publickey: secp256k1::PublicKey::from_str(
+                gateway_address_response.aggregate_public_key.as_str(),
+            )
+            .expect("valid public key"),
+            tx: pegin_tx1.clone(),
+            merkle_proof: pmt1.clone(),
+            block_headers: headers.clone(),
+        },
+        ref_block_hash: B256::from_slice(&[0; 32]),
+    })];
+    invalid_pegin_meta_cases.push((invalid_ref_hash_meta, "Invalid reference hash"));
+
     // Create invalid pegin meta with empty headers list
     let empty_headers_meta = vec![PeginMeta::V0(PeginMetaV0 {
         version: PEGIN_META_VERSION_V0,
@@ -70,24 +89,6 @@ async fn generate_invalid_pegin_metas(
         block_headers: headers.clone(),
     })];
     invalid_pegin_meta_cases.push((invalid_pmt_meta, "Invalid merkle proof"));
-
-    // Create invalid pegin meta with invalid reference hash for v1
-    let invalid_ref_hash_meta = vec![PeginMeta::V1(PeginMetaV1 {
-        inner: PeginMetaV0 {
-            version: PEGIN_META_VERSION_V1,
-            outpoint: bitcoin::OutPoint::new(pegin_tx1.compute_txid(), vout1),
-            address: eth_account.clone(),
-            aggregate_publickey: secp256k1::PublicKey::from_str(
-                gateway_address_response.aggregate_public_key.as_str(),
-            )
-            .expect("valid public key"),
-            tx: pegin_tx1.clone(),
-            merkle_proof: pmt1.clone(),
-            block_headers: headers.clone(),
-        },
-        ref_block_hash: B256::from_slice(&[0; 32]),
-    })];
-    invalid_pegin_meta_cases.push((invalid_ref_hash_meta, "Invalid reference hash for v1"));
 
     // Create invalid pegin meta v1 with incorrect version
     let latest_block_with_edh = provider

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -468,27 +468,30 @@ where
                         })
                     }
                     (1, Some(hash)) => {
-                        if let Some(block) = provider
-                            .find_block_by_hash(hash, reth_provider::BlockSource::Any)
-                            .map_err(|_| MintContractError::InvalidPeginData {
-                                error: "Reference block hash not found".to_string(),
-                                revert_address: pegin_data.account,
-                                revert_amount: pegin_data.amount,
-                            })?
-                        {
-                            let header = block.header;
-                            let package = header
-                                .botanix_consensus_package(
-                                    self.bitcoin_network,
-                                    self.bitcoind_factory.clone(),
-                                )
-                                .map_err(|_| MintContractError::InvalidPeginData {
-                                    error: "Failed to get botanix consensus package".to_string(),
+                        match provider.find_block_by_hash(hash, reth_provider::BlockSource::Any) {
+                            Ok(Some(block)) => {
+                                let header = block.header;
+                                let package = header
+                                    .botanix_consensus_package(
+                                        self.bitcoin_network,
+                                        self.bitcoind_factory.clone(),
+                                    )
+                                    .map_err(|_| MintContractError::InvalidPeginData {
+                                        error: "Failed to get botanix consensus package".to_string(),
+                                        revert_address: pegin_data.account,
+                                        revert_amount: pegin_data.amount,
+                                    })?;
+                                bitcoin_checkpoint = package.bitcoin_checkpoint;
+                            }
+                            Ok(None) => {
+                                return Err(MintContractError::InvalidPeginData {
+                                    error: "No block found for reference block hash".to_string(),
                                     revert_address: pegin_data.account,
                                     revert_amount: pegin_data.amount,
-                                })?;
-                            bitcoin_checkpoint = package.bitcoin_checkpoint;
-                        }
+                                })
+                            }
+                            Err(_) => panic!("Database error fetching reference block hash")
+                        };
                     }
                     (0, Some(_)) => {
                         return Err(MintContractError::InvalidPeginData {


### PR DESCRIPTION
Fix for https://github.com/botanix-labs/botanix/issues/996

Also moved the test case for invalid ref block hash in `test_invalid_pegin` to the front of the invalid pegin list as it essentially replicates the edge case encountered in https://github.com/botanix-labs/Macbeth/pull/664#discussion_r2048381145