### PR TITLE
properly handling pending state connection for violated peers

### DIFF
--- a/crates/net/network/src/frost/manager.rs
+++ b/crates/net/network/src/frost/manager.rs
@@ -1,5 +1,5 @@
 use super::{FrostPeerCommand, FrostProtocolEvent, PeerMessageResponse};
-use crate::{session::Direction, NetworkHandle};
+use crate::{frost::ConnectionEstablishedStatus, session::Direction, NetworkHandle};
 use frost_secp256k1_tr as frost;
 use futures::{Future, StreamExt};
 use reth_network_peers::PeerId;
@@ -215,6 +215,29 @@ impl FrostManager {
         self.authorities.contains_key(peer_id)
     }
 
+    fn respond_with_status(
+        sender: tokio::sync::oneshot::Sender<ConnectionEstablishedStatus>,
+        status: ConnectionEstablishedStatus,
+        message: &str,
+        peer_id: &PeerId,
+    ) -> bool {
+        if sender.is_closed() {
+            return false;
+        }
+        let msg = format!(
+            "Received FrostProtocolEvent::ConnectionEstablished event from peer {:?}. Error: {:?}",
+            peer_id, message
+        );
+        if sender.send(status).is_err() {
+            warn!(
+                target: "network::frost::on_network_event",
+                msg
+            );
+            return false;
+        }
+        true
+    }
+
     fn on_network_event(&mut self, protocol_event: FrostProtocolEvent) {
         match protocol_event {
             FrostProtocolEvent::ConnectionEstablished {
@@ -234,6 +257,12 @@ impl FrostManager {
                         "Received FrostProtocolEvent::ConnectionEstablished event from non-authority peer {:?}, protocol_event",
                         peer_id
                     );
+                    Self::respond_with_status(
+                        sender,
+                        ConnectionEstablishedStatus::NoneAuthority,
+                        "None authority peer",
+                        &peer_id,
+                    );
                     return;
                 }
 
@@ -244,6 +273,12 @@ impl FrostManager {
                         "Received FrostProtocolEvent::ConnectionEstablished event from our own peer {:?}",
                         peer_id
                     );
+                    Self::respond_with_status(
+                        sender,
+                        ConnectionEstablishedStatus::ConnectedToOurself,
+                        "Event from our own peer",
+                        &peer_id,
+                    );
                     return;
                 }
 
@@ -252,6 +287,12 @@ impl FrostManager {
                         target: "network::frost::on_network_event",
                         "Received FrostProtocolEvent::ConnectionEstablished event from peer with id = {:?}, but the connection channel is already closed",
                         peer_id
+                    );
+                    Self::respond_with_status(
+                        sender,
+                        ConnectionEstablishedStatus::ClosedPeerCommandsCommunicationChannel,
+                        "Peer commands communication channel is already closed",
+                        &peer_id,
                     );
                     return;
                 }
@@ -264,13 +305,12 @@ impl FrostManager {
                 self.connection_counter = idx.wrapping_add(1);
 
                 // send the assigned idx back to the initiator
-                if sender.send(idx).is_err() {
-                    // the initiator already dropped...
-                    warn!(
-                        target: "network::frost::on_network_event",
-                        "Received FrostProtocolEvent::ConnectionEstablished event from peer with id = {:?}, but the connection channel is already closed",
-                        peer_id
-                    );
+                if !Self::respond_with_status(
+                    sender,
+                    ConnectionEstablishedStatus::Success(idx),
+                    "Connection channel is already closed",
+                    &peer_id,
+                ) {
                     return;
                 }
 

--- a/crates/net/network/src/frost/mod.rs
+++ b/crates/net/network/src/frost/mod.rs
@@ -183,6 +183,19 @@ impl fmt::Display for SigningEventResponseType {
     }
 }
 
+/// Status enum reporting the status of the connection on the frost manager.
+#[derive(Debug)]
+pub enum ConnectionEstablishedStatus {
+    /// The connection was established successfully
+    Success(u64),
+    /// The peer command communication connection was already closed
+    ClosedPeerCommandsCommunicationChannel,
+    /// Non-authority member attempted to connect
+    NoneAuthority,
+    /// Connected to ourself
+    ConnectedToOurself,
+}
+
 /// All events related to frost events emitted by the network.
 /// These are events that are emitted by the network to the frost manager.
 /// And most likely will be used to update the frost task state.
@@ -197,7 +210,7 @@ pub enum FrostProtocolEvent {
         /// the connection direction - we connected to them, or they to us
         direction: Direction,
         /// callback to send the assigned idx back to the initiator
-        sender: oneshot::Sender<u64>,
+        sender: oneshot::Sender<ConnectionEstablishedStatus>,
     },
     /// An emitted event once the connection is closed
     ConnectionClosed {

--- a/crates/net/network/src/frost/protocol.rs
+++ b/crates/net/network/src/frost/protocol.rs
@@ -27,7 +27,7 @@ use crate::{
 
 use super::{
     messages::{FrostProtoMessage, FrostProtoMessageKind, SignRequest},
-    FrostPeerCommand, FrostProtocolEvent, PeerMessageResponse,
+    ConnectionEstablishedStatus, FrostPeerCommand, FrostProtocolEvent, PeerMessageResponse,
 };
 
 /// Frost Protocol Handler
@@ -157,7 +157,7 @@ enum RegistrationState {
     NotRegistered,
     Pending {
         remote_peer_rx: mpsc::UnboundedReceiver<FrostPeerCommand>,
-        callback_rx: oneshot::Receiver<u64>,
+        callback_rx: oneshot::Receiver<ConnectionEstablishedStatus>,
     },
     Registered(u64),
 }
@@ -243,12 +243,23 @@ impl Stream for FrostProtoConnection {
 
                 // Wait for the FROST manager to assign an idx to this connection.
                 match callback_rx.poll_unpin(cx) {
-                    Poll::Ready(Ok(idx)) => {
+                    Poll::Ready(Ok(conn_established_status)) => {
                         // connection was registered immediately and
                         // successfully (unlikely that actually happens in
                         // practice)
-                        this.registration = RegistrationState::Registered(idx);
-                        this.commands_rx = Some(UnboundedReceiverStream::new(remote_peer_rx));
+                        match conn_established_status {
+                            ConnectionEstablishedStatus::Success(idx) => {
+                                // connection was registered successfully
+                                this.registration = RegistrationState::Registered(idx);
+                                this.commands_rx =
+                                    Some(UnboundedReceiverStream::new(remote_peer_rx));
+                            }
+                            ConnectionEstablishedStatus::ClosedPeerCommandsCommunicationChannel |
+                            ConnectionEstablishedStatus::NoneAuthority |
+                            ConnectionEstablishedStatus::ConnectedToOurself => {
+                                return Poll::Ready(None);
+                            }
+                        }
                     }
                     Poll::Ready(Err(e)) => {
                         // this error only occurs if the FROST manager has been dropped.
@@ -272,10 +283,20 @@ impl Stream for FrostProtoConnection {
                 };
 
                 match callback_rx.poll_unpin(cx) {
-                    Poll::Ready(Ok(idx)) => {
-                        // connection was registered successfully
-                        this.registration = RegistrationState::Registered(idx);
-                        this.commands_rx = Some(UnboundedReceiverStream::new(remote_peer_rx));
+                    Poll::Ready(Ok(conn_established_status)) => {
+                        match conn_established_status {
+                            ConnectionEstablishedStatus::Success(idx) => {
+                                // connection was registered successfully
+                                this.registration = RegistrationState::Registered(idx);
+                                this.commands_rx =
+                                    Some(UnboundedReceiverStream::new(remote_peer_rx));
+                            }
+                            ConnectionEstablishedStatus::ClosedPeerCommandsCommunicationChannel |
+                            ConnectionEstablishedStatus::NoneAuthority |
+                            ConnectionEstablishedStatus::ConnectedToOurself => {
+                                return Poll::Ready(None);
+                            }
+                        }
                     }
                     Poll::Ready(Err(e)) => {
                         error!(target: "network::frost::protocol", "Failed to send ConnectionEstablished event: {:?}", e.to_string());
@@ -562,7 +583,7 @@ mod tests {
         };
 
         // Manager assigns the connection idx
-        sender.send(0).unwrap();
+        sender.send(ConnectionEstablishedStatus::Success(0)).unwrap();
 
         // Send wire message to the connection (ping)
         let wire_msg = FrostProtoMessage::ping().encoded();
@@ -629,7 +650,7 @@ mod tests {
         };
 
         // Manager assigns the connection idx
-        sender.send(0).unwrap();
+        sender.send(ConnectionEstablishedStatus::Success(0)).unwrap();
 
         // Connection receives all wire messages and generates a response each (pong)
         for _ in 0..4 {
@@ -700,7 +721,7 @@ mod tests {
         };
 
         // Manager assigns the connection idx
-        sender.send(0).unwrap();
+        sender.send(ConnectionEstablishedStatus::Success(0)).unwrap();
 
         let event_queue = protocol_events_rx.len();
         assert_eq!(event_queue, 0); // max=3
@@ -754,5 +775,61 @@ mod tests {
         let Poll::Pending = res else { panic!() };
 
         assert!(protocol_events_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn frost_proto_conn_established_violation() {
+        let (protocol_events_tx, mut protocol_events_rx) = mpsc::channel(3);
+        let protocol_events_tx = PollSender::new(protocol_events_tx);
+
+        let (_conn_tx, conn_rx) = mpsc::unbounded_channel();
+        let conn_rx = UnboundedReceiverStream::new(conn_rx);
+        let conn_rx = ProtocolConnection::from(conn_rx);
+
+        let direction = Direction::Incoming;
+
+        let mut conn = FrostProtoConnection {
+            protocol_events_tx,
+            registration: RegistrationState::NotRegistered,
+            conn_rx,
+            commands_rx: None,
+            my_peer_id: PeerId::new([0; 64]),
+            peer_id: PeerId::new([1; 64]),
+            direction,
+            pending_pong: None,
+        };
+
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        // Poll connection for the first time; it's pending as it needs to be registered first.
+        let res = conn.poll_next_unpin(&mut cx);
+        let Poll::Pending = res else { panic!() };
+
+        let res = conn.poll_next_unpin(&mut cx);
+        let Poll::Pending = res else { panic!() };
+
+        // Manager receives the connection established event.
+        let msg = protocol_events_rx.try_recv().unwrap();
+        let FrostProtocolEvent::ConnectionEstablished {
+            direction: _,
+            peer_id: _,
+            peer_commands_tx: _,
+            sender,
+        } = msg
+        else {
+            panic!()
+        };
+
+        // Connection is pending at this point
+        let res = conn.poll_next_unpin(&mut cx);
+        let Poll::Pending = res else { panic!() };
+
+        // Manager reports a none authority connection attempt
+        sender.send(ConnectionEstablishedStatus::NoneAuthority).unwrap();
+
+        // Connection has to be closed and no longer pending here
+        let res = conn.poll_next_unpin(&mut cx);
+        let Poll::Ready(None) = res else { panic!() };
     }
 }


### PR DESCRIPTION
Fixes audit finding: https://github.com/botanix-labs/botanix/issues/1005