### PR TITLE
cleanup(frost_task): add Frost Id lookup for `DkgRunnerTask`

### DIFF
--- a/crates/consensus/authority/src/frost_task.rs
+++ b/crates/consensus/authority/src/frost_task.rs
@@ -801,18 +801,21 @@ where
         for payload in payloads {
             let recipient = frost_id_from_bytes(&payload.recipient).expect("valid frost id");
 
+            // Lookup the public key of the recipient.
+            let Some(pk) = self.frost_ids.get(&recipient) else {
+                error!(target: "consensus::authority::frost_task::DkgRunnerTask", "No Frost Id lookup available for recipient {:?}, dropping DKG payload...", recipient);
+                continue;
+            };
+
+            let pk_string = pk.to_string();
+
             // TODO (lamafab): This could be improved, by using a hashmap or so.
             let Some(peer_data) = all_peers_handles
                 .iter()
                 .find(|(_, peer_data)| peer_data.frost_identifier == recipient)
                 .map(|(_, peer_data)| peer_data)
             else {
-                let Some(pk) = self.frost_ids.get(&recipient) else {
-                    error!(target: "consensus::authority::frost_task::DkgRunnerTask", "No Frost Id lookup available for recipient {:?}, dropping DKG payload...", recipient);
-                    continue;
-                };
-
-                warn!(target: "consensus::authority::frost_task::DkgRunnerTask", "Peer handle not found for recipient {}, dropping DKG payload...", pk.to_string());
+                warn!(target: "consensus::authority::frost_task::DkgRunnerTask", "Peer handle not found for recipient {}, dropping DKG payload...", pk_string);
                 continue;
             };
 
@@ -822,9 +825,13 @@ where
                 recipient: payload.recipient,
             });
 
-            if peer_data.peer_commands_tx.send(FrostPeerCommand::PeerMessage(resp)).is_err() {
-                error!(target: "consensus::authority::frost_task::DkgRunnerTask", "Error sending DKG payload to peer {:?}", peer_data.peer_id);
-                continue;
+            match peer_data.peer_commands_tx.send(FrostPeerCommand::PeerMessage(resp)) {
+                Ok(_) => {
+                    info!(target: "consensus::authority::frost_task::DkgRunnerTask", "Gossiping DKG payload to peer {:?}", pk_string);
+                }
+                Err(err) => {
+                    error!(target: "consensus::authority::frost_task::DkgRunnerTask", "Error sending DKG payload to recipient {}: {:?}", pk_string, err);
+                }
             }
         }
     }

--- a/crates/consensus/authority/src/frost_task.rs
+++ b/crates/consensus/authority/src/frost_task.rs
@@ -830,7 +830,7 @@ where
 
             match peer_data.peer_commands_tx.send(FrostPeerCommand::PeerMessage(resp)) {
                 Ok(_) => {
-                    info!(target: "consensus::authority::frost_task::DkgRunnerTask", "Gossiping DKG payload to peer {:?}", pk_string);
+                    info!(target: "consensus::authority::frost_task::DkgRunnerTask", "Gossiping DKG payload to peer {}", pk_string);
                 }
                 Err(err) => {
                     error!(target: "consensus::authority::frost_task::DkgRunnerTask", "Error sending DKG payload to recipient {}: {:?}", pk_string, err);

--- a/crates/consensus/authority/src/frost_task.rs
+++ b/crates/consensus/authority/src/frost_task.rs
@@ -74,6 +74,9 @@ pub struct FrostTask<EF, BF, DB, ToFrostMan, Source, BtcServerClient> {
     pub(crate) signing_state_machine: SigningStateMachine<ToFrostMan, Source, BtcServerClient>,
     /// Shared storage to insert aggregate public key
     pub(crate) storage: Storage<EF, BF, DB>,
+    /// A handle to the `DkgRunnerTask` task. This is only `Some` if no
+    /// aggregate public key is available, and the `start_task` method has hence
+    /// started the DKG process.
     dkg_task: Option<mpsc::Sender<DkgResponse>>,
     /// Pre-configured data-parser
     compressor: DataParser,

--- a/crates/consensus/authority/src/frost_task.rs
+++ b/crates/consensus/authority/src/frost_task.rs
@@ -1,4 +1,4 @@
-use std::{str::FromStr, sync::Arc, time::Duration};
+use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
 
 use crate::{
     metrics::AuthorityMetrics,
@@ -23,7 +23,10 @@ use reth_chainspec::ChainSpec;
 use reth_data_parser::{DataParser, Error as DataParserError};
 use reth_network::{
     frost::{
-        manager::{FrostCommand, FrostConfig, PeerData, ToFrostManager},
+        manager::{
+            authority_index_to_frost_identifier, FrostCommand, FrostConfig, PeerData,
+            ToFrostManager,
+        },
         DkgResponse, FrostPeerCommand, PeerMessageResponse, SigningEventResponseType,
         SigningResponse, WalletStateResponse,
     },
@@ -253,6 +256,7 @@ where
             // Start the dkg state machine task runner.
             let tx = DkgRunnerTask::new(
                 self.frost_handle.clone(),
+                self.frost_config.authorities.as_ref(),
                 self.storage.clone(),
                 self.btc_server.clone(),
                 Arc::clone(&self.metrics),
@@ -655,6 +659,8 @@ struct DkgRunnerTask<EF, BF, DB, ToFrostMan, BtcServerClient> {
     rx: mpsc::Receiver<DkgResponse>,
     // Frost network Handler
     frost_handle: ToFrostMan,
+    // Frost Id lookup table
+    frost_ids: HashMap<frost_secp256k1_tr::Identifier, secp256k1::PublicKey>,
     // Shared storage to insert aggregate public key
     storage: Storage<EF, BF, DB>,
     // btc-server client
@@ -680,13 +686,23 @@ where
     #[allow(clippy::new_ret_no_self)]
     fn new(
         frost_handle: ToFrostMan,
+        authorities: &[secp256k1::PublicKey],
         storage: Storage<EF, BF, DB>,
         btc_server: BtcServerClient,
         metrics: Arc<AuthorityMetrics>,
     ) -> mpsc::Sender<DkgResponse> {
         let (tx, rx) = mpsc::channel(100);
 
-        let this = DkgRunnerTask { rx, frost_handle, storage, btc_server, metrics };
+        let frost_ids = authorities
+            .iter()
+            .enumerate()
+            .map(|(index, pk)| {
+                let frost_id = authority_index_to_frost_identifier(index as u16);
+                (frost_id, pk.clone())
+            })
+            .collect();
+
+        let this = DkgRunnerTask { rx, frost_handle, frost_ids, storage, btc_server, metrics };
 
         // Spawn-off the task, which will keep interacting with the btc-server.
         tokio::spawn(this.run());
@@ -791,7 +807,12 @@ where
                 .find(|(_, peer_data)| peer_data.frost_identifier == recipient)
                 .map(|(_, peer_data)| peer_data)
             else {
-                warn!(target: "consensus::authority::frost_task::DkgRunnerTask", "Peer handle not found for recipient {:?}, dropping DKG payload...", payload.recipient);
+                let Some(pk) = self.frost_ids.get(&recipient) else {
+                    error!(target: "consensus::authority::frost_task::DkgRunnerTask", "No Frost Id lookup available for recipient {:?}, dropping DKG payload...", recipient);
+                    continue;
+                };
+
+                warn!(target: "consensus::authority::frost_task::DkgRunnerTask", "Peer handle not found for recipient {}, dropping DKG payload...", pk.to_string());
                 continue;
             };
 

--- a/crates/consensus/authority/src/frost_task.rs
+++ b/crates/consensus/authority/src/frost_task.rs
@@ -701,7 +701,7 @@ where
             .enumerate()
             .map(|(index, pk)| {
                 let frost_id = authority_index_to_frost_identifier(index as u16);
-                (frost_id, pk.clone())
+                (frost_id, *pk)
             })
             .collect();
 


### PR DESCRIPTION
Follow-up PR for https://github.com/botanix-labs/Macbeth/pull/663

This adds a simple lookup table to the DKG process such that the log statements print the actual public key instead of the verbose Frost Id. For example:

```console
2025-05-06T21:44:57.253626Z  WARN DKG timeout triggered
2025-05-06T21:44:57.256617Z  INFO Ready to gossip 1 generated DKG payload(s)
2025-05-06T21:44:57.256748Z  WARN Peer handle not found for recipient 038df7fcb0e1cdd68741ca85184e046a42c914e0c3ffcb2464d46be3d8b4a5b140, dropping DKG payload...
```

This allows the administrator to easily find the corresponding match in the federation Toml, knowing what federation member to blame.