### PR TITLE
fix(primitives): set explicit cap on block header Vec capacity

### DIFF
--- a/crates/primitives/src/botanix/peg_contract.rs
+++ b/crates/primitives/src/botanix/peg_contract.rs
@@ -217,7 +217,9 @@ impl PeginMetaV0 {
                             remaining_bytes: bytes.len(),
                         });
                     }
-                    let mut block_headers = Vec::with_capacity(len as usize);
+
+                    let cap = len.min(MAX_BITCOIN_BLOCK_HEADERS) as usize;
+                    let mut block_headers = Vec::with_capacity(cap);
                     for _ in 0..len {
                         block_headers.push(Decodable::consensus_decode(&mut bytes)?);
                     }


### PR DESCRIPTION
Fixes https://github.com/botanix-labs/botanix/issues/1000, **HOWEVER**:

I think @SatwikPrabhu already made some appropriate changes here since the audit commit; if we look at the current version on `main`:

```rust
let len = btcencode::VarInt::consensus_decode(&mut bytes)?.0;

if len > MAX_BITCOIN_BLOCK_HEADERS {
	return Err(PeginDataError::TooManyBlockHeaders(len));
}

// ...

let mut block_headers = Vec::with_capacity(len as usize);
```

We do an explicit check and return an error if `len > MAX_BITCOIN_BLOCK_HEADERS`. That constant is defined as:

```rust
/// Bitcoin's difficulty adjustment period, a reasonable maximum
const MAX_BITCOIN_BLOCK_HEADERS: u64 = 2016;
```

This PR sets an explicit cap on the Vec capacity in case that `if len > MAX_BITCOIN_BLOCK_HEADERS` ever gets removed, **but technically we do not need it**. We can just close this issue/PR, up for debate.

EDIT: Yeah honestly this change is BS, let's just close it.