### PR TITLE
fix(coin_selection): use Segwit satisfaction weight instead of Taproot.

### DIFF
--- a/bin/btc-server/src/util.rs
+++ b/bin/btc-server/src/util.rs
@@ -1422,11 +1422,26 @@ mod tests {
 
     #[test]
     fn test_btc_per_kb_to_sat_per_vb() {
+        // 0.000_5 BTC = 50_000 sats
+        // 50_000 sats/kb = 50 sats/vb
+
         let btc_per_kb =
-            bitcoin::Amount::from_float_in(0.0005, bitcoin::Denomination::Bitcoin).unwrap();
+            bitcoin::Amount::from_float_in(0.000_5, bitcoin::Denomination::Bitcoin).unwrap();
         let sat_per_vb = btc_per_kb_to_sat_per_vb(btc_per_kb);
 
         assert_eq!(sat_per_vb.to_sat_per_vb_ceil(), 50);
+    }
+
+    #[test]
+    fn test_btc_per_kb_to_sat_per_vb_min_fee_rate() {
+        // 0.000_005 BTC = 500 sats
+        // 500 sats/kb = 0.5 sats/vb => 1 sat/vb
+
+        let btc_per_kb =
+            bitcoin::Amount::from_float_in(0.000_005, bitcoin::Denomination::Bitcoin).unwrap();
+        let sat_per_vb = btc_per_kb_to_sat_per_vb(btc_per_kb);
+
+        assert_eq!(sat_per_vb.to_sat_per_vb_ceil(), 1);
     }
 
     #[tokio::test]

--- a/bin/btc-server/src/util.rs
+++ b/bin/btc-server/src/util.rs
@@ -78,11 +78,23 @@ where
 /// With a pegout bound of 500, we can conclude: (32 + 110) * 500 = 71_000
 pub const UPPER_PEGOUT_BOUND: usize = 500;
 
+/// Converts the BTC/kB fee rate as returned by the Bitcoin Core API endpoint
+/// `estimatesmartfee` to sat/vB.
+///
+/// https://developer.bitcoin.org/reference/rpc/estimatesmartfee.html
+///
+/// > Estimates the approximate fee per kilobyte needed for a transaction to
+/// > begin confirmation within conf_target blocks if possible and return the
+/// > number of blocks for which the estimate is valid. Uses virtual transaction
+/// > size as defined in BIP 141 (witness data is discounted).
 pub fn btc_per_kb_to_sat_per_vb(btc_per_kb: bitcoin::Amount) -> FeeRate {
     let sats = btc_per_kb.to_sat();
     info!("fee rate sats: {:?}", sats);
 
     // Conversion formula
+    //
+    // To convert BTC/kB to sat/vB:
+    // (BTC * 100_000_000) / 1_000 = BTC * 100_000
     let sat_per_vb = btc_per_kb.to_float_in(bitcoin::Denomination::Bitcoin) * 100_000.0;
     info!("fee rate sat_per_vb: {:?}", sat_per_vb);
 

--- a/bin/btc-server/src/wallet/coin_selection.rs
+++ b/bin/btc-server/src/wallet/coin_selection.rs
@@ -1,4 +1,4 @@
-use crate::{database::version::UtxoVersion, wallet::TAPROOT_KEYSPEND_SATISFACTION_WEIGHT};
+use crate::{database::version::UtxoVersion, wallet::SEGWIT_KEYSPEND_SATISFACTION_WEIGHT};
 use bdk_wallet::coin_selection::{
     CoinSelectionAlgorithm, InsufficientFunds, OldestFirstCoinSelection,
 };
@@ -53,7 +53,7 @@ pub(crate) fn coin_selection(
 
     let to_bdk = |u: &Utxo| {
         bdk_wallet::WeightedUtxo {
-            satisfaction_weight: TAPROOT_KEYSPEND_SATISFACTION_WEIGHT,
+            satisfaction_weight: SEGWIT_KEYSPEND_SATISFACTION_WEIGHT,
             utxo: bdk_wallet::Utxo::Local(bdk_wallet::LocalOutput {
                 outpoint: u.outpoint.to_bdk(),
                 txout: bdk_wallet::bitcoin::TxOut {

--- a/bin/btc-server/src/wallet/mod.rs
+++ b/bin/btc-server/src/wallet/mod.rs
@@ -5,8 +5,8 @@ pub mod util;
 
 use bitcoin::Weight;
 
-/// The weight needed to satisfy a taproot output using keyspend.
-pub const TAPROOT_KEYSPEND_SATISFACTION_WEIGHT: Weight = Weight::from_wu(66);
+/// The weight needed to satisfy a Segwit WPKH output.
+pub const SEGWIT_KEYSPEND_SATISFACTION_WEIGHT: Weight = Weight::from_wu(107);
 
 #[cfg(test)]
 mod test {
@@ -21,8 +21,8 @@ mod test {
         let key_pair = Keypair::new(&secp, &mut rand::thread_rng());
 
         let desc =
-            Descriptor::Tr(miniscript::descriptor::Tr::new(key_pair.public_key(), None).unwrap());
+            Descriptor::Wpkh(miniscript::descriptor::Wpkh::new(key_pair.public_key()).unwrap());
         let weight = desc.max_weight_to_satisfy().unwrap();
-        assert_eq!(weight, TAPROOT_KEYSPEND_SATISFACTION_WEIGHT);
+        assert_eq!(weight, SEGWIT_KEYSPEND_SATISFACTION_WEIGHT);
     }
 }


### PR DESCRIPTION
We rely on the `bdk_wallet` [coin selection](https://docs.rs/bdk/latest/bdk/wallet/coin_selection/struct.BranchAndBoundCoinSelection.html#method.coin_select) mechanism to pick to necessary amount of UTXOs (inputs) for our transaction. But before we pass on the UTXO, we prepare the necessary `WeightedUtxo` structure where we use **66wu** (Taproot) for the [satisfaction weight field](https://docs.rs/bdk/latest/bdk/struct.WeightedUtxo.html#structfield.satisfaction_weight). However, all our transactions are Segwit (P2WPKH), hence we should be using **107wu**. Our current implementation severely underestimates the actual transaction weight. 

I believe that this is what is causing that _"min relay fee not met"_ issue we occasionally encounter in `bitcoind`, but we probably need to do further monitoring on whether this is the main cause.