### PR TITLE
fix btc-server docker build

### DIFF
--- a/Dockerfile.btc_server
+++ b/Dockerfile.btc_server
@@ -3,19 +3,18 @@ FROM rust:1.74.0 AS builder
 
 WORKDIR /app
 
-# Copy your Rust project files into the container
-COPY crates/btc-wallet /app/crates/btc-wallet
-COPY bin/btc-server /app/server/btc-server
+COPY . .
 
-WORKDIR /app/server/btc-server
+WORKDIR /app
 
 # Install necessary dependencies in the runtime stage
 RUN apt-get update && apt-get install -y libclang-dev pkg-config build-essential libssl-dev protobuf-compiler
 
-# Build your Rust application using the specified nightly version
+# Build only btc-server package
 RUN rustup toolchain install stable && \
     rustup default stable && \
-    cargo build --release --target-dir /app/server/btc-server/target/
+    cd bin/btc-server && \
+    cargo build --release
 
 # Stage 2: Create the final lightweight image
 FROM ubuntu AS runtime
@@ -23,7 +22,7 @@ FROM ubuntu AS runtime
 WORKDIR /app
 
 # Copy the built artifacts from the builder stage
-COPY --from=builder /app/server/btc-server/target/release/btc-server /usr/local/bin/server
+COPY --from=builder /app/bin/btc-server/target/release/btc-server /usr/local/bin/server
 
 EXPOSE 8080
 

--- a/Dockerfile.btc_server
+++ b/Dockerfile.btc_server
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y libclang-dev pkg-config build-essential
 RUN rustup toolchain install stable && \
     rustup default stable && \
     cd bin/btc-server && \
-    cargo build --release
+    cargo build --release --package btc-server 
 
 # Stage 2: Create the final lightweight image
 FROM ubuntu AS runtime
@@ -22,7 +22,7 @@ FROM ubuntu AS runtime
 WORKDIR /app
 
 # Copy the built artifacts from the builder stage
-COPY --from=builder /app/bin/btc-server/target/release/btc-server /usr/local/bin/server
+COPY --from=builder /app/target/release/btc-server /usr/local/bin/server
 
 EXPOSE 8080
 


### PR DESCRIPTION
cargo build broke inside the container because btc-server inherits futures and tokio-stream from [workspace.dependencies], but the root workspace manifest isn’t copied into the image. Cargo aborts with “failed to find a workspace root”.

Fixed by copying the entire workspace into the builder image and compiling the ``btc-server`` package