### PR TITLE
Revert "replace Taproot satisfaction weight with Segwit satisfaction …

### DIFF
--- a/bin/btc-server/src/wallet/coin_selection.rs
+++ b/bin/btc-server/src/wallet/coin_selection.rs
@@ -1,4 +1,4 @@
-use crate::{database::version::UtxoVersion, wallet::SEGWIT_KEYSPEND_SATISFACTION_WEIGHT};
+use crate::{database::version::UtxoVersion, wallet::TAPROOT_KEYSPEND_SATISFACTION_WEIGHT};
 use bdk_wallet::coin_selection::{
     CoinSelectionAlgorithm, InsufficientFunds, OldestFirstCoinSelection,
 };
@@ -53,7 +53,7 @@ pub(crate) fn coin_selection(
 
     let to_bdk = |u: &Utxo| {
         bdk_wallet::WeightedUtxo {
-            satisfaction_weight: SEGWIT_KEYSPEND_SATISFACTION_WEIGHT,
+            satisfaction_weight: TAPROOT_KEYSPEND_SATISFACTION_WEIGHT,
             utxo: bdk_wallet::Utxo::Local(bdk_wallet::LocalOutput {
                 outpoint: u.outpoint.to_bdk(),
                 txout: bdk_wallet::bitcoin::TxOut {

--- a/bin/btc-server/src/wallet/mod.rs
+++ b/bin/btc-server/src/wallet/mod.rs
@@ -5,8 +5,8 @@ pub mod util;
 
 use bitcoin::Weight;
 
-/// The weight needed to satisfy a Segwit WPKH output.
-pub const SEGWIT_KEYSPEND_SATISFACTION_WEIGHT: Weight = Weight::from_wu(107);
+/// The weight needed to satisfy a taproot output using keyspend.
+pub const TAPROOT_KEYSPEND_SATISFACTION_WEIGHT: Weight = Weight::from_wu(66);
 
 #[cfg(test)]
 mod test {
@@ -21,8 +21,8 @@ mod test {
         let key_pair = Keypair::new(&secp, &mut rand::thread_rng());
 
         let desc =
-            Descriptor::Wpkh(miniscript::descriptor::Wpkh::new(key_pair.public_key()).unwrap());
+            Descriptor::Tr(miniscript::descriptor::Tr::new(key_pair.public_key(), None).unwrap());
         let weight = desc.max_weight_to_satisfy().unwrap();
-        assert_eq!(weight, SEGWIT_KEYSPEND_SATISFACTION_WEIGHT);
+        assert_eq!(weight, TAPROOT_KEYSPEND_SATISFACTION_WEIGHT);
     }
 }


### PR DESCRIPTION
…weight"

This reverts commit 694cf78f0c4e03f8321a54e5919d41798f0374fc.

There was a misunderstanding that our inputs are non-taproot. All of the inputs we create are taproot (segwitv0). And all the spends are taproot key spends which should be using a estimated 66 wu.