### PR TITLE
chore: reduce e2e test runtime

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,6 +5,7 @@ self-hosted-runner:
     - botanix-actions-runner-vm-1
     - image-builder
     - botanix-actions-runner
+    - k8-runners
 # Configuration variables in array of strings defined in your repository or
 # organization. `null` means disabling configuration variables check.
 # Empty array means no configuration variable is allowed.

--- a/.github/scripts/deps.sh
+++ b/.github/scripts/deps.sh
@@ -1,0 +1,32 @@
+#! /bin/env bash
+
+# Install rustc dependencies for reth and btc-server
+sudo apt-get update
+sudo apt-get install -y \
+    build-essential \
+    libssl-dev \
+    pkg-config \
+    libclang-dev \
+    llvm-dev \
+    protobuf-compiler \
+    gcc \
+    pkg-config \
+    libprotobuf-dev 
+
+
+# Download and install bitcoin core
+wget https://bitcoin.org/bin/bitcoin-core-28.1/bitcoin-28.1-x86_64-linux-gnu.tar.gz
+tar -xzf bitcoin-28.1-x86_64-linux-gnu.tar.gz
+sudo mv bitcoin-28.1/bin/bitcoin-cli /usr/local/bin/bitcoin-cli
+sudo mv bitcoin-28.1/bin/bitcoin-tx /usr/local/bin/bitcoin-tx
+sudo mv bitcoin-28.1/bin/bitcoin-wallet /usr/local/bin/bitcoin-wallet
+sudo mv bitcoin-28.1/bin/bitcoind /usr/local/bin/bitcoind
+
+
+# Download and install cometbft v1.0.1
+wget https://github.com/cometbft/cometbft/releases/download/v1.0.1/cometbft_1.0.1_linux_amd64.tar.gz
+tar -xzf cometbft_1.0.1_linux_amd64.tar.gz
+sudo mv cometbft /usr/local/bin/cometbft
+rm cometbft_1.0.1_linux_amd64.tar.gz
+
+

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -7,178 +7,256 @@ on:
     branches:
       - main
   push:
-    branches:
-      - main
+    branches: [main]
+
+permissions:
+  id-token: write
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
   SEED: rustethereumethereumrust
   JWT_DIR: "/home/runner/actions-runner/_work/Macbeth/Macbeth/bin/test-suite/jwt"
+  # sccache configuration
+  RUSTC_WRAPPER: "sccache"
+  SCCACHE_GHA_ENABLED: "false"  # Disable GitHub Actions cache in favor of GCS
+  SCCACHE_GCS_RW_MODE: "READ_WRITE"
+  SCCACHE_GCS_BUCKET: "macbeth-sccache-bucket"
+  SCCACHE_ERROR_LOG: "/tmp/sccache_log.txt"
+  SCCACHE_LOG: "warn"
+  SCCACHE_GCS_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+  GCP_PROJECT_ID: botanix-391913
+  SCCACHE_GCS_KEY_PATH: "/tmp/gcs-key.json"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
-  e2e:
-    name: test / e2e
-    runs-on:
-      group: macbeth
+  build:
+    name: build test binaries
+    runs-on: ubuntu-latest
     env:
       RUST_BACKTRACE: 1
-    timeout-minutes: 90
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt, clippy
+          components: rustfmt, clippy, cargo
           toolchain: stable
 
-      - name: Install nextest
-        uses: taiki-e/install-action@nextest
+      - name: Install dependencies
+        run: |
+          bash .github/scripts/deps.sh
 
-      - name: Install killall
-        run: sudo apt-get install psmisc
+      - name: gcloud auth
+        id: 'auth'
+        uses: google-github-actions/auth@v2
+        with: 
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      
+      - name: gcloud setup
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ env.GCP_PROJECT_ID }}
+
+      - name: 'Create GCS credentials file for sccache'
+        run: |
+          echo '${{ secrets.GKE_WORKLOAD_KEY }}' > ${SCCACHE_GCS_KEY_PATH}
+          chmod 600 ${SCCACHE_GCS_KEY_PATH}
+
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@v0.0.8
+      
+      - name: Configure sccache
+        run: |
+          sccache --start-server
+          sccache --show-stats
 
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
           cache-all-crates: true
           env-vars: |
-            CARGO_HOME="/home/runner/.cargo"
+            RUSTC_WRAPPER
 
       - name: Compile btc-server
         run: |
           cd ./bin/btc-server && \
           cargo build --bin btc-server && \
           echo "Bitcoin server compiled successfully!"
+          sccache --show-stats
 
       - name: Compile poa-node
         run: |
           cargo build --bin reth && \
           echo "Poa node compiled successfully!"
+          sccache --show-stats
 
-      # Define individual steps for each test
-      - name: Run dkg_flow
+      - name: Compile test-suite
         run: |
-          export TEST_TO_RUN="dkg_flow"
-          make start-test-suite
+          cd ./bin/test-suite && \
+          cargo build --bin test-suite && \
+          echo "Test suite compiled successfully!"
+          sccache --show-stats
+
+      - name: Prepare binaries for upload
+        run: |
+          mkdir -p /tmp/binaries
+          cp target/debug/btc-server /tmp/binaries/ || true
+          cp target/debug/reth /tmp/binaries/ || true
+          cp target/debug/test-suite /tmp/binaries/ || true
+          cp -r ./bin/test-suite /tmp/binaries/ || true
+
+      - name: Upload compiled binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: compiled-binaries
+          path: /tmp/binaries
+          retention-days: 1
+
+      
+  e2e-tests:
+    name: test / ${{ matrix.test }}
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false  # Continue running other tests even if one fails
+      matrix: 
+        test: ["dkg_flow",
+          "utxo_commitment",
+          "signing_flow",
+          "test_mempool_gossip",
+          "utxo_sync",
+          "state_sync",
+          "frost_e2e_stable",
+          "test_pegin_v1",
+          "invalid_pegin",
+          "invalid_pegout",
+          "block_builder",
+          "test_conflicting_input",
+          "test_round1_then_new_signing_session",
+          "test_track_mempool"]
+    env:
+      RUST_BACKTRACE: 1
+      TEST_TO_RUN: ${{ matrix.test }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy, cargo
+          toolchain: stable
+
+      - name: Install dependencies
+        run: |
+          bash .github/scripts/deps.sh
+
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Install killall
+        run: sudo apt-get install psmisc
+      
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v2'
+        with:
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: 'Create GCS credentials file for sccache'
+        run: |
+          echo '${{ secrets.GKE_WORKLOAD_KEY }}' > ${SCCACHE_GCS_KEY_PATH}
+          chmod 600 ${SCCACHE_GCS_KEY_PATH}
+          
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@v0.0.8
+      
+      - name: Configure sccache
+        run: |
+          sccache --start-server
+          sccache --show-stats
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          cache-all-crates: true
+          env-vars: |
+            RUSTC_WRAPPER
+
+      - name: Download compiled binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: compiled-binaries
+          path: /tmp/binaries
+          
+      - name: Setup binaries
+        run: |
+          mkdir -p target/debug
+          mkdir -p ./bin/test-suite
+          
+          if [ -f "/tmp/binaries/btc-server" ]; then
+            cp /tmp/binaries/btc-server target/debug/ 
+            chmod +x target/debug/btc-server
+          fi
+          
+          if [ -f "/tmp/binaries/reth" ]; then
+            cp /tmp/binaries/reth target/debug/
+            chmod +x target/debug/reth
+          fi
+
+          if [ -f "/tmp/binaries/test-suite" ]; then
+            sudo cp /tmp/binaries/test-suite /usr/local/bin/
+            sudo chmod +x /usr/local/bin/test-suite
+          fi
+          
+          if [ -d "/tmp/binaries/test-suite" ]; then
+            cp -r /tmp/binaries/test-suite/* ./bin/test-suite/
+          fi
+      
+      - name: Run ${{ matrix.test }}
+        run: |
+          make start-test-suite-runners
+          
+      - name: Display sccache stats
+        if: always()
+        run: |
+          sccache --show-stats
+          
+      - name: Cleanup resources
+        if: always()
+        run: |
           killall btc-server || true
           killall bitcoind || true
+          sccache --stop-server || true
 
-      - name: Run utxo_commitment
-        run: |
-          export TEST_TO_RUN="utxo_commitment"
-          make start-test-suite
-          killall btc-server || true
-          killall bitcoind || true
-
-      - name: Run signing_flow
-        run: |
-          export TEST_TO_RUN="signing_flow"
-          make start-test-suite
-          killall btc-server || true
-          killall bitcoind || true
-
-      - name: Run test_mempool_gossip
-        run: |
-          export TEST_TO_RUN="test_mempool_gossip"
-          make start-test-suite
-          killall btc-server || true
-          killall bitcoind || true
-
-      - name: Run wallet_sync
-        run: |
-          export TEST_TO_RUN="wallet_sync"
-          make start-test-suite
-          killall btc-server || true
-          killall bitcoind || true
-
-      - name: Run utxo_sync
-        run: |
-          export TEST_TO_RUN="utxo_sync"
-          make start-test-suite
-          killall btc-server || true
-          killall bitcoind || true
-
-      - name: Run state_sync
-        run: |
-          export TEST_TO_RUN="state_sync"
-          make start-test-suite
-          killall btc-server || true
-          killall bitcoind || true
-
-      - name: Run frost_e2e_stable
-        run: |
-          export TEST_TO_RUN="frost_e2e_stable"
-          make start-test-suite
-          killall btc-server || true
-          killall bitcoind || true
-
-      - name: Run test_pegin_v1
-        run: |
-          export TEST_TO_RUN="test_pegin_v1"
-          make start-test-suite
-          killall btc-server || true
-          killall bitcoind || true
-
-      - name: Run invalid_pegin
-        run: |
-          export TEST_TO_RUN="invalid_pegin"
-          make start-test-suite
-          killall btc-server || true
-          killall bitcoind || true
-
-      - name: Run invalid_pegout
-        run: |
-          export TEST_TO_RUN="invalid_pegout"
-          make start-test-suite
-          killall btc-server || true
-          killall bitcoind || true
-
-      - name: Run block_builder
-        run: |
-          export TEST_TO_RUN="block_builder"
-          make start-test-suite
-          killall btc-server || true
-          killall bitcoind || true
-
-      - name: Run test_conflicting_input
-        run: |
-          export TEST_TO_RUN="test_conflicting_input"
-          make start-test-suite
-          killall btc-server || true
-          killall bitcoind || true
-
-      - name: Run test_round1_then_new_signing_session
-        run: |
-          export TEST_TO_RUN="test_round1_then_new_signing_session"
-          make start-test-suite
-          killall btc-server || true
-          killall bitcoind || true
-
-      - name: Run test_track_mempool
-        run: |
-          export TEST_TO_RUN="test_track_mempool"
-          make start-test-suite
-          killall btc-server || true
-          killall bitcoind || true
-
-      # ✅ Final success step if all tests pass
-      - name: All tests passed!
-        if: success()
-        run: echo "✅ All tests completed successfully!"
-
-  integration-success:
-    name: integration success
+  # Final job to report overall status
+  integration-summary:
+    name: integration summary
     runs-on: ubuntu-latest
     if: always()
-    needs:
-      - e2e
-    timeout-minutes: 30
+    needs: [e2e-tests]
+    timeout-minutes: 10
     steps:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}
+      
+      - name: Generate test report
+        if: always()
+        run: |
+          echo "## Integration Test Results" >> $GITHUB_STEP_SUMMARY
+          echo "✅ All tests completed with status: ${{ needs.e2e-tests.result }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Build Cache Performance" >> $GITHUB_STEP_SUMMARY
+          echo "Parallel execution with sccache was used to optimize build times." >> $GITHUB_STEP_SUMMARY
+
+

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -124,7 +124,7 @@ jobs:
     name: test / ${{ matrix.test }}
     runs-on: ubuntu-latest
     needs: build
-    timeout-minutes: 30
+    timeout-minutes: 10
     strategy:
       fail-fast: false  # Continue running other tests even if one fails
       matrix: 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -148,11 +148,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy, cargo
-          toolchain: stable
-
       - name: Install dependencies
         run: |
           bash .github/scripts/deps.sh
@@ -176,20 +171,6 @@ jobs:
           echo '${{ secrets.GKE_WORKLOAD_KEY }}' > ${SCCACHE_GCS_KEY_PATH}
           chmod 600 ${SCCACHE_GCS_KEY_PATH}
           
-      - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.8
-      
-      - name: Configure sccache
-        run: |
-          sccache --start-server
-          sccache --show-stats
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-          cache-all-crates: true
-          env-vars: |
-            RUSTC_WRAPPER
 
       - name: Download compiled binaries
         uses: actions/download-artifact@v4
@@ -225,17 +206,12 @@ jobs:
         run: |
           make start-test-suite-runners
           
-      - name: Display sccache stats
-        if: always()
-        run: |
-          sccache --show-stats
           
       - name: Cleanup resources
         if: always()
         run: |
           killall btc-server || true
           killall bitcoind || true
-          sccache --stop-server || true
 
   # Final job to report overall status
   integration-summary:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -47,7 +47,6 @@ jobs:
           cache-all-crates: true
           
       - name: Ensure registry is up to date
-        if: steps.rust-cache.outputs.cache-hit != 'true'
         run: cargo fetch
 
       - name: Run tests
@@ -98,7 +97,6 @@ jobs:
           cache-all-crates: true
 
       - name: Ensure registry is up to date
-        if: steps.rust-cache.outputs.cache-hit != 'true'
         run: cargo fetch
 
       - name: Run doctests

--- a/Makefile
+++ b/Makefile
@@ -558,6 +558,19 @@ clean-unused-deps:
 # Botanix
 # ------------------------------------------------------------
 
+start-test-suite-runners:
+	cd ./bin/test-suite && \
+	/usr/local/bin/test-suite \
+	--test-to-run "${TEST_TO_RUN}" \
+	--config "./config.toml" \
+	--run-suite all \
+	--timeout 500000 \
+	--dry-run false \
+	--min-signers 3 \
+	--max-signers 4 \
+	--rpc-nodes 1 \
+	--syncing-nodes 1
+
 start-test-suite:
 	cd ./bin/test-suite && \
 	cargo run --bin test-suite -- \

--- a/bin/test-suite/src/suite/consensus/common/bitcoind_node.rs
+++ b/bin/test-suite/src/suite/consensus/common/bitcoind_node.rs
@@ -2,7 +2,7 @@ use super::{create_temp_working_directory, kill_process_at_port, Scope};
 use crate::{
     context::GlobalContext,
     suite::consensus::{
-        common::{events::BITCOIND_WALLET_NAME, spawn_child_process},
+        common::{events::get_unique_wallet_name, spawn_child_process},
         ConsensusIntegrationTestSuite,
     },
     utils::{generate_blocks, MIN_BLOCKS_COINBASE_MATURE},
@@ -78,6 +78,7 @@ pub struct BitcoindNodeConfig {
     pub bitcoind_url: Url,
     pub bitcoind_user: String,
     pub bitcoind_password: String,
+    pub wallet_name: String,
 }
 
 impl BitcoindNodeConfig {
@@ -93,6 +94,7 @@ impl BitcoindNodeConfig {
             bitcoind_url,
             bitcoind_user,
             bitcoind_password,
+            wallet_name: get_unique_wallet_name(),
         })
     }
 
@@ -141,7 +143,7 @@ impl BitcoindNodeConfig {
                 ));
                 let bitcoind_client =
                     bitcoind_factory.build_and_connect().expect("to build and connect client");
-                bitcoind_client.load_wallet(BITCOIND_WALLET_NAME).expect("wallet exists");
+                bitcoind_client.load_wallet(&self.wallet_name).expect("wallet exists");
 
                 // update local context
                 suite.local_context.bitcoind_process = Some(bitcoind_process);
@@ -159,19 +161,19 @@ impl BitcoindNodeConfig {
 
 impl BitcoindNodeConfig {
     pub async fn setup_wallet(&self, bitcoin_client: &impl RpcApi) -> anyhow::Result<()> {
-        match bitcoin_client.create_wallet(BITCOIND_WALLET_NAME, None, None, None, None) {
+        match bitcoin_client.create_wallet(&self.wallet_name, None, None, None, None) {
             Ok(res) => {
-                tracing::info!("Created wallet: {BITCOIND_WALLET_NAME} with result {res:?}");
+                tracing::info!("Created wallet: {} with result {res:?}", &self.wallet_name);
             }
             Err(e) => {
                 let err_msg = e.to_string();
                 // Load the wallet if it already exists
                 if err_msg.contains("already exists") || err_msg.contains("already loaded") {
-                    tracing::info!("Wallet {BITCOIND_WALLET_NAME} already loaded or existing");
+                    tracing::info!("Wallet {} already loaded or existing", &self.wallet_name);
                 } else {
-                    tracing::info!("Loading wallet {BITCOIND_WALLET_NAME} ...");
+                    tracing::info!("Loading wallet {} ...", &self.wallet_name);
                     bitcoin_client
-                        .load_wallet(BITCOIND_WALLET_NAME)
+                        .load_wallet(&self.wallet_name)
                         .map_err(|e| anyhow::anyhow!("Failed to create wallet: {}", e))?;
                 }
             }

--- a/bin/test-suite/src/suite/consensus/common/events.rs
+++ b/bin/test-suite/src/suite/consensus/common/events.rs
@@ -6,7 +6,9 @@ use client::SigningStatus;
 use reth_primitives::{constants::EPOCH_LENGTH, B256};
 use std::collections::BTreeMap;
 
-pub const BITCOIND_WALLET_NAME: &str = "botanix_integration_test_wallet";
+pub fn get_unique_wallet_name() -> String {
+    format!("botanix_test_wallet_{}", uuid::Uuid::new_v4().to_string().replace("-", ""))
+}
 pub const SEND_AMOUNT: u64 = 1; // = 1 ether
 
 pub async fn await_dkg(

--- a/bin/test-suite/src/suite/consensus/frost/test_conflicting_input.rs
+++ b/bin/test-suite/src/suite/consensus/frost/test_conflicting_input.rs
@@ -16,7 +16,7 @@ use rand::{rngs::StdRng, RngCore, SeedableRng};
 use crate::{
     it_info_print,
     suite::consensus::{
-        common::events::BITCOIND_WALLET_NAME,
+        common::events::get_unique_wallet_name,
         frost::{error::Error, test_dkg::do_dkg},
         ConsensusIntegrationTestSuite,
     },
@@ -34,11 +34,12 @@ pub async fn test_conflicting_input(
         it_info_print!("#UNLOADING WALLET?", &wallet);
         let _ = bitcoind.unload_wallet(Some(&wallet))?;
     }
-    let create_res = bitcoind.create_wallet(BITCOIND_WALLET_NAME, None, None, None, None);
+    let wallet_name = get_unique_wallet_name();
+    let create_res = bitcoind.create_wallet(&wallet_name, None, None, None, None);
     if create_res.is_err() {
         tracing::info!("Wallet already exists, loading wallet ...");
         // wallet already exists, load wallet
-        let _ = bitcoind.load_wallet(BITCOIND_WALLET_NAME);
+        let _ = bitcoind.load_wallet(&wallet_name);
     }
     generate_blocks(&bitcoind, MIN_BLOCKS_COINBASE_MATURE).await;
 

--- a/bin/test-suite/src/suite/consensus/frost/test_frost_e2e_signing_disconnect.rs
+++ b/bin/test-suite/src/suite/consensus/frost/test_frost_e2e_signing_disconnect.rs
@@ -21,7 +21,7 @@ use crate::{
     suite::consensus::{
         common::{
             events::{
-                await_botanix_event, GatewayAddressResponse, BITCOIND_WALLET_NAME, SEND_AMOUNT,
+                await_botanix_event, get_unique_wallet_name, GatewayAddressResponse, SEND_AMOUNT,
             },
             poa_node::TestSignal,
         },
@@ -54,11 +54,12 @@ pub async fn frost_e2e_failed_signing_disconnect(
     }
 
     // Load up the bitcoin wallet and generate some blocks
-    let create_res = bitcoind_rpc.create_wallet(BITCOIND_WALLET_NAME, None, None, None, None);
+    let wallet_name = get_unique_wallet_name();
+    let create_res = bitcoind_rpc.create_wallet(&wallet_name, None, None, None, None);
     if create_res.is_err() {
         // wallet already exists
         // load wallet
-        let _ = bitcoind_rpc.load_wallet(BITCOIND_WALLET_NAME);
+        let _ = bitcoind_rpc.load_wallet(&wallet_name);
     }
     // Set up dummy eth address
     let eth_destination = ethers::core::types::Address::random();

--- a/bin/test-suite/src/suite/consensus/frost/test_pending_pegouts.rs
+++ b/bin/test-suite/src/suite/consensus/frost/test_pending_pegouts.rs
@@ -9,7 +9,7 @@ use rand::{rngs::StdRng, RngCore, SeedableRng};
 use crate::{
     it_info_print,
     suite::consensus::{
-        common::events::BITCOIND_WALLET_NAME,
+        common::events::get_unique_wallet_name,
         frost::{error::Error, test_dkg::do_dkg},
         ConsensusIntegrationTestSuite,
     },
@@ -40,10 +40,11 @@ pub async fn test_pending_pegouts(suite: &ConsensusIntegrationTestSuite) -> Resu
         it_info_print!("#UNLOADING WALLET?", &wallet);
         let _ = bitcoind.unload_wallet(Some(&wallet));
     }
-    let create_res = bitcoind.create_wallet(BITCOIND_WALLET_NAME, None, None, None, None);
+    let wallet_name = get_unique_wallet_name();
+    let create_res = bitcoind.create_wallet(&wallet_name, None, None, None, None);
     if create_res.is_err() {
         // wallet already exists, load wallet
-        let _ = bitcoind.load_wallet(BITCOIND_WALLET_NAME);
+        let _ = bitcoind.load_wallet(&wallet_name);
     }
     // generate a block to the network looks live
     generate_blocks(&bitcoind, 1).await;

--- a/bin/test-suite/src/suite/consensus/frost/test_round1_then_new_signing_session.rs
+++ b/bin/test-suite/src/suite/consensus/frost/test_round1_then_new_signing_session.rs
@@ -19,7 +19,7 @@ use tonic::transport::Channel;
 use crate::{
     it_info_print,
     suite::consensus::{
-        common::events::BITCOIND_WALLET_NAME,
+        common::events::get_unique_wallet_name,
         frost::{error::Error, test_dkg::do_dkg},
         ConsensusIntegrationTestSuite,
     },
@@ -102,11 +102,12 @@ pub async fn test_round1_then_new_signing_session(
         it_info_print!("#UNLOADING WALLET?", &wallet);
         let _ = bitcoind.unload_wallet(Some(&wallet))?;
     }
-    let create_res = bitcoind.create_wallet(BITCOIND_WALLET_NAME, None, None, None, None);
+    let wallet_name = get_unique_wallet_name();
+    let create_res = bitcoind.create_wallet(&wallet_name, None, None, None, None);
     if create_res.is_err() {
         tracing::info!("Wallet already exists, loading wallet ...");
         // wallet already exists, load wallet
-        let _ = bitcoind.load_wallet(BITCOIND_WALLET_NAME);
+        let _ = bitcoind.load_wallet(&wallet_name);
     }
     generate_blocks(&bitcoind, MIN_BLOCKS_COINBASE_MATURE).await;
 


### PR DESCRIPTION
Summary

  - Add randomized Bitcoin regtest wallet names for parallel test run on github actions
  - Replace static wallet name with a UUID-based function to generate random wallet names
  - Refactored `integrattion.yml` to aallow e2e test run in parallel