### PR TITLE
build: consistent rust code format

### DIFF
--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -1,0 +1,48 @@
+---
+name: "Setup Rust"
+description: "Install Rust toolchain, dependencies, and setup cache"
+inputs:
+  toolchain:
+    description: Rust toolchain to use, stable / nightly / beta, or exact version; uses rust-toolchain.toml if not specified
+    required: false
+  target:
+    description: Target Rust platform
+    required: false
+  components:
+    description: List of additional Rust toolchain components to install
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Extract Rust toolchain version from rust-toolchain.toml
+      shell: bash
+      id: rust_toolchain
+      run: |
+        TOOLCHAIN_VERSION="${{ inputs.toolchain }}"
+        if [[ -z "$TOOLCHAIN_VERSION" ]]; then
+          TOOLCHAIN_VERSION=$(grep channel rust-toolchain.toml | awk '{print $3}' | tr -d '"')
+        fi
+
+        echo "TOOLCHAIN_VERSION=$TOOLCHAIN_VERSION" >> $GITHUB_ENV
+        echo "version=$TOOLCHAIN_VERSION"  >> $GITHUB_OUTPUT
+
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ steps.rust_toolchain.outputs.version }}
+        target: ${{ inputs.target }}
+        components: ${{ inputs.components }}
+
+    - name: Install Protobuf Compiler
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y protobuf-compiler
+      shell: sh
+
+    - uses: Swatinem/rust-cache@v2
+      with:
+        cache-on-failure: true
+        cache-all-crates: true
+        env-vars: |
+          RUSTC_WRAPPER

--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -34,12 +34,6 @@ runs:
         target: ${{ inputs.target }}
         components: ${{ inputs.components }}
 
-    - name: Install Protobuf Compiler
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y protobuf-compiler
-      shell: bash
-
     - uses: Swatinem/rust-cache@v2
       with:
         cache-on-failure: true

--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -36,9 +36,9 @@ runs:
 
     - name: Install Protobuf Compiler
       run: |
-        apt-get update
-        apt-get install -y protobuf-compiler
-      shell: sh
+        sudo apt-get update
+        sudo apt-get install -y protobuf-compiler
+      shell: bash
 
     - uses: Swatinem/rust-cache@v2
       with:

--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -36,9 +36,9 @@ runs:
 
     - name: Install Protobuf Compiler
       run: |
-        sudo apt-get update
-        sudo apt-get install -y protobuf-compiler
-      shell: bash
+        apt-get update
+        apt-get install -y protobuf-compiler
+      shell: sh
 
     - uses: Swatinem/rust-cache@v2
       with:

--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -38,7 +38,7 @@ runs:
       run: |
         sudo apt-get update
         sudo apt-get install -y protobuf-compiler
-      shell: sh
+      shell: bash
 
     - uses: Swatinem/rust-cache@v2
       with:

--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -26,10 +26,10 @@ jobs:
         id: extract_version
     outputs:
       VERSION: ${{ steps.extract_version.outputs.VERSION }}
-  
+
   build:
     name: build release
-    runs-on: 
+    runs-on:
       group: macbeth
     permissions:
       contents: read
@@ -51,22 +51,17 @@ jobs:
     steps:
         - uses: actions/checkout@v4
         - uses: rui314/setup-mold@v1
-        - uses: dtolnay/rust-toolchain@stable
+
+        - name: Setup Rust
+          uses: ./.github/actions/setup-rust
           with:
             target: ${{ matrix.configs.target }}
+
         - name: Install cross main
           id: cross_main
           run: |
             cargo install cross --git https://github.com/cross-rs/cross
 
-        - name: Install protoc
-          run: |
-            sudo apt-get update
-            sudo apt-get install -y protobuf-compiler
-
-        - uses: Swatinem/rust-cache@v2
-          with:
-            cache-on-failure: true
         - name: Build Reth Binary
           run: make PROFILE=${{ matrix.configs.profile }} build-${{ matrix.configs.target }}
 
@@ -81,15 +76,14 @@ jobs:
             mv "target/${{ matrix.configs.target }}/${{ matrix.configs.profile }}/reth${ext}" ./artifacts
             mv "target/${{ matrix.configs.target }}/release/btc-server${ext}" ./artifacts
 
-
         - name: gcloud auth
           id: 'auth'
           uses: google-github-actions/auth@v2
-          with: 
+          with:
             project_id: botanix-391913
             workload_identity_provider: projects/1091390741689/locations/global/workloadIdentityPools/github-pool/providers/github-provider
             service_account: github-actions-sa@botanix-391913.iam.gserviceaccount.com
-        
+
         - name: gcloud setup
           uses: google-github-actions/setup-gcloud@v2
           with:
@@ -101,7 +95,7 @@ jobs:
             tar -cvf ${{ matrix.build.binary }}-${{ matrix.configs.target }}.tar.gz ${{ matrix.build.binary }}*
             sha256sum ${{ matrix.build.binary }}-${{ matrix.configs.target }}.tar.gz > ${{ matrix.build.binary }}-${{ matrix.configs.target }}.tar.gz.sha256sum
             mv ${{ matrix.build.binary }}-${{ matrix.configs.target }}.tar.gz ${{ matrix.build.binary }}-${{ matrix.configs.target }}.tar.gz.sha256sum ..
-            
+
         - name: Upload Artifacts
           uses: actions/upload-artifact@v4
           with:
@@ -129,4 +123,3 @@ jobs:
             echo "https://storage.googleapis.com/botanix-artifact-registry/releases/${{ matrix.build.binary }}/${VERSION}/${{ matrix.build.binary }}-${{ matrix.configs.target }}.tar.gz.sha256sum"
 
 
-  

--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -62,6 +62,11 @@ jobs:
           run: |
             cargo install cross --git https://github.com/cross-rs/cross
 
+        - name: Install protoc
+          run: |
+            sudo apt-get update
+            sudo apt-get install -y protobuf-compiler
+
         - name: Build Reth Binary
           run: make PROFILE=${{ matrix.configs.profile }} build-${{ matrix.configs.target }}
 

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -82,7 +82,7 @@ jobs:
         run: mdbook build
 
       - name: Build docs
-        run: cargo doc --no-deps --workspace --exclude "example-*"
+        run: cargo +nightly doc --no-deps --workspace --exclude "example-*"
         env:
           # Keep in sync with ./ci.yml:jobs.docs
           RUSTDOCFLAGS:

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -60,6 +60,8 @@ jobs:
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
+        with:
+          toolchain: nightly
 
       - name: Install Protobuf Compiler
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
 
+      - name: Install Protobuf Compiler
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
       - name: Install mdbook
         run: |
           mkdir mdbook

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -57,9 +57,10 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
-      - name: Install Protobuf Compiler
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+
       - name: Install mdbook
         run: |
           mkdir mdbook
@@ -71,10 +72,6 @@ jobs:
           mkdir mdbook-template
           curl -sSL https://github.com/sgoudham/mdbook-template/releases/latest/download/mdbook-template-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook-template
           echo $(pwd)/mdbook-template >> $GITHUB_PATH
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
 
       - name: Build book
         run: mdbook build

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential libclang-dev lld llvm curl
+          sudo apt-get install -y build-essential libclang-dev lld llvm curl protobuf-compiler
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,19 +24,10 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential libclang-dev lld llvm curl protobuf-compiler
+          sudo apt-get install -y build-essential libclang-dev lld llvm curl
 
-      - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
-          toolchain: stable
-
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-          cache-all-crates: true
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
 
       - name: Install nextest
         uses: taiki-e/install-action@nextest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -42,10 +42,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy, cargo
-          toolchain: stable
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
 
       - name: Install dependencies
         run: |
@@ -54,11 +52,11 @@ jobs:
       - name: gcloud auth
         id: 'auth'
         uses: google-github-actions/auth@v2
-        with: 
+        with:
           project_id: ${{ env.GCP_PROJECT_ID }}
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-      
+
       - name: gcloud setup
         uses: google-github-actions/setup-gcloud@v2
         with:
@@ -71,18 +69,11 @@ jobs:
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.9
-      
+
       - name: Configure sccache
         run: |
           sccache --start-server
           sccache --show-stats
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-          cache-all-crates: true
-          env-vars: |
-            RUSTC_WRAPPER
 
       - name: Compile btc-server
         run: |
@@ -91,7 +82,7 @@ jobs:
           cargo build --bin btc-server 
           echo "Bitcoin server compiled successfully!"
           sccache --show-stats
-    
+
       - name: Compile poa-node
         run: |
           set -eo pipefail
@@ -122,7 +113,7 @@ jobs:
           path: /tmp/binaries
           retention-days: 1
 
-      
+
   e2e-tests:
     name: test / ${{ matrix.test }}
     runs-on: ubuntu-latest
@@ -130,7 +121,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       fail-fast: false  # Continue running other tests even if one fails
-      matrix: 
+      matrix:
         test: ["dkg_flow",
           "utxo_commitment",
           "signing_flow",
@@ -161,7 +152,7 @@ jobs:
 
       - name: Install killall
         run: sudo apt-get install psmisc
-      
+
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
         uses: 'google-github-actions/auth@v2'
@@ -174,13 +165,13 @@ jobs:
         run: |
           echo '${{ secrets.GKE_WORKLOAD_KEY }}' > ${SCCACHE_GCS_KEY_PATH}
           chmod 600 ${SCCACHE_GCS_KEY_PATH}
-          
+
       - name: Download compiled binaries
         uses: actions/download-artifact@v4
         with:
           name: compiled-binaries
           path: /tmp/binaries
-          
+
       - name: Setup binaries
         run: |
           mkdir -p target/debug
@@ -204,12 +195,12 @@ jobs:
           if [ -d "/tmp/binaries/test-suite-dir" ]; then
             cp -r /tmp/binaries/test-suite-dir/* ./bin/test-suite/
           fi
-      
+
       - name: Run ${{ matrix.test }}
         run: |
           make start-test-suite-runners
           
-          
+
       - name: Cleanup resources
         if: always()
         run: |
@@ -228,7 +219,7 @@ jobs:
         uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}
-      
+
       - name: Generate test report
         if: always()
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,16 +45,12 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - name: Install Protobuf Compiler
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-      - uses: dtolnay/rust-toolchain@clippy
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
         with:
-          components: rustfmt, clippy
-          toolchain: 1.85.0
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-          cache-all-crates: true
+          components: clippy
+
       - run: cargo clippy -p reth-authority-consensus -p reth-network -p reth-primitives -p reth-rpc --lib
           --tests --benches --all-features --locked
         env:
@@ -65,14 +61,12 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+
       - uses: taiki-e/install-action@cargo-hack
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-          cache-all-crates: true
-      - name: Install Protobuf Compiler
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
       - run: cargo hack check --workspace --exclude example-custom-evm --exclude example-stateful-precompile
 
   lockfile:
@@ -80,10 +74,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
-          toolchain: stable
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+
       - run: cargo update --workspace --locked
 
   # pre-commit:
@@ -176,18 +170,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: rustfmt, clippy
-          toolchain: nightly
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
 
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
-
-      - name: Install Protobuf Compiler
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - uses: pnpm/action-setup@v4
         name: Install pnpm

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,6 +46,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install Protobuf Compiler
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:
@@ -66,6 +69,9 @@ jobs:
         uses: ./.github/actions/setup-rust
 
       - uses: taiki-e/install-action@cargo-hack
+
+      - name: Install Protobuf Compiler
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - run: cargo hack check --workspace --exclude example-custom-evm --exclude example-stateful-precompile
 
@@ -177,6 +183,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+
+      - name: Install Protobuf Compiler
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - uses: pnpm/action-setup@v4
         name: Install pnpm

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -33,19 +33,13 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
-          toolchain: stable
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
 
       - name: Install nextest
         uses: taiki-e/install-action@nextest
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-          cache-all-crates: true
-          
       - name: Ensure registry is up to date
         run: cargo fetch
 
@@ -55,7 +49,7 @@ jobs:
             --locked --features "ethereum" \
             --workspace --exclude example-custom-evm --exclude example-stateful-precompile --exclude ef-tests \
             -E "kind(lib) | kind(bin) | kind(proc-macro)"
-  
+
   # Commented out till we fix the test harness
   # state:
   #   name: Ethereum state tests
@@ -90,11 +84,9 @@ jobs:
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-          cache-all-crates: true
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
 
       - name: Ensure registry is up to date
         run: cargo fetch

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace.package]
 version = "1.0.10"
 edition = "2021"
+# rust-toolchain.toml must be updated as well
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"
 homepage = "https://paradigmxyz.github.io/reth"

--- a/Makefile
+++ b/Makefile
@@ -335,7 +335,7 @@ fmt-cargo:
 	cargo sort -w
 
 fmt-rust:
-	cargo +nightly fmt --all -- --color always
+	cargo fmt --all -- --color always
 
 fmt-prettier:
 	pnpm prettier:fix
@@ -729,7 +729,7 @@ start-poa-server-2:
 	--abci-port=36658 \
 	--sync.enable_state_sync \
 	--sync.enable_historical_sync \
-	--block-fee-recipient-address "${BLOCK_FEE_RECIPIENT_ADDRESS}" 
+	--block-fee-recipient-address "${BLOCK_FEE_RECIPIENT_ADDRESS}"
 
 start-poa-server-3:
 	cd ./bin/reth && \

--- a/bin/btc-server/client/src/btc_server.rs
+++ b/bin/btc-server/client/src/btc_server.rs
@@ -306,10 +306,10 @@ pub mod btc_server_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     #[derive(Debug, Clone)]
     pub struct BtcServerClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -353,9 +353,8 @@ pub mod btc_server_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             BtcServerClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -394,42 +393,26 @@ pub mod btc_server_client {
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> std::result::Result<tonic::Response<super::Empty>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/btc_server.BtcServer/HealthCheck",
-            );
+            let path = http::uri::PathAndQuery::from_static("/btc_server.BtcServer/HealthCheck");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("btc_server.BtcServer", "HealthCheck"));
+            req.extensions_mut().insert(GrpcMethod::new("btc_server.BtcServer", "HealthCheck"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_pending_pegouts(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetPendingPegoutsResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::GetPendingPegoutsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/btc_server.BtcServer/GetPendingPegouts",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/btc_server.BtcServer/GetPendingPegouts");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("btc_server.BtcServer", "GetPendingPegouts"));
@@ -439,49 +422,31 @@ pub mod btc_server_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetFinalizedPegoutIdsRequest>,
         ) -> std::result::Result<
-            tonic::Response<
-                tonic::codec::Streaming<super::GetFinalizedPegoutIdsResponse>,
-            >,
+            tonic::Response<tonic::codec::Streaming<super::GetFinalizedPegoutIdsResponse>>,
             tonic::Status,
         > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/btc_server.BtcServer/GetFinalizedPegoutIds",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/btc_server.BtcServer/GetFinalizedPegoutIds");
             let mut req = request.into_request();
             req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("btc_server.BtcServer", "GetFinalizedPegoutIds"),
-                );
+                .insert(GrpcMethod::new("btc_server.BtcServer", "GetFinalizedPegoutIds"));
             self.inner.server_streaming(req, path, codec).await
         }
         pub async fn get_gateway_address(
             &mut self,
             request: impl tonic::IntoRequest<super::GetGatewayAddressRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetGatewayAddressResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::GetGatewayAddressResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/btc_server.BtcServer/GetGatewayAddress",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/btc_server.BtcServer/GetGatewayAddress");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("btc_server.BtcServer", "GetGatewayAddress"));
@@ -490,159 +455,101 @@ pub mod btc_server_client {
         pub async fn get_public_key(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetPublicKeyResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::GetPublicKeyResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/btc_server.BtcServer/GetPublicKey",
-            );
+            let path = http::uri::PathAndQuery::from_static("/btc_server.BtcServer/GetPublicKey");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("btc_server.BtcServer", "GetPublicKey"));
+            req.extensions_mut().insert(GrpcMethod::new("btc_server.BtcServer", "GetPublicKey"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_dkg_payloads(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> std::result::Result<tonic::Response<super::DkgPayloads>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/btc_server.BtcServer/GetDkgPayloads",
-            );
+            let path = http::uri::PathAndQuery::from_static("/btc_server.BtcServer/GetDkgPayloads");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("btc_server.BtcServer", "GetDkgPayloads"));
+            req.extensions_mut().insert(GrpcMethod::new("btc_server.BtcServer", "GetDkgPayloads"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn new_dkg_payload(
             &mut self,
             request: impl tonic::IntoRequest<super::DkgPayload>,
         ) -> std::result::Result<tonic::Response<super::DkgPayloads>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/btc_server.BtcServer/NewDkgPayload",
-            );
+            let path = http::uri::PathAndQuery::from_static("/btc_server.BtcServer/NewDkgPayload");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("btc_server.BtcServer", "NewDkgPayload"));
+            req.extensions_mut().insert(GrpcMethod::new("btc_server.BtcServer", "NewDkgPayload"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_round1_signing_package(
             &mut self,
             request: impl tonic::IntoRequest<super::SigningPackageRequest>,
         ) -> std::result::Result<tonic::Response<super::SigningPackage>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/btc_server.BtcServer/GetRound1SigningPackage",
             );
             let mut req = request.into_request();
             req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("btc_server.BtcServer", "GetRound1SigningPackage"),
-                );
+                .insert(GrpcMethod::new("btc_server.BtcServer", "GetRound1SigningPackage"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_round2_signing_package(
             &mut self,
             request: impl tonic::IntoRequest<super::SigningPackageRequest>,
         ) -> std::result::Result<tonic::Response<super::SigningPackage>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/btc_server.BtcServer/GetRound2SigningPackage",
             );
             let mut req = request.into_request();
             req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("btc_server.BtcServer", "GetRound2SigningPackage"),
-                );
+                .insert(GrpcMethod::new("btc_server.BtcServer", "GetRound2SigningPackage"));
             self.inner.unary(req, path, codec).await
         }
         /// Ran by the signer.
         pub async fn signer_finalize(
             &mut self,
             request: impl tonic::IntoRequest<super::FinalizeSignerRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::FinalizeSigningResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::FinalizeSigningResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/btc_server.BtcServer/SignerFinalize",
-            );
+            let path = http::uri::PathAndQuery::from_static("/btc_server.BtcServer/SignerFinalize");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("btc_server.BtcServer", "SignerFinalize"));
+            req.extensions_mut().insert(GrpcMethod::new("btc_server.BtcServer", "SignerFinalize"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn abort_signing(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> std::result::Result<tonic::Response<super::Empty>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/btc_server.BtcServer/AbortSigning",
-            );
+            let path = http::uri::PathAndQuery::from_static("/btc_server.BtcServer/AbortSigning");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("btc_server.BtcServer", "AbortSigning"));
+            req.extensions_mut().insert(GrpcMethod::new("btc_server.BtcServer", "AbortSigning"));
             self.inner.unary(req, path, codec).await
         }
         /// only meant to be used by the cordinator
@@ -650,46 +557,32 @@ pub mod btc_server_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SigningPackage>,
         ) -> std::result::Result<tonic::Response<super::Empty>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/btc_server.BtcServer/NewRound1SigningPackage",
             );
             let mut req = request.into_request();
             req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("btc_server.BtcServer", "NewRound1SigningPackage"),
-                );
+                .insert(GrpcMethod::new("btc_server.BtcServer", "NewRound1SigningPackage"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn new_round2_signing_package(
             &mut self,
             request: impl tonic::IntoRequest<super::SigningPackage>,
         ) -> std::result::Result<tonic::Response<super::Empty>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/btc_server.BtcServer/NewRound2SigningPackage",
             );
             let mut req = request.into_request();
             req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("btc_server.BtcServer", "NewRound2SigningPackage"),
-                );
+                .insert(GrpcMethod::new("btc_server.BtcServer", "NewRound2SigningPackage"));
             self.inner.unary(req, path, codec).await
         }
         /// Meant to be used at anytime to perform utxo selection and create a tx
@@ -697,21 +590,13 @@ pub mod btc_server_client {
             &mut self,
             request: impl tonic::IntoRequest<super::MakeTxRequest>,
         ) -> std::result::Result<tonic::Response<super::SigningPackage>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/btc_server.BtcServer/GetPsbt",
-            );
+            let path = http::uri::PathAndQuery::from_static("/btc_server.BtcServer/GetPsbt");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("btc_server.BtcServer", "GetPsbt"));
+            req.extensions_mut().insert(GrpcMethod::new("btc_server.BtcServer", "GetPsbt"));
             self.inner.unary(req, path, codec).await
         }
         /// Meant to be used to transition the signing round to round 2 after round 1
@@ -720,18 +605,12 @@ pub mod btc_server_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ToSignRequest>,
         ) -> std::result::Result<tonic::Response<super::SigningPackage>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/btc_server.BtcServer/GetToSignPackage",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/btc_server.BtcServer/GetToSignPackage");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("btc_server.BtcServer", "GetToSignPackage"));
@@ -741,115 +620,70 @@ pub mod btc_server_client {
         pub async fn finalize_signing(
             &mut self,
             request: impl tonic::IntoRequest<super::FinalizeSigningRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::FinalizeSigningResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::FinalizeSigningResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/btc_server.BtcServer/FinalizeSigning",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/btc_server.BtcServer/FinalizeSigning");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("btc_server.BtcServer", "FinalizeSigning"));
+            req.extensions_mut().insert(GrpcMethod::new("btc_server.BtcServer", "FinalizeSigning"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_all_utxos(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetAllUtxosResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::GetAllUtxosResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/btc_server.BtcServer/GetAllUtxos",
-            );
+            let path = http::uri::PathAndQuery::from_static("/btc_server.BtcServer/GetAllUtxos");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("btc_server.BtcServer", "GetAllUtxos"));
+            req.extensions_mut().insert(GrpcMethod::new("btc_server.BtcServer", "GetAllUtxos"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_wallet_state(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
-        ) -> std::result::Result<
-            tonic::Response<super::WalletStateResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::WalletStateResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/btc_server.BtcServer/GetWalletState",
-            );
+            let path = http::uri::PathAndQuery::from_static("/btc_server.BtcServer/GetWalletState");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("btc_server.BtcServer", "GetWalletState"));
+            req.extensions_mut().insert(GrpcMethod::new("btc_server.BtcServer", "GetWalletState"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn reset_all_utxos(
             &mut self,
             request: impl tonic::IntoRequest<super::ResetAllUtxosRequest>,
         ) -> std::result::Result<tonic::Response<super::Empty>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/btc_server.BtcServer/ResetAllUtxos",
-            );
+            let path = http::uri::PathAndQuery::from_static("/btc_server.BtcServer/ResetAllUtxos");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("btc_server.BtcServer", "ResetAllUtxos"));
+            req.extensions_mut().insert(GrpcMethod::new("btc_server.BtcServer", "ResetAllUtxos"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_signing_status(
             &mut self,
             request: impl tonic::IntoRequest<super::GetSigningStatusRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetSigningStatusResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::GetSigningStatusResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/btc_server.BtcServer/GetSigningStatus",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/btc_server.BtcServer/GetSigningStatus");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("btc_server.BtcServer", "GetSigningStatus"));
@@ -858,67 +692,41 @@ pub mod btc_server_client {
         pub async fn get_session_ids(
             &mut self,
             request: impl tonic::IntoRequest<super::GetSessionIdsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetSessionIdsResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::GetSessionIdsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/btc_server.BtcServer/GetSessionIds",
-            );
+            let path = http::uri::PathAndQuery::from_static("/btc_server.BtcServer/GetSessionIds");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("btc_server.BtcServer", "GetSessionIds"));
+            req.extensions_mut().insert(GrpcMethod::new("btc_server.BtcServer", "GetSessionIds"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_tracked_txs(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetTrackedTxsResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::GetTrackedTxsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/btc_server.BtcServer/GetTrackedTxs",
-            );
+            let path = http::uri::PathAndQuery::from_static("/btc_server.BtcServer/GetTrackedTxs");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("btc_server.BtcServer", "GetTrackedTxs"));
+            req.extensions_mut().insert(GrpcMethod::new("btc_server.BtcServer", "GetTrackedTxs"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn reset_wallet_state(
             &mut self,
             request: impl tonic::IntoRequest<super::ResetWalletStateRequest>,
         ) -> std::result::Result<tonic::Response<super::Empty>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/btc_server.BtcServer/ResetWalletState",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/btc_server.BtcServer/ResetWalletState");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("btc_server.BtcServer", "ResetWalletState"));
@@ -928,23 +736,16 @@ pub mod btc_server_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ConsensusCheckpointRequest>,
         ) -> std::result::Result<tonic::Response<super::Empty>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/btc_server.BtcServer/NewConsensusCheckpoint",
             );
             let mut req = request.into_request();
             req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("btc_server.BtcServer", "NewConsensusCheckpoint"),
-                );
+                .insert(GrpcMethod::new("btc_server.BtcServer", "NewConsensusCheckpoint"));
             self.inner.unary(req, path, codec).await
         }
     }

--- a/bin/btc-server/src/bin/main.rs
+++ b/bin/btc-server/src/bin/main.rs
@@ -1138,7 +1138,8 @@ where
 
         debug!("Cord Fee rate: {:?}", fee_rate);
 
-        // First sync the pegout scheduler as this may add tracked pegouts back to the pending pegouts list
+        // First sync the pegout scheduler as this may add tracked pegouts back to the pending
+        // pegouts list
         self.sync_pegout_scheduler(checkpoint).await.to_status()?;
         let tracked_txs = self.db.get_tracked_txs().to_status()?;
 

--- a/bin/btc-server/src/dkg/mod.rs
+++ b/bin/btc-server/src/dkg/mod.rs
@@ -281,9 +281,9 @@ impl StageState {
     fn did_round_one_finalize(&self) -> bool {
         matches!(
             self,
-            StageState::RoundTwoActive { .. } |
-                StageState::RoundThreeActive { .. } |
-                StageState::Finalized { .. }
+            StageState::RoundTwoActive { .. }
+                | StageState::RoundThreeActive { .. }
+                | StageState::Finalized { .. }
         )
     }
     fn did_round_two_finalize(&self) -> bool {

--- a/bin/btc-server/src/rpc/btc_server.rs
+++ b/bin/btc-server/src/rpc/btc_server.rs
@@ -306,7 +306,7 @@ pub mod btc_server_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with BtcServerServer.
@@ -319,40 +319,24 @@ pub mod btc_server_server {
         async fn get_pending_pegouts(
             &self,
             request: tonic::Request<super::Empty>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetPendingPegoutsResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::GetPendingPegoutsResponse>, tonic::Status>;
         /// Server streaming response type for the GetFinalizedPegoutIds method.
         type GetFinalizedPegoutIdsStream: tonic::codegen::tokio_stream::Stream<
-                Item = std::result::Result<
-                    super::GetFinalizedPegoutIdsResponse,
-                    tonic::Status,
-                >,
-            >
-            + std::marker::Send
+                Item = std::result::Result<super::GetFinalizedPegoutIdsResponse, tonic::Status>,
+            > + std::marker::Send
             + 'static;
         async fn get_finalized_pegout_ids(
             &self,
             request: tonic::Request<super::GetFinalizedPegoutIdsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<Self::GetFinalizedPegoutIdsStream>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<Self::GetFinalizedPegoutIdsStream>, tonic::Status>;
         async fn get_gateway_address(
             &self,
             request: tonic::Request<super::GetGatewayAddressRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetGatewayAddressResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::GetGatewayAddressResponse>, tonic::Status>;
         async fn get_public_key(
             &self,
             request: tonic::Request<super::Empty>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetPublicKeyResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::GetPublicKeyResponse>, tonic::Status>;
         async fn get_dkg_payloads(
             &self,
             request: tonic::Request<super::Empty>,
@@ -373,10 +357,7 @@ pub mod btc_server_server {
         async fn signer_finalize(
             &self,
             request: tonic::Request<super::FinalizeSignerRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::FinalizeSigningResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::FinalizeSigningResponse>, tonic::Status>;
         async fn abort_signing(
             &self,
             request: tonic::Request<super::Empty>,
@@ -405,24 +386,15 @@ pub mod btc_server_server {
         async fn finalize_signing(
             &self,
             request: tonic::Request<super::FinalizeSigningRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::FinalizeSigningResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::FinalizeSigningResponse>, tonic::Status>;
         async fn get_all_utxos(
             &self,
             request: tonic::Request<super::Empty>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetAllUtxosResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::GetAllUtxosResponse>, tonic::Status>;
         async fn get_wallet_state(
             &self,
             request: tonic::Request<super::Empty>,
-        ) -> std::result::Result<
-            tonic::Response<super::WalletStateResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::WalletStateResponse>, tonic::Status>;
         async fn reset_all_utxos(
             &self,
             request: tonic::Request<super::ResetAllUtxosRequest>,
@@ -430,24 +402,15 @@ pub mod btc_server_server {
         async fn get_signing_status(
             &self,
             request: tonic::Request<super::GetSigningStatusRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetSigningStatusResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::GetSigningStatusResponse>, tonic::Status>;
         async fn get_session_ids(
             &self,
             request: tonic::Request<super::GetSessionIdsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetSessionIdsResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::GetSessionIdsResponse>, tonic::Status>;
         async fn get_tracked_txs(
             &self,
             request: tonic::Request<super::Empty>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetTrackedTxsResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::GetTrackedTxsResponse>, tonic::Status>;
         async fn reset_wallet_state(
             &self,
             request: tonic::Request<super::ResetWalletStateRequest>,
@@ -478,10 +441,7 @@ pub mod btc_server_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -536,17 +496,10 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/HealthCheck" => {
                     #[allow(non_camel_case_types)]
                     struct HealthCheckSvc<T: BtcServer>(pub Arc<T>);
-                    impl<T: BtcServer> tonic::server::UnaryService<super::Empty>
-                    for HealthCheckSvc<T> {
+                    impl<T: BtcServer> tonic::server::UnaryService<super::Empty> for HealthCheckSvc<T> {
                         type Response = super::Empty;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::Empty>,
-                        ) -> Self::Future {
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(&mut self, request: tonic::Request<super::Empty>) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 <T as BtcServer>::health_check(&inner, request).await
@@ -579,17 +532,10 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/GetPendingPegouts" => {
                     #[allow(non_camel_case_types)]
                     struct GetPendingPegoutsSvc<T: BtcServer>(pub Arc<T>);
-                    impl<T: BtcServer> tonic::server::UnaryService<super::Empty>
-                    for GetPendingPegoutsSvc<T> {
+                    impl<T: BtcServer> tonic::server::UnaryService<super::Empty> for GetPendingPegoutsSvc<T> {
                         type Response = super::GetPendingPegoutsResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::Empty>,
-                        ) -> Self::Future {
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(&mut self, request: tonic::Request<super::Empty>) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 <T as BtcServer>::get_pending_pegouts(&inner, request).await
@@ -622,25 +568,21 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/GetFinalizedPegoutIds" => {
                     #[allow(non_camel_case_types)]
                     struct GetFinalizedPegoutIdsSvc<T: BtcServer>(pub Arc<T>);
-                    impl<
-                        T: BtcServer,
-                    > tonic::server::ServerStreamingService<
-                        super::GetFinalizedPegoutIdsRequest,
-                    > for GetFinalizedPegoutIdsSvc<T> {
+                    impl<T: BtcServer>
+                        tonic::server::ServerStreamingService<super::GetFinalizedPegoutIdsRequest>
+                        for GetFinalizedPegoutIdsSvc<T>
+                    {
                         type Response = super::GetFinalizedPegoutIdsResponse;
                         type ResponseStream = T::GetFinalizedPegoutIdsStream;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::ResponseStream>,
-                            tonic::Status,
-                        >;
+                        type Future =
+                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetFinalizedPegoutIdsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as BtcServer>::get_finalized_pegout_ids(&inner, request)
-                                    .await
+                                <T as BtcServer>::get_finalized_pegout_ids(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -670,15 +612,11 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/GetGatewayAddress" => {
                     #[allow(non_camel_case_types)]
                     struct GetGatewayAddressSvc<T: BtcServer>(pub Arc<T>);
-                    impl<
-                        T: BtcServer,
-                    > tonic::server::UnaryService<super::GetGatewayAddressRequest>
-                    for GetGatewayAddressSvc<T> {
+                    impl<T: BtcServer> tonic::server::UnaryService<super::GetGatewayAddressRequest>
+                        for GetGatewayAddressSvc<T>
+                    {
                         type Response = super::GetGatewayAddressResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetGatewayAddressRequest>,
@@ -715,17 +653,10 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/GetPublicKey" => {
                     #[allow(non_camel_case_types)]
                     struct GetPublicKeySvc<T: BtcServer>(pub Arc<T>);
-                    impl<T: BtcServer> tonic::server::UnaryService<super::Empty>
-                    for GetPublicKeySvc<T> {
+                    impl<T: BtcServer> tonic::server::UnaryService<super::Empty> for GetPublicKeySvc<T> {
                         type Response = super::GetPublicKeyResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::Empty>,
-                        ) -> Self::Future {
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(&mut self, request: tonic::Request<super::Empty>) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 <T as BtcServer>::get_public_key(&inner, request).await
@@ -758,17 +689,10 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/GetDkgPayloads" => {
                     #[allow(non_camel_case_types)]
                     struct GetDkgPayloadsSvc<T: BtcServer>(pub Arc<T>);
-                    impl<T: BtcServer> tonic::server::UnaryService<super::Empty>
-                    for GetDkgPayloadsSvc<T> {
+                    impl<T: BtcServer> tonic::server::UnaryService<super::Empty> for GetDkgPayloadsSvc<T> {
                         type Response = super::DkgPayloads;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::Empty>,
-                        ) -> Self::Future {
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(&mut self, request: tonic::Request<super::Empty>) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 <T as BtcServer>::get_dkg_payloads(&inner, request).await
@@ -801,13 +725,9 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/NewDkgPayload" => {
                     #[allow(non_camel_case_types)]
                     struct NewDkgPayloadSvc<T: BtcServer>(pub Arc<T>);
-                    impl<T: BtcServer> tonic::server::UnaryService<super::DkgPayload>
-                    for NewDkgPayloadSvc<T> {
+                    impl<T: BtcServer> tonic::server::UnaryService<super::DkgPayload> for NewDkgPayloadSvc<T> {
                         type Response = super::DkgPayloads;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::DkgPayload>,
@@ -844,26 +764,18 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/GetRound1SigningPackage" => {
                     #[allow(non_camel_case_types)]
                     struct GetRound1SigningPackageSvc<T: BtcServer>(pub Arc<T>);
-                    impl<
-                        T: BtcServer,
-                    > tonic::server::UnaryService<super::SigningPackageRequest>
-                    for GetRound1SigningPackageSvc<T> {
+                    impl<T: BtcServer> tonic::server::UnaryService<super::SigningPackageRequest>
+                        for GetRound1SigningPackageSvc<T>
+                    {
                         type Response = super::SigningPackage;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SigningPackageRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as BtcServer>::get_round1_signing_package(
-                                        &inner,
-                                        request,
-                                    )
-                                    .await
+                                <T as BtcServer>::get_round1_signing_package(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -893,26 +805,18 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/GetRound2SigningPackage" => {
                     #[allow(non_camel_case_types)]
                     struct GetRound2SigningPackageSvc<T: BtcServer>(pub Arc<T>);
-                    impl<
-                        T: BtcServer,
-                    > tonic::server::UnaryService<super::SigningPackageRequest>
-                    for GetRound2SigningPackageSvc<T> {
+                    impl<T: BtcServer> tonic::server::UnaryService<super::SigningPackageRequest>
+                        for GetRound2SigningPackageSvc<T>
+                    {
                         type Response = super::SigningPackage;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SigningPackageRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as BtcServer>::get_round2_signing_package(
-                                        &inner,
-                                        request,
-                                    )
-                                    .await
+                                <T as BtcServer>::get_round2_signing_package(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -942,15 +846,11 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/SignerFinalize" => {
                     #[allow(non_camel_case_types)]
                     struct SignerFinalizeSvc<T: BtcServer>(pub Arc<T>);
-                    impl<
-                        T: BtcServer,
-                    > tonic::server::UnaryService<super::FinalizeSignerRequest>
-                    for SignerFinalizeSvc<T> {
+                    impl<T: BtcServer> tonic::server::UnaryService<super::FinalizeSignerRequest>
+                        for SignerFinalizeSvc<T>
+                    {
                         type Response = super::FinalizeSigningResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::FinalizeSignerRequest>,
@@ -987,17 +887,10 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/AbortSigning" => {
                     #[allow(non_camel_case_types)]
                     struct AbortSigningSvc<T: BtcServer>(pub Arc<T>);
-                    impl<T: BtcServer> tonic::server::UnaryService<super::Empty>
-                    for AbortSigningSvc<T> {
+                    impl<T: BtcServer> tonic::server::UnaryService<super::Empty> for AbortSigningSvc<T> {
                         type Response = super::Empty;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::Empty>,
-                        ) -> Self::Future {
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(&mut self, request: tonic::Request<super::Empty>) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 <T as BtcServer>::abort_signing(&inner, request).await
@@ -1031,23 +924,17 @@ pub mod btc_server_server {
                     #[allow(non_camel_case_types)]
                     struct NewRound1SigningPackageSvc<T: BtcServer>(pub Arc<T>);
                     impl<T: BtcServer> tonic::server::UnaryService<super::SigningPackage>
-                    for NewRound1SigningPackageSvc<T> {
+                        for NewRound1SigningPackageSvc<T>
+                    {
                         type Response = super::Empty;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SigningPackage>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as BtcServer>::new_round1_signing_package(
-                                        &inner,
-                                        request,
-                                    )
-                                    .await
+                                <T as BtcServer>::new_round1_signing_package(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1078,23 +965,17 @@ pub mod btc_server_server {
                     #[allow(non_camel_case_types)]
                     struct NewRound2SigningPackageSvc<T: BtcServer>(pub Arc<T>);
                     impl<T: BtcServer> tonic::server::UnaryService<super::SigningPackage>
-                    for NewRound2SigningPackageSvc<T> {
+                        for NewRound2SigningPackageSvc<T>
+                    {
                         type Response = super::Empty;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SigningPackage>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as BtcServer>::new_round2_signing_package(
-                                        &inner,
-                                        request,
-                                    )
-                                    .await
+                                <T as BtcServer>::new_round2_signing_package(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1124,21 +1005,16 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/GetPsbt" => {
                     #[allow(non_camel_case_types)]
                     struct GetPsbtSvc<T: BtcServer>(pub Arc<T>);
-                    impl<T: BtcServer> tonic::server::UnaryService<super::MakeTxRequest>
-                    for GetPsbtSvc<T> {
+                    impl<T: BtcServer> tonic::server::UnaryService<super::MakeTxRequest> for GetPsbtSvc<T> {
                         type Response = super::SigningPackage;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::MakeTxRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as BtcServer>::get_psbt(&inner, request).await
-                            };
+                            let fut =
+                                async move { <T as BtcServer>::get_psbt(&inner, request).await };
                             Box::pin(fut)
                         }
                     }
@@ -1167,13 +1043,9 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/GetToSignPackage" => {
                     #[allow(non_camel_case_types)]
                     struct GetToSignPackageSvc<T: BtcServer>(pub Arc<T>);
-                    impl<T: BtcServer> tonic::server::UnaryService<super::ToSignRequest>
-                    for GetToSignPackageSvc<T> {
+                    impl<T: BtcServer> tonic::server::UnaryService<super::ToSignRequest> for GetToSignPackageSvc<T> {
                         type Response = super::SigningPackage;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ToSignRequest>,
@@ -1210,15 +1082,11 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/FinalizeSigning" => {
                     #[allow(non_camel_case_types)]
                     struct FinalizeSigningSvc<T: BtcServer>(pub Arc<T>);
-                    impl<
-                        T: BtcServer,
-                    > tonic::server::UnaryService<super::FinalizeSigningRequest>
-                    for FinalizeSigningSvc<T> {
+                    impl<T: BtcServer> tonic::server::UnaryService<super::FinalizeSigningRequest>
+                        for FinalizeSigningSvc<T>
+                    {
                         type Response = super::FinalizeSigningResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::FinalizeSigningRequest>,
@@ -1255,17 +1123,10 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/GetAllUtxos" => {
                     #[allow(non_camel_case_types)]
                     struct GetAllUtxosSvc<T: BtcServer>(pub Arc<T>);
-                    impl<T: BtcServer> tonic::server::UnaryService<super::Empty>
-                    for GetAllUtxosSvc<T> {
+                    impl<T: BtcServer> tonic::server::UnaryService<super::Empty> for GetAllUtxosSvc<T> {
                         type Response = super::GetAllUtxosResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::Empty>,
-                        ) -> Self::Future {
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(&mut self, request: tonic::Request<super::Empty>) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 <T as BtcServer>::get_all_utxos(&inner, request).await
@@ -1298,17 +1159,10 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/GetWalletState" => {
                     #[allow(non_camel_case_types)]
                     struct GetWalletStateSvc<T: BtcServer>(pub Arc<T>);
-                    impl<T: BtcServer> tonic::server::UnaryService<super::Empty>
-                    for GetWalletStateSvc<T> {
+                    impl<T: BtcServer> tonic::server::UnaryService<super::Empty> for GetWalletStateSvc<T> {
                         type Response = super::WalletStateResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::Empty>,
-                        ) -> Self::Future {
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(&mut self, request: tonic::Request<super::Empty>) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 <T as BtcServer>::get_wallet_state(&inner, request).await
@@ -1341,15 +1195,11 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/ResetAllUtxos" => {
                     #[allow(non_camel_case_types)]
                     struct ResetAllUtxosSvc<T: BtcServer>(pub Arc<T>);
-                    impl<
-                        T: BtcServer,
-                    > tonic::server::UnaryService<super::ResetAllUtxosRequest>
-                    for ResetAllUtxosSvc<T> {
+                    impl<T: BtcServer> tonic::server::UnaryService<super::ResetAllUtxosRequest>
+                        for ResetAllUtxosSvc<T>
+                    {
                         type Response = super::Empty;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ResetAllUtxosRequest>,
@@ -1386,15 +1236,11 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/GetSigningStatus" => {
                     #[allow(non_camel_case_types)]
                     struct GetSigningStatusSvc<T: BtcServer>(pub Arc<T>);
-                    impl<
-                        T: BtcServer,
-                    > tonic::server::UnaryService<super::GetSigningStatusRequest>
-                    for GetSigningStatusSvc<T> {
+                    impl<T: BtcServer> tonic::server::UnaryService<super::GetSigningStatusRequest>
+                        for GetSigningStatusSvc<T>
+                    {
                         type Response = super::GetSigningStatusResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetSigningStatusRequest>,
@@ -1431,15 +1277,11 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/GetSessionIds" => {
                     #[allow(non_camel_case_types)]
                     struct GetSessionIdsSvc<T: BtcServer>(pub Arc<T>);
-                    impl<
-                        T: BtcServer,
-                    > tonic::server::UnaryService<super::GetSessionIdsRequest>
-                    for GetSessionIdsSvc<T> {
+                    impl<T: BtcServer> tonic::server::UnaryService<super::GetSessionIdsRequest>
+                        for GetSessionIdsSvc<T>
+                    {
                         type Response = super::GetSessionIdsResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetSessionIdsRequest>,
@@ -1476,17 +1318,10 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/GetTrackedTxs" => {
                     #[allow(non_camel_case_types)]
                     struct GetTrackedTxsSvc<T: BtcServer>(pub Arc<T>);
-                    impl<T: BtcServer> tonic::server::UnaryService<super::Empty>
-                    for GetTrackedTxsSvc<T> {
+                    impl<T: BtcServer> tonic::server::UnaryService<super::Empty> for GetTrackedTxsSvc<T> {
                         type Response = super::GetTrackedTxsResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::Empty>,
-                        ) -> Self::Future {
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(&mut self, request: tonic::Request<super::Empty>) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 <T as BtcServer>::get_tracked_txs(&inner, request).await
@@ -1519,15 +1354,11 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/ResetWalletState" => {
                     #[allow(non_camel_case_types)]
                     struct ResetWalletStateSvc<T: BtcServer>(pub Arc<T>);
-                    impl<
-                        T: BtcServer,
-                    > tonic::server::UnaryService<super::ResetWalletStateRequest>
-                    for ResetWalletStateSvc<T> {
+                    impl<T: BtcServer> tonic::server::UnaryService<super::ResetWalletStateRequest>
+                        for ResetWalletStateSvc<T>
+                    {
                         type Response = super::Empty;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ResetWalletStateRequest>,
@@ -1564,23 +1395,19 @@ pub mod btc_server_server {
                 "/btc_server.BtcServer/NewConsensusCheckpoint" => {
                     #[allow(non_camel_case_types)]
                     struct NewConsensusCheckpointSvc<T: BtcServer>(pub Arc<T>);
-                    impl<
-                        T: BtcServer,
-                    > tonic::server::UnaryService<super::ConsensusCheckpointRequest>
-                    for NewConsensusCheckpointSvc<T> {
+                    impl<T: BtcServer>
+                        tonic::server::UnaryService<super::ConsensusCheckpointRequest>
+                        for NewConsensusCheckpointSvc<T>
+                    {
                         type Response = super::Empty;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ConsensusCheckpointRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as BtcServer>::new_consensus_checkpoint(&inner, request)
-                                    .await
+                                <T as BtcServer>::new_consensus_checkpoint(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1607,23 +1434,16 @@ pub mod btc_server_server {
                     };
                     Box::pin(fut)
                 }
-                _ => {
-                    Box::pin(async move {
-                        let mut response = http::Response::new(empty_body());
-                        let headers = response.headers_mut();
-                        headers
-                            .insert(
-                                tonic::Status::GRPC_STATUS,
-                                (tonic::Code::Unimplemented as i32).into(),
-                            );
-                        headers
-                            .insert(
-                                http::header::CONTENT_TYPE,
-                                tonic::metadata::GRPC_CONTENT_TYPE,
-                            );
-                        Ok(response)
-                    })
-                }
+                _ => Box::pin(async move {
+                    let mut response = http::Response::new(empty_body());
+                    let headers = response.headers_mut();
+                    headers.insert(
+                        tonic::Status::GRPC_STATUS,
+                        (tonic::Code::Unimplemented as i32).into(),
+                    );
+                    headers.insert(http::header::CONTENT_TYPE, tonic::metadata::GRPC_CONTENT_TYPE);
+                    Ok(response)
+                }),
             }
         }
     }

--- a/bin/btc-server/src/test_utils/mod.rs
+++ b/bin/btc-server/src/test_utils/mod.rs
@@ -124,8 +124,8 @@ impl bitcoincore_rpc::RpcApi for MockBitcoind {
             // used by test `track_mempool_should_untrack_and_add_back_pegout_when_not_in_mempool`
             let error_txid =
                 String::from("855b53d27666779a179ec93d88dbe28f456040155c4b712a1261ad211f4ba6f2");
-            if !raw_args.is_empty() &&
-                raw_args[0].get().to_string().trim_matches('\"') == error_txid
+            if !raw_args.is_empty()
+                && raw_args[0].get().to_string().trim_matches('\"') == error_txid
             {
                 return Err(bitcoincore_rpc::Error::Json(serde_json::error::Error::custom(
                     TX_NOT_IN_MEMPOOL_BITCOIND_ERROR,
@@ -141,8 +141,8 @@ impl bitcoincore_rpc::RpcApi for MockBitcoind {
             // used by test `track_mempool_should_untrack_and_add_back_pegout_when_not_in_mempool`
             let error_txid =
                 String::from("855b53d27666779a179ec93d88dbe28f456040155c4b712a1261ad211f4ba6f2");
-            if !raw_args.is_empty() &&
-                raw_args[0].get().to_string().trim_matches('\"') == error_txid
+            if !raw_args.is_empty()
+                && raw_args[0].get().to_string().trim_matches('\"') == error_txid
             {
                 return Err(bitcoincore_rpc::Error::Json(serde_json::error::Error::custom(
                     TX_NOT_FOUND_BITCOIND_ERROR,

--- a/bin/btc-server/src/util.rs
+++ b/bin/btc-server/src/util.rs
@@ -656,9 +656,9 @@ mod tests {
                 .unwrap_or_default()
         });
 
-        let diff = total_inputs.checked_sub(total_outputs).unwrap_or_default().to_sat() /
-            psbt.unsigned_tx.output.len() as u64 +
-            100;
+        let diff = total_inputs.checked_sub(total_outputs).unwrap_or_default().to_sat()
+            / psbt.unsigned_tx.output.len() as u64
+            + 100;
 
         // increase each output accordingly to cause negative fee
         for output in psbt.unsigned_tx.output.iter_mut() {

--- a/bin/federation-utils/src/handler.rs
+++ b/bin/federation-utils/src/handler.rs
@@ -31,8 +31,8 @@ pub fn handle_init_config(config_path: Option<&str>) {
 
     let config_path = config_path.map(PathBuf::from).unwrap_or_else(get_default_config_path);
 
-    let config_file_path = if config_path.to_str().map(|s| s.ends_with('/')).unwrap_or(false) ||
-        config_path.extension().is_none()
+    let config_file_path = if config_path.to_str().map(|s| s.ends_with('/')).unwrap_or(false)
+        || config_path.extension().is_none()
     {
         config_path.join("config.toml")
     } else {

--- a/bin/test-suite/src/suite/consensus/common/events.rs
+++ b/bin/test-suite/src/suite/consensus/common/events.rs
@@ -86,9 +86,9 @@ pub async fn await_epoch_block(rx: &mut tokio::sync::broadcast::Receiver<Notific
                 canon_state_notification.engine_index
             );
 
-            if canon_state_notification.block.number.map(|b| b.as_u64()).unwrap_or_default() %
-                EPOCH_LENGTH ==
-                0
+            if canon_state_notification.block.number.map(|b| b.as_u64()).unwrap_or_default()
+                % EPOCH_LENGTH
+                == 0
             {
                 break;
             }

--- a/bin/test-suite/src/suite/consensus/frost/test_batch_pegins.rs
+++ b/bin/test-suite/src/suite/consensus/frost/test_batch_pegins.rs
@@ -314,8 +314,8 @@ pub async fn batch_pegins(
     for pegin in pegins.iter() {
         let utxo = utxos.iter().find(|utxo| {
             bitcoin::Txid::from_slice(utxo.outpoint.as_ref().unwrap().txid.as_slice())
-                .expect("valid txid") ==
-                pegin.meta[0].tx().compute_txid()
+                .expect("valid txid")
+                == pegin.meta[0].tx().compute_txid()
         });
         assert!(utxo.is_some());
     }

--- a/bin/test-suite/src/suite/consensus/frost/test_block_builder.rs
+++ b/bin/test-suite/src/suite/consensus/frost/test_block_builder.rs
@@ -127,8 +127,8 @@ pub async fn block_builder(
             botanix_eth_client.get_botanix_balance(block_fee_recipient_address).await.unwrap();
         it_info_print!("Fed member balance", fed_member_balance);
 
-        let botanix_block_reward = botanix_block_reward_address_balance_after -
-            botanix_block_reward_address_balance_before;
+        let botanix_block_reward = botanix_block_reward_address_balance_after
+            - botanix_block_reward_address_balance_before;
 
         let lst_fee_receiver_block_reward =
             lst_fee_receiver_address_balance_after - lst_fee_receiver_address_balance_before;

--- a/bin/test-suite/src/suite/consensus/frost/test_conflicting_input.rs
+++ b/bin/test-suite/src/suite/consensus/frost/test_conflicting_input.rs
@@ -186,8 +186,8 @@ pub async fn test_conflicting_input(
     if let Err(e) = do_signing(&mut clients, &bitcoind, &[2u8; 32]).await {
         let error_message = e.to_string();
         assert!(
-            error_message.contains("txn-mempool-conflict") ||
-                error_message.contains("insufficient fee, rejecting replacement"),
+            error_message.contains("txn-mempool-conflict")
+                || error_message.contains("insufficient fee, rejecting replacement"),
             "Unexpected error: {}",
             error_message
         );

--- a/bin/test-suite/src/suite/consensus/invalid_transactions/test_multi_pegin.rs
+++ b/bin/test-suite/src/suite/consensus/invalid_transactions/test_multi_pegin.rs
@@ -360,7 +360,7 @@ pub async fn multi_pegin_revert_scenarios(
             bitcoin_block_height,
             ethers::core::types::Bytes::from(serialized_valid_meta.clone()), // Clone valid meta
             ethers::core::types::Address::random(),
-            eth_destination1, // Invalid Pegin (Dest 1)
+            eth_destination1,                    // Invalid Pegin (Dest 1)
             1_000_000_000_000_000_000u64.into(), // Amount irrelevant
             bitcoin_block_height,
             ethers::core::types::Bytes::from(serialized_invalid_meta_s2.clone()), // Clone invalid meta
@@ -438,7 +438,7 @@ pub async fn multi_pegin_revert_scenarios(
     it_info_print!("Calling multiMintTwo with invalid then valid pegin...");
     let tx_receipt_s3 = botanix_eth_client
         .multi_mint_two(
-            eth_destination1, // Invalid Pegin (Dest 1)
+            eth_destination1,                    // Invalid Pegin (Dest 1)
             1_000_000_000_000_000_000u64.into(), // Amount irrelevant
             bitcoin_block_height,
             ethers::core::types::Bytes::from(serialized_invalid_meta_s2.clone()), // Clone invalid meta first

--- a/bin/test-suite/src/utils.rs
+++ b/bin/test-suite/src/utils.rs
@@ -162,8 +162,8 @@ pub struct BlockChainInfoRes {
 }
 
 pub fn get_checkpoint_block_hash(bitcoind: &impl RpcApi) -> Result<Vec<u8>, Error> {
-    let deep_tip = bitcoind.call::<BlockChainInfoRes>("getblockchaininfo", &[]).unwrap().blocks -
-        (BOTANIX_TESTNET.parent_confirmation_depth as u64);
+    let deep_tip = bitcoind.call::<BlockChainInfoRes>("getblockchaininfo", &[]).unwrap().blocks
+        - (BOTANIX_TESTNET.parent_confirmation_depth as u64);
     let deep_block_hash = bitcoind.get_block_hash(deep_tip).unwrap();
     let mut checkpoint_block_hash = vec![];
     if let Err(e) = deep_block_hash.consensus_encode(&mut checkpoint_block_hash) {
@@ -217,8 +217,8 @@ pub async fn wait_until_genesis_block_exists(client: &BotanixEthClient) -> Resul
         .await
         .map_err(|_| Error::LatestBlockDoesNotExist)?
         .number
-        .ok_or(Error::LatestBlockDoesNotExist)? ==
-        0.into()
+        .ok_or(Error::LatestBlockDoesNotExist)?
+        == 0.into()
     {
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     }

--- a/crates/blockchain-tree-api/src/error.rs
+++ b/crates/blockchain-tree-api/src/error.rs
@@ -450,10 +450,10 @@ impl InsertBlockErrorKind {
             Self::Canonical(err) => {
                 matches!(
                     err,
-                    CanonicalError::Validation(BlockValidationError::StateRoot { .. }) |
-                        CanonicalError::Provider(
-                            ProviderError::StateRootMismatch(_) |
-                                ProviderError::UnwindStateRootMismatch(_)
+                    CanonicalError::Validation(BlockValidationError::StateRoot { .. })
+                        | CanonicalError::Provider(
+                            ProviderError::StateRootMismatch(_)
+                                | ProviderError::UnwindStateRootMismatch(_)
                         )
                 )
             }
@@ -491,12 +491,12 @@ impl InsertBlockErrorKind {
                         // the block's number is lower than the finalized block's number
                         true
                     }
-                    BlockchainTreeError::BlockSideChainIdConsistency { .. } |
-                    BlockchainTreeError::CanonicalChain { .. } |
-                    BlockchainTreeError::BlockNumberNotFoundInChain { .. } |
-                    BlockchainTreeError::BlockHashNotFoundInChain { .. } |
-                    BlockchainTreeError::BlockBufferingFailed { .. } |
-                    BlockchainTreeError::GenesisBlockHasNoParent => false,
+                    BlockchainTreeError::BlockSideChainIdConsistency { .. }
+                    | BlockchainTreeError::CanonicalChain { .. }
+                    | BlockchainTreeError::BlockNumberNotFoundInChain { .. }
+                    | BlockchainTreeError::BlockHashNotFoundInChain { .. }
+                    | BlockchainTreeError::BlockBufferingFailed { .. }
+                    | BlockchainTreeError::GenesisBlockHasNoParent => false,
                 }
             }
             Self::Provider(_) | Self::Internal(_) => {
@@ -504,11 +504,11 @@ impl InsertBlockErrorKind {
                 false
             }
             Self::Canonical(err) => match err {
-                CanonicalError::BlockchainTree(_) |
-                CanonicalError::CanonicalCommit(_) |
-                CanonicalError::CanonicalRevert(_) |
-                CanonicalError::OptimisticTargetRevert(_) |
-                CanonicalError::Provider(_) => false,
+                CanonicalError::BlockchainTree(_)
+                | CanonicalError::CanonicalCommit(_)
+                | CanonicalError::CanonicalRevert(_)
+                | CanonicalError::OptimisticTargetRevert(_)
+                | CanonicalError::Provider(_) => false,
                 CanonicalError::Validation(_) => true,
             },
         }

--- a/crates/blockchain-tree/src/block_buffer.rs
+++ b/crates/blockchain-tree/src/block_buffer.rs
@@ -107,7 +107,7 @@ impl BlockBuffer {
         // discard all blocks that are before the finalized number.
         while let Some(entry) = self.earliest_blocks.first_entry() {
             if *entry.key() > block_number {
-                break
+                break;
             }
             let block_hashes = entry.remove();
             block_hashes_to_remove.extend(block_hashes);

--- a/crates/blockchain-tree/src/block_indices.rs
+++ b/crates/blockchain-tree/src/block_indices.rs
@@ -155,7 +155,7 @@ impl BlockIndices {
                     added.push(new.into());
                     new_hash = new_hashes.next();
                 }
-                break
+                break;
             };
             let Some(new_block_value) = new_hash else {
                 // Old canonical chain had more block than new chain.
@@ -165,7 +165,7 @@ impl BlockIndices {
                     removed.push(rem);
                     old_hash = old_hashes.next();
                 }
-                break
+                break;
             };
             // compare old and new canonical block number
             match new_block_value.0.cmp(&old_block_value.0) {
@@ -252,7 +252,7 @@ impl BlockIndices {
     /// It is assumed that blocks are interconnected and that they connect to canonical chain
     pub fn canonicalize_blocks(&mut self, blocks: &BTreeMap<BlockNumber, SealedBlockWithSenders>) {
         if blocks.is_empty() {
-            return
+            return;
         }
 
         // Remove all blocks from canonical chain

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -1324,8 +1324,8 @@ where
             .provider_factory
             .static_file_provider()
             .get_highest_static_file_block(StaticFileSegment::Headers)
-            .unwrap_or_default() >
-            revert_until
+            .unwrap_or_default()
+            > revert_until
         {
             trace!(
                 target: "blockchain_tree",
@@ -1621,8 +1621,8 @@ mod tests {
                     signer,
                     (
                         AccountInfo {
-                            balance: initial_signer_balance -
-                                (single_tx_cost * U256::from(num_of_signer_txs)),
+                            balance: initial_signer_balance
+                                - (single_tx_cost * U256::from(num_of_signer_txs)),
                             nonce: num_of_signer_txs,
                             ..Default::default()
                         },

--- a/crates/blockchain-tree/src/bundle.rs
+++ b/crates/blockchain-tree/src/bundle.rs
@@ -25,7 +25,7 @@ impl ExecutionDataProvider for BundleStateDataRef<'_> {
     fn block_hash(&self, block_number: BlockNumber) -> Option<BlockHash> {
         let block_hash = self.sidechain_block_hashes.get(&block_number).cloned();
         if block_hash.is_some() {
-            return block_hash
+            return block_hash;
         }
 
         self.canonical_block_hashes.get(&block_number).cloned()

--- a/crates/blockchain-tree/src/state.rs
+++ b/crates/blockchain-tree/src/state.rs
@@ -87,7 +87,7 @@ impl TreeState {
     /// Inserts a chain into the tree and builds the block indices.
     pub(crate) fn insert_chain(&mut self, chain: AppendableChain) -> Option<SidechainId> {
         if chain.is_empty() {
-            return None
+            return None;
         }
         let chain_id = self.next_id();
 

--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -521,7 +521,7 @@ impl CanonicalInMemoryState {
     pub fn transaction_by_hash(&self, hash: TxHash) -> Option<TransactionSigned> {
         for block_state in self.canonical_chain() {
             if let Some(tx) = block_state.block().block().body.iter().find(|tx| tx.hash() == hash) {
-                return Some(tx.clone())
+                return Some(tx.clone());
             }
         }
         None
@@ -551,7 +551,7 @@ impl CanonicalInMemoryState {
                     timestamp: block_state.block().block.timestamp,
                     excess_blob_gas: block_state.block().block.excess_blob_gas,
                 };
-                return Some((tx.clone(), meta))
+                return Some((tx.clone(), meta));
             }
         }
         None

--- a/crates/chain-state/src/memory_overlay.rs
+++ b/crates/chain-state/src/memory_overlay.rs
@@ -55,7 +55,7 @@ impl BlockHashReader for MemoryOverlayStateProvider {
     fn block_hash(&self, number: BlockNumber) -> ProviderResult<Option<B256>> {
         for block in &self.in_memory {
             if block.block.number == number {
-                return Ok(Some(block.block.hash()))
+                return Ok(Some(block.block.hash()));
             }
         }
 
@@ -88,7 +88,7 @@ impl AccountReader for MemoryOverlayStateProvider {
     fn basic_account(&self, address: Address) -> ProviderResult<Option<Account>> {
         for block in &self.in_memory {
             if let Some(account) = block.execution_output.account(&address) {
-                return Ok(account)
+                return Ok(account);
             }
         }
 
@@ -182,7 +182,7 @@ impl StateProvider for MemoryOverlayStateProvider {
     ) -> ProviderResult<Option<StorageValue>> {
         for block in &self.in_memory {
             if let Some(value) = block.execution_output.storage(&address, storage_key.into()) {
-                return Ok(Some(value))
+                return Ok(Some(value));
             }
         }
 
@@ -192,7 +192,7 @@ impl StateProvider for MemoryOverlayStateProvider {
     fn bytecode_by_hash(&self, code_hash: B256) -> ProviderResult<Option<Bytecode>> {
         for block in &self.in_memory {
             if let Some(contract) = block.execution_output.bytecode(&code_hash) {
-                return Ok(Some(contract))
+                return Ok(Some(contract));
             }
         }
 

--- a/crates/chain-state/src/notifications.rs
+++ b/crates/chain-state/src/notifications.rs
@@ -58,10 +58,10 @@ impl Stream for CanonStateNotificationStream {
                 Some(Ok(notification)) => Poll::Ready(Some(notification)),
                 Some(Err(err)) => {
                     debug!(%err, "canonical state notification stream lagging behind");
-                    continue
+                    continue;
                 }
                 None => Poll::Ready(None),
-            }
+            };
         }
     }
 }
@@ -221,7 +221,7 @@ impl<T: Clone + Sync + Send + 'static> Stream for BlockStateNotificationStream<T
                     }
                 }
                 None => Poll::Ready(None),
-            }
+            };
         }
     }
 }

--- a/crates/chain-state/src/test_utils.rs
+++ b/crates/chain-state/src/test_utils.rs
@@ -156,8 +156,8 @@ impl TestBlockBuilder {
                 ),
             )])),
             // use the number as the timestamp so it is monotonically increasing
-            timestamp: number +
-                EthereumHardfork::Cancun.activation_timestamp(self.chain_spec.chain).unwrap(),
+            timestamp: number
+                + EthereumHardfork::Cancun.activation_timestamp(self.chain_spec.chain).unwrap(),
             withdrawals_root: Some(calculate_withdrawals_root(&[])),
             blob_gas_used: Some(0),
             excess_blob_gas: Some(0),

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -359,14 +359,14 @@ impl ChainSpec {
         matches!(
             self.chain.kind(),
             ChainKind::Named(
-                NamedChain::Mainnet |
-                    NamedChain::Morden |
-                    NamedChain::Ropsten |
-                    NamedChain::Rinkeby |
-                    NamedChain::Goerli |
-                    NamedChain::Kovan |
-                    NamedChain::Holesky |
-                    NamedChain::Sepolia
+                NamedChain::Mainnet
+                    | NamedChain::Morden
+                    | NamedChain::Ropsten
+                    | NamedChain::Rinkeby
+                    | NamedChain::Goerli
+                    | NamedChain::Kovan
+                    | NamedChain::Holesky
+                    | NamedChain::Sepolia
             )
         )
     }
@@ -581,8 +581,8 @@ impl ChainSpec {
             // We filter out TTD-based forks w/o a pre-known block since those do not show up in the
             // fork filter.
             Some(match condition {
-                ForkCondition::Block(block) |
-                ForkCondition::TTD { fork_block: Some(block), .. } => ForkFilterKey::Block(block),
+                ForkCondition::Block(block)
+                | ForkCondition::TTD { fork_block: Some(block), .. } => ForkFilterKey::Block(block),
                 ForkCondition::Timestamp(time) => ForkFilterKey::Time(time),
                 _ => return None,
             })
@@ -600,8 +600,8 @@ impl ChainSpec {
         for (_, cond) in self.hardforks.forks_iter() {
             // handle block based forks and the sepolia merge netsplit block edge case (TTD
             // ForkCondition with Some(block))
-            if let ForkCondition::Block(block) |
-            ForkCondition::TTD { fork_block: Some(block), .. } = cond
+            if let ForkCondition::Block(block)
+            | ForkCondition::TTD { fork_block: Some(block), .. } = cond
             {
                 if cond.active_at_head(head) {
                     if block != current_applied {

--- a/crates/cli/util/src/sigsegv_handler.rs
+++ b/crates/cli/util/src/sigsegv_handler.rs
@@ -52,7 +52,7 @@ extern "C" fn print_stack_trace(_: libc::c_int) {
         // Collect return addresses
         let depth = libc::backtrace(STACK_TRACE.as_mut_ptr(), MAX_FRAMES as i32);
         if depth == 0 {
-            return
+            return;
         }
         &STACK_TRACE[..depth as usize]
     };
@@ -70,7 +70,7 @@ extern "C" fn print_stack_trace(_: libc::c_int) {
         let period = period.saturating_add(1); // avoid "what if wrapped?" branches
         let Some(offset) = stack.iter().skip(period).zip(stack).position(cycled) else {
             // impossible.
-            return
+            return;
         };
 
         // Count matching trace slices, else we could miscount "biphasic cycles"

--- a/crates/consensus/authority/src/comet_bft/abci.rs
+++ b/crates/consensus/authority/src/comet_bft/abci.rs
@@ -757,7 +757,9 @@ where
                     Ok(snapshot_sync_state_lock) => snapshot_sync_state_lock,
                     Err(e) => {
                         error!("Error getting a snapshot state lock: {:?}", e);
-                        return ResponseOfferSnapshot { result: SnapshotOfferResult::Reject as i32 };
+                        return ResponseOfferSnapshot {
+                            result: SnapshotOfferResult::Reject as i32,
+                        };
                     }
                 };
 
@@ -804,7 +806,9 @@ where
                     Ok(snapshot_sync_state_lock_height) => snapshot_sync_state_lock_height,
                     Err(e) => {
                         error!("Error getting a snapshot state lock: {:?}", e);
-                        return ResponseOfferSnapshot { result: SnapshotOfferResult::Reject as i32 };
+                        return ResponseOfferSnapshot {
+                            result: SnapshotOfferResult::Reject as i32,
+                        };
                     }
                 };
 

--- a/crates/consensus/authority/src/lib.rs
+++ b/crates/consensus/authority/src/lib.rs
@@ -90,8 +90,9 @@ impl AuthorityConsensus {
         // Determine the parent gas limit, considering elasticity multiplier on the London fork.
         let parent_gas_limit =
             if self.chain_spec.fork(EthereumHardfork::London).transitions_at_block(header.number) {
-                parent.gas_limit *
-                    self.chain_spec
+                parent.gas_limit
+                    * self
+                        .chain_spec
                         .base_fee_params_at_timestamp(header.timestamp)
                         .elasticity_multiplier as u64
             } else {

--- a/crates/consensus/authority/src/snapshot_manager.rs
+++ b/crates/consensus/authority/src/snapshot_manager.rs
@@ -472,8 +472,8 @@ where
 
         // Check if there is enough space in the latest snapshot
         debug!(target: "consensus::authority::snapshot_manager::run", "Snapshot size: {}", latest_snapshot_size);
-        if latest_snapshot_size + serialized_block.len() >
-            self.snapshot_size_limits.snapshot_max_size
+        if latest_snapshot_size + serialized_block.len()
+            > self.snapshot_size_limits.snapshot_max_size
         {
             info!(target: "consensus::authority::snapshot_manager::run", "Snapshot size exceeds limit of {} bytes. Current size: {}, Attempted: {}", self.snapshot_size_limits.snapshot_max_size, latest_snapshot_size, serialized_block.len());
             // create a new snapshot
@@ -492,8 +492,8 @@ where
                 // Check if there is enough space in the latest chunk
                 let latest_chunk_size =
                     self.provider_factory.provider()?.get_chunk_size(chunk_id)?;
-                if latest_chunk_size + serialized_block.len() >
-                    self.snapshot_size_limits.snapshot_chunk_size
+                if latest_chunk_size + serialized_block.len()
+                    > self.snapshot_size_limits.snapshot_chunk_size
                 {
                     self.create_new_chunk(last_snapshot_id, block.number, serialized_block.clone())?
                 } else {
@@ -517,8 +517,8 @@ where
 
     /// Apply retention policy for snapshots
     fn apply_retention_policy(&self) -> Result<(), SnapshotManagerError> {
-        if !self.state_lock.read().expect("snapshot state sync locked").is_syncing_history() &&
-            self.get_snapshots_count()? > self.snapshots_to_keep as usize
+        if !self.state_lock.read().expect("snapshot state sync locked").is_syncing_history()
+            && self.get_snapshots_count()? > self.snapshots_to_keep as usize
         {
             if let Some((_, oldest_height)) = self.provider_factory.get_first_snapshot_height()? {
                 let state_lock = self.state_lock.read().expect("snapshot state sync locked");

--- a/crates/consensus/authority/src/utils.rs
+++ b/crates/consensus/authority/src/utils.rs
@@ -159,14 +159,14 @@ fn bloom_contains_minting_contract_address(bloom: Bloom) -> bool {
 }
 
 pub(crate) fn bloom_contains_pegout(bloom: Bloom) -> bool {
-    bloom_contains_minting_contract_address(bloom) &&
-        bloom.contains_input(BloomInput::Raw(BURN_TOPIC.as_ref()))
+    bloom_contains_minting_contract_address(bloom)
+        && bloom.contains_input(BloomInput::Raw(BURN_TOPIC.as_ref()))
 }
 
 #[allow(dead_code)]
 pub(crate) fn bloom_contains_pegin(bloom: Bloom) -> bool {
-    bloom_contains_minting_contract_address(bloom) &&
-        bloom.contains_input(BloomInput::Raw(MINT_TOPIC.as_ref()))
+    bloom_contains_minting_contract_address(bloom)
+        && bloom.contains_input(BloomInput::Raw(MINT_TOPIC.as_ref()))
 }
 
 /// Finds the starting block number for the current epoch based on the current block number

--- a/crates/consensus/auto-seal/src/client.rs
+++ b/crates/consensus/auto-seal/src/client.rs
@@ -41,7 +41,7 @@ impl AutoSealClient {
                     hash.into()
                 } else {
                     warn!(target: "consensus::auto", num, "no matching block found");
-                    return headers
+                    return headers;
                 }
             }
         };
@@ -58,7 +58,7 @@ impl AutoSealClient {
                 }
                 headers.push(header);
             } else {
-                break
+                break;
             }
         }
 
@@ -75,7 +75,7 @@ impl AutoSealClient {
             if let Some(body) = storage.bodies.get(&hash).cloned() {
                 bodies.push(body);
             } else {
-                break
+                break;
             }
         }
 

--- a/crates/consensus/auto-seal/src/mode.rs
+++ b/crates/consensus/auto-seal/src/mode.rs
@@ -102,7 +102,7 @@ impl FixedBlockTimeMiner {
     {
         if self.interval.poll_tick(cx).is_ready() {
             // drain the pool
-            return Poll::Ready(pool.best_transactions().collect())
+            return Poll::Ready(pool.best_transactions().collect());
         }
         Poll::Pending
     }
@@ -141,7 +141,7 @@ impl ReadyTransactionMiner {
         }
 
         if self.has_pending_txs == Some(false) {
-            return Poll::Pending
+            return Poll::Pending;
         }
 
         let transactions = pool.best_transactions().take(self.max_transactions).collect::<Vec<_>>();
@@ -150,7 +150,7 @@ impl ReadyTransactionMiner {
         self.has_pending_txs = Some(transactions.len() >= self.max_transactions);
 
         if transactions.is_empty() {
-            return Poll::Pending
+            return Poll::Pending;
         }
 
         Poll::Ready(transactions)

--- a/crates/consensus/beacon/src/engine/hooks/controller.rs
+++ b/crates/consensus/beacon/src/engine/hooks/controller.rs
@@ -74,7 +74,7 @@ impl EngineHooksController {
                     self.hooks.push_back(hook);
                 }
 
-                return Poll::Ready(Ok(result))
+                return Poll::Ready(Ok(result));
             }
             Poll::Pending => {
                 self.active_db_write_hook = Some(hook);
@@ -136,12 +136,12 @@ impl EngineHooksController {
         // - Active DB write according to passed argument
         // - Missing a finalized block number. We might be on an optimistic sync scenario where we
         // cannot skip the FCU with the finalized hash, otherwise CL might misbehave.
-        if hook.db_access_level().is_read_write() &&
-            (self.active_db_write_hook.is_some() ||
-                db_write_active ||
-                args.finalized_block_number.is_none())
+        if hook.db_access_level().is_read_write()
+            && (self.active_db_write_hook.is_some()
+                || db_write_active
+                || args.finalized_block_number.is_none())
         {
-            return Poll::Pending
+            return Poll::Pending;
         }
 
         if let Poll::Ready(event) = hook.poll(cx, args)? {
@@ -155,7 +155,7 @@ impl EngineHooksController {
                 "Polled next hook"
             );
 
-            return Poll::Ready(Ok(result))
+            return Poll::Ready(Ok(result));
         } else {
             debug!(target: "consensus::engine::hooks", hook = hook.name(), "Next hook is not ready");
         }
@@ -307,9 +307,9 @@ mod tests {
         assert_eq!(
             result.map(|result| {
                 let polled_hook = result.unwrap();
-                polled_hook.name == hook_ro_name &&
-                    polled_hook.event.is_started() &&
-                    polled_hook.db_access_level.is_read_only()
+                polled_hook.name == hook_ro_name
+                    && polled_hook.event.is_started()
+                    && polled_hook.db_access_level.is_read_only()
             }),
             Poll::Ready(true)
         );
@@ -346,9 +346,9 @@ mod tests {
         assert_eq!(
             result.map(|result| {
                 let polled_hook = result.unwrap();
-                polled_hook.name == hook_rw_1_name &&
-                    polled_hook.event.is_started() &&
-                    polled_hook.db_access_level.is_read_write()
+                polled_hook.name == hook_rw_1_name
+                    && polled_hook.event.is_started()
+                    && polled_hook.db_access_level.is_read_write()
             }),
             Poll::Ready(true)
         );
@@ -368,9 +368,9 @@ mod tests {
         assert_eq!(
             result.map(|result| {
                 let polled_hook = result.unwrap();
-                polled_hook.name == hook_ro_name &&
-                    polled_hook.event.is_started() &&
-                    polled_hook.db_access_level.is_read_only()
+                polled_hook.name == hook_ro_name
+                    && polled_hook.event.is_started()
+                    && polled_hook.db_access_level.is_read_only()
             }),
             Poll::Ready(true)
         );

--- a/crates/consensus/beacon/src/engine/hooks/static_file.rs
+++ b/crates/consensus/beacon/src/engine/hooks/static_file.rs
@@ -88,12 +88,12 @@ impl<DB: Database + 'static> StaticFileHook<DB> {
             StaticFileProducerState::Idle(static_file_producer) => {
                 let Some(static_file_producer) = static_file_producer.take() else {
                     trace!(target: "consensus::engine::hooks::static_file", "StaticFileProducer is already running but the state is idle");
-                    return Ok(None)
+                    return Ok(None);
                 };
 
                 let Some(locked_static_file_producer) = static_file_producer.try_lock_arc() else {
                     trace!(target: "consensus::engine::hooks::static_file", "StaticFileProducer lock is already taken");
-                    return Ok(None)
+                    return Ok(None);
                 };
 
                 let targets =
@@ -138,7 +138,7 @@ impl<DB: Database + 'static> EngineHook for StaticFileHook<DB> {
     ) -> Poll<RethResult<EngineHookEvent>> {
         let Some(finalized_block_number) = ctx.finalized_block_number else {
             trace!(target: "consensus::engine::hooks::static_file", ?ctx, "Finalized block number is not available");
-            return Poll::Pending
+            return Poll::Pending;
         };
 
         // Try to spawn a static_file_producer

--- a/crates/consensus/beacon/src/engine/invalid_headers.rs
+++ b/crates/consensus/beacon/src/engine/invalid_headers.rs
@@ -41,7 +41,7 @@ impl InvalidHeaderCache {
             let entry = self.headers.get(hash)?;
             entry.hit_count += 1;
             if entry.hit_count < INVALID_HEADER_HIT_EVICTION_THRESHOLD {
-                return Some(entry.header.clone())
+                return Some(entry.header.clone());
             }
         }
         // if we get here, the entry has been hit too many times, so we evict it

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -745,8 +745,8 @@ where
 
             // If current_header is None, then the current_hash does not have an invalid
             // ancestor in the cache, check its presence in blockchain tree
-            if current_header.is_none() &&
-                self.blockchain.find_block_by_hash(current_hash, BlockSource::Any)?.is_some()
+            if current_header.is_none()
+                && self.blockchain.find_block_by_hash(current_hash, BlockSource::Any)?.is_some()
             {
                 return Ok(Some(current_hash));
             }
@@ -845,8 +845,8 @@ where
         //
         // This ensures that the finalized block is consistent with the head block, i.e. the
         // finalized block is an ancestor of the head block.
-        if !state.finalized_block_hash.is_zero() &&
-            !self.blockchain.is_canonical(state.finalized_block_hash)?
+        if !state.finalized_block_hash.is_zero()
+            && !self.blockchain.is_canonical(state.finalized_block_hash)?
         {
             return Ok(Some(OnForkChoiceUpdated::invalid_state()));
         }
@@ -859,8 +859,8 @@ where
         //
         // This ensures that the safe block is consistent with the head block, i.e. the safe
         // block is an ancestor of the head block.
-        if !state.safe_block_hash.is_zero() &&
-            !self.blockchain.is_canonical(state.safe_block_hash)?
+        if !state.safe_block_hash.is_zero()
+            && !self.blockchain.is_canonical(state.safe_block_hash)?
         {
             return Ok(Some(OnForkChoiceUpdated::invalid_state()));
         }
@@ -1243,8 +1243,8 @@ where
                 latest_valid_hash = Some(block_hash);
                 PayloadStatusEnum::Valid
             }
-            InsertPayloadOk::Inserted(BlockStatus::Disconnected { .. }) |
-            InsertPayloadOk::AlreadySeen(BlockStatus::Disconnected { .. }) => {
+            InsertPayloadOk::Inserted(BlockStatus::Disconnected { .. })
+            | InsertPayloadOk::AlreadySeen(BlockStatus::Disconnected { .. }) => {
                 // check if the block's parent is already marked as invalid
                 if let Some(status) =
                     self.check_invalid_ancestor_with_head(block.parent_hash, block.hash()).map_err(

--- a/crates/consensus/beacon/src/engine/sync.rs
+++ b/crates/consensus/beacon/src/engine/sync.rs
@@ -175,7 +175,7 @@ where
     /// given hash.
     pub(crate) fn download_full_block(&mut self, hash: B256) -> bool {
         if self.is_inflight_request(hash) {
-            return false
+            return false;
         }
         trace!(
             target: "consensus::engine::sync",
@@ -209,7 +209,7 @@ where
                 "Pipeline target cannot be zero hash."
             );
             // precaution to never sync to the zero hash
-            return
+            return;
         }
         self.pending_pipeline_target = Some(target);
     }
@@ -289,14 +289,14 @@ where
     pub(crate) fn poll(&mut self, cx: &mut Context<'_>) -> Poll<EngineSyncEvent> {
         // try to spawn a pipeline if a target is set
         if let Some(event) = self.try_spawn_pipeline() {
-            return Poll::Ready(event)
+            return Poll::Ready(event);
         }
 
         // make sure we poll the pipeline if it's active, and return any ready pipeline events
         if !self.is_pipeline_idle() {
             // advance the pipeline
             if let Poll::Ready(event) = self.poll_pipeline(cx) {
-                return Poll::Ready(event)
+                return Poll::Ready(event);
             }
         }
 
@@ -334,10 +334,10 @@ where
                 if peek.0 .0.hash() == block.0 .0.hash() {
                     PeekMut::pop(peek);
                 } else {
-                    break
+                    break;
                 }
             }
-            return Poll::Ready(EngineSyncEvent::FetchedFullBlock(block.0 .0))
+            return Poll::Ready(EngineSyncEvent::FetchedFullBlock(block.0 .0));
         }
 
         Poll::Pending

--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -29,8 +29,8 @@ pub fn validate_header_base_fee(
     header: &Header,
     chain_spec: &ChainSpec,
 ) -> Result<(), ConsensusError> {
-    if chain_spec.is_fork_active_at_block(EthereumHardfork::London, header.number) &&
-        header.base_fee_per_gas.is_none()
+    if chain_spec.is_fork_active_at_block(EthereumHardfork::London, header.number)
+        && header.base_fee_per_gas.is_none()
     {
         return Err(ConsensusError::BaseFeeMissing);
     }
@@ -62,9 +62,9 @@ pub fn validate_block_pre_execution(
 
     // EIP-4895: Beacon chain push withdrawals as operations
     // Botanix chain will skip withdrawals root check
-    if chain_spec.is_shanghai_active_at_timestamp(block.timestamp) &&
-        chain_spec.chain.id() != BOTANIX_TESTNET.chain.id() &&
-        chain_spec.chain.id() != BOTANIX_MAINNET.chain.id()
+    if chain_spec.is_shanghai_active_at_timestamp(block.timestamp)
+        && chain_spec.chain.id() != BOTANIX_TESTNET.chain.id()
+        && chain_spec.chain.id() != BOTANIX_MAINNET.chain.id()
     {
         let withdrawals =
             block.withdrawals.as_ref().ok_or(ConsensusError::BodyWithdrawalsMissing)?;

--- a/crates/consensus/debug-client/src/providers/etherscan.rs
+++ b/crates/consensus/debug-client/src/providers/etherscan.rs
@@ -63,7 +63,7 @@ impl BlockProvider for EtherscanBlockProvider {
                 Ok(block) => block,
                 Err(err) => {
                     warn!(target: "consensus::debug-client", %err, "failed to fetch a block from Etherscan");
-                    continue
+                    continue;
                 }
             };
             let block_number = block.header.number.unwrap();

--- a/crates/e2e-test-utils/src/network.rs
+++ b/crates/e2e-test-utils/src/network.rs
@@ -45,7 +45,7 @@ where
             match ev {
                 NetworkEvent::SessionEstablished { peer_id, .. } => {
                     info!("Session established with peer: {:?}", peer_id);
-                    return Some(peer_id)
+                    return Some(peer_id);
                 }
                 _ => continue,
             }

--- a/crates/e2e-test-utils/src/node.rs
+++ b/crates/e2e-test-utils/src/node.rs
@@ -189,7 +189,7 @@ where
             if check {
                 if let Some(latest_block) = self.inner.provider.block_by_number(number)? {
                     assert_eq!(latest_block.hash_slow(), expected_block_hash);
-                    break
+                    break;
                 }
                 assert!(
                     !wait_finish_checkpoint,
@@ -206,7 +206,7 @@ where
             tokio::time::sleep(std::time::Duration::from_millis(10)).await;
             if let Some(checkpoint) = self.inner.provider.get_stage_checkpoint(StageId::Headers)? {
                 if checkpoint.block_number == number {
-                    break
+                    break;
                 }
             }
         }
@@ -239,7 +239,7 @@ where
                     // make sure the block hash we submitted via FCU engine api is the new latest
                     // block using an RPC call
                     assert_eq!(latest_block.hash_slow(), block_hash);
-                    break
+                    break;
                 }
             }
         }

--- a/crates/e2e-test-utils/src/payload.rs
+++ b/crates/e2e-test-utils/src/payload.rs
@@ -51,9 +51,9 @@ impl<E: EngineTypes> PayloadTestContext<E> {
             let payload = self.payload_builder.best_payload(payload_id).await.unwrap().unwrap();
             if payload.block().body.is_empty() {
                 tokio::time::sleep(std::time::Duration::from_millis(20)).await;
-                continue
+                continue;
             }
-            break
+            break;
         }
     }
 

--- a/crates/engine/tree/src/backfill.rs
+++ b/crates/engine/tree/src/backfill.rs
@@ -130,7 +130,7 @@ where
                 "Pipeline target cannot be zero hash."
             );
             // precaution to never sync to the zero hash
-            return
+            return;
         }
         self.pending_pipeline_target = Some(target);
     }
@@ -196,14 +196,14 @@ where
     fn poll(&mut self, cx: &mut Context<'_>) -> Poll<BackfillEvent> {
         // try to spawn a pipeline if a target is set
         if let Some(event) = self.try_spawn_pipeline() {
-            return Poll::Ready(event)
+            return Poll::Ready(event);
         }
 
         // make sure we poll the pipeline if it's active, and return any ready pipeline events
         if self.is_pipeline_active() {
             // advance the pipeline
             if let Poll::Ready(event) = self.poll_pipeline(cx) {
-                return Poll::Ready(event)
+                return Poll::Ready(event);
             }
         }
 

--- a/crates/engine/tree/src/chain.rs
+++ b/crates/engine/tree/src/chain.rs
@@ -99,7 +99,7 @@ where
                                 tracing::error!( %err, "backfill sync failed");
                                 Poll::Ready(ChainEvent::FatalError)
                             }
-                        }
+                        };
                     }
                     BackfillEvent::TaskDropped(err) => {
                         tracing::error!( %err, "backfill sync task dropped");
@@ -123,13 +123,13 @@ where
                         }
                         HandlerEvent::FatalError => {
                             error!(target: "engine::tree", "Fatal error");
-                            return Poll::Ready(ChainEvent::FatalError)
+                            return Poll::Ready(ChainEvent::FatalError);
                         }
                     }
                 }
                 Poll::Pending => {
                     // no more events to process
-                    break 'outer
+                    break 'outer;
                 }
             }
         }

--- a/crates/engine/tree/src/download.rs
+++ b/crates/engine/tree/src/download.rs
@@ -135,7 +135,7 @@ where
     /// given hash.
     fn download_full_block(&mut self, hash: B256) -> bool {
         if self.is_inflight_request(hash) {
-            return false
+            return false;
         }
         self.push_pending_event(DownloadOutcome::NewDownloadStarted {
             remaining_blocks: 1,
@@ -246,7 +246,7 @@ where
                 if peek.0 .0.hash() == block.0 .0.hash() {
                     PeekMut::pop(peek);
                 } else {
-                    break
+                    break;
                 }
             }
             downloaded_blocks.push(block.0.into());

--- a/crates/engine/tree/src/engine.rs
+++ b/crates/engine/tree/src/engine.rs
@@ -93,7 +93,7 @@ where
                                 Poll::Ready(HandlerEvent::Event(ev))
                             }
                             HandlerEvent::FatalError => Poll::Ready(HandlerEvent::FatalError),
-                        }
+                        };
                     }
                     RequestHandlerEvent::Download(req) => {
                         // delegate download request to the downloader
@@ -107,17 +107,17 @@ where
                 // and delegate the request to the handler
                 self.handler.on_event(FromEngine::Request(req.into()));
                 // skip downloading in this iteration to allow the handler to process the request
-                continue
+                continue;
             }
 
             // advance the downloader
             if let Poll::Ready(DownloadOutcome::Blocks(blocks)) = self.downloader.poll(cx) {
                 // delegate the downloaded blocks to the handler
                 self.handler.on_event(FromEngine::DownloadedBlocks(blocks));
-                continue
+                continue;
             }
 
-            return Poll::Pending
+            return Poll::Pending;
         }
     }
 }
@@ -194,7 +194,7 @@ where
 
     fn poll(&mut self, cx: &mut Context<'_>) -> Poll<RequestHandlerEvent<Self::Event>> {
         let Some(ev) = ready!(self.from_tree.poll_recv(cx)) else {
-            return Poll::Ready(RequestHandlerEvent::HandlerEvent(HandlerEvent::FatalError))
+            return Poll::Ready(RequestHandlerEvent::HandlerEvent(HandlerEvent::FatalError));
         };
 
         let ev = match ev {

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -161,7 +161,7 @@ impl TreeState {
         let mut current_hash = target_hash;
         while let Some(current_block) = self.block_by_hash(current_hash) {
             if current_block.hash() == self.canonical_block_hash() {
-                return false
+                return false;
             }
             current_hash = current_block.header.parent_hash;
         }
@@ -170,7 +170,7 @@ impl TreeState {
         current_hash = self.canonical_block_hash();
         while let Some(current_block) = self.block_by_hash(current_hash) {
             if current_block.hash() == target_hash {
-                return false
+                return false;
             }
             current_hash = current_block.header.parent_hash;
         }
@@ -526,13 +526,13 @@ where
                 }
                 Err(_err) => {
                     error!(target: "engine", "Engine channel disconnected");
-                    return
+                    return;
                 }
             }
 
             if let Err(err) = self.advance_persistence() {
                 error!(target: "engine", %err, "Advancing persistence failed");
-                break
+                break;
             }
         }
     }
@@ -545,7 +545,7 @@ where
     fn on_downloaded(&mut self, mut blocks: Vec<SealedBlockWithSenders>) -> Option<TreeEvent> {
         if blocks.is_empty() {
             // nothing to execute
-            return None
+            return None;
         }
 
         trace!(target: "engine", block_count = %blocks.len(), "received downloaded blocks");
@@ -556,7 +556,7 @@ where
                 self.on_tree_event(event);
                 if needs_backfill {
                     // can exit early if backfill is needed
-                    return None
+                    return None;
                 }
             }
         }
@@ -636,7 +636,7 @@ where
                     };
 
                 let status = PayloadStatusEnum::from(error);
-                return Ok(TreeOutcome::new(PayloadStatus::new(status, latest_valid_hash)))
+                return Ok(TreeOutcome::new(PayloadStatus::new(status, latest_valid_hash)));
             }
         };
 
@@ -650,7 +650,7 @@ where
         if let Some(status) =
             self.check_invalid_ancestor_with_head(lowest_buffered_ancestor, block_hash)?
         {
-            return Ok(TreeOutcome::new(status))
+            return Ok(TreeOutcome::new(status));
         }
 
         let status = if !self.backfill_sync_state.is_idle() {
@@ -674,8 +674,8 @@ where
                             latest_valid_hash = Some(block_hash);
                             PayloadStatusEnum::Valid
                         }
-                        InsertPayloadOk::Inserted(BlockStatus::Disconnected { .. }) |
-                        InsertPayloadOk::AlreadySeen(BlockStatus::Disconnected { .. }) => {
+                        InsertPayloadOk::Inserted(BlockStatus::Disconnected { .. })
+                        | InsertPayloadOk::AlreadySeen(BlockStatus::Disconnected { .. }) => {
                             // not known to be invalid, but we don't know anything else
                             PayloadStatusEnum::Syncing
                         }
@@ -716,7 +716,7 @@ where
         self.canonical_in_memory_state.on_forkchoice_update_received();
 
         if let Some(on_updated) = self.pre_validate_forkchoice_update(state)? {
-            return Ok(TreeOutcome::new(on_updated))
+            return Ok(TreeOutcome::new(on_updated));
         }
 
         let valid_outcome = |head| {
@@ -747,7 +747,7 @@ where
             // update the safe and finalized blocks and ensure their values are valid
             if let Err(outcome) = self.ensure_consistent_forkchoice_state(state) {
                 // safe or finalized hashes are invalid
-                return Ok(TreeOutcome::new(outcome))
+                return Ok(TreeOutcome::new(outcome));
             }
 
             // we still need to process payload attributes if the head is already canonical
@@ -760,11 +760,11 @@ where
                         ProviderError::HeaderNotFound(state.head_block_hash.into())
                     })?;
                 let updated = self.process_payload_attributes(attr, &tip, state);
-                return Ok(TreeOutcome::new(updated))
+                return Ok(TreeOutcome::new(updated));
             }
 
             // the head block is already canonical
-            return Ok(valid_outcome(state.head_block_hash))
+            return Ok(valid_outcome(state.head_block_hash));
         }
 
         // 2. ensure we can apply a new chain update for the head block
@@ -775,15 +775,15 @@ where
             // update the safe and finalized blocks and ensure their values are valid
             if let Err(outcome) = self.ensure_consistent_forkchoice_state(state) {
                 // safe or finalized hashes are invalid
-                return Ok(TreeOutcome::new(outcome))
+                return Ok(TreeOutcome::new(outcome));
             }
 
             if let Some(attr) = attrs {
                 let updated = self.process_payload_attributes(attr, &tip, state);
-                return Ok(TreeOutcome::new(updated))
+                return Ok(TreeOutcome::new(updated));
             }
 
-            return Ok(valid_outcome(state.head_block_hash))
+            return Ok(valid_outcome(state.head_block_hash));
         }
 
         // 3. check if the head is already part of the canonical chain
@@ -802,7 +802,7 @@ where
 
             // the head block is already canonical, so we're not triggering a payload job and can
             // return right away
-            return Ok(valid_outcome(state.head_block_hash))
+            return Ok(valid_outcome(state.head_block_hash));
         }
 
         // 4. we don't have the block to perform the update
@@ -886,7 +886,7 @@ where
                         // if this happened, then we persisted no blocks because we sent an
                         // empty vec of blocks
                         warn!(target: "engine", "Persistence task completed but did not persist any blocks");
-                        return Ok(())
+                        return Ok(());
                     };
                     if let Some(block) =
                         self.state.tree_state.block_by_hash(last_persisted_block_hash)
@@ -995,7 +995,7 @@ where
             warn!(target: "consensus::engine", invalid_hash=?bad_block.hash(), invalid_number=?bad_block.number, "Bad block detected in unwind");
             // update the `invalid_headers` cache with the new invalid header
             self.state.invalid_headers.insert(*bad_block);
-            return
+            return;
         }
 
         // backfill height is the block number that the backfill finished at
@@ -1026,11 +1026,11 @@ where
         // the backfill height
         let Some(sync_target_state) = self.state.forkchoice_state_tracker.sync_target_state()
         else {
-            return
+            return;
         };
         if sync_target_state.finalized_block_hash.is_zero() {
             // no finalized block, can't check distance
-            return
+            return;
         }
         // get the block number of the finalized block, if we have it
         let newest_finalized = self
@@ -1055,7 +1055,7 @@ where
             self.emit_event(EngineApiEvent::BackfillAction(BackfillAction::Start(
                 backfill_target.into(),
             )));
-            return
+            return;
         };
 
         // try to close the gap by executing buffered blocks that are child blocks of the new head
@@ -1110,7 +1110,7 @@ where
                 // backfill sync and persisting data are mutually exclusive, so we can't start
                 // backfill while we're still persisting
                 debug!(target: "engine", "skipping backfill file while persistence task is active");
-                return
+                return;
             }
 
             self.backfill_sync_state = BackfillSyncState::Pending;
@@ -1130,12 +1130,12 @@ where
     const fn should_persist(&self) -> bool {
         if !self.backfill_sync_state.is_idle() {
             // can't persist if backfill is running
-            return false
+            return false;
         }
 
         let min_block = self.persistence_state.last_persisted_block_number;
-        self.state.tree_state.canonical_block_number().saturating_sub(min_block) >
-            self.config.persistence_threshold()
+        self.state.tree_state.canonical_block_number().saturating_sub(min_block)
+            > self.config.persistence_threshold()
     }
 
     /// Returns a batch of consecutive canonical blocks to persist in the range
@@ -1235,7 +1235,7 @@ where
             trace!(target: "engine", %hash, "found canonical state for block in memory");
             // the block leads back to the canonical chain
             let historical = self.provider.state_by_block_hash(historical)?;
-            return Ok(Some(Box::new(MemoryOverlayStateProvider::new(blocks, historical))))
+            return Ok(Some(Box::new(MemoryOverlayStateProvider::new(blocks, historical))));
         }
 
         // the hash could belong to an unknown block or a persisted block
@@ -1243,7 +1243,7 @@ where
             trace!(target: "engine", %hash, number = %header.number, "found canonical state for block in database");
             // the block is known and persisted
             let historical = self.provider.state_by_block_hash(hash)?;
-            return Ok(Some(historical))
+            return Ok(Some(historical));
         }
 
         trace!(target: "engine", %hash, "no canonical state found for block");
@@ -1281,7 +1281,7 @@ where
     ) -> ProviderResult<Option<B256>> {
         // Check if parent exists in side chain or in canonical chain.
         if self.block_by_hash(parent_hash)?.is_some() {
-            return Ok(Some(parent_hash))
+            return Ok(Some(parent_hash));
         }
 
         // iterate over ancestors in the invalid cache
@@ -1295,7 +1295,7 @@ where
             // If current_header is None, then the current_hash does not have an invalid
             // ancestor in the cache, check its presence in blockchain tree
             if current_header.is_none() && self.block_by_hash(current_hash)?.is_some() {
-                return Ok(Some(current_hash))
+                return Ok(Some(current_hash));
             }
         }
         Ok(None)
@@ -1325,7 +1325,7 @@ where
     /// See [`ForkchoiceStateTracker::sync_target_state`]
     fn is_sync_target_head(&self, block_hash: B256) -> bool {
         if let Some(target) = self.state.forkchoice_state_tracker.sync_target_state() {
-            return target.head_block_hash == block_hash
+            return target.head_block_hash == block_hash;
         }
         false
     }
@@ -1370,17 +1370,17 @@ where
                 "Failed to validate total difficulty for block {}: {e}",
                 block.header.hash()
             );
-            return Err(e)
+            return Err(e);
         }
 
         if let Err(e) = self.consensus.validate_header(block) {
             error!(?block, "Failed to validate header {}: {e}", block.header.hash());
-            return Err(e)
+            return Err(e);
         }
 
         if let Err(e) = self.consensus.validate_block_pre_execution(block) {
             error!(?block, "Failed to validate block {}: {e}", block.header.hash());
-            return Err(e)
+            return Err(e);
         }
 
         Ok(())
@@ -1393,7 +1393,7 @@ where
 
         if blocks.is_empty() {
             // nothing to append
-            return
+            return;
         }
 
         let now = Instant::now();
@@ -1403,8 +1403,8 @@ where
             match self.insert_block(child) {
                 Ok(res) => {
                     debug!(target: "engine", child =?child_num_hash, ?res, "connected buffered block");
-                    if self.is_sync_target_head(child_num_hash.hash) &&
-                        matches!(
+                    if self.is_sync_target_head(child_num_hash.hash)
+                        && matches!(
                             res,
                             InsertPayloadOk::Inserted(BlockStatus::Valid(
                                 BlockAttachment::Canonical
@@ -1442,7 +1442,7 @@ where
     /// Pre-validates the block and inserts it into the buffer.
     fn buffer_block(&mut self, block: SealedBlockWithSenders) -> Result<(), InsertBlockErrorTwo> {
         if let Err(err) = self.validate_block(&block) {
-            return Err(InsertBlockErrorTwo::consensus_error(err, block.block))
+            return Err(InsertBlockErrorTwo::consensus_error(err, block.block));
         }
         self.state.buffer.insert_block(block);
         Ok(())
@@ -1520,7 +1520,7 @@ where
                         if !state.finalized_block_hash.is_zero() {
                             // we don't have the block yet and the distance exceeds the allowed
                             // threshold
-                            return Some(state.finalized_block_hash)
+                            return Some(state.finalized_block_hash);
                         }
 
                         // OPTIMISTIC SYNCING
@@ -1536,7 +1536,7 @@ where
                         // However, optimism chains will do this. The risk of a reorg is however
                         // low.
                         debug!(target: "engine", hash=?state.head_block_hash, "Setting head hash as an optimistic backfill target.");
-                        return Some(state.head_block_hash)
+                        return Some(state.head_block_hash);
                     }
                     Ok(Some(_)) => {
                         // we're fully synced to the finalized block
@@ -1631,11 +1631,11 @@ where
             .ok()?
             .is_some()
         {
-            return None
+            return None;
         }
 
         if !self.backfill_sync_state.is_idle() {
-            return None
+            return None;
         }
 
         // try to append the block
@@ -1647,7 +1647,7 @@ where
                     // canonical
                     return Some(TreeEvent::TreeAction(TreeAction::MakeCanonical(
                         block_num_hash.hash,
-                    )))
+                    )));
                 }
                 trace!(target: "engine", "appended downloaded block");
                 self.try_connect_buffered_blocks(block_num_hash);
@@ -1655,7 +1655,11 @@ where
             Ok(InsertPayloadOk::Inserted(BlockStatus::Disconnected { head, missing_ancestor })) => {
                 // block is not connected to the canonical head, we need to download
                 // its missing branch first
-                return self.on_disconnected_downloaded_block(block_num_hash, missing_ancestor, head)
+                return self.on_disconnected_downloaded_block(
+                    block_num_hash,
+                    missing_ancestor,
+                    head,
+                );
             }
             Ok(InsertPayloadOk::AlreadySeen(_)) => {
                 trace!(target: "engine", "downloaded block already executed");
@@ -1694,7 +1698,7 @@ where
     ) -> Result<InsertPayloadOk, InsertBlockErrorKindTwo> {
         if self.block_by_hash(block.hash())?.is_some() {
             let attachment = BlockAttachment::Canonical; // TODO: remove or revise attachment
-            return Ok(InsertPayloadOk::AlreadySeen(BlockStatus::Valid(attachment)))
+            return Ok(InsertPayloadOk::AlreadySeen(BlockStatus::Valid(attachment)));
         }
 
         let start = Instant::now();
@@ -1717,7 +1721,7 @@ where
             return Ok(InsertPayloadOk::Inserted(BlockStatus::Disconnected {
                 head: self.state.tree_state.current_canonical_head,
                 missing_ancestor,
-            }))
+            }));
         };
 
         // now validate against the parent
@@ -1728,7 +1732,7 @@ where
         })?;
         if let Err(e) = self.consensus.validate_header_against_parent(&block, &parent_block) {
             warn!(?block, "Failed to validate header {} against parent: {e}", block.header.hash());
-            return Err(e.into())
+            return Err(e.into());
         }
 
         let executor = self.executor_provider.executor(StateProviderDatabase::new(&state_provider));
@@ -1756,7 +1760,7 @@ where
             return Err(ConsensusError::BodyStateRootDiff(
                 GotExpected { got: state_root, expected: block.state_root }.into(),
             )
-            .into())
+            .into());
         }
 
         debug!(target: "engine", elapsed=?root_time.elapsed(), ?block_number, "Calculated state root");
@@ -1847,14 +1851,14 @@ where
         finalized_block_hash: B256,
     ) -> Result<(), OnForkChoiceUpdated> {
         if finalized_block_hash.is_zero() {
-            return Ok(())
+            return Ok(());
         }
 
         match self.find_canonical_header(finalized_block_hash) {
             Ok(None) => {
                 debug!(target: "engine", "Finalized block not found in canonical chain");
                 // if the finalized block is not known, we can't update the finalized block
-                return Err(OnForkChoiceUpdated::invalid_state())
+                return Err(OnForkChoiceUpdated::invalid_state());
             }
             Ok(Some(finalized)) => {
                 self.canonical_in_memory_state.set_finalized(finalized);
@@ -1870,14 +1874,14 @@ where
     /// Updates the tracked safe block if we have it
     fn update_safe_block(&self, safe_block_hash: B256) -> Result<(), OnForkChoiceUpdated> {
         if safe_block_hash.is_zero() {
-            return Ok(())
+            return Ok(());
         }
 
         match self.find_canonical_header(safe_block_hash) {
             Ok(None) => {
                 debug!(target: "engine", "Safe block not found in canonical chain");
                 // if the safe block is not known, we can't update the safe block
-                return Err(OnForkChoiceUpdated::invalid_state())
+                return Err(OnForkChoiceUpdated::invalid_state());
             }
             Ok(Some(finalized)) => {
                 self.canonical_in_memory_state.set_safe(finalized);
@@ -1926,21 +1930,21 @@ where
         state: ForkchoiceState,
     ) -> ProviderResult<Option<OnForkChoiceUpdated>> {
         if state.head_block_hash.is_zero() {
-            return Ok(Some(OnForkChoiceUpdated::invalid_state()))
+            return Ok(Some(OnForkChoiceUpdated::invalid_state()));
         }
 
         // check if the new head hash is connected to any ancestor that we previously marked as
         // invalid
         let lowest_buffered_ancestor_fcu = self.lowest_buffered_ancestor_or(state.head_block_hash);
         if let Some(status) = self.check_invalid_ancestor(lowest_buffered_ancestor_fcu)? {
-            return Ok(Some(OnForkChoiceUpdated::with_invalid(status)))
+            return Ok(Some(OnForkChoiceUpdated::with_invalid(status)));
         }
 
         if !self.backfill_sync_state.is_idle() {
             // We can only process new forkchoice updates if the pipeline is idle, since it requires
             // exclusive access to the database
             trace!(target: "consensus::engine", "Pipeline is syncing, skipping forkchoice update");
-            return Ok(Some(OnForkChoiceUpdated::syncing()))
+            return Ok(Some(OnForkChoiceUpdated::syncing()));
         }
 
         Ok(None)
@@ -1962,7 +1966,7 @@ where
         //    begin a payload build process. In such an event, the forkchoiceState update MUST NOT
         //    be rolled back.
         if attrs.timestamp() <= head.timestamp {
-            return OnForkChoiceUpdated::invalid_payload_attributes()
+            return OnForkChoiceUpdated::invalid_payload_attributes();
         }
 
         // 8. Client software MUST begin a payload build process building on top of

--- a/crates/engine/util/src/reorg.rs
+++ b/crates/engine/util/src/reorg.rs
@@ -124,7 +124,7 @@ where
                     }
                     Err(_) => {}
                 };
-                continue
+                continue;
             }
 
             if let EngineReorgState::Reorg { queue } = &mut this.state {
@@ -172,7 +172,7 @@ where
                                         payload,
                                         cancun_fields,
                                         tx,
-                                    }))
+                                    }));
                                 }
                             };
                             let reorg_forkchoice_state = ForkchoiceState {
@@ -206,7 +206,7 @@ where
                                     },
                                 ]),
                             };
-                            continue
+                            continue;
                         }
                     }
                     Some(BeaconEngineMessage::NewPayload { payload, cancun_fields, tx })
@@ -221,7 +221,7 @@ where
                 }
                 item => item,
             };
-            return Poll::Ready(item)
+            return Poll::Ready(item);
         }
     }
 }
@@ -290,7 +290,7 @@ where
     for tx in next_block.body {
         // ensure we still have capacity for this transaction
         if cumulative_gas_used + tx.gas_limit() > reorg_target.gas_limit {
-            continue
+            continue;
         }
 
         // Configure the environment for the block.
@@ -302,7 +302,7 @@ where
             Ok(result) => result,
             error @ Err(EVMError::Transaction(_) | EVMError::Header(_)) => {
                 trace!(target: "engine::stream::reorg", hash = %tx.hash(), ?error, "Error executing transaction from next block");
-                continue
+                continue;
             }
             // Treat error as fatal
             Err(error) => {

--- a/crates/engine/util/src/skip_fcu.rs
+++ b/crates/engine/util/src/skip_fcu.rs
@@ -50,7 +50,7 @@ where
                         *this.skipped += 1;
                         tracing::warn!(target: "engine::stream::skip_fcu", ?state, ?payload_attrs, threshold=this.threshold, skipped=this.skipped, "Skipping FCU");
                         let _ = tx.send(Ok(OnForkChoiceUpdated::syncing()));
-                        continue
+                        continue;
                     } else {
                         *this.skipped = 0;
                         Some(BeaconEngineMessage::ForkchoiceUpdated { state, payload_attrs, tx })
@@ -58,7 +58,7 @@ where
                 }
                 next => next,
             };
-            return Poll::Ready(item)
+            return Poll::Ready(item);
         }
     }
 }

--- a/crates/engine/util/src/skip_new_payload.rs
+++ b/crates/engine/util/src/skip_new_payload.rs
@@ -53,7 +53,7 @@ where
                             skipped=this.skipped, "Skipping new payload"
                         );
                         let _ = tx.send(Ok(PayloadStatus::from_status(PayloadStatusEnum::Syncing)));
-                        continue
+                        continue;
                     } else {
                         *this.skipped = 0;
                         Some(BeaconEngineMessage::NewPayload { payload, cancun_fields, tx })
@@ -61,7 +61,7 @@ where
                 }
                 next => next,
             };
-            return Poll::Ready(item)
+            return Poll::Ready(item);
         }
     }
 }

--- a/crates/ethereum-forks/src/forkcondition.rs
+++ b/crates/ethereum-forks/src/forkcondition.rs
@@ -85,9 +85,9 @@ impl ForkCondition {
     /// - The condition is satisfied by the timestamp;
     /// - or the condition is satisfied by the total difficulty
     pub fn active_at_head(&self, head: &Head) -> bool {
-        self.active_at_block(head.number) ||
-            self.active_at_timestamp(head.timestamp) ||
-            self.active_at_ttd(head.total_difficulty, head.difficulty)
+        self.active_at_block(head.number)
+            || self.active_at_timestamp(head.timestamp)
+            || self.active_at_ttd(head.total_difficulty, head.difficulty)
     }
 
     /// Get the total terminal difficulty for this fork condition.

--- a/crates/ethereum-forks/src/forkid.rs
+++ b/crates/ethereum-forks/src/forkid.rs
@@ -141,7 +141,7 @@ impl Decodable for EnrForkIdEntry {
         let b = &mut &**buf;
         let rlp_head = Header::decode(b)?;
         if !rlp_head.list {
-            return Err(RlpError::UnexpectedString)
+            return Err(RlpError::UnexpectedString);
         }
         let started_len = b.len();
 
@@ -155,7 +155,7 @@ impl Decodable for EnrForkIdEntry {
             return Err(RlpError::ListLengthMismatch {
                 expected: rlp_head.payload_length,
                 got: consumed,
-            })
+            });
         }
 
         let rem = rlp_head.payload_length - consumed;
@@ -324,7 +324,7 @@ impl ForkFilter {
         if self.current().hash == fork_id.hash {
             if fork_id.next == 0 {
                 // 1b) No remotely announced fork, connect.
-                return Ok(())
+                return Ok(());
             }
 
             let is_incompatible = if self.head.number < TIMESTAMP_BEFORE_ETHEREUM_MAINNET {
@@ -332,10 +332,10 @@ impl ForkFilter {
                 // we check if this fork is time-based or block number-based by estimating that,
                 // if fork_id.next is bigger than the old timestamp, we are dealing with a
                 // timestamp, otherwise with a block.
-                (fork_id.next > TIMESTAMP_BEFORE_ETHEREUM_MAINNET &&
-                    self.head.timestamp >= fork_id.next) ||
-                    (fork_id.next <= TIMESTAMP_BEFORE_ETHEREUM_MAINNET &&
-                        self.head.number >= fork_id.next)
+                (fork_id.next > TIMESTAMP_BEFORE_ETHEREUM_MAINNET
+                    && self.head.timestamp >= fork_id.next)
+                    || (fork_id.next <= TIMESTAMP_BEFORE_ETHEREUM_MAINNET
+                        && self.head.number >= fork_id.next)
             } else {
                 // Extra safety check to future-proof for when Ethereum has over a billion blocks.
                 let head_block_or_time = match self.cache.epoch_start {
@@ -355,7 +355,7 @@ impl ForkFilter {
             } else {
                 // 1b) Remotely announced fork not yet passed locally, connect.
                 Ok(())
-            }
+            };
         }
 
         // 2) If the remote FORK_HASH is a subset of the local past forks...
@@ -369,10 +369,10 @@ impl ForkFilter {
                         Ok(())
                     } else {
                         Err(ValidationError::RemoteStale { local: self.current(), remote: fork_id })
-                    }
+                    };
                 }
 
-                break
+                break;
             }
         }
 
@@ -380,7 +380,7 @@ impl ForkFilter {
         // with locally known future forks, connect.
         for future_fork_hash in &self.cache.future {
             if *future_fork_hash == fork_id.hash {
-                return Ok(())
+                return Ok(());
             }
         }
 

--- a/crates/ethereum-forks/src/hardfork/ethereum.rs
+++ b/crates/ethereum-forks/src/hardfork/ethereum.rs
@@ -58,13 +58,13 @@ impl EthereumHardfork {
     /// Retrieves the activation block for the specified hardfork on the given chain.
     pub fn activation_block(&self, chain: Chain) -> Option<u64> {
         if chain == Chain::mainnet() {
-            return self.mainnet_activation_block()
+            return self.mainnet_activation_block();
         }
         if chain == Chain::sepolia() {
-            return self.sepolia_activation_block()
+            return self.sepolia_activation_block();
         }
         if chain == Chain::holesky() {
-            return self.holesky_activation_block()
+            return self.holesky_activation_block();
         }
 
         None
@@ -99,20 +99,20 @@ impl EthereumHardfork {
             Self::Paris => Some(1735371),
             Self::Shanghai => Some(2990908),
             Self::Cancun => Some(5187023),
-            Self::Frontier |
-            Self::Homestead |
-            Self::Dao |
-            Self::Tangerine |
-            Self::SpuriousDragon |
-            Self::Byzantium |
-            Self::Constantinople |
-            Self::Petersburg |
-            Self::Istanbul |
-            Self::MuirGlacier |
-            Self::Berlin |
-            Self::London |
-            Self::ArrowGlacier |
-            Self::GrayGlacier => Some(0),
+            Self::Frontier
+            | Self::Homestead
+            | Self::Dao
+            | Self::Tangerine
+            | Self::SpuriousDragon
+            | Self::Byzantium
+            | Self::Constantinople
+            | Self::Petersburg
+            | Self::Istanbul
+            | Self::MuirGlacier
+            | Self::Berlin
+            | Self::London
+            | Self::ArrowGlacier
+            | Self::GrayGlacier => Some(0),
             _ => None,
         }
     }
@@ -120,19 +120,19 @@ impl EthereumHardfork {
     /// Retrieves the activation block for the specified hardfork on the holesky testnet.
     const fn holesky_activation_block(&self) -> Option<u64> {
         match self {
-            Self::Dao |
-            Self::Tangerine |
-            Self::SpuriousDragon |
-            Self::Byzantium |
-            Self::Constantinople |
-            Self::Petersburg |
-            Self::Istanbul |
-            Self::MuirGlacier |
-            Self::Berlin |
-            Self::London |
-            Self::ArrowGlacier |
-            Self::GrayGlacier |
-            Self::Paris => Some(0),
+            Self::Dao
+            | Self::Tangerine
+            | Self::SpuriousDragon
+            | Self::Byzantium
+            | Self::Constantinople
+            | Self::Petersburg
+            | Self::Istanbul
+            | Self::MuirGlacier
+            | Self::Berlin
+            | Self::London
+            | Self::ArrowGlacier
+            | Self::GrayGlacier
+            | Self::Paris => Some(0),
             Self::Shanghai => Some(6698),
             Self::Cancun => Some(894733),
             _ => None,
@@ -142,21 +142,21 @@ impl EthereumHardfork {
     /// Retrieves the activation block for the specified hardfork on the Arbitrum Sepolia testnet.
     pub const fn arbitrum_sepolia_activation_block(&self) -> Option<u64> {
         match self {
-            Self::Frontier |
-            Self::Homestead |
-            Self::Dao |
-            Self::Tangerine |
-            Self::SpuriousDragon |
-            Self::Byzantium |
-            Self::Constantinople |
-            Self::Petersburg |
-            Self::Istanbul |
-            Self::MuirGlacier |
-            Self::Berlin |
-            Self::London |
-            Self::ArrowGlacier |
-            Self::GrayGlacier |
-            Self::Paris => Some(0),
+            Self::Frontier
+            | Self::Homestead
+            | Self::Dao
+            | Self::Tangerine
+            | Self::SpuriousDragon
+            | Self::Byzantium
+            | Self::Constantinople
+            | Self::Petersburg
+            | Self::Istanbul
+            | Self::MuirGlacier
+            | Self::Berlin
+            | Self::London
+            | Self::ArrowGlacier
+            | Self::GrayGlacier
+            | Self::Paris => Some(0),
             Self::Shanghai => Some(10653737),
             // Hardfork::ArbOS11 => Some(10653737),
             Self::Cancun => Some(18683405),
@@ -168,21 +168,21 @@ impl EthereumHardfork {
     /// Retrieves the activation block for the specified hardfork on the Arbitrum One mainnet.
     pub const fn arbitrum_activation_block(&self) -> Option<u64> {
         match self {
-            Self::Frontier |
-            Self::Homestead |
-            Self::Dao |
-            Self::Tangerine |
-            Self::SpuriousDragon |
-            Self::Byzantium |
-            Self::Constantinople |
-            Self::Petersburg |
-            Self::Istanbul |
-            Self::MuirGlacier |
-            Self::Berlin |
-            Self::London |
-            Self::ArrowGlacier |
-            Self::GrayGlacier |
-            Self::Paris => Some(0),
+            Self::Frontier
+            | Self::Homestead
+            | Self::Dao
+            | Self::Tangerine
+            | Self::SpuriousDragon
+            | Self::Byzantium
+            | Self::Constantinople
+            | Self::Petersburg
+            | Self::Istanbul
+            | Self::MuirGlacier
+            | Self::Berlin
+            | Self::London
+            | Self::ArrowGlacier
+            | Self::GrayGlacier
+            | Self::Paris => Some(0),
             Self::Shanghai => Some(184097479),
             // Hardfork::ArbOS11 => Some(184097479),
             Self::Cancun => Some(190301729),
@@ -194,13 +194,13 @@ impl EthereumHardfork {
     /// Retrieves the activation timestamp for the specified hardfork on the given chain.
     pub fn activation_timestamp(&self, chain: Chain) -> Option<u64> {
         if chain == Chain::mainnet() {
-            return self.mainnet_activation_timestamp()
+            return self.mainnet_activation_timestamp();
         }
         if chain == Chain::sepolia() {
-            return self.sepolia_activation_timestamp()
+            return self.sepolia_activation_timestamp();
         }
         if chain == Chain::holesky() {
-            return self.holesky_activation_timestamp()
+            return self.holesky_activation_timestamp();
         }
 
         None
@@ -234,21 +234,21 @@ impl EthereumHardfork {
     /// Retrieves the activation timestamp for the specified hardfork on the Sepolia testnet.
     pub const fn sepolia_activation_timestamp(&self) -> Option<u64> {
         match self {
-            Self::Frontier |
-            Self::Homestead |
-            Self::Dao |
-            Self::Tangerine |
-            Self::SpuriousDragon |
-            Self::Byzantium |
-            Self::Constantinople |
-            Self::Petersburg |
-            Self::Istanbul |
-            Self::MuirGlacier |
-            Self::Berlin |
-            Self::London |
-            Self::ArrowGlacier |
-            Self::GrayGlacier |
-            Self::Paris => Some(1633267481),
+            Self::Frontier
+            | Self::Homestead
+            | Self::Dao
+            | Self::Tangerine
+            | Self::SpuriousDragon
+            | Self::Byzantium
+            | Self::Constantinople
+            | Self::Petersburg
+            | Self::Istanbul
+            | Self::MuirGlacier
+            | Self::Berlin
+            | Self::London
+            | Self::ArrowGlacier
+            | Self::GrayGlacier
+            | Self::Paris => Some(1633267481),
             Self::Shanghai => Some(1677557088),
             Self::Cancun => Some(1706655072),
             _ => None,
@@ -260,21 +260,21 @@ impl EthereumHardfork {
         match self {
             Self::Shanghai => Some(1696000704),
             Self::Cancun => Some(1707305664),
-            Self::Frontier |
-            Self::Homestead |
-            Self::Dao |
-            Self::Tangerine |
-            Self::SpuriousDragon |
-            Self::Byzantium |
-            Self::Constantinople |
-            Self::Petersburg |
-            Self::Istanbul |
-            Self::MuirGlacier |
-            Self::Berlin |
-            Self::London |
-            Self::ArrowGlacier |
-            Self::GrayGlacier |
-            Self::Paris => Some(1695902100),
+            Self::Frontier
+            | Self::Homestead
+            | Self::Dao
+            | Self::Tangerine
+            | Self::SpuriousDragon
+            | Self::Byzantium
+            | Self::Constantinople
+            | Self::Petersburg
+            | Self::Istanbul
+            | Self::MuirGlacier
+            | Self::Berlin
+            | Self::London
+            | Self::ArrowGlacier
+            | Self::GrayGlacier
+            | Self::Paris => Some(1695902100),
             _ => None,
         }
     }
@@ -283,21 +283,21 @@ impl EthereumHardfork {
     /// testnet.
     pub const fn arbitrum_sepolia_activation_timestamp(&self) -> Option<u64> {
         match self {
-            Self::Frontier |
-            Self::Homestead |
-            Self::Dao |
-            Self::Tangerine |
-            Self::SpuriousDragon |
-            Self::Byzantium |
-            Self::Constantinople |
-            Self::Petersburg |
-            Self::Istanbul |
-            Self::MuirGlacier |
-            Self::Berlin |
-            Self::London |
-            Self::ArrowGlacier |
-            Self::GrayGlacier |
-            Self::Paris => Some(1692726996),
+            Self::Frontier
+            | Self::Homestead
+            | Self::Dao
+            | Self::Tangerine
+            | Self::SpuriousDragon
+            | Self::Byzantium
+            | Self::Constantinople
+            | Self::Petersburg
+            | Self::Istanbul
+            | Self::MuirGlacier
+            | Self::Berlin
+            | Self::London
+            | Self::ArrowGlacier
+            | Self::GrayGlacier
+            | Self::Paris => Some(1692726996),
             Self::Shanghai => Some(1706634000),
             // Hardfork::ArbOS11 => Some(1706634000),
             Self::Cancun => Some(1709229600),
@@ -309,21 +309,21 @@ impl EthereumHardfork {
     /// Retrieves the activation timestamp for the specified hardfork on the Arbitrum One mainnet.
     pub const fn arbitrum_activation_timestamp(&self) -> Option<u64> {
         match self {
-            Self::Frontier |
-            Self::Homestead |
-            Self::Dao |
-            Self::Tangerine |
-            Self::SpuriousDragon |
-            Self::Byzantium |
-            Self::Constantinople |
-            Self::Petersburg |
-            Self::Istanbul |
-            Self::MuirGlacier |
-            Self::Berlin |
-            Self::London |
-            Self::ArrowGlacier |
-            Self::GrayGlacier |
-            Self::Paris => Some(1622240000),
+            Self::Frontier
+            | Self::Homestead
+            | Self::Dao
+            | Self::Tangerine
+            | Self::SpuriousDragon
+            | Self::Byzantium
+            | Self::Constantinople
+            | Self::Petersburg
+            | Self::Istanbul
+            | Self::MuirGlacier
+            | Self::Berlin
+            | Self::London
+            | Self::ArrowGlacier
+            | Self::GrayGlacier
+            | Self::Paris => Some(1622240000),
             Self::Shanghai => Some(1708804873),
             // Hardfork::ArbOS11 => Some(1708804873),
             Self::Cancun => Some(1710424089),

--- a/crates/ethereum-forks/src/hardfork/optimism.rs
+++ b/crates/ethereum-forks/src/hardfork/optimism.rs
@@ -36,10 +36,10 @@ impl OptimismHardfork {
     /// Retrieves the activation block for the specified hardfork on the given chain.
     pub fn activation_block<H: Hardfork>(self, fork: H, chain: Chain) -> Option<u64> {
         if chain == Chain::base_sepolia() {
-            return Self::base_sepolia_activation_block(fork)
+            return Self::base_sepolia_activation_block(fork);
         }
         if chain == Chain::base_mainnet() {
-            return Self::base_mainnet_activation_block(fork)
+            return Self::base_mainnet_activation_block(fork);
         }
 
         None
@@ -48,10 +48,10 @@ impl OptimismHardfork {
     /// Retrieves the activation timestamp for the specified hardfork on the given chain.
     pub fn activation_timestamp<H: Hardfork>(self, fork: H, chain: Chain) -> Option<u64> {
         if chain == Chain::base_sepolia() {
-            return Self::base_sepolia_activation_timestamp(fork)
+            return Self::base_sepolia_activation_timestamp(fork);
         }
         if chain == Chain::base_mainnet() {
-            return Self::base_mainnet_activation_timestamp(fork)
+            return Self::base_mainnet_activation_timestamp(fork);
         }
 
         None
@@ -62,22 +62,22 @@ impl OptimismHardfork {
         match_hardfork(
             fork,
             |fork| match fork {
-                EthereumHardfork::Frontier |
-                EthereumHardfork::Homestead |
-                EthereumHardfork::Dao |
-                EthereumHardfork::Tangerine |
-                EthereumHardfork::SpuriousDragon |
-                EthereumHardfork::Byzantium |
-                EthereumHardfork::Constantinople |
-                EthereumHardfork::Petersburg |
-                EthereumHardfork::Istanbul |
-                EthereumHardfork::MuirGlacier |
-                EthereumHardfork::Berlin |
-                EthereumHardfork::London |
-                EthereumHardfork::ArrowGlacier |
-                EthereumHardfork::GrayGlacier |
-                EthereumHardfork::Paris |
-                EthereumHardfork::Shanghai => Some(2106456),
+                EthereumHardfork::Frontier
+                | EthereumHardfork::Homestead
+                | EthereumHardfork::Dao
+                | EthereumHardfork::Tangerine
+                | EthereumHardfork::SpuriousDragon
+                | EthereumHardfork::Byzantium
+                | EthereumHardfork::Constantinople
+                | EthereumHardfork::Petersburg
+                | EthereumHardfork::Istanbul
+                | EthereumHardfork::MuirGlacier
+                | EthereumHardfork::Berlin
+                | EthereumHardfork::London
+                | EthereumHardfork::ArrowGlacier
+                | EthereumHardfork::GrayGlacier
+                | EthereumHardfork::Paris
+                | EthereumHardfork::Shanghai => Some(2106456),
                 EthereumHardfork::Cancun => Some(6383256),
                 _ => None,
             },
@@ -96,22 +96,22 @@ impl OptimismHardfork {
         match_hardfork(
             fork,
             |fork| match fork {
-                EthereumHardfork::Frontier |
-                EthereumHardfork::Homestead |
-                EthereumHardfork::Dao |
-                EthereumHardfork::Tangerine |
-                EthereumHardfork::SpuriousDragon |
-                EthereumHardfork::Byzantium |
-                EthereumHardfork::Constantinople |
-                EthereumHardfork::Petersburg |
-                EthereumHardfork::Istanbul |
-                EthereumHardfork::MuirGlacier |
-                EthereumHardfork::Berlin |
-                EthereumHardfork::London |
-                EthereumHardfork::ArrowGlacier |
-                EthereumHardfork::GrayGlacier |
-                EthereumHardfork::Paris |
-                EthereumHardfork::Shanghai => Some(9101527),
+                EthereumHardfork::Frontier
+                | EthereumHardfork::Homestead
+                | EthereumHardfork::Dao
+                | EthereumHardfork::Tangerine
+                | EthereumHardfork::SpuriousDragon
+                | EthereumHardfork::Byzantium
+                | EthereumHardfork::Constantinople
+                | EthereumHardfork::Petersburg
+                | EthereumHardfork::Istanbul
+                | EthereumHardfork::MuirGlacier
+                | EthereumHardfork::Berlin
+                | EthereumHardfork::London
+                | EthereumHardfork::ArrowGlacier
+                | EthereumHardfork::GrayGlacier
+                | EthereumHardfork::Paris
+                | EthereumHardfork::Shanghai => Some(9101527),
                 EthereumHardfork::Cancun => Some(11188936),
                 _ => None,
             },
@@ -129,22 +129,22 @@ impl OptimismHardfork {
         match_hardfork(
             fork,
             |fork| match fork {
-                EthereumHardfork::Frontier |
-                EthereumHardfork::Homestead |
-                EthereumHardfork::Dao |
-                EthereumHardfork::Tangerine |
-                EthereumHardfork::SpuriousDragon |
-                EthereumHardfork::Byzantium |
-                EthereumHardfork::Constantinople |
-                EthereumHardfork::Petersburg |
-                EthereumHardfork::Istanbul |
-                EthereumHardfork::MuirGlacier |
-                EthereumHardfork::Berlin |
-                EthereumHardfork::London |
-                EthereumHardfork::ArrowGlacier |
-                EthereumHardfork::GrayGlacier |
-                EthereumHardfork::Paris |
-                EthereumHardfork::Shanghai => Some(1699981200),
+                EthereumHardfork::Frontier
+                | EthereumHardfork::Homestead
+                | EthereumHardfork::Dao
+                | EthereumHardfork::Tangerine
+                | EthereumHardfork::SpuriousDragon
+                | EthereumHardfork::Byzantium
+                | EthereumHardfork::Constantinople
+                | EthereumHardfork::Petersburg
+                | EthereumHardfork::Istanbul
+                | EthereumHardfork::MuirGlacier
+                | EthereumHardfork::Berlin
+                | EthereumHardfork::London
+                | EthereumHardfork::ArrowGlacier
+                | EthereumHardfork::GrayGlacier
+                | EthereumHardfork::Paris
+                | EthereumHardfork::Shanghai => Some(1699981200),
                 EthereumHardfork::Cancun => Some(1708534800),
                 _ => None,
             },
@@ -163,22 +163,22 @@ impl OptimismHardfork {
         match_hardfork(
             fork,
             |fork| match fork {
-                EthereumHardfork::Frontier |
-                EthereumHardfork::Homestead |
-                EthereumHardfork::Dao |
-                EthereumHardfork::Tangerine |
-                EthereumHardfork::SpuriousDragon |
-                EthereumHardfork::Byzantium |
-                EthereumHardfork::Constantinople |
-                EthereumHardfork::Petersburg |
-                EthereumHardfork::Istanbul |
-                EthereumHardfork::MuirGlacier |
-                EthereumHardfork::Berlin |
-                EthereumHardfork::London |
-                EthereumHardfork::ArrowGlacier |
-                EthereumHardfork::GrayGlacier |
-                EthereumHardfork::Paris |
-                EthereumHardfork::Shanghai => Some(1704992401),
+                EthereumHardfork::Frontier
+                | EthereumHardfork::Homestead
+                | EthereumHardfork::Dao
+                | EthereumHardfork::Tangerine
+                | EthereumHardfork::SpuriousDragon
+                | EthereumHardfork::Byzantium
+                | EthereumHardfork::Constantinople
+                | EthereumHardfork::Petersburg
+                | EthereumHardfork::Istanbul
+                | EthereumHardfork::MuirGlacier
+                | EthereumHardfork::Berlin
+                | EthereumHardfork::London
+                | EthereumHardfork::ArrowGlacier
+                | EthereumHardfork::GrayGlacier
+                | EthereumHardfork::Paris
+                | EthereumHardfork::Shanghai => Some(1704992401),
                 EthereumHardfork::Cancun => Some(1710374401),
                 _ => None,
             },
@@ -326,7 +326,7 @@ where
 {
     let fork: &dyn Any = &fork;
     if let Some(fork) = fork.downcast_ref::<EthereumHardfork>() {
-        return hardfork_fn(fork)
+        return hardfork_fn(fork);
     }
     fork.downcast_ref::<OptimismHardfork>().and_then(optimism_hardfork_fn)
 }

--- a/crates/ethereum/cli/src/chainspec.rs
+++ b/crates/ethereum/cli/src/chainspec.rs
@@ -23,7 +23,7 @@ fn chain_value_parser(s: &str) -> eyre::Result<Arc<ChainSpec>, eyre::Error> {
                     if s.contains('{') {
                         s.to_string()
                     } else {
-                        return Err(io_err.into()) // assume invalid path
+                        return Err(io_err.into()); // assume invalid path
                     }
                 }
             };

--- a/crates/ethereum/consensus/src/lib.rs
+++ b/crates/ethereum/consensus/src/lib.rs
@@ -52,8 +52,9 @@ impl EthBeaconConsensus {
         // Determine the parent gas limit, considering elasticity multiplier on the London fork.
         let parent_gas_limit =
             if self.chain_spec.fork(EthereumHardfork::London).transitions_at_block(header.number) {
-                parent.gas_limit *
-                    self.chain_spec
+                parent.gas_limit
+                    * self
+                        .chain_spec
                         .base_fee_params_at_timestamp(header.timestamp)
                         .elasticity_multiplier as u64
             } else {
@@ -93,12 +94,12 @@ impl Consensus for EthBeaconConsensus {
         validate_header_base_fee(header, &self.chain_spec)?;
 
         // EIP-4895: Beacon chain push withdrawals as operations
-        if self.chain_spec.is_shanghai_active_at_timestamp(header.timestamp) &&
-            header.withdrawals_root.is_none()
+        if self.chain_spec.is_shanghai_active_at_timestamp(header.timestamp)
+            && header.withdrawals_root.is_none()
         {
             return Err(ConsensusError::WithdrawalsRootMissing);
-        } else if !self.chain_spec.is_shanghai_active_at_timestamp(header.timestamp) &&
-            header.withdrawals_root.is_some()
+        } else if !self.chain_spec.is_shanghai_active_at_timestamp(header.timestamp)
+            && header.withdrawals_root.is_some()
         {
             return Err(ConsensusError::WithdrawalsRootUnexpected);
         }

--- a/crates/ethereum/consensus/src/validation.rs
+++ b/crates/ethereum/consensus/src/validation.rs
@@ -21,7 +21,7 @@ pub fn validate_block_post_execution(
         return Err(ConsensusError::BlockGasUsed {
             gas: GotExpected { got: cumulative_gas_used, expected: block.gas_used },
             gas_spent_by_tx: gas_spent_by_transactions(receipts),
-        })
+        });
     }
 
     // Before Byzantium, receipts contained state root that would mean that expensive
@@ -33,20 +33,20 @@ pub fn validate_block_post_execution(
             verify_receipts(block.header.receipts_root, block.header.logs_bloom, receipts)
         {
             tracing::debug!(%error, ?receipts, "receipts verification failed");
-            return Err(error)
+            return Err(error);
         }
     }
 
     // Validate that the header requests root matches the calculated requests root
     if chain_spec.is_prague_active_at_timestamp(block.timestamp) {
         let Some(header_requests_root) = block.header.requests_root else {
-            return Err(ConsensusError::RequestsRootMissing)
+            return Err(ConsensusError::RequestsRootMissing);
         };
         let requests_root = reth_primitives::proofs::calculate_requests_root(requests);
         if requests_root != header_requests_root {
             return Err(ConsensusError::BodyRequestsRootDiff(
                 GotExpected::new(requests_root, header_requests_root).into(),
-            ))
+            ));
         }
     }
 
@@ -88,13 +88,13 @@ fn compare_receipts_root_and_logs_bloom(
     if calculated_receipts_root != expected_receipts_root {
         return Err(ConsensusError::BodyReceiptRootDiff(
             GotExpected { got: calculated_receipts_root, expected: expected_receipts_root }.into(),
-        ))
+        ));
     }
 
     if calculated_logs_bloom != expected_logs_bloom {
         return Err(ConsensusError::BodyBloomLogDiff(
             GotExpected { got: calculated_logs_bloom, expected: expected_logs_bloom }.into(),
-        ))
+        ));
     }
 
     Ok(())

--- a/crates/etl/src/lib.rs
+++ b/crates/etl/src/lib.rs
@@ -253,7 +253,7 @@ impl EtlFile {
     /// Can return error if it reaches EOF before filling the internal buffers.
     pub(crate) fn read_next(&mut self) -> std::io::Result<Option<(Vec<u8>, Vec<u8>)>> {
         if self.len == 0 {
-            return Ok(None)
+            return Ok(None);
         }
 
         let mut buffer_key_length = [0; 8];

--- a/crates/evm/execution-errors/src/trie.rs
+++ b/crates/evm/execution-errors/src/trie.rs
@@ -42,8 +42,8 @@ impl std::error::Error for StateRootError {
 impl From<StateRootError> for DatabaseError {
     fn from(err: StateRootError) -> Self {
         match err {
-            StateRootError::Database(err) |
-            StateRootError::StorageRootError(StorageRootError::Database(err)) => err,
+            StateRootError::Database(err)
+            | StateRootError::StorageRootError(StorageRootError::Database(err)) => err,
         }
     }
 }

--- a/crates/evm/execution-types/src/chain.rs
+++ b/crates/evm/execution-types/src/chain.rs
@@ -136,13 +136,13 @@ impl Chain {
         block_number: BlockNumber,
     ) -> Option<ExecutionOutcome> {
         if self.tip().number == block_number {
-            return Some(self.execution_outcome.clone())
+            return Some(self.execution_outcome.clone());
         }
 
         if self.blocks.contains_key(&block_number) {
             let mut execution_outcome = self.execution_outcome.clone();
             execution_outcome.revert_to(block_number);
-            return Some(execution_outcome)
+            return Some(execution_outcome);
         }
         None
     }
@@ -270,7 +270,7 @@ impl Chain {
                 chain_tip: Box::new(chain_tip.num_hash()),
                 other_chain_fork: Box::new(other_fork_block),
             }
-            .into())
+            .into());
         }
 
         // Insert blocks from other chain
@@ -307,23 +307,23 @@ impl Chain {
         let block_number = match split_at {
             ChainSplitTarget::Hash(block_hash) => {
                 let Some(block_number) = self.block_number(block_hash) else {
-                    return ChainSplit::NoSplitPending(self)
+                    return ChainSplit::NoSplitPending(self);
                 };
                 // If block number is same as tip whole chain is becoming canonical.
                 if block_number == chain_tip {
-                    return ChainSplit::NoSplitCanonical(self)
+                    return ChainSplit::NoSplitCanonical(self);
                 }
                 block_number
             }
             ChainSplitTarget::Number(block_number) => {
                 if block_number > chain_tip {
-                    return ChainSplit::NoSplitPending(self)
+                    return ChainSplit::NoSplitPending(self);
                 }
                 if block_number == chain_tip {
-                    return ChainSplit::NoSplitCanonical(self)
+                    return ChainSplit::NoSplitCanonical(self);
                 }
                 if block_number < *self.blocks.first_entry().expect("chain is never empty").key() {
-                    return ChainSplit::NoSplitPending(self)
+                    return ChainSplit::NoSplitPending(self);
                 }
                 block_number
             }

--- a/crates/evm/execution-types/src/execution_outcome.rs
+++ b/crates/evm/execution-types/src/execution_outcome.rs
@@ -152,11 +152,11 @@ impl ExecutionOutcome {
     /// Transform block number to the index of block.
     fn block_number_to_index(&self, block_number: BlockNumber) -> Option<usize> {
         if self.first_block > block_number {
-            return None
+            return None;
         }
         let index = block_number - self.first_block;
         if index >= self.receipts.len() as u64 {
-            return None
+            return None;
         }
         Some(index as usize)
     }
@@ -244,7 +244,7 @@ impl ExecutionOutcome {
     /// If the target block number is not included in the state block range.
     pub fn split_at(self, at: BlockNumber) -> (Option<Self>, Self) {
         if at == self.first_block {
-            return (None, self)
+            return (None, self);
         }
 
         let (mut lower_state, mut higher_state) = (self.clone(), self);

--- a/crates/evm/src/system_calls.rs
+++ b/crates/evm/src/system_calls.rs
@@ -89,7 +89,7 @@ where
     EvmConfig: ConfigureEvm,
 {
     if !chain_spec.is_cancun_active_at_timestamp(block_timestamp) {
-        return Ok(())
+        return Ok(());
     }
 
     let parent_beacon_block_root =
@@ -102,9 +102,9 @@ where
             return Err(BlockValidationError::CancunGenesisParentBeaconBlockRootNotZero {
                 parent_beacon_block_root,
             }
-            .into())
+            .into());
         }
-        return Ok(())
+        return Ok(());
     }
 
     // get previous env
@@ -126,7 +126,7 @@ where
                 parent_beacon_block_root: Box::new(parent_beacon_block_root),
                 message: e.to_string(),
             }
-            .into())
+            .into());
         }
     };
 
@@ -212,7 +212,7 @@ where
             return Err(BlockValidationError::WithdrawalRequestsContractCall {
                 message: format!("execution failed: {e}"),
             }
-            .into())
+            .into());
         }
     };
 
@@ -253,7 +253,7 @@ where
             return Err(BlockValidationError::WithdrawalRequestsContractCall {
                 message: "invalid withdrawal request length".to_string(),
             }
-            .into())
+            .into());
         }
 
         let mut source_address = Address::ZERO;
@@ -343,7 +343,7 @@ where
             return Err(BlockValidationError::ConsolidationRequestsContractCall {
                 message: format!("execution failed: {e}"),
             }
-            .into())
+            .into());
         }
     };
 
@@ -384,7 +384,7 @@ where
             return Err(BlockValidationError::ConsolidationRequestsContractCall {
                 message: "invalid consolidation request length".to_string(),
             }
-            .into())
+            .into());
         }
 
         let mut source_address = Address::ZERO;

--- a/crates/exex/exex/src/manager.rs
+++ b/crates/exex/exex/src/manager.rs
@@ -102,7 +102,7 @@ impl ExExHandle {
                         );
 
                         self.next_notification_id = notification_id + 1;
-                        return Poll::Ready(Ok(()))
+                        return Poll::Ready(Ok(()));
                     }
                 }
                 // Do not handle [ExExNotification::ChainReorged] and
@@ -291,9 +291,9 @@ impl Future for ExExManager {
                     "Received new notification"
                 );
                 self.push_notification(notification);
-                continue
+                continue;
             }
-            break
+            break;
         }
 
         // update capacity
@@ -313,7 +313,7 @@ impl Future for ExExManager {
             if let Some(notification) = self.buffer.get(notification_index) {
                 if let Poll::Ready(Err(err)) = exex.send(cx, notification) {
                     // the channel was closed, which is irrecoverable for the manager
-                    return Poll::Ready(Err(err.into()))
+                    return Poll::Ready(Err(err.into()));
                 }
             }
             min_id = min_id.min(exex.next_notification_id);

--- a/crates/metrics/metrics-derive/src/expand.rs
+++ b/crates/metrics/metrics-derive/src/expand.rs
@@ -242,14 +242,14 @@ fn parse_metrics_attr(node: &DeriveInput) -> Result<MetricsAttr> {
         };
         if kv.path.is_ident("scope") {
             if scope.is_some() {
-                return Err(Error::new_spanned(kv, "Duplicate `scope` value provided."))
+                return Err(Error::new_spanned(kv, "Duplicate `scope` value provided."));
             }
             let scope_lit = parse_str_lit(lit)?;
             validate_metric_name(&scope_lit)?;
             scope = Some(scope_lit);
         } else if kv.path.is_ident("separator") {
             if separator.is_some() {
-                return Err(Error::new_spanned(kv, "Duplicate `separator` value provided."))
+                return Err(Error::new_spanned(kv, "Duplicate `separator` value provided."));
             }
             let separator_lit = parse_str_lit(lit)?;
             if !SUPPORTED_SEPARATORS.contains(&&*separator_lit.value()) {
@@ -263,16 +263,16 @@ fn parse_metrics_attr(node: &DeriveInput) -> Result<MetricsAttr> {
                             .collect::<Vec<_>>()
                             .join(", ")
                     ),
-                ))
+                ));
             }
             separator = Some(separator_lit);
         } else if kv.path.is_ident("dynamic") {
             if dynamic.is_some() {
-                return Err(Error::new_spanned(kv, "Duplicate `dynamic` flag provided."))
+                return Err(Error::new_spanned(kv, "Duplicate `dynamic` flag provided."));
             }
             dynamic = Some(parse_bool_lit(lit)?.value);
         } else {
-            return Err(Error::new_spanned(kv, "Unsupported attribute entry."))
+            return Err(Error::new_spanned(kv, "Unsupported attribute entry."));
         }
     }
 
@@ -295,7 +295,7 @@ fn parse_metrics_attr(node: &DeriveInput) -> Result<MetricsAttr> {
 
 fn parse_metric_fields(node: &DeriveInput) -> Result<Vec<MetricField<'_>>> {
     let Data::Struct(ref data) = node.data else {
-        return Err(Error::new_spanned(node, "Only structs are supported."))
+        return Err(Error::new_spanned(node, "Only structs are supported."));
     };
 
     let mut metrics = Vec::with_capacity(data.fields.len());
@@ -317,7 +317,7 @@ fn parse_metric_fields(node: &DeriveInput) -> Result<Vec<MetricField<'_>>> {
                                 return Err(Error::new_spanned(
                                     kv,
                                     "Duplicate `describe` value provided.",
-                                ))
+                                ));
                             }
                             describe = Some(parse_str_lit(lit)?);
                         } else if kv.path.is_ident("rename") {
@@ -325,13 +325,13 @@ fn parse_metric_fields(node: &DeriveInput) -> Result<Vec<MetricField<'_>>> {
                                 return Err(Error::new_spanned(
                                     kv,
                                     "Duplicate `rename` value provided.",
-                                ))
+                                ));
                             }
                             let rename_lit = parse_str_lit(lit)?;
                             validate_metric_name(&rename_lit)?;
                             rename = Some(rename_lit)
                         } else {
-                            return Err(Error::new_spanned(kv, "Unsupported attribute entry."))
+                            return Err(Error::new_spanned(kv, "Unsupported attribute entry."));
                         }
                     }
                     _ => return Err(Error::new_spanned(meta, "Unsupported attribute entry.")),
@@ -341,7 +341,7 @@ fn parse_metric_fields(node: &DeriveInput) -> Result<Vec<MetricField<'_>>> {
 
         if skip {
             metrics.push(MetricField::Skipped(field));
-            continue
+            continue;
         }
 
         let description = match describe {

--- a/crates/metrics/metrics-derive/src/metric.rs
+++ b/crates/metrics/metrics-derive/src/metric.rs
@@ -33,7 +33,7 @@ impl<'a> Metric<'a> {
                     _ => return Err(Error::new_spanned(path_ty, "Unsupported metric type")),
                 };
 
-                return Ok(quote! { #registrar })
+                return Ok(quote! { #registrar });
             }
         }
 
@@ -50,7 +50,7 @@ impl<'a> Metric<'a> {
                     _ => return Err(Error::new_spanned(path_ty, "Unsupported metric type")),
                 };
 
-                return Ok(quote! { #descriptor })
+                return Ok(quote! { #descriptor });
             }
         }
 

--- a/crates/net/banlist/src/lib.rs
+++ b/crates/net/banlist/src/lib.rs
@@ -16,7 +16,7 @@ use std::{collections::HashMap, net::IpAddr, time::Instant};
 /// Should be replaced with [`IpAddr::is_global`](std::net::IpAddr::is_global) once it is stable.
 pub const fn is_global(ip: &IpAddr) -> bool {
     if ip.is_unspecified() || ip.is_loopback() {
-        return false
+        return false;
     }
 
     match ip {
@@ -62,7 +62,7 @@ impl BanList {
             if let Some(until) = until {
                 if now > *until {
                     evicted.push(*peer);
-                    return false
+                    return false;
                 }
             }
             true
@@ -77,7 +77,7 @@ impl BanList {
             if let Some(until) = until {
                 if now > *until {
                     evicted.push(*peer);
-                    return false
+                    return false;
                 }
             }
             true

--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -749,8 +749,8 @@ impl Discv4Service {
             self.kbuckets
                 .closest_values(&target_key)
                 .filter(|node| {
-                    node.value.has_endpoint_proof &&
-                        !self.pending_find_nodes.contains_key(&node.key.preimage().0)
+                    node.value.has_endpoint_proof
+                        && !self.pending_find_nodes.contains_key(&node.key.preimage().0)
                 })
                 .take(MAX_NODES_PER_BUCKET)
                 .map(|n| (target_key.distance(&n.key), n.value.record)),
@@ -766,7 +766,7 @@ impl Discv4Service {
             // (e.g. connectivity problems over a long period of time, or issues during initial
             // bootstrapping) so we attempt to bootstrap again
             self.bootstrap();
-            return
+            return;
         }
 
         trace!(target: "discv4", ?target, num = closest.len(), "Start lookup closest nodes");
@@ -846,7 +846,7 @@ impl Discv4Service {
     fn has_bond(&self, remote_id: PeerId, remote_ip: IpAddr) -> bool {
         if let Some(timestamp) = self.received_pongs.last_pong(remote_id, remote_ip) {
             if timestamp.elapsed() < self.config.bond_expiration {
-                return true
+                return true;
             }
         }
         false
@@ -858,7 +858,7 @@ impl Discv4Service {
     /// a followup request to retrieve the updated ENR
     fn update_on_reping(&mut self, record: NodeRecord, mut last_enr_seq: Option<u64>) {
         if record.id == self.local_node_record.id {
-            return
+            return;
         }
 
         // If EIP868 extension is disabled then we want to ignore this
@@ -893,7 +893,7 @@ impl Discv4Service {
     /// Callback invoked when we receive a pong from the peer.
     fn update_on_pong(&mut self, record: NodeRecord, mut last_enr_seq: Option<u64>) {
         if record.id == *self.local_peer_id() {
-            return
+            return;
         }
 
         // If EIP868 extension is disabled then we want to ignore this
@@ -1002,7 +1002,7 @@ impl Discv4Service {
     fn on_ping(&mut self, ping: Ping, remote_addr: SocketAddr, remote_id: PeerId, hash: B256) {
         if self.is_expired(ping.expire) {
             // ping's expiration timestamp is in the past
-            return
+            return;
         }
 
         // create the record
@@ -1120,17 +1120,17 @@ impl Discv4Service {
     fn try_ping(&mut self, node: NodeRecord, reason: PingReason) {
         if node.id == *self.local_peer_id() {
             // don't ping ourselves
-            return
+            return;
         }
 
-        if self.pending_pings.contains_key(&node.id) ||
-            self.pending_find_nodes.contains_key(&node.id)
+        if self.pending_pings.contains_key(&node.id)
+            || self.pending_find_nodes.contains_key(&node.id)
         {
-            return
+            return;
         }
 
         if self.queued_pings.iter().any(|(n, _)| n.id == node.id) {
-            return
+            return;
         }
 
         if self.pending_pings.len() < MAX_NODES_PING {
@@ -1165,7 +1165,7 @@ impl Discv4Service {
     /// Returns the echo hash of the ping message.
     pub(crate) fn send_enr_request(&mut self, node: NodeRecord) {
         if !self.config.enable_eip868 {
-            return
+            return;
         }
         let remote_addr = node.udp_addr();
         let enr_request = EnrRequest { expire: self.enr_request_expiration() };
@@ -1180,7 +1180,7 @@ impl Discv4Service {
     /// Message handler for an incoming `Pong`.
     fn on_pong(&mut self, pong: Pong, remote_addr: SocketAddr, remote_id: PeerId) {
         if self.is_expired(pong.expire) {
-            return
+            return;
         }
 
         let PingRequest { node, reason, .. } = match self.pending_pings.entry(remote_id) {
@@ -1189,7 +1189,7 @@ impl Discv4Service {
                     let request = entry.get();
                     if request.echo_hash != pong.echo {
                         trace!(target: "discv4", from=?remote_addr, expected=?request.echo_hash, echo_hash=?pong.echo,"Got unexpected Pong");
-                        return
+                        return;
                     }
                 }
                 entry.remove()
@@ -1225,11 +1225,11 @@ impl Discv4Service {
     fn on_find_node(&mut self, msg: FindNode, remote_addr: SocketAddr, node_id: PeerId) {
         if self.is_expired(msg.expire) {
             // expiration timestamp is in the past
-            return
+            return;
         }
         if node_id == *self.local_peer_id() {
             // ignore find node requests to ourselves
-            return
+            return;
         }
 
         if self.has_bond(node_id, remote_addr.ip()) {
@@ -1244,7 +1244,7 @@ impl Discv4Service {
             // ensure the ENR's public key matches the expected node id
             let enr_id = pk2id(&msg.enr.public_key());
             if id != enr_id {
-                return
+                return;
             }
 
             if resp.echo_hash == msg.request_hash {
@@ -1283,7 +1283,7 @@ impl Discv4Service {
         request_hash: B256,
     ) {
         if !self.config.enable_eip868 || self.is_expired(msg.expire) {
-            return
+            return;
         }
 
         if self.has_bond(id, remote_addr.ip()) {
@@ -1302,7 +1302,7 @@ impl Discv4Service {
     fn on_neighbours(&mut self, msg: Neighbours, remote_addr: SocketAddr, node_id: PeerId) {
         if self.is_expired(msg.expire) {
             // response is expired
-            return
+            return;
         }
         // check if this request was expected
         let ctx = match self.pending_find_nodes.entry(node_id) {
@@ -1318,7 +1318,7 @@ impl Discv4Service {
                         request.response_count = total;
                     } else {
                         trace!(target: "discv4", total, from=?remote_addr, "Received neighbors packet entries exceeds max nodes per bucket");
-                        return
+                        return;
                     }
                 };
 
@@ -1334,7 +1334,7 @@ impl Discv4Service {
             Entry::Vacant(_) => {
                 // received neighbours response without requesting it
                 trace!(target: "discv4", from=?remote_addr, "Received unsolicited Neighbours");
-                return
+                return;
             }
         };
 
@@ -1344,7 +1344,7 @@ impl Discv4Service {
             // prevent banned peers from being added to the context
             if self.config.ban_list.is_banned(&node.id, &node.address) {
                 trace!(target: "discv4", peer_id=?node.id, ip=?node.address, "ignoring banned record");
-                continue
+                continue;
             }
 
             ctx.add_node(node);
@@ -1426,7 +1426,7 @@ impl Discv4Service {
         self.pending_pings.retain(|node_id, ping_request| {
             if now.duration_since(ping_request.sent_at) > self.config.ping_expiration {
                 failed_pings.push(*node_id);
-                return false
+                return false;
             }
             true
         });
@@ -1442,7 +1442,7 @@ impl Discv4Service {
         self.pending_lookup.retain(|node_id, (lookup_sent_at, _)| {
             if now.duration_since(*lookup_sent_at) > self.config.request_timeout {
                 failed_lookups.push(*node_id);
-                return false
+                return false;
             }
             true
         });
@@ -1466,7 +1466,7 @@ impl Discv4Service {
                     // treat this as an hard error since it responded.
                     failed_neighbours.push(*node_id);
                 }
-                return false
+                return false;
             }
             true
         });
@@ -1494,7 +1494,7 @@ impl Discv4Service {
                 if let Some(bucket) = self.kbuckets.get_bucket(&key) {
                     if bucket.num_entries() < MAX_NODES_PER_BUCKET / 2 {
                         // skip half empty bucket
-                        continue
+                        continue;
                     }
                 }
                 self.remove_node(node_id);
@@ -1541,7 +1541,7 @@ impl Discv4Service {
         let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
         if self.config.enforce_expiration_timestamps && timestamp < now {
             trace!(target: "discv4", "Expired packet");
-            return Err(())
+            return Err(());
         }
         Ok(())
     }
@@ -1585,7 +1585,7 @@ impl Discv4Service {
         loop {
             // drain buffered events first
             if let Some(event) = self.queued_events.pop_front() {
-                return Poll::Ready(event)
+                return Poll::Ready(event);
             }
 
             // trigger self lookup
@@ -1710,7 +1710,7 @@ impl Discv4Service {
                         // this will make sure we're woken up again
                         cx.waker().wake_by_ref();
                     }
-                    break
+                    break;
                 }
             }
 
@@ -1728,7 +1728,7 @@ impl Discv4Service {
             }
 
             if self.queued_events.is_empty() {
-                return Poll::Pending
+                return Poll::Pending;
             }
         }
     }
@@ -1835,7 +1835,7 @@ pub(crate) async fn receive_loop(udp: Arc<UdpSocket>, tx: IngressSender, local_i
                 // rate limit incoming packets by IP
                 if cache.inc_ip(remote_addr.ip()) > MAX_INCOMING_PACKETS_PER_MINUTE_BY_IP {
                     trace!(target: "discv4", ?remote_addr, "Too many incoming packets from IP.");
-                    continue
+                    continue;
                 }
 
                 let packet = &buf[..read];
@@ -1844,13 +1844,13 @@ pub(crate) async fn receive_loop(udp: Arc<UdpSocket>, tx: IngressSender, local_i
                         if packet.node_id == local_id {
                             // received our own message
                             debug!(target: "discv4", ?remote_addr, "Received own packet.");
-                            continue
+                            continue;
                         }
 
                         // skip if we've already received the same packet
                         if cache.contains_packet(packet.hash) {
                             debug!(target: "discv4", ?remote_addr, "Received duplicate packet.");
-                            continue
+                            continue;
                         }
 
                         send(IngressEvent::Packet(remote_addr, packet)).await;
@@ -1999,7 +1999,7 @@ impl LookupTargetRotator {
         self.counter += 1;
         self.counter %= self.interval;
         if self.counter == 0 {
-            return *local
+            return *local;
         }
         PeerId::random()
     }
@@ -2363,7 +2363,7 @@ mod tests {
                 assert!(service.pending_pings.contains_key(&node.id));
                 assert_eq!(service.pending_pings.len(), num_inserted);
                 if num_inserted == MAX_NODES_PING {
-                    break
+                    break;
                 }
             }
         }
@@ -2543,8 +2543,8 @@ mod tests {
         })
         .await;
 
-        let expiry = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs() +
-            10000000000000;
+        let expiry = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs()
+            + 10000000000000;
         let msg = Neighbours { nodes: vec![service2.local_node_record], expire: expiry };
         service.on_neighbours(msg, record.tcp_addr(), id);
         // wait for the processed ping

--- a/crates/net/discv4/src/proto.rs
+++ b/crates/net/discv4/src/proto.rs
@@ -282,7 +282,7 @@ impl Decodable for FindNode {
         let b = &mut &**buf;
         let rlp_head = Header::decode(b)?;
         if !rlp_head.list {
-            return Err(RlpError::UnexpectedString)
+            return Err(RlpError::UnexpectedString);
         }
         let started_len = b.len();
 
@@ -296,7 +296,7 @@ impl Decodable for FindNode {
             return Err(RlpError::ListLengthMismatch {
                 expected: rlp_head.payload_length,
                 got: consumed,
-            })
+            });
         }
 
         let rem = rlp_head.payload_length - consumed;
@@ -324,7 +324,7 @@ impl Decodable for Neighbours {
         let b = &mut &**buf;
         let rlp_head = Header::decode(b)?;
         if !rlp_head.list {
-            return Err(RlpError::UnexpectedString)
+            return Err(RlpError::UnexpectedString);
         }
         let started_len = b.len();
 
@@ -338,7 +338,7 @@ impl Decodable for Neighbours {
             return Err(RlpError::ListLengthMismatch {
                 expected: rlp_head.payload_length,
                 got: consumed,
-            })
+            });
         }
 
         let rem = rlp_head.payload_length - consumed;
@@ -367,7 +367,7 @@ impl Decodable for EnrRequest {
         let b = &mut &**buf;
         let rlp_head = Header::decode(b)?;
         if !rlp_head.list {
-            return Err(RlpError::UnexpectedString)
+            return Err(RlpError::UnexpectedString);
         }
         let started_len = b.len();
 
@@ -381,7 +381,7 @@ impl Decodable for EnrRequest {
             return Err(RlpError::ListLengthMismatch {
                 expected: rlp_head.payload_length,
                 got: consumed,
-            })
+            });
         }
 
         let rem = rlp_head.payload_length - consumed;

--- a/crates/net/discv4/src/test_utils.rs
+++ b/crates/net/discv4/src/test_utils.rs
@@ -165,7 +165,7 @@ impl Stream for MockDiscovery {
                                 ping,
                                 pong,
                                 to: remote_addr,
-                            }))
+                            }));
                         }
                     }
                     Message::Pong(_) | Message::Neighbours(_) => {}
@@ -179,7 +179,7 @@ impl Stream for MockDiscovery {
                             return Poll::Ready(Some(MockEvent::Neighbours {
                                 nodes,
                                 to: remote_addr,
-                            }))
+                            }));
                         }
                     }
                     Message::EnrRequest(_) | Message::EnrResponse(_) => todo!(),

--- a/crates/net/discv5/src/config.rs
+++ b/crates/net/discv5/src/config.rs
@@ -341,8 +341,8 @@ impl Config {
 /// Returns the IPv4 discovery socket if one is configured.
 pub const fn ipv4(listen_config: &ListenConfig) -> Option<SocketAddrV4> {
     match listen_config {
-        ListenConfig::Ipv4 { ip, port } |
-        ListenConfig::DualStack { ipv4: ip, ipv4_port: port, .. } => {
+        ListenConfig::Ipv4 { ip, port }
+        | ListenConfig::DualStack { ipv4: ip, ipv4_port: port, .. } => {
             Some(SocketAddrV4::new(*ip, *port))
         }
         ListenConfig::Ipv6 { .. } => None,
@@ -353,8 +353,8 @@ pub const fn ipv4(listen_config: &ListenConfig) -> Option<SocketAddrV4> {
 pub const fn ipv6(listen_config: &ListenConfig) -> Option<SocketAddrV6> {
     match listen_config {
         ListenConfig::Ipv4 { .. } => None,
-        ListenConfig::Ipv6 { ip, port } |
-        ListenConfig::DualStack { ipv6: ip, ipv6_port: port, .. } => {
+        ListenConfig::Ipv6 { ip, port }
+        | ListenConfig::DualStack { ipv6: ip, ipv6_port: port, .. } => {
             Some(SocketAddrV6::new(*ip, *port, 0, 0))
         }
     }
@@ -500,9 +500,9 @@ mod test {
         for node in config.bootstrap_nodes {
             let BootNode::Enr(node) = node else { panic!() };
             assert!(
-                socket_1 == node.udp4_socket().unwrap() && socket_1 == node.tcp4_socket().unwrap() ||
-                    socket_2 == node.udp4_socket().unwrap() &&
-                        socket_2 == node.tcp4_socket().unwrap()
+                socket_1 == node.udp4_socket().unwrap() && socket_1 == node.tcp4_socket().unwrap()
+                    || socket_2 == node.udp4_socket().unwrap()
+                        && socket_2 == node.tcp4_socket().unwrap()
             );
             assert_eq!("84b4940500", hex::encode(node.get_raw_rlp("opstack").unwrap()));
         }

--- a/crates/net/discv5/src/enr.rs
+++ b/crates/net/discv5/src/enr.rs
@@ -11,7 +11,7 @@ use secp256k1::{PublicKey, SecretKey};
 pub fn enr_to_discv4_id(enr: &discv5::Enr) -> Option<PeerId> {
     let pk = enr.public_key();
     if !matches!(pk, CombinedPublicKey::Secp256k1(_)) {
-        return None
+        return None;
     }
 
     let pk = PublicKey::from_slice(&pk.encode()).unwrap();

--- a/crates/net/discv5/src/filter.rs
+++ b/crates/net/discv5/src/filter.rs
@@ -37,7 +37,7 @@ impl MustIncludeKey {
         if enr.get_raw_rlp(self.key).is_none() {
             return FilterOutcome::Ignore {
                 reason: format!("{} fork required", String::from_utf8_lossy(self.key)),
-            }
+            };
         }
         FilterOutcome::Ok
     }
@@ -72,7 +72,7 @@ impl MustNotIncludeKeys {
                         "{} forks not allowed",
                         self.keys.iter().map(|key| String::from_utf8_lossy(key.key)).format(",")
                     ),
-                }
+                };
             }
         }
 

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -99,7 +99,7 @@ impl Discv5 {
                 err="key not utf-8",
                 "failed to update local enr"
             );
-            return
+            return;
         };
         if let Err(err) = self.discv5.enr_insert(key_str, &rlp) {
             error!(target: "discv5",
@@ -302,7 +302,7 @@ impl Discv5 {
 
                 self.metrics.discovered_peers.increment_established_sessions_unreachable_enr(1);
 
-                return None
+                return None;
             }
         };
         if let FilterOutcome::Ignore { reason } = self.filter_discovered_peer(enr) {
@@ -314,7 +314,7 @@ impl Discv5 {
 
             self.metrics.discovered_peers.increment_established_sessions_filtered(1);
 
-            return None
+            return None;
         }
 
         // todo: extend for all network stacks in reth-network rlpx logic
@@ -341,14 +341,14 @@ impl Discv5 {
         let id = enr_to_discv4_id(enr).ok_or(Error::IncompatibleKeyType)?;
 
         if enr.tcp4().is_none() && enr.tcp6().is_none() {
-            return Err(Error::UnreachableRlpx)
+            return Err(Error::UnreachableRlpx);
         }
         let Some(tcp_port) = (match self.rlpx_ip_mode {
             IpMode::Ip4 => enr.tcp4(),
             IpMode::Ip6 => enr.tcp6(),
             _ => unimplemented!("dual-stack support not implemented for rlpx"),
         }) else {
-            return Err(Error::IpVersionMismatchRlpx(self.rlpx_ip_mode))
+            return Err(Error::IpVersionMismatchRlpx(self.rlpx_ip_mode));
         };
 
         Ok(NodeRecord { address: socket.ip(), tcp_port, udp_port: socket.port(), id })
@@ -499,7 +499,7 @@ pub async fn bootstrap(
         match node {
             BootNode::Enr(node) => {
                 if let Err(err) = discv5.add_enr(node) {
-                    return Err(Error::AddNodeFailed(err))
+                    return Err(Error::AddNodeFailed(err));
                 }
             }
             BootNode::Enode(enode) => {

--- a/crates/net/discv5/src/network_stack_id.rs
+++ b/crates/net/discv5/src/network_stack_id.rs
@@ -24,9 +24,9 @@ impl NetworkStackId {
     /// Returns the [`NetworkStackId`] that matches the given [`ChainSpec`].
     pub fn id(chain: &ChainSpec) -> Option<&'static [u8]> {
         if chain.is_optimism() {
-            return Some(Self::OPEL)
+            return Some(Self::OPEL);
         } else if chain.is_eth() {
-            return Some(Self::ETH)
+            return Some(Self::ETH);
         }
 
         None

--- a/crates/net/dns/src/query.rs
+++ b/crates/net/dns/src/query.rs
@@ -75,7 +75,7 @@ impl<R: Resolver, K: EnrKeyUnambiguous> QueryPool<R, K> {
         loop {
             // drain buffered events first
             if let Some(event) = self.queued_outcomes.pop_front() {
-                return Poll::Ready(event)
+                return Poll::Ready(event);
             }
 
             // queue in new queries if we have capacity
@@ -84,10 +84,10 @@ impl<R: Resolver, K: EnrKeyUnambiguous> QueryPool<R, K> {
                     if let Some(query) = self.queued_queries.pop_front() {
                         self.rate_limit.tick();
                         self.active_queries.push(query);
-                        continue 'queries
+                        continue 'queries;
                     }
                 }
-                break
+                break;
             }
 
             // advance all queries
@@ -102,7 +102,7 @@ impl<R: Resolver, K: EnrKeyUnambiguous> QueryPool<R, K> {
             }
 
             if self.queued_outcomes.is_empty() {
-                return Poll::Pending
+                return Poll::Pending;
             }
         }
     }

--- a/crates/net/dns/src/sync.rs
+++ b/crates/net/dns/src/sync.rs
@@ -73,27 +73,27 @@ impl<K: EnrKeyUnambiguous> SyncTree<K> {
         match self.sync_state {
             SyncState::Pending => {
                 self.sync_state = SyncState::Enr;
-                return Some(SyncAction::Link(self.root.link_root.clone()))
+                return Some(SyncAction::Link(self.root.link_root.clone()));
             }
             SyncState::Enr => {
                 self.sync_state = SyncState::Active;
-                return Some(SyncAction::Enr(self.root.enr_root.clone()))
+                return Some(SyncAction::Enr(self.root.enr_root.clone()));
             }
             SyncState::Link => {
                 self.sync_state = SyncState::Active;
-                return Some(SyncAction::Link(self.root.link_root.clone()))
+                return Some(SyncAction::Link(self.root.link_root.clone()));
             }
             SyncState::Active => {
                 if now > self.root_updated + update_timeout {
                     self.sync_state = SyncState::RootUpdate;
-                    return Some(SyncAction::UpdateRoot)
+                    return Some(SyncAction::UpdateRoot);
                 }
             }
             SyncState::RootUpdate => return None,
         }
 
         if let Some(link) = self.unresolved_links.pop_front() {
-            return Some(SyncAction::Link(link))
+            return Some(SyncAction::Link(link));
         }
 
         let enr = self.unresolved_nodes.pop_front()?;
@@ -124,7 +124,7 @@ impl<K: EnrKeyUnambiguous> SyncTree<K> {
             }
             _ => {
                 // unchanged
-                return
+                return;
             }
         };
         self.sync_state = state;

--- a/crates/net/dns/src/tree.rs
+++ b/crates/net/dns/src/tree.rs
@@ -205,7 +205,7 @@ impl BranchEntry {
 
             let decoded_len = base32_no_padding_decoded_len(hash.len());
             if !(12..=32).contains(&decoded_len) || hash.chars().any(|c| c.is_whitespace()) {
-                return Err(ParseDnsEntryError::InvalidChildHash(hash.to_string()))
+                return Err(ParseDnsEntryError::InvalidChildHash(hash.to_string()));
             }
             Ok(hash.to_string())
         }

--- a/crates/net/downloaders/src/bodies/bodies.rs
+++ b/crates/net/downloaders/src/bodies/bodies.rs
@@ -95,7 +95,7 @@ where
         max_non_empty: u64,
     ) -> DownloadResult<Option<Vec<SealedHeader>>> {
         if range.is_empty() || max_non_empty == 0 {
-            return Ok(None)
+            return Ok(None);
         }
 
         // Collect headers while
@@ -106,9 +106,9 @@ where
         let mut collected = 0;
         let mut non_empty_headers = 0;
         let headers = self.provider.sealed_headers_while(range.clone(), |header| {
-            let should_take = range.contains(&header.number) &&
-                non_empty_headers < max_non_empty &&
-                collected < self.stream_batch_size;
+            let should_take = range.contains(&header.number)
+                && non_empty_headers < max_non_empty
+                && collected < self.stream_batch_size;
 
             if should_take {
                 collected += 1;
@@ -144,7 +144,7 @@ where
 
         // if we're only connected to a few peers, we keep it low
         if num_peers < *self.concurrent_requests_range.start() {
-            return max_requests
+            return max_requests;
         }
 
         max_requests.min(*self.concurrent_requests_range.end())
@@ -165,10 +165,10 @@ where
                 .map(|last| last == *self.download_range.end())
                 .unwrap_or_default();
 
-        nothing_to_request &&
-            self.in_progress_queue.is_empty() &&
-            self.buffered_responses.is_empty() &&
-            self.queued_bodies.is_empty()
+        nothing_to_request
+            && self.in_progress_queue.is_empty()
+            && self.buffered_responses.is_empty()
+            && self.queued_bodies.is_empty()
     }
 
     /// Clear all download related data.
@@ -210,8 +210,8 @@ where
     /// Adds a new response to the internal buffer
     fn buffer_bodies_response(&mut self, response: Vec<BlockResponse>) {
         // take into account capacity
-        let size = response.iter().map(BlockResponse::size).sum::<usize>() +
-            response.capacity() * mem::size_of::<BlockResponse>();
+        let size = response.iter().map(BlockResponse::size).sum::<usize>()
+            + response.capacity() * mem::size_of::<BlockResponse>();
 
         let response = OrderedBodiesResponse { resp: response, size };
         let response_len = response.len();
@@ -238,7 +238,7 @@ where
                         .skip_while(|b| b.block_number() < expected)
                         .take_while(|b| self.download_range.contains(&b.block_number()))
                         .collect()
-                })
+                });
             }
 
             // Drop buffered response since we passed that range
@@ -257,7 +257,7 @@ where
             self.queued_bodies.shrink_to_fit();
             self.metrics.total_flushed.increment(next_batch.len() as u64);
             self.metrics.queued_blocks.set(self.queued_bodies.len() as f64);
-            return Some(next_batch)
+            return Some(next_batch);
         }
         None
     }
@@ -270,9 +270,9 @@ where
         // requests are issued in order but not necessarily finished in order, so the queued bodies
         // can grow large if a certain request is slow, so we limit the followup requests if the
         // queued bodies grew too large
-        self.queued_bodies.len() < 4 * self.stream_batch_size &&
-            self.has_buffer_capacity() &&
-            self.in_progress_queue.len() < self.concurrent_request_limit()
+        self.queued_bodies.len() < 4 * self.stream_batch_size
+            && self.has_buffer_capacity()
+            && self.in_progress_queue.len() < self.concurrent_request_limit()
     }
 }
 
@@ -311,16 +311,16 @@ where
         // Check if the range is valid.
         if range.is_empty() {
             tracing::error!(target: "downloaders::bodies", ?range, "Bodies download range is invalid (empty)");
-            return Err(DownloadError::InvalidBodyRange { range })
+            return Err(DownloadError::InvalidBodyRange { range });
         }
 
         // Check if the provided range is the subset of the existing range.
-        let is_current_range_subset = self.download_range.contains(range.start()) &&
-            *range.end() == *self.download_range.end();
+        let is_current_range_subset = self.download_range.contains(range.start())
+            && *range.end() == *self.download_range.end();
         if is_current_range_subset {
             tracing::trace!(target: "downloaders::bodies", ?range, "Download range already in progress");
             // The current range already includes requested.
-            return Ok(())
+            return Ok(());
         }
 
         // Check if the provided range is the next expected range.
@@ -331,7 +331,7 @@ where
             tracing::trace!(target: "downloaders::bodies", ?range, "New download range set");
             info!(target: "downloaders::bodies", count, ?range, "Downloading bodies");
             self.download_range = range;
-            return Ok(())
+            return Ok(());
         }
 
         // The block range is reset. This can happen either after unwind or after the bodies were
@@ -354,13 +354,13 @@ where
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
         if this.is_terminated() {
-            return Poll::Ready(None)
+            return Poll::Ready(None);
         }
         // Submit new requests and poll any in progress
         loop {
             // Yield next batch if ready
             if let Some(next_batch) = this.try_split_next_batch() {
-                return Poll::Ready(Some(Ok(next_batch)))
+                return Poll::Ready(Some(Ok(next_batch)));
             }
 
             // Poll requests
@@ -373,7 +373,7 @@ where
                     Err(error) => {
                         tracing::debug!(target: "downloaders::bodies", %error, "Request failed");
                         this.clear();
-                        return Poll::Ready(Some(Err(error)))
+                        return Poll::Ready(Some(Err(error)));
                     }
                 };
             }
@@ -396,7 +396,7 @@ where
                     Err(error) => {
                         tracing::error!(target: "downloaders::bodies", %error, "Failed to download from next request");
                         this.clear();
-                        return Poll::Ready(Some(Err(error)))
+                        return Poll::Ready(Some(Err(error)));
                     }
                 };
             }
@@ -409,21 +409,21 @@ where
             this.buffered_responses.shrink_to_fit();
 
             if !new_request_submitted {
-                break
+                break;
             }
         }
 
         // All requests are handled, stream is finished
         if this.in_progress_queue.is_empty() {
             if this.queued_bodies.is_empty() {
-                return Poll::Ready(None)
+                return Poll::Ready(None);
             }
             let batch_size = this.stream_batch_size.min(this.queued_bodies.len());
             let next_batch = this.queued_bodies.drain(..batch_size).collect::<Vec<_>>();
             this.queued_bodies.shrink_to_fit();
             this.metrics.total_flushed.increment(next_batch.len() as u64);
             this.metrics.queued_blocks.set(this.queued_bodies.len() as f64);
-            return Poll::Ready(Some(Ok(next_batch)))
+            return Poll::Ready(Some(Ok(next_batch)));
         }
 
         Poll::Pending
@@ -510,8 +510,8 @@ impl BodiesDownloaderBuilder {
             .with_request_limit(config.downloader_request_limit)
             .with_max_buffered_blocks_size_bytes(config.downloader_max_buffered_blocks_size_bytes)
             .with_concurrent_requests_range(
-                config.downloader_min_concurrent_requests..=
-                    config.downloader_max_concurrent_requests,
+                config.downloader_min_concurrent_requests
+                    ..=config.downloader_max_concurrent_requests,
             )
     }
 }

--- a/crates/net/downloaders/src/bodies/request.rs
+++ b/crates/net/downloaders/src/bodies/request.rs
@@ -128,14 +128,14 @@ where
         // next one exceed the soft response limit, if not then peer either does not have the next
         // block or deliberately sent a single block.
         if bodies.is_empty() {
-            return Err(DownloadError::EmptyResponse)
+            return Err(DownloadError::EmptyResponse);
         }
 
         if response_len > request_len {
             return Err(DownloadError::TooManyBodies(GotExpected {
                 got: response_len,
                 expected: request_len,
-            }))
+            }));
         }
 
         // Buffer block responses
@@ -189,7 +189,7 @@ where
                         hash,
                         number,
                         error: Box::new(error),
-                    })
+                    });
                 }
 
                 self.buffer.push(BlockResponse::Full(block));
@@ -215,7 +215,7 @@ where
 
         loop {
             if this.pending_headers.is_empty() {
-                return Poll::Ready(Ok(std::mem::take(&mut this.buffer)))
+                return Poll::Ready(Ok(std::mem::take(&mut this.buffer)));
             }
 
             // Check if there is a pending requests. It might not exist if all
@@ -230,7 +230,7 @@ where
                     }
                     Err(error) => {
                         if error.is_channel_closed() {
-                            return Poll::Ready(Err(error.into()))
+                            return Poll::Ready(Err(error.into()));
                         }
 
                         this.on_error(error.into(), None);

--- a/crates/net/downloaders/src/bodies/task.rs
+++ b/crates/net/downloaders/src/bodies/task.rs
@@ -128,13 +128,13 @@ impl<T: BodyDownloader> Future for SpawnedDownloader<T> {
                         if forward_error_result.is_err() {
                             // channel closed, this means [TaskDownloader] was dropped,
                             // so we can also exit
-                            return Poll::Ready(())
+                            return Poll::Ready(());
                         }
                     }
                 } else {
                     // channel closed, this means [TaskDownloader] was dropped, so we can also
                     // exit
-                    return Poll::Ready(())
+                    return Poll::Ready(());
                 }
             }
 
@@ -144,7 +144,7 @@ impl<T: BodyDownloader> Future for SpawnedDownloader<T> {
                         if this.bodies_tx.send_item(bodies).is_err() {
                             // channel closed, this means [TaskDownloader] was dropped, so we can
                             // also exit
-                            return Poll::Ready(())
+                            return Poll::Ready(());
                         }
                     }
                     None => return Poll::Pending,
@@ -152,7 +152,7 @@ impl<T: BodyDownloader> Future for SpawnedDownloader<T> {
                 Err(_) => {
                     // channel closed, this means [TaskDownloader] was dropped, so we can also
                     // exit
-                    return Poll::Ready(())
+                    return Poll::Ready(());
                 }
             }
         }

--- a/crates/net/downloaders/src/file_client.rs
+++ b/crates/net/downloaders/src/file_client.rs
@@ -117,7 +117,7 @@ impl FileClient {
     /// Returns true if all blocks are canonical (no gaps)
     pub fn has_canonical_blocks(&self) -> bool {
         if self.headers.is_empty() {
-            return true
+            return true;
         }
         let mut nums = self.headers.keys().copied().collect::<Vec<_>>();
         nums.sort_unstable();
@@ -125,7 +125,7 @@ impl FileClient {
         let mut lowest = iter.next().expect("not empty");
         for next in iter {
             if next != lowest + 1 {
-                return false
+                return false;
             }
             lowest = next;
         }
@@ -217,7 +217,7 @@ impl FromReader for FileClient {
                             "partial block returned from decoding chunk"
                         );
                         remaining_bytes = bytes;
-                        break
+                        break;
                     }
                     Err(err) => return Err(err),
                 };
@@ -269,7 +269,7 @@ impl HeadersClient for FileClient {
                 Some(num) => *num,
                 None => {
                     warn!(%hash, "Could not find starting block number for requested header hash");
-                    return Box::pin(async move { Err(RequestError::BadResponse) })
+                    return Box::pin(async move { Err(RequestError::BadResponse) });
                 }
             },
             BlockHashOrNumber::Number(num) => num,
@@ -293,7 +293,7 @@ impl HeadersClient for FileClient {
                 Some(header) => headers.push(header),
                 None => {
                     warn!(number=%block_number, "Could not find header");
-                    return Box::pin(async move { Err(RequestError::BadResponse) })
+                    return Box::pin(async move { Err(RequestError::BadResponse) });
                 }
             }
         }
@@ -400,7 +400,7 @@ impl ChunkedFileReader {
         if self.file_byte_len == 0 && self.chunk.is_empty() {
             dbg!(self.chunk.is_empty());
             // eof
-            return Ok(None)
+            return Ok(None);
         }
 
         let chunk_target_len = self.chunk_len();

--- a/crates/net/downloaders/src/file_codec.rs
+++ b/crates/net/downloaders/src/file_codec.rs
@@ -29,7 +29,7 @@ impl Decoder for BlockFileCodec {
 
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
         if src.is_empty() {
-            return Ok(None)
+            return Ok(None);
         }
 
         let buf_slice = &mut src.as_ref();

--- a/crates/net/downloaders/src/headers/reverse_headers.rs
+++ b/crates/net/downloaders/src/headers/reverse_headers.rs
@@ -156,7 +156,7 @@ where
 
         // If only a few peers are connected we keep it low
         if num_peers < self.min_concurrent_requests {
-            return max_dynamic
+            return max_dynamic;
         }
 
         max_dynamic.min(self.max_concurrent_requests)
@@ -179,7 +179,7 @@ where
                 // headers so follow-up requests will use that as start.
                 self.next_request_block_number -= request.limit;
 
-                return Some(request)
+                return Some(request);
             }
         }
 
@@ -257,7 +257,7 @@ where
                     trace!(target: "downloaders::headers", %error ,"Failed to validate header");
                     return Err(
                         HeadersResponseError { request, peer_id: Some(peer_id), error }.into()
-                    )
+                    );
                 }
             } else {
                 self.validate_sync_target(&parent, request.clone(), peer_id)?;
@@ -284,7 +284,7 @@ where
                         error: Box::new(error),
                     },
                 }
-                .into())
+                .into());
             }
 
             // If the header is valid on its own, but not against its parent, we return it as
@@ -297,7 +297,7 @@ where
                     header: Box::new(last_header.clone()),
                     error: Box::new(error),
                 }
-                .into())
+                .into());
             }
         }
 
@@ -370,7 +370,7 @@ where
                         peer_id: Some(peer_id),
                         error: DownloadError::EmptyResponse,
                     }
-                    .into())
+                    .into());
                 }
 
                 let target = headers.remove(0).seal_slow();
@@ -385,7 +385,7 @@ where
                                     GotExpected { got: target.hash(), expected: hash }.into(),
                                 ),
                             }
-                            .into())
+                            .into());
                         }
                     }
                     SyncTargetBlock::Number(number) => {
@@ -398,7 +398,7 @@ where
                                     expected: number,
                                 }),
                             }
-                            .into())
+                            .into());
                         }
                     }
                 }
@@ -447,7 +447,7 @@ where
                         peer_id: Some(peer_id),
                         error: DownloadError::EmptyResponse,
                     }
-                    .into())
+                    .into());
                 }
 
                 if (headers.len() as u64) != request.limit {
@@ -459,7 +459,7 @@ where
                         }),
                         request,
                     }
-                    .into())
+                    .into());
                 }
 
                 // sort headers from highest to lowest block number
@@ -479,7 +479,7 @@ where
                             expected: requested_block_number,
                         }),
                     }
-                    .into())
+                    .into());
                 }
 
                 // check if the response is the next expected
@@ -550,7 +550,7 @@ where
                     self.metrics.buffered_responses.decrement(1.);
 
                     if let Err(err) = self.process_next_headers(request, headers, peer_id) {
-                        return Some(err)
+                        return Some(err);
                     }
                 }
                 Ordering::Greater => {
@@ -682,7 +682,7 @@ where
                         .map(|h| h.number)
                     {
                         self.sync_target = Some(new_sync_target.with_number(target_number));
-                        return
+                        return;
                     }
 
                     trace!(target: "downloaders::headers", new=?target, "Request new sync target");
@@ -749,7 +749,7 @@ where
                 sync_target=?this.sync_target,
                 "The downloader sync boundaries have not been set"
             );
-            return Poll::Pending
+            return Poll::Pending;
         }
 
         // If we have a new tip request we need to complete that first before we send batched
@@ -763,7 +763,7 @@ where
                             trace!(target: "downloaders::headers", %error, "invalid sync target response");
                             if error.is_channel_closed() {
                                 // download channel closed which means the network was dropped
-                                return Poll::Ready(None)
+                                return Poll::Ready(None);
                             }
 
                             this.penalize_peer(error.peer_id, &error.error);
@@ -773,13 +773,13 @@ where
                         }
                         Err(ReverseHeadersDownloaderError::Downloader(error)) => {
                             this.clear();
-                            return Poll::Ready(Some(Err(error)))
+                            return Poll::Ready(Some(Err(error)));
                         }
                     };
                 }
                 Poll::Pending => {
                     this.sync_target_request = Some(req);
-                    return Poll::Pending
+                    return Poll::Pending;
                 }
             }
         }
@@ -805,13 +805,13 @@ where
                     Err(ReverseHeadersDownloaderError::Response(error)) => {
                         if error.is_channel_closed() {
                             // download channel closed which means the network was dropped
-                            return Poll::Ready(None)
+                            return Poll::Ready(None);
                         }
                         this.on_headers_error(error);
                     }
                     Err(ReverseHeadersDownloaderError::Downloader(error)) => {
                         this.clear();
-                        return Poll::Ready(Some(Err(error)))
+                        return Poll::Ready(Some(Err(error)));
                     }
                 };
             }
@@ -824,8 +824,8 @@ where
 
             let concurrent_request_limit = this.concurrent_request_limit();
             // populate requests
-            while this.in_progress_queue.len() < concurrent_request_limit &&
-                this.buffered_responses.len() < this.max_buffered_responses
+            while this.in_progress_queue.len() < concurrent_request_limit
+                && this.buffered_responses.len() < this.max_buffered_responses
             {
                 if let Some(request) = this.next_request() {
                     trace!(
@@ -836,7 +836,7 @@ where
                     this.submit_request(request, Priority::Normal);
                 } else {
                     // no more requests
-                    break
+                    break;
                 }
             }
 
@@ -853,11 +853,11 @@ where
                 trace!(target: "downloaders::headers", batch=%next_batch.len(), "Returning validated batch");
 
                 this.metrics.total_flushed.increment(next_batch.len() as u64);
-                return Poll::Ready(Some(Ok(next_batch)))
+                return Poll::Ready(Some(Ok(next_batch)));
             }
 
             if !progress {
-                break
+                break;
             }
         }
 
@@ -866,10 +866,10 @@ where
             let next_batch = this.split_next_batch();
             if next_batch.is_empty() {
                 this.clear();
-                return Poll::Ready(None)
+                return Poll::Ready(None);
             }
             this.metrics.total_flushed.increment(next_batch.len() as u64);
-            return Poll::Ready(Some(Ok(next_batch)))
+            return Poll::Ready(Some(Ok(next_batch)));
         }
 
         Poll::Pending
@@ -962,7 +962,7 @@ impl HeadersResponseError {
     /// Returns true if the error was caused by a closed channel to the network.
     const fn is_channel_closed(&self) -> bool {
         if let DownloadError::RequestError(ref err) = self.error {
-            return err.is_channel_closed()
+            return err.is_channel_closed();
         }
         false
     }

--- a/crates/net/downloaders/src/headers/task.rs
+++ b/crates/net/downloaders/src/headers/task.rs
@@ -127,7 +127,7 @@ impl<T: HeaderDownloader> Future for SpawnedDownloader<T> {
                     Poll::Ready(None) => {
                         // channel closed, this means [TaskDownloader] was dropped, so we can also
                         // exit
-                        return Poll::Ready(())
+                        return Poll::Ready(());
                     }
                     Poll::Ready(Some(update)) => match update {
                         DownloaderUpdates::UpdateSyncGap(head, target) => {
@@ -153,7 +153,7 @@ impl<T: HeaderDownloader> Future for SpawnedDownloader<T> {
                             if this.headers_tx.send_item(headers).is_err() {
                                 // channel closed, this means [TaskDownloader] was dropped, so we
                                 // can also exit
-                                return Poll::Ready(())
+                                return Poll::Ready(());
                             }
                         }
                         None => return Poll::Pending,
@@ -162,7 +162,7 @@ impl<T: HeaderDownloader> Future for SpawnedDownloader<T> {
                 Err(_) => {
                     // channel closed, this means [TaskDownloader] was dropped, so
                     // we can also exit
-                    return Poll::Ready(())
+                    return Poll::Ready(());
                 }
             }
         }

--- a/crates/net/downloaders/src/receipt_file_client.rs
+++ b/crates/net/downloaders/src/receipt_file_client.rs
@@ -118,7 +118,7 @@ where
 
                         remaining_bytes = bytes;
 
-                        break
+                        break;
                     }
                     Err(err) => return Err(err),
                 };
@@ -272,7 +272,7 @@ mod test {
 
         fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
             if src.is_empty() {
-                return Ok(None)
+                return Ok(None);
             }
 
             let buf_slice = &mut src.as_ref();

--- a/crates/net/downloaders/src/test_utils/bodies_client.rs
+++ b/crates/net/downloaders/src/test_utils/bodies_client.rs
@@ -93,7 +93,7 @@ impl BodiesClient for TestBodiesClient {
 
         Box::pin(async move {
             if should_respond_empty {
-                return Ok((PeerId::default(), vec![]).into())
+                return Ok((PeerId::default(), vec![]).into());
             }
 
             if should_delay {

--- a/crates/net/ecies/src/codec.rs
+++ b/crates/net/ecies/src/codec.rs
@@ -57,7 +57,7 @@ impl Decoder for ECIESCodec {
                 ECIESState::Auth => {
                     trace!("parsing auth");
                     if buf.len() < 2 {
-                        return Ok(None)
+                        return Ok(None);
                     }
 
                     let payload_size = u16::from_be_bytes([buf[0], buf[1]]) as usize;
@@ -65,18 +65,18 @@ impl Decoder for ECIESCodec {
 
                     if buf.len() < total_size {
                         trace!("current len {}, need {}", buf.len(), total_size);
-                        return Ok(None)
+                        return Ok(None);
                     }
 
                     self.ecies.read_auth(&mut buf.split_to(total_size))?;
 
                     self.state = ECIESState::Header;
-                    return Ok(Some(IngressECIESValue::AuthReceive(self.ecies.remote_id())))
+                    return Ok(Some(IngressECIESValue::AuthReceive(self.ecies.remote_id())));
                 }
                 ECIESState::Ack => {
                     trace!("parsing ack with len {}", buf.len());
                     if buf.len() < 2 {
-                        return Ok(None)
+                        return Ok(None);
                     }
 
                     let payload_size = u16::from_be_bytes([buf[0], buf[1]]) as usize;
@@ -84,18 +84,18 @@ impl Decoder for ECIESCodec {
 
                     if buf.len() < total_size {
                         trace!("current len {}, need {}", buf.len(), total_size);
-                        return Ok(None)
+                        return Ok(None);
                     }
 
                     self.ecies.read_ack(&mut buf.split_to(total_size))?;
 
                     self.state = ECIESState::Header;
-                    return Ok(Some(IngressECIESValue::Ack))
+                    return Ok(Some(IngressECIESValue::Ack));
                 }
                 ECIESState::Header => {
                     if buf.len() < ECIES::header_len() {
                         trace!("current len {}, need {}", buf.len(), ECIES::header_len());
-                        return Ok(None)
+                        return Ok(None);
                     }
 
                     self.ecies.read_header(&mut buf.split_to(ECIES::header_len()))?;
@@ -104,7 +104,7 @@ impl Decoder for ECIESCodec {
                 }
                 ECIESState::Body => {
                     if buf.len() < self.ecies.body_len() {
-                        return Ok(None)
+                        return Ok(None);
                     }
 
                     let mut data = buf.split_to(self.ecies.body_len());
@@ -112,7 +112,7 @@ impl Decoder for ECIESCodec {
                     ret.extend_from_slice(self.ecies.read_body(&mut data)?);
 
                     self.state = ECIESState::Header;
-                    return Ok(Some(IngressECIESValue::Message(ret)))
+                    return Ok(Some(IngressECIESValue::Message(ret)));
                 }
             }
         }

--- a/crates/net/eth-wire-types/src/broadcast.rs
+++ b/crates/net/eth-wire-types/src/broadcast.rs
@@ -40,7 +40,7 @@ impl NewBlockHashes {
     pub fn latest(&self) -> Option<&BlockHashNumber> {
         self.0.iter().fold(None, |latest, block| {
             if let Some(latest) = latest {
-                return if latest.number > block.number { Some(latest) } else { Some(block) }
+                return if latest.number > block.number { Some(latest) } else { Some(block) };
             }
             Some(block)
         })
@@ -433,13 +433,13 @@ impl Decodable for NewPooledTransactionHashes68 {
             return Err(alloy_rlp::Error::ListLengthMismatch {
                 expected: msg.hashes.len(),
                 got: msg.types.len(),
-            })
+            });
         }
         if msg.hashes.len() != msg.sizes.len() {
             return Err(alloy_rlp::Error::ListLengthMismatch {
                 expected: msg.hashes.len(),
                 got: msg.sizes.len(),
-            })
+            });
         }
 
         Ok(msg)
@@ -712,7 +712,7 @@ impl RequestTxHashes {
     pub fn retain_count(&mut self, count: usize) -> Self {
         let rest_capacity = self.hashes.len().saturating_sub(count);
         if rest_capacity == 0 {
-            return Self::empty()
+            return Self::empty();
         }
         let mut rest = Self::with_capacity(rest_capacity);
 
@@ -720,7 +720,7 @@ impl RequestTxHashes {
         self.hashes.retain(|hash| {
             if i >= count {
                 rest.insert(*hash);
-                return false
+                return false;
             }
             i += 1;
 

--- a/crates/net/eth-wire-types/src/disconnect_reason.rs
+++ b/crates/net/eth-wire-types/src/disconnect_reason.rs
@@ -95,9 +95,9 @@ impl Decodable for DisconnectReason {
     /// reason encoded a single byte or a RLP list containing the disconnect reason.
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
         if buf.is_empty() {
-            return Err(alloy_rlp::Error::InputTooShort)
+            return Err(alloy_rlp::Error::InputTooShort);
         } else if buf.len() > 2 {
-            return Err(alloy_rlp::Error::Overflow)
+            return Err(alloy_rlp::Error::Overflow);
         }
 
         if buf.len() > 1 {
@@ -106,14 +106,14 @@ impl Decodable for DisconnectReason {
             let header = Header::decode(buf)?;
 
             if !header.list {
-                return Err(alloy_rlp::Error::UnexpectedString)
+                return Err(alloy_rlp::Error::UnexpectedString);
             }
 
             if header.payload_length != 1 {
                 return Err(alloy_rlp::Error::ListLengthMismatch {
                     expected: 1,
                     got: header.payload_length,
-                })
+                });
             }
         }
 

--- a/crates/net/eth-wire-types/src/message.rs
+++ b/crates/net/eth-wire-types/src/message.rs
@@ -91,14 +91,14 @@ impl ProtocolMessage {
             }
             EthMessageID::GetNodeData => {
                 if version >= EthVersion::Eth67 {
-                    return Err(MessageError::Invalid(version, EthMessageID::GetNodeData))
+                    return Err(MessageError::Invalid(version, EthMessageID::GetNodeData));
                 }
                 let request_pair = RequestPair::<GetNodeData>::decode(buf)?;
                 EthMessage::GetNodeData(request_pair)
             }
             EthMessageID::NodeData => {
                 if version >= EthVersion::Eth67 {
-                    return Err(MessageError::Invalid(version, EthMessageID::GetNodeData))
+                    return Err(MessageError::Invalid(version, EthMessageID::GetNodeData));
                 }
                 let request_pair = RequestPair::<NodeData>::decode(buf)?;
                 EthMessage::NodeData(request_pair)
@@ -483,7 +483,7 @@ where
         // RequestPair
         let consumed_len = initial_length - buf.len();
         if consumed_len != header.payload_length {
-            return Err(alloy_rlp::Error::UnexpectedLength)
+            return Err(alloy_rlp::Error::UnexpectedLength);
         }
 
         Ok(Self { request_id, message })

--- a/crates/net/eth-wire/src/capability.rs
+++ b/crates/net/eth-wire/src/capability.rs
@@ -82,7 +82,7 @@ impl SharedCapability {
         messages: u8,
     ) -> Result<Self, SharedCapabilityError> {
         if offset <= MAX_RESERVED_MESSAGE_ID {
-            return Err(SharedCapabilityError::ReservedMessageIdOffset(offset))
+            return Err(SharedCapabilityError::ReservedMessageIdOffset(offset));
         }
 
         match name {
@@ -238,12 +238,12 @@ impl SharedCapabilities {
         let mut cap = iter.next()?;
         if offset < cap.message_id_offset() {
             // reserved message id space
-            return None
+            return None;
         }
 
         for next in iter {
             if offset < next.message_id_offset() {
-                return Some(cap)
+                return Some(cap);
             }
             cap = next
         }
@@ -327,7 +327,7 @@ pub fn shared_capability_offsets(
 
     // disconnect if we don't share any capabilities
     if shared_capabilities.is_empty() {
-        return Err(P2PStreamError::HandshakeError(P2PHandshakeError::NoSharedCapabilities))
+        return Err(P2PStreamError::HandshakeError(P2PHandshakeError::NoSharedCapabilities));
     }
 
     // order versions based on capability name (alphabetical) and select offsets based on
@@ -351,7 +351,7 @@ pub fn shared_capability_offsets(
     }
 
     if shared_with_offsets.is_empty() {
-        return Err(P2PStreamError::HandshakeError(P2PHandshakeError::NoSharedCapabilities))
+        return Err(P2PStreamError::HandshakeError(P2PHandshakeError::NoSharedCapabilities));
     }
 
     Ok(shared_with_offsets)

--- a/crates/net/eth-wire/src/errors/eth.rs
+++ b/crates/net/eth-wire/src/errors/eth.rs
@@ -55,7 +55,7 @@ impl EthStreamError {
     /// Returns the [`io::Error`] if it was caused by IO
     pub const fn as_io(&self) -> Option<&io::Error> {
         if let Self::P2PStreamError(P2PStreamError::Io(io)) = self {
-            return Some(io)
+            return Some(io);
         }
         None
     }

--- a/crates/net/eth-wire/src/errors/p2p.rs
+++ b/crates/net/eth-wire/src/errors/p2p.rs
@@ -86,8 +86,8 @@ impl P2PStreamError {
     /// Returns the [`DisconnectReason`] if it is the `Disconnected` variant.
     pub const fn as_disconnected(&self) -> Option<DisconnectReason> {
         let reason = match self {
-            Self::HandshakeError(P2PHandshakeError::Disconnected(reason)) |
-            Self::Disconnected(reason) => reason,
+            Self::HandshakeError(P2PHandshakeError::Disconnected(reason))
+            | Self::Disconnected(reason) => reason,
             _ => return None,
         };
 

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -95,13 +95,13 @@ where
             Some(msg) => msg,
             None => {
                 self.inner.disconnect(DisconnectReason::DisconnectRequested).await?;
-                return Err(EthStreamError::EthHandshakeError(EthHandshakeError::NoResponse))
+                return Err(EthStreamError::EthHandshakeError(EthHandshakeError::NoResponse));
             }
         }?;
 
         if their_msg.len() > MAX_MESSAGE_SIZE {
             self.inner.disconnect(DisconnectReason::ProtocolBreach).await?;
-            return Err(EthStreamError::MessageTooBig(their_msg.len()))
+            return Err(EthStreamError::MessageTooBig(their_msg.len()));
         }
 
         let version = EthVersion::try_from(status.version)?;
@@ -110,7 +110,7 @@ where
             Err(err) => {
                 debug!("decode error in eth handshake: msg={their_msg:x}");
                 self.inner.disconnect(DisconnectReason::DisconnectRequested).await?;
-                return Err(EthStreamError::InvalidMessage(err))
+                return Err(EthStreamError::InvalidMessage(err));
             }
         };
 
@@ -127,7 +127,7 @@ where
                     return Err(EthHandshakeError::MismatchedGenesis(
                         GotExpected { expected: status.genesis, got: resp.genesis }.into(),
                     )
-                    .into())
+                    .into());
                 }
 
                 if status.version != resp.version {
@@ -136,7 +136,7 @@ where
                         got: resp.version,
                         expected: status.version,
                     })
-                    .into())
+                    .into());
                 }
 
                 if status.chain != resp.chain {
@@ -145,7 +145,7 @@ where
                         got: resp.chain,
                         expected: status.chain,
                     })
-                    .into())
+                    .into());
                 }
 
                 // TD at mainnet block #7753254 is 76 bits. If it becomes 100 million times
@@ -156,14 +156,14 @@ where
                         got: status.total_difficulty.bit_len(),
                         maximum: 100,
                     }
-                    .into())
+                    .into());
                 }
 
                 if let Err(err) =
                     fork_filter.validate(resp.forkid).map_err(EthHandshakeError::InvalidFork)
                 {
                     self.inner.disconnect(DisconnectReason::ProtocolBreach).await?;
-                    return Err(err.into())
+                    return Err(err.into());
                 }
 
                 // now we can create the `EthStream` because the peer has successfully completed
@@ -261,7 +261,7 @@ where
         };
 
         if bytes.len() > MAX_MESSAGE_SIZE {
-            return Poll::Ready(Some(Err(EthStreamError::MessageTooBig(bytes.len()))))
+            return Poll::Ready(Some(Err(EthStreamError::MessageTooBig(bytes.len()))));
         }
 
         let msg = match ProtocolMessage::decode_message(*this.version, &mut bytes.as_ref()) {
@@ -277,14 +277,14 @@ where
                     %msg,
                     "failed to decode protocol message"
                 );
-                return Poll::Ready(Some(Err(EthStreamError::InvalidMessage(err))))
+                return Poll::Ready(Some(Err(EthStreamError::InvalidMessage(err))));
             }
         };
 
         if matches!(msg.message, EthMessage::Status(_)) {
             return Poll::Ready(Some(Err(EthStreamError::EthHandshakeError(
                 EthHandshakeError::StatusNotInHandshake,
-            ))))
+            ))));
         }
 
         Poll::Ready(Some(Ok(msg.message)))
@@ -313,7 +313,7 @@ where
             // allowing for its start_disconnect method to be called.
             //
             // self.project().inner.start_disconnect(DisconnectReason::ProtocolBreach);
-            return Err(EthStreamError::EthHandshakeError(EthHandshakeError::StatusNotInHandshake))
+            return Err(EthStreamError::EthHandshakeError(EthHandshakeError::StatusNotInHandshake));
         }
 
         self.project()

--- a/crates/net/eth-wire/src/multiplex.rs
+++ b/crates/net/eth-wire/src/multiplex.rs
@@ -79,7 +79,7 @@ impl<St> RlpxProtocolMultiplexer<St> {
     {
         let Ok(shared_cap) = self.shared_capabilities().ensure_matching_capability(cap).cloned()
         else {
-            return Err(P2PStreamError::CapabilityNotShared)
+            return Err(P2PStreamError::CapabilityNotShared);
         };
 
         let (to_primary, from_wire) = mpsc::unbounded_channel();
@@ -147,7 +147,7 @@ impl<St> RlpxProtocolMultiplexer<St> {
     {
         let Ok(shared_cap) = self.shared_capabilities().ensure_matching_capability(cap).cloned()
         else {
-            return Err(P2PStreamError::CapabilityNotShared.into())
+            return Err(P2PStreamError::CapabilityNotShared.into());
         };
 
         let (to_primary, from_wire) = mpsc::unbounded_channel();
@@ -243,7 +243,7 @@ impl<St> MultiplexInner<St> {
         for proto in &self.protocols {
             if proto.shared_cap == *cap {
                 proto.send_raw(msg);
-                return true
+                return true;
             }
         }
         false
@@ -299,7 +299,7 @@ impl ProtocolProxy {
     fn try_send(&self, msg: Bytes) -> Result<(), io::Error> {
         if msg.is_empty() {
             // message must not be empty
-            return Err(io::ErrorKind::InvalidInput.into())
+            return Err(io::ErrorKind::InvalidInput.into());
         }
         self.to_wire.send(self.mask_msg_id(msg)?).map_err(|_| io::ErrorKind::BrokenPipe.into())
     }
@@ -309,7 +309,7 @@ impl ProtocolProxy {
     fn mask_msg_id(&self, msg: Bytes) -> Result<Bytes, io::Error> {
         if msg.is_empty() {
             // message must not be empty
-            return Err(io::ErrorKind::InvalidInput.into())
+            return Err(io::ErrorKind::InvalidInput.into());
         }
 
         let offset = self.shared_cap.relative_message_id_offset();
@@ -327,7 +327,7 @@ impl ProtocolProxy {
     fn unmask_id(&self, mut msg: BytesMut) -> Result<BytesMut, io::Error> {
         if msg.is_empty() {
             // message must not be empty
-            return Err(io::ErrorKind::InvalidInput.into())
+            return Err(io::ErrorKind::InvalidInput.into());
         }
         msg[0] = msg[0]
             .checked_sub(self.shared_cap.relative_message_id_offset())
@@ -469,7 +469,7 @@ where
         loop {
             // first drain the primary stream
             if let Poll::Ready(Some(msg)) = this.primary.st.try_poll_next_unpin(cx) {
-                return Poll::Ready(Some(msg))
+                return Poll::Ready(Some(msg));
             }
 
             let mut conn_ready = true;
@@ -478,23 +478,23 @@ where
                     Poll::Ready(Ok(())) => {
                         if let Some(msg) = this.inner.out_buffer.pop_front() {
                             if let Err(err) = this.inner.conn.start_send_unpin(msg) {
-                                return Poll::Ready(Some(Err(err.into())))
+                                return Poll::Ready(Some(Err(err.into())));
                             }
                         } else {
-                            break
+                            break;
                         }
                     }
                     Poll::Ready(Err(err)) => {
                         if let Err(disconnect_err) =
                             this.inner.conn.start_disconnect(DisconnectReason::DisconnectRequested)
                         {
-                            return Poll::Ready(Some(Err(disconnect_err.into())))
+                            return Poll::Ready(Some(Err(disconnect_err.into())));
                         }
-                        return Poll::Ready(Some(Err(err.into())))
+                        return Poll::Ready(Some(Err(err.into())));
                     }
                     Poll::Pending => {
                         conn_ready = false;
-                        break
+                        break;
                     }
                 }
             }
@@ -507,7 +507,7 @@ where
                     }
                     Poll::Ready(None) => {
                         // primary closed
-                        return Poll::Ready(None)
+                        return Poll::Ready(None);
                     }
                     Poll::Pending => break,
                 }
@@ -527,7 +527,7 @@ where
                         Poll::Ready(None) => return Poll::Ready(None),
                         Poll::Pending => {
                             this.inner.protocols.push(proto);
-                            break
+                            break;
                         }
                     }
                 }
@@ -542,7 +542,7 @@ where
                         let Some(offset) = msg.first().copied() else {
                             return Poll::Ready(Some(Err(
                                 P2PStreamError::EmptyProtocolMessage.into()
-                            )))
+                            )));
                         };
                         // delegate the multiplexed message to the correct protocol
                         if let Some(cap) =
@@ -556,28 +556,27 @@ where
                                 for proto in &this.inner.protocols {
                                     if proto.shared_cap == *cap {
                                         proto.send_raw(msg);
-                                        break
+                                        break;
                                     }
                                 }
                             }
                         } else {
-                            return Poll::Ready(Some(Err(P2PStreamError::UnknownReservedMessageId(
-                                offset,
-                            )
-                            .into())))
+                            return Poll::Ready(Some(Err(
+                                P2PStreamError::UnknownReservedMessageId(offset).into(),
+                            )));
                         }
                     }
                     Poll::Ready(Some(Err(err))) => return Poll::Ready(Some(Err(err.into()))),
                     Poll::Ready(None) => {
                         // connection closed
-                        return Poll::Ready(None)
+                        return Poll::Ready(None);
                     }
                     Poll::Pending => break,
                 }
             }
 
             if !conn_ready || (!delegated && this.inner.out_buffer.is_empty()) {
-                return Poll::Pending
+                return Poll::Pending;
             }
         }
     }
@@ -594,10 +593,10 @@ where
     fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         let this = self.get_mut();
         if let Err(err) = ready!(this.inner.conn.poll_ready_unpin(cx)) {
-            return Poll::Ready(Err(err.into()))
+            return Poll::Ready(Err(err.into()));
         }
         if let Err(err) = ready!(this.primary.st.poll_ready_unpin(cx)) {
-            return Poll::Ready(Err(err))
+            return Poll::Ready(Err(err));
         }
         Poll::Ready(Ok(()))
     }
@@ -629,7 +628,7 @@ impl ProtocolStream {
     fn mask_msg_id(&self, mut msg: BytesMut) -> Result<Bytes, io::Error> {
         if msg.is_empty() {
             // message must not be empty
-            return Err(io::ErrorKind::InvalidInput.into())
+            return Err(io::ErrorKind::InvalidInput.into());
         }
         msg[0] = msg[0]
             .checked_add(self.shared_cap.relative_message_id_offset())
@@ -642,7 +641,7 @@ impl ProtocolStream {
     fn unmask_id(&self, mut msg: BytesMut) -> Result<BytesMut, io::Error> {
         if msg.is_empty() {
             // message must not be empty
-            return Err(io::ErrorKind::InvalidInput.into())
+            return Err(io::ErrorKind::InvalidInput.into());
         }
         msg[0] = msg[0]
             .checked_sub(self.shared_cap.relative_message_id_offset())

--- a/crates/net/eth-wire/src/pinger.rs
+++ b/crates/net/eth-wire/src/pinger.rs
@@ -73,19 +73,19 @@ impl Pinger {
                 if self.ping_interval.poll_tick(cx).is_ready() {
                     self.timeout_timer.as_mut().reset(Instant::now() + self.timeout);
                     self.state = PingState::WaitingForPong;
-                    return Poll::Ready(Ok(PingerEvent::Ping))
+                    return Poll::Ready(Ok(PingerEvent::Ping));
                 }
             }
             PingState::WaitingForPong => {
                 if self.timeout_timer.is_elapsed() {
                     self.state = PingState::TimedOut;
-                    return Poll::Ready(Ok(PingerEvent::Timeout))
+                    return Poll::Ready(Ok(PingerEvent::Timeout));
                 }
             }
             PingState::TimedOut => {
                 // we treat continuous calls while in timeout as pending, since the connection is
                 // not yet terminated
-                return Poll::Pending
+                return Poll::Pending;
             }
         };
         Poll::Pending

--- a/crates/net/eth-wire/src/protocol.rs
+++ b/crates/net/eth-wire/src/protocol.rs
@@ -54,7 +54,7 @@ impl Protocol {
     /// The number of values needed to represent all message IDs of capability.
     pub fn messages(&self) -> u8 {
         if self.cap.is_eth() {
-            return EthMessageID::max() + 1
+            return EthMessageID::max() + 1;
         }
         self.messages
     }

--- a/crates/net/eth-wire/src/test_utils.rs
+++ b/crates/net/eth-wire/src/test_utils.rs
@@ -137,7 +137,7 @@ pub mod proto {
         /// Decodes a `TestProtoMessage` from the given message buffer.
         pub fn decode_message(buf: &mut &[u8]) -> Option<Self> {
             if buf.is_empty() {
-                return None
+                return None;
             }
             let id = buf[0];
             buf.advance(1);

--- a/crates/net/nat/src/lib.rs
+++ b/crates/net/nat/src/lib.rs
@@ -91,7 +91,7 @@ impl FromStr for NatResolver {
                 let Some(ip) = s.strip_prefix("extip:") else {
                     return Err(ParseNatResolverError::UnknownVariant(format!(
                         "Unknown Nat Resolver: {s}"
-                    )))
+                    )));
                 };
                 Self::ExternalIp(ip.parse::<IpAddr>()?)
             }

--- a/crates/net/network-types/src/peers/mod.rs
+++ b/crates/net/network-types/src/peers/mod.rs
@@ -92,15 +92,15 @@ impl Peer {
 
         if self.state.is_connected() && self.is_banned() {
             self.state.disconnect();
-            return ReputationChangeOutcome::DisconnectAndBan
+            return ReputationChangeOutcome::DisconnectAndBan;
         }
 
         if self.is_banned() && !is_banned_reputation(previous) {
-            return ReputationChangeOutcome::Ban
+            return ReputationChangeOutcome::Ban;
         }
 
         if !self.is_banned() && is_banned_reputation(previous) {
-            return ReputationChangeOutcome::Unban
+            return ReputationChangeOutcome::Unban;
         }
 
         ReputationChangeOutcome::None

--- a/crates/net/network/src/discovery.rs
+++ b/crates/net/network/src/discovery.rs
@@ -245,7 +245,7 @@ impl Discovery {
             // Drain all buffered events first
             if let Some(event) = self.queued_events.pop_front() {
                 self.notify_listeners(&event);
-                return Poll::Ready(event)
+                return Poll::Ready(event);
             }
 
             // drain the discv4 update stream
@@ -283,7 +283,7 @@ impl Discovery {
             }
 
             if self.queued_events.is_empty() {
-                return Poll::Pending
+                return Poll::Pending;
             }
         }
     }

--- a/crates/net/network/src/error.rs
+++ b/crates/net/network/src/error.rs
@@ -73,7 +73,7 @@ impl NetworkError {
             ErrorKind::AddrInUse => Self::AddressAlreadyInUse { kind, error: err },
             _ => {
                 if let ServiceKind::Discovery(_) = kind {
-                    return Self::Discovery(err)
+                    return Self::Discovery(err);
                 }
                 Self::Io(err)
             }
@@ -112,8 +112,8 @@ impl SessionError for EthStreamError {
         match self {
             Self::P2PStreamError(P2PStreamError::HandshakeError(
                 P2PHandshakeError::HelloNotInHandshake,
-            )) |
-            Self::P2PStreamError(P2PStreamError::HandshakeError(
+            ))
+            | Self::P2PStreamError(P2PStreamError::HandshakeError(
                 P2PHandshakeError::NonHelloMessageInHandshake,
             )) => true,
             Self::EthHandshakeError(err) => !matches!(err, EthHandshakeError::NoResponse),
@@ -126,30 +126,30 @@ impl SessionError for EthStreamError {
             Self::P2PStreamError(err) => {
                 matches!(
                     err,
-                    P2PStreamError::HandshakeError(P2PHandshakeError::NoSharedCapabilities) |
-                        P2PStreamError::HandshakeError(P2PHandshakeError::HelloNotInHandshake) |
-                        P2PStreamError::HandshakeError(
+                    P2PStreamError::HandshakeError(P2PHandshakeError::NoSharedCapabilities)
+                        | P2PStreamError::HandshakeError(P2PHandshakeError::HelloNotInHandshake)
+                        | P2PStreamError::HandshakeError(
                             P2PHandshakeError::NonHelloMessageInHandshake
-                        ) |
-                        P2PStreamError::HandshakeError(P2PHandshakeError::Disconnected(
+                        )
+                        | P2PStreamError::HandshakeError(P2PHandshakeError::Disconnected(
                             DisconnectReason::UselessPeer
-                        )) |
-                        P2PStreamError::HandshakeError(P2PHandshakeError::Disconnected(
+                        ))
+                        | P2PStreamError::HandshakeError(P2PHandshakeError::Disconnected(
                             DisconnectReason::IncompatibleP2PProtocolVersion
-                        )) |
-                        P2PStreamError::HandshakeError(P2PHandshakeError::Disconnected(
+                        ))
+                        | P2PStreamError::HandshakeError(P2PHandshakeError::Disconnected(
                             DisconnectReason::ProtocolBreach
-                        )) |
-                        P2PStreamError::UnknownReservedMessageId(_) |
-                        P2PStreamError::EmptyProtocolMessage |
-                        P2PStreamError::ParseSharedCapability(_) |
-                        P2PStreamError::CapabilityNotShared |
-                        P2PStreamError::Disconnected(DisconnectReason::UselessPeer) |
-                        P2PStreamError::Disconnected(
+                        ))
+                        | P2PStreamError::UnknownReservedMessageId(_)
+                        | P2PStreamError::EmptyProtocolMessage
+                        | P2PStreamError::ParseSharedCapability(_)
+                        | P2PStreamError::CapabilityNotShared
+                        | P2PStreamError::Disconnected(DisconnectReason::UselessPeer)
+                        | P2PStreamError::Disconnected(
                             DisconnectReason::IncompatibleP2PProtocolVersion
-                        ) |
-                        P2PStreamError::Disconnected(DisconnectReason::ProtocolBreach) |
-                        P2PStreamError::MismatchedProtocolVersion { .. }
+                        )
+                        | P2PStreamError::Disconnected(DisconnectReason::ProtocolBreach)
+                        | P2PStreamError::MismatchedProtocolVersion { .. }
                 )
             }
             Self::EthHandshakeError(err) => !matches!(err, EthHandshakeError::NoResponse),
@@ -159,47 +159,47 @@ impl SessionError for EthStreamError {
 
     fn should_backoff(&self) -> Option<BackoffKind> {
         if let Some(err) = self.as_io() {
-            return err.should_backoff()
+            return err.should_backoff();
         }
 
         if let Some(err) = self.as_disconnected() {
             return match err {
-                DisconnectReason::TooManyPeers |
-                DisconnectReason::AlreadyConnected |
-                DisconnectReason::PingTimeout |
-                DisconnectReason::DisconnectRequested |
-                DisconnectReason::TcpSubsystemError => Some(BackoffKind::Low),
+                DisconnectReason::TooManyPeers
+                | DisconnectReason::AlreadyConnected
+                | DisconnectReason::PingTimeout
+                | DisconnectReason::DisconnectRequested
+                | DisconnectReason::TcpSubsystemError => Some(BackoffKind::Low),
 
-                DisconnectReason::ProtocolBreach |
-                DisconnectReason::UselessPeer |
-                DisconnectReason::IncompatibleP2PProtocolVersion |
-                DisconnectReason::NullNodeIdentity |
-                DisconnectReason::ClientQuitting |
-                DisconnectReason::UnexpectedHandshakeIdentity |
-                DisconnectReason::ConnectedToSelf |
-                DisconnectReason::SubprotocolSpecific => {
+                DisconnectReason::ProtocolBreach
+                | DisconnectReason::UselessPeer
+                | DisconnectReason::IncompatibleP2PProtocolVersion
+                | DisconnectReason::NullNodeIdentity
+                | DisconnectReason::ClientQuitting
+                | DisconnectReason::UnexpectedHandshakeIdentity
+                | DisconnectReason::ConnectedToSelf
+                | DisconnectReason::SubprotocolSpecific => {
                     // These are considered fatal, and are handled by the
                     // [`SessionError::is_fatal_protocol_error`]
                     Some(BackoffKind::High)
                 }
-            }
+            };
         }
 
         // This only checks for a subset of error variants, the counterpart of
         // [`SessionError::is_fatal_protocol_error`]
         match self {
             // timeouts
-            Self::EthHandshakeError(EthHandshakeError::NoResponse) |
-            Self::P2PStreamError(P2PStreamError::HandshakeError(P2PHandshakeError::NoResponse)) |
-            Self::P2PStreamError(P2PStreamError::PingTimeout) => Some(BackoffKind::Low),
+            Self::EthHandshakeError(EthHandshakeError::NoResponse)
+            | Self::P2PStreamError(P2PStreamError::HandshakeError(P2PHandshakeError::NoResponse))
+            | Self::P2PStreamError(P2PStreamError::PingTimeout) => Some(BackoffKind::Low),
             // malformed messages
-            Self::P2PStreamError(P2PStreamError::Rlp(_)) |
-            Self::P2PStreamError(P2PStreamError::UnknownReservedMessageId(_)) |
-            Self::P2PStreamError(P2PStreamError::UnknownDisconnectReason(_)) |
-            Self::P2PStreamError(P2PStreamError::MessageTooBig { .. }) |
-            Self::P2PStreamError(P2PStreamError::EmptyProtocolMessage) |
-            Self::P2PStreamError(P2PStreamError::PingerError(_)) |
-            Self::P2PStreamError(P2PStreamError::Snap(_)) => Some(BackoffKind::Medium),
+            Self::P2PStreamError(P2PStreamError::Rlp(_))
+            | Self::P2PStreamError(P2PStreamError::UnknownReservedMessageId(_))
+            | Self::P2PStreamError(P2PStreamError::UnknownDisconnectReason(_))
+            | Self::P2PStreamError(P2PStreamError::MessageTooBig { .. })
+            | Self::P2PStreamError(P2PStreamError::EmptyProtocolMessage)
+            | Self::P2PStreamError(P2PStreamError::PingerError(_))
+            | Self::P2PStreamError(P2PStreamError::Snap(_)) => Some(BackoffKind::Medium),
             _ => None,
         }
     }

--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -92,7 +92,7 @@ where
             BlockHashOrNumber::Hash(start) => start.into(),
             BlockHashOrNumber::Number(num) => {
                 let Some(hash) = self.client.block_hash(num).unwrap_or_default() else {
-                    return headers
+                    return headers;
                 };
                 hash.into()
             }
@@ -108,7 +108,7 @@ where
                         if let Some(next) = (header.number + 1).checked_add(skip) {
                             block = next.into()
                         } else {
-                            break
+                            break;
                         }
                     }
                     HeadersDirection::Falling => {
@@ -120,7 +120,7 @@ where
                             {
                                 block = next.into()
                             } else {
-                                break
+                                break;
                             }
                         } else {
                             block = header.parent_hash.into()
@@ -132,10 +132,10 @@ where
                 headers.push(header);
 
                 if headers.len() >= MAX_HEADERS_SERVE || total_bytes > SOFT_RESPONSE_LIMIT {
-                    break
+                    break;
                 }
             } else {
-                break
+                break;
             }
         }
 
@@ -172,10 +172,10 @@ where
                 bodies.push(body);
 
                 if bodies.len() >= MAX_BODIES_SERVE || total_bytes > SOFT_RESPONSE_LIMIT {
-                    break
+                    break;
                 }
             } else {
-                break
+                break;
             }
         }
 
@@ -207,10 +207,10 @@ where
                 receipts.push(receipt);
 
                 if receipts.len() >= MAX_RECEIPTS_SERVE || total_bytes > SOFT_RESPONSE_LIMIT {
-                    break
+                    break;
                 }
             } else {
-                break
+                break;
             }
         }
 
@@ -261,7 +261,7 @@ where
         if maybe_more_incoming_requests {
             // make sure we're woken up again
             cx.waker().wake_by_ref();
-            return Poll::Pending
+            return Poll::Pending;
         }
 
         Poll::Pending

--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -118,7 +118,7 @@ impl StateFetcher {
             if number > peer.best_number {
                 peer.best_hash = hash;
                 peer.best_number = number;
-                return true
+                return true;
             }
         }
         false
@@ -143,12 +143,12 @@ impl StateFetcher {
             // replace best peer if our current best peer sent us a bad response last time
             if best_peer.1.last_response_likely_bad && !maybe_better.1.last_response_likely_bad {
                 best_peer = maybe_better;
-                continue
+                continue;
             }
 
             // replace best peer if this peer has better rtt
-            if maybe_better.1.timeout() < best_peer.1.timeout() &&
-                !maybe_better.1.last_response_likely_bad
+            if maybe_better.1.timeout() < best_peer.1.timeout()
+                && !maybe_better.1.last_response_likely_bad
             {
                 best_peer = maybe_better;
             }
@@ -161,7 +161,7 @@ impl StateFetcher {
     fn poll_action(&mut self) -> PollAction {
         // we only check and not pop here since we don't know yet whether a peer is available.
         if self.queued_requests.is_empty() {
-            return PollAction::NoRequests
+            return PollAction::NoRequests;
         }
 
         let Some(peer_id) = self.next_best_peer() else { return PollAction::NoPeersAvailable };
@@ -208,7 +208,7 @@ impl StateFetcher {
             }
 
             if self.queued_requests.is_empty() || no_peers_available {
-                return Poll::Pending
+                return Poll::Pending;
             }
         }
     }
@@ -283,7 +283,7 @@ impl StateFetcher {
             // If the peer is still ready to accept new requests, we try to send a followup
             // request immediately.
             if peer.state.on_request_finished() && !is_error && !is_likely_bad_response {
-                return self.followup_request(peer_id)
+                return self.followup_request(peer_id);
             }
         }
 
@@ -309,7 +309,7 @@ impl StateFetcher {
             peer.last_response_likely_bad = is_likely_bad_response;
 
             if peer.state.on_request_finished() && !is_likely_bad_response {
-                return self.followup_request(peer_id)
+                return self.followup_request(peer_id);
             }
         }
         None
@@ -387,7 +387,7 @@ impl PeerState {
     fn on_request_finished(&mut self) -> bool {
         if !matches!(self, Self::Closing) {
             *self = Self::Idle;
-            return true
+            return true;
         }
         false
     }

--- a/crates/net/network/src/frost/messages.rs
+++ b/crates/net/network/src/frost/messages.rs
@@ -243,18 +243,18 @@ impl FrostProtoMessage {
                 buf.put_slice(&resource.data);
             }
             FrostProtoMessageKind::Ping | FrostProtoMessageKind::Pong => {}
-            FrostProtoMessageKind::PingMessage(peer_id) |
-            FrostProtoMessageKind::PongMessage(peer_id) => {
+            FrostProtoMessageKind::PingMessage(peer_id)
+            | FrostProtoMessageKind::PongMessage(peer_id) => {
                 // peer id
                 let peer_id_str = peer_id.to_string();
                 let peer_id_bytes = peer_id_str.as_bytes();
                 buf.put_u16_le(peer_id_bytes.len() as u16); // Store the length of the peer_id string
                 buf.put_slice(peer_id_bytes); // Store the peer_id string itself
             }
-            FrostProtoMessageKind::SignerRound1SigningPackage(resource) |
-            FrostProtoMessageKind::SignerRound2SigningPackage(resource) |
-            FrostProtoMessageKind::CoordinatorRound1SigningPackage(resource) |
-            FrostProtoMessageKind::CoordinatorRound2SigningPackage(resource) => {
+            FrostProtoMessageKind::SignerRound1SigningPackage(resource)
+            | FrostProtoMessageKind::SignerRound2SigningPackage(resource)
+            | FrostProtoMessageKind::CoordinatorRound1SigningPackage(resource)
+            | FrostProtoMessageKind::CoordinatorRound2SigningPackage(resource) => {
                 // signing session id
                 buf.put_u32_le(resource.signing_session_id.len() as u32); // Use u32 to support larger data sizes
                 buf.put_slice(&resource.signing_session_id);
@@ -368,10 +368,10 @@ impl FrostProtoMessage {
                 }
             }
 
-            FrostProtoMessageId::SignerRound1SigningPackage |
-            FrostProtoMessageId::CoordinatorRound1SigningPackage |
-            FrostProtoMessageId::SignerRound2SigningPackage |
-            FrostProtoMessageId::CoordinatorRound2SigningPackage => {
+            FrostProtoMessageId::SignerRound1SigningPackage
+            | FrostProtoMessageId::CoordinatorRound1SigningPackage
+            | FrostProtoMessageId::SignerRound2SigningPackage
+            | FrostProtoMessageId::CoordinatorRound2SigningPackage => {
                 // Check if there's enough data for session_id_len
                 if buf.len() < 4 {
                     return None;

--- a/crates/net/network/src/frost/protocol.rs
+++ b/crates/net/network/src/frost/protocol.rs
@@ -253,9 +253,9 @@ impl Stream for FrostProtoConnection {
                                 this.commands_rx =
                                     Some(UnboundedReceiverStream::new(remote_peer_rx));
                             }
-                            ConnectionEstablishedStatus::ClosedPeerCommandsCommunicationChannel |
-                            ConnectionEstablishedStatus::NoneAuthority |
-                            ConnectionEstablishedStatus::ConnectedToOurself => {
+                            ConnectionEstablishedStatus::ClosedPeerCommandsCommunicationChannel
+                            | ConnectionEstablishedStatus::NoneAuthority
+                            | ConnectionEstablishedStatus::ConnectedToOurself => {
                                 return Poll::Ready(None);
                             }
                         }
@@ -290,9 +290,9 @@ impl Stream for FrostProtoConnection {
                                 this.commands_rx =
                                     Some(UnboundedReceiverStream::new(remote_peer_rx));
                             }
-                            ConnectionEstablishedStatus::ClosedPeerCommandsCommunicationChannel |
-                            ConnectionEstablishedStatus::NoneAuthority |
-                            ConnectionEstablishedStatus::ConnectedToOurself => {
+                            ConnectionEstablishedStatus::ClosedPeerCommandsCommunicationChannel
+                            | ConnectionEstablishedStatus::NoneAuthority
+                            | ConnectionEstablishedStatus::ConnectedToOurself => {
                                 return Poll::Ready(None);
                             }
                         }

--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -350,7 +350,7 @@ impl SyncStateProvider for NetworkHandle {
     // used to guard the txpool
     fn is_initially_syncing(&self) -> bool {
         if self.inner.initial_sync_done.load(Ordering::Relaxed) {
-            return false
+            return false;
         }
         self.inner.is_syncing.load(Ordering::Relaxed)
     }

--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -226,13 +226,13 @@ impl PeersManager {
         addr: IpAddr,
     ) -> Result<(), InboundConnectionError> {
         if self.ban_list.is_banned_ip(&addr) {
-            return Err(InboundConnectionError::IpBanned)
+            return Err(InboundConnectionError::IpBanned);
         }
 
         if !self.connection_info.has_in_capacity() && self.trusted_peer_ids.is_empty() {
             // if we don't have any inbound slots and no trusted peers, we don't accept any new
             // connections
-            return Err(InboundConnectionError::ExceedsCapacity)
+            return Err(InboundConnectionError::ExceedsCapacity);
         }
 
         self.connection_info.inc_pending_in();
@@ -281,14 +281,14 @@ impl PeersManager {
         // on_incoming_pending_session. We also check if the peer is in the backoff list here.
         if self.ban_list.is_banned_peer(&peer_id) {
             self.queued_actions.push_back(PeerAction::DisconnectBannedIncoming { peer_id });
-            return
+            return;
         }
 
         // check if the peer is trustable or not
         let mut is_trusted = self.trusted_peer_ids.contains(&peer_id);
         if self.trusted_nodes_only && !is_trusted {
             self.queued_actions.push_back(PeerAction::DisconnectUntrustedIncoming { peer_id });
-            return
+            return;
         }
 
         // start a new tick, so the peer is not immediately rewarded for the time since last tick
@@ -302,7 +302,7 @@ impl PeersManager {
                 let peer = entry.get_mut();
                 if peer.is_banned() {
                     self.queued_actions.push_back(PeerAction::DisconnectBannedIncoming { peer_id });
-                    return
+                    return;
                 }
                 // it might be the case that we're also trying to connect to this peer at the same
                 // time, so we need to adjust the state here
@@ -413,12 +413,12 @@ impl PeersManager {
                     // exempt trusted and static peers from reputation slashing for
                     if matches!(
                         rep,
-                        ReputationChangeKind::Dropped |
-                            ReputationChangeKind::BadAnnouncement |
-                            ReputationChangeKind::Timeout |
-                            ReputationChangeKind::AlreadySeenTransaction
+                        ReputationChangeKind::Dropped
+                            | ReputationChangeKind::BadAnnouncement
+                            | ReputationChangeKind::Timeout
+                            | ReputationChangeKind::AlreadySeenTransaction
                     ) {
-                        return
+                        return;
                     }
 
                     // also be less strict with the reputation slashing for trusted peers
@@ -430,7 +430,7 @@ impl PeersManager {
                 peer.apply_reputation(reputation_change)
             }
         } else {
-            return
+            return;
         };
 
         match outcome {
@@ -484,7 +484,7 @@ impl PeersManager {
                     // session to that peer
                     entry.get_mut().severe_backoff_counter = 0;
                     entry.get_mut().state = PeerConnectionState::Idle;
-                    return
+                    return;
                 }
             }
             Entry::Vacant(_) => return,
@@ -529,7 +529,7 @@ impl PeersManager {
         if let Some(peer) = self.peers.get(peer_id) {
             if peer.state.is_incoming() {
                 // we already have an active connection to the peer, so we can ignore this error
-                return
+                return;
             }
         }
 
@@ -671,7 +671,7 @@ impl PeersManager {
         fork_id: Option<ForkId>,
     ) {
         if self.ban_list.is_banned(&peer_id, &addr.tcp().ip()) {
-            return
+            return;
         }
 
         match self.peers.entry(peer_id) {
@@ -706,7 +706,7 @@ impl PeersManager {
     pub(crate) fn remove_peer(&mut self, peer_id: PeerId) {
         let Entry::Occupied(entry) = self.peers.entry(peer_id) else { return };
         if entry.get().is_trusted() {
-            return
+            return;
         }
         let mut peer = entry.remove();
 
@@ -733,7 +733,7 @@ impl PeersManager {
     pub(crate) fn remove_peer_from_trusted_set(&mut self, peer_id: PeerId) {
         let Entry::Occupied(mut entry) = self.peers.entry(peer_id) else { return };
         if !entry.get().is_trusted() {
-            return
+            return;
         }
 
         let peer = entry.get_mut();
@@ -753,23 +753,23 @@ impl PeersManager {
     /// Returns `None` if no peer is available.
     fn best_unconnected(&mut self) -> Option<(PeerId, &mut Peer)> {
         let mut unconnected = self.peers.iter_mut().filter(|(_, peer)| {
-            !peer.is_backed_off() &&
-                !peer.is_banned() &&
-                peer.state.is_unconnected() &&
-                (!self.trusted_nodes_only || peer.is_trusted())
+            !peer.is_backed_off()
+                && !peer.is_banned()
+                && peer.state.is_unconnected()
+                && (!self.trusted_nodes_only || peer.is_trusted())
         });
 
         // keep track of the best peer, if there's one
         let mut best_peer = unconnected.next()?;
 
         if best_peer.1.is_trusted() || best_peer.1.is_static() {
-            return Some((*best_peer.0, best_peer.1))
+            return Some((*best_peer.0, best_peer.1));
         }
 
         for maybe_better in unconnected {
             // if the peer is trusted or static, return it immediately
             if maybe_better.1.is_trusted() || maybe_better.1.is_static() {
-                return Some((*maybe_better.0, maybe_better.1))
+                return Some((*maybe_better.0, maybe_better.1));
             }
 
             // otherwise we keep track of the best peer using the reputation
@@ -790,7 +790,7 @@ impl PeersManager {
 
         if !self.net_connection_state.is_active() {
             // nothing to fill
-            return
+            return;
         }
 
         // as long as there are slots available fill them with the best peers
@@ -836,7 +836,7 @@ impl PeersManager {
         loop {
             // drain buffered actions
             if let Some(action) = self.queued_actions.pop_front() {
-                return Poll::Ready(action)
+                return Poll::Ready(action);
             }
 
             while let Poll::Ready(Some(cmd)) = self.handle_rx.poll_next_unpin(cx) {
@@ -875,7 +875,7 @@ impl PeersManager {
                         if let Some(peer) = self.peers.get_mut(peer_id) {
                             peer.backed_off = false;
                         }
-                        return false
+                        return false;
                     }
                     true
                 })
@@ -886,7 +886,7 @@ impl PeersManager {
             }
 
             if self.queued_actions.is_empty() {
-                return Poll::Pending
+                return Poll::Pending;
             }
         }
     }
@@ -923,8 +923,8 @@ impl ConnectionInfo {
 
     ///  Returns `true` if there's still capacity for a new outgoing connection.
     const fn has_out_capacity(&self) -> bool {
-        self.num_pending_out < self.config.max_concurrent_outbound_dials &&
-            self.num_outbound < self.config.max_outbound
+        self.num_pending_out < self.config.max_concurrent_outbound_dials
+            && self.num_outbound < self.config.max_outbound
     }
 
     ///  Returns `true` if there's still capacity for a new incoming connection.
@@ -1778,7 +1778,7 @@ mod tests {
 
             let p = peers.peers.get(&peer).unwrap();
             if p.is_banned() {
-                break
+                break;
             }
         }
 

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -199,7 +199,7 @@ impl ActiveSession {
                             sizes_len: msg.sizes.len(),
                         },
                         message: EthMessage::NewPooledTransactionHashes68(msg),
-                    }
+                    };
                 }
                 self.try_emit_broadcast(PeerMessage::PooledTransactions(msg.into())).into()
             }
@@ -281,8 +281,8 @@ impl ActiveSession {
 
     /// Returns the deadline timestamp at which the request times out
     fn request_deadline(&self) -> Instant {
-        Instant::now() +
-            Duration::from_millis(self.internal_request_timeout.load(Ordering::Relaxed))
+        Instant::now()
+            + Duration::from_millis(self.internal_request_timeout.load(Ordering::Relaxed))
     }
 
     /// Handle a Response to the peer
@@ -425,7 +425,7 @@ impl ActiveSession {
                     debug!(target: "net::session", ?id, remote_peer_id=?self.remote_peer_id, "timed out outgoing request");
                     req.timeout();
                 } else if now - req.timestamp > self.protocol_breach_request_timeout {
-                    return true
+                    return true;
                 }
             }
         }
@@ -449,7 +449,7 @@ impl ActiveSession {
         match tx.poll_reserve(cx) {
             Poll::Pending => {
                 self.terminate_message = Some((tx, msg));
-                return Some(Poll::Pending)
+                return Some(Poll::Pending);
             }
             Poll::Ready(Ok(())) => {
                 let _ = tx.send_item(msg);
@@ -471,11 +471,11 @@ impl Future for ActiveSession {
 
         // if the session is terminate we have to send the termination message before we can close
         if let Some(terminate) = this.poll_terminate_message(cx) {
-            return terminate
+            return terminate;
         }
 
         if this.is_disconnecting() {
-            return this.poll_disconnect(cx)
+            return this.poll_disconnect(cx);
         }
 
         // The receive loop can be CPU intensive since it involves message decoding which could take
@@ -496,7 +496,7 @@ impl Future for ActiveSession {
                     Poll::Ready(None) => {
                         // this is only possible when the manager was dropped, in which case we also
                         // terminate this session
-                        return Poll::Ready(())
+                        return Poll::Ready(());
                     }
                     Poll::Ready(Some(cmd)) => {
                         progress = true;
@@ -511,7 +511,7 @@ impl Future for ActiveSession {
                                 let reason =
                                     reason.unwrap_or(DisconnectReason::DisconnectRequested);
 
-                                return this.try_disconnect(reason, cx)
+                                return this.try_disconnect(reason, cx);
                             }
                             SessionCommand::Message(msg) => {
                                 this.on_internal_peer_message(msg);
@@ -554,11 +554,11 @@ impl Future for ActiveSession {
                     if let Err(err) = res {
                         debug!(target: "net::session", %err, remote_peer_id=?this.remote_peer_id, "failed to send message");
                         // notify the manager
-                        return this.close_on_error(err, cx)
+                        return this.close_on_error(err, cx);
                     }
                 } else {
                     // no more messages to send over the wire
-                    break
+                    break;
                 }
             }
 
@@ -569,7 +569,7 @@ impl Future for ActiveSession {
                 if budget == 0 {
                     // make sure we're woken up again
                     cx.waker().wake_by_ref();
-                    break 'main
+                    break 'main;
                 }
 
                 // try to resend the pending message that we could not send because the channel was
@@ -583,7 +583,7 @@ impl Future for ActiveSession {
                         Poll::Ready(Err(_)) => return Poll::Ready(()),
                         Poll::Pending => {
                             this.pending_message_to_session = Some(msg);
-                            break 'receive
+                            break 'receive;
                         }
                     };
                 }
@@ -592,10 +592,10 @@ impl Future for ActiveSession {
                     Poll::Pending => break,
                     Poll::Ready(None) => {
                         if this.is_disconnecting() {
-                            break
+                            break;
                         } else {
                             debug!(target: "net::session", remote_peer_id=?this.remote_peer_id, "eth stream completed");
-                            return this.emit_disconnect(cx)
+                            return this.emit_disconnect(cx);
                         }
                     }
                     Poll::Ready(Some(res)) => {
@@ -610,7 +610,7 @@ impl Future for ActiveSession {
                                     }
                                     OnIncomingMessageOutcome::BadMessage { error, message } => {
                                         debug!(target: "net::session", %error, msg=?message, remote_peer_id=?this.remote_peer_id, "received invalid protocol message");
-                                        return this.close_on_error(error, cx)
+                                        return this.close_on_error(error, cx);
                                     }
                                     OnIncomingMessageOutcome::NoCapacity(msg) => {
                                         // failed to send due to lack of capacity
@@ -620,7 +620,7 @@ impl Future for ActiveSession {
                             }
                             Err(err) => {
                                 debug!(target: "net::session", %err, remote_peer_id=?this.remote_peer_id, "failed to receive message");
-                                return this.close_on_error(err, cx)
+                                return this.close_on_error(err, cx);
                             }
                         }
                     }
@@ -628,7 +628,7 @@ impl Future for ActiveSession {
             }
 
             if !progress {
-                break 'main
+                break 'main;
             }
         }
 
@@ -1108,7 +1108,7 @@ mod tests {
                 .try_send(ActiveSessionMessage::ProtocolBreach { peer_id: PeerId::random() })
                 .is_err()
             {
-                break
+                break;
             }
             num_fill_messages += 1;
         }

--- a/crates/net/network/src/session/counter.rs
+++ b/crates/net/network/src/session/counter.rs
@@ -83,7 +83,7 @@ impl SessionCounter {
     const fn ensure(current: u32, limit: Option<u32>) -> Result<(), ExceedsSessionLimit> {
         if let Some(limit) = limit {
             if current >= limit {
-                return Err(ExceedsSessionLimit(limit))
+                return Err(ExceedsSessionLimit(limit));
             }
         }
         Ok(())

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -467,7 +467,7 @@ impl SessionManager {
                         peer_id,
                         remote_addr,
                         direction,
-                    })
+                    });
                 }
 
                 let (commands_to_session, commands_rx) = mpsc::channel(self.session_command_buffer);
@@ -833,7 +833,7 @@ async fn start_pending_outbound_session(
                     error,
                 })
                 .await;
-            return
+            return;
         }
     };
     authenticate(
@@ -879,7 +879,7 @@ async fn authenticate(
                     direction,
                 })
                 .await;
-            return
+            return;
         }
     };
 

--- a/crates/net/network/src/state.rs
+++ b/crates/net/network/src/state.rs
@@ -196,7 +196,7 @@ impl NetworkState {
         for (peer_id, peer) in peers {
             if peer.blocks.contains(&msg.hash) {
                 // skip peers which already reported the block
-                continue
+                continue;
             }
 
             // Queue a `NewBlock` message for the peer
@@ -216,7 +216,7 @@ impl NetworkState {
             }
 
             if count >= num_propagate {
-                break
+                break;
             }
         }
     }
@@ -229,7 +229,7 @@ impl NetworkState {
         for (peer_id, peer) in &mut self.active_peers {
             if peer.blocks.contains(&msg.hash) {
                 // skip peers which already reported the block
-                continue
+                continue;
             }
 
             if self.state_fetcher.update_peer_block(peer_id, msg.hash, number) {
@@ -331,8 +331,8 @@ impl NetworkState {
                 self.state_fetcher.on_pending_disconnect(&peer_id);
                 self.queued_messages.push_back(StateAction::Disconnect { peer_id, reason });
             }
-            PeerAction::DisconnectBannedIncoming { peer_id } |
-            PeerAction::DisconnectUntrustedIncoming { peer_id } => {
+            PeerAction::DisconnectBannedIncoming { peer_id }
+            | PeerAction::DisconnectUntrustedIncoming { peer_id } => {
                 self.state_fetcher.on_pending_disconnect(&peer_id);
                 self.queued_messages.push_back(StateAction::Disconnect { peer_id, reason: None });
             }
@@ -412,7 +412,7 @@ impl NetworkState {
         loop {
             // drain buffered messages
             if let Some(message) = self.queued_messages.pop_front() {
-                return Poll::Ready(message)
+                return Poll::Ready(message);
             }
 
             while let Poll::Ready(discovery) = self.discovery.poll(cx) {
@@ -476,7 +476,7 @@ impl NetworkState {
             }
 
             if self.queued_messages.is_empty() {
-                return Poll::Pending
+                return Poll::Pending;
             }
         }
     }

--- a/crates/net/network/src/swarm.rs
+++ b/crates/net/network/src/swarm.rs
@@ -189,7 +189,7 @@ impl Swarm {
             ListenerEvent::Incoming { stream, remote_addr } => {
                 // Reject incoming connection if node is shutting down.
                 if self.is_shutting_down() {
-                    return None
+                    return None;
                 }
                 // ensure we can handle an incoming connection from this address
                 if let Err(err) =
@@ -203,13 +203,13 @@ impl Swarm {
                             trace!(target: "net", ?remote_addr, "No capacity for incoming connection");
                         }
                     }
-                    return None
+                    return None;
                 }
 
                 match self.sessions.on_incoming(stream, remote_addr) {
                     Ok(session_id) => {
                         trace!(target: "net", ?remote_addr, "Incoming connection");
-                        return Some(SwarmEvent::IncomingTcpConnection { session_id, remote_addr })
+                        return Some(SwarmEvent::IncomingTcpConnection { session_id, remote_addr });
                     }
                     Err(err) => {
                         trace!(target: "net", %err, "Incoming connection rejected, capacity already reached.");
@@ -228,7 +228,7 @@ impl Swarm {
         match event {
             StateAction::Connect { remote_addr, peer_id } => {
                 self.dial_outbound(remote_addr, peer_id);
-                return Some(SwarmEvent::OutgoingTcpConnection { remote_addr, peer_id })
+                return Some(SwarmEvent::OutgoingTcpConnection { remote_addr, peer_id });
             }
             StateAction::Disconnect { peer_id, reason } => {
                 self.sessions.disconnect(peer_id, reason);
@@ -246,7 +246,7 @@ impl Swarm {
             StateAction::DiscoveredNode { peer_id, addr, fork_id } => {
                 // Don't try to connect to peer if node is shutting down
                 if self.is_shutting_down() {
-                    return None
+                    return None;
                 }
                 // Insert peer only if no fork id or a valid fork id
                 if fork_id.map_or_else(|| true, |f| self.sessions.is_valid_fork_id(f)) {
@@ -300,7 +300,7 @@ impl Stream for Swarm {
         loop {
             while let Poll::Ready(action) = this.state.poll(cx) {
                 if let Some(event) = this.on_state_action(action) {
-                    return Poll::Ready(Some(event))
+                    return Poll::Ready(Some(event));
                 }
             }
 
@@ -309,9 +309,9 @@ impl Stream for Swarm {
                 Poll::Pending => {}
                 Poll::Ready(event) => {
                     if let Some(event) = this.on_session_event(event) {
-                        return Poll::Ready(Some(event))
+                        return Poll::Ready(Some(event));
                     }
-                    continue
+                    continue;
                 }
             }
 
@@ -320,13 +320,13 @@ impl Stream for Swarm {
                 Poll::Pending => {}
                 Poll::Ready(event) => {
                     if let Some(event) = this.on_connection(event) {
-                        return Poll::Ready(Some(event))
+                        return Poll::Ready(Some(event));
                     }
-                    continue
+                    continue;
                 }
             }
 
-            return Poll::Pending
+            return Poll::Pending;
         }
     }
 }

--- a/crates/net/network/src/test_utils/init.rs
+++ b/crates/net/network/src/test_utils/init.rs
@@ -46,7 +46,7 @@ pub fn unused_tcp_and_udp_port() -> u16 {
     loop {
         let port = unused_port();
         if std::net::UdpSocket::bind(format!("127.0.0.1:{port}")).is_ok() {
-            return port
+            return port;
         }
     }
 }

--- a/crates/net/network/src/test_utils/testnet.rs
+++ b/crates/net/network/src/test_utils/testnet.rs
@@ -299,7 +299,7 @@ impl<C, Pool> TestnetHandle<C, Pool> {
     /// Returns once all sessions are established.
     pub async fn connect_peers(&self) {
         if self.peers.len() < 2 {
-            return
+            return;
         }
 
         // add an event stream for _each_ peer
@@ -608,7 +608,7 @@ impl NetworkEventStream {
     pub async fn next_session_closed(&mut self) -> Option<(PeerId, Option<DisconnectReason>)> {
         while let Some(ev) = self.inner.next().await {
             if let NetworkEvent::SessionClosed { peer_id, reason } = ev {
-                return Some((peer_id, reason))
+                return Some((peer_id, reason));
             }
         }
         None
@@ -618,7 +618,7 @@ impl NetworkEventStream {
     pub async fn next_session_established(&mut self) -> Option<PeerId> {
         while let Some(ev) = self.inner.next().await {
             if let NetworkEvent::SessionEstablished { peer_id, .. } = ev {
-                return Some(peer_id)
+                return Some(peer_id);
             }
         }
         None
@@ -627,7 +627,7 @@ impl NetworkEventStream {
     /// Awaits the next `num` events for an established session
     pub async fn take_session_established(&mut self, mut num: usize) -> Vec<PeerId> {
         if num == 0 {
-            return Vec::new()
+            return Vec::new();
         }
         let mut peers = Vec::with_capacity(num);
         while let Some(ev) = self.inner.next().await {
@@ -635,7 +635,7 @@ impl NetworkEventStream {
                 peers.push(peer_id);
                 num -= 1;
                 if num == 0 {
-                    return peers
+                    return peers;
                 }
             }
         }

--- a/crates/net/network/src/transactions/constants.rs
+++ b/crates/net/network/src/transactions/constants.rs
@@ -138,8 +138,8 @@ pub mod tx_fetcher {
     /// [`DEFAULT_MAX_COUNT_INFLIGHT_REQUESTS_ON_FETCH_PENDING_HASHES`], which is 25600 hashes and
     /// 65 requests, so it is 25665 hashes.
     pub const DEFAULT_MAX_CAPACITY_CACHE_INFLIGHT_AND_PENDING_FETCH: u32 =
-        DEFAULT_MAX_CAPACITY_CACHE_PENDING_FETCH +
-            DEFAULT_MAX_COUNT_INFLIGHT_REQUESTS_ON_FETCH_PENDING_HASHES as u32;
+        DEFAULT_MAX_CAPACITY_CACHE_PENDING_FETCH
+            + DEFAULT_MAX_COUNT_INFLIGHT_REQUESTS_ON_FETCH_PENDING_HASHES as u32;
 
     /// Default maximum number of hashes pending fetch to tolerate at any time.
     ///
@@ -190,8 +190,8 @@ pub mod tx_fetcher {
     /// which defaults to 128 KiB, so 64 KiB.
     pub const DEFAULT_SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESPONSE_ON_FETCH_PENDING_HASHES:
         usize =
-        DEFAULT_SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESP_ON_PACK_GET_POOLED_TRANSACTIONS_REQ /
-            2;
+        DEFAULT_SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESP_ON_PACK_GET_POOLED_TRANSACTIONS_REQ
+            / 2;
 
     /// Default max inflight request when fetching pending hashes.
     ///
@@ -238,8 +238,8 @@ pub mod tx_fetcher {
     /// divided by [`SOFT_LIMIT_COUNT_HASHES_IN_NEW_POOLED_TRANSACTIONS_BROADCAST_MESSAGE`], which
     /// is spec'd at 4096 hashes, so 521 bytes.
     pub const AVERAGE_BYTE_SIZE_TX_ENCODED: usize =
-        SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESPONSE /
-            SOFT_LIMIT_COUNT_HASHES_IN_NEW_POOLED_TRANSACTIONS_BROADCAST_MESSAGE;
+        SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESPONSE
+            / SOFT_LIMIT_COUNT_HASHES_IN_NEW_POOLED_TRANSACTIONS_BROADCAST_MESSAGE;
 
     /// Median observed size in bytes of a small encoded legacy transaction.
     ///
@@ -267,8 +267,8 @@ pub mod tx_fetcher {
         let max_size_expected_response =
             info.soft_limit_byte_size_pooled_transactions_response_on_pack_request;
 
-        max_size_expected_response / MEDIAN_BYTE_SIZE_SMALL_LEGACY_TX_ENCODED +
-            DEFAULT_MARGINAL_COUNT_HASHES_GET_POOLED_TRANSACTIONS_REQUEST
+        max_size_expected_response / MEDIAN_BYTE_SIZE_SMALL_LEGACY_TX_ENCODED
+            + DEFAULT_MARGINAL_COUNT_HASHES_GET_POOLED_TRANSACTIONS_REQUEST
     }
 
     /// Returns the approx number of transactions that a

--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -156,7 +156,7 @@ impl TransactionFetcher {
             if let Some(inflight_count) = self.active_peers.get(peer_id) {
                 *inflight_count -= 1;
                 if *inflight_count == 0 {
-                    return true
+                    return true;
                 }
             }
             false
@@ -171,7 +171,7 @@ impl TransactionFetcher {
     pub fn is_idle(&self, peer_id: &PeerId) -> bool {
         let Some(inflight_count) = self.active_peers.peek(peer_id) else { return true };
         if *inflight_count < DEFAULT_MAX_COUNT_CONCURRENT_REQUESTS_PER_PEER {
-            return true
+            return true;
         }
         false
     }
@@ -187,7 +187,7 @@ impl TransactionFetcher {
 
         for peer_id in fallback_peers.iter() {
             if self.is_idle(peer_id) && is_session_active(peer_id) {
-                return Some(peer_id)
+                return Some(peer_id);
             }
         }
 
@@ -214,13 +214,13 @@ impl TransactionFetcher {
 
             if idle_peer.is_some() {
                 hashes_to_request.insert(hash);
-                break idle_peer.copied()
+                break idle_peer.copied();
             }
 
             if let Some(ref mut bud) = budget {
                 *bud = bud.saturating_sub(1);
                 if *bud == 0 {
-                    return None
+                    return None;
                 }
             }
         };
@@ -243,7 +243,7 @@ impl TransactionFetcher {
         hashes_from_announcement: ValidAnnouncementData,
     ) -> RequestTxHashes {
         if hashes_from_announcement.msg_version().is_eth68() {
-            return self.pack_request_eth68(hashes_to_request, hashes_from_announcement)
+            return self.pack_request_eth68(hashes_to_request, hashes_from_announcement);
         }
         self.pack_request_eth66(hashes_to_request, hashes_from_announcement)
     }
@@ -274,7 +274,7 @@ impl TransactionFetcher {
 
             // tx is really big, pack request with single tx
             if size >= self.info.soft_limit_byte_size_pooled_transactions_response_on_pack_request {
-                return hashes_from_announcement_iter.collect::<RequestTxHashes>()
+                return hashes_from_announcement_iter.collect::<RequestTxHashes>();
             } else {
                 acc_size_response = size;
             }
@@ -293,8 +293,8 @@ impl TransactionFetcher {
 
             let next_acc_size = acc_size_response + size;
 
-            if next_acc_size <=
-                self.info.soft_limit_byte_size_pooled_transactions_response_on_pack_request
+            if next_acc_size
+                <= self.info.soft_limit_byte_size_pooled_transactions_response_on_pack_request
             {
                 // only update accumulated size of tx response if tx will fit in without exceeding
                 // soft limit
@@ -305,11 +305,11 @@ impl TransactionFetcher {
             }
 
             let free_space =
-                self.info.soft_limit_byte_size_pooled_transactions_response_on_pack_request -
-                    acc_size_response;
+                self.info.soft_limit_byte_size_pooled_transactions_response_on_pack_request
+                    - acc_size_response;
 
             if free_space < MEDIAN_BYTE_SIZE_SMALL_LEGACY_TX_ENCODED {
-                break
+                break;
             }
         }
 
@@ -358,7 +358,7 @@ impl TransactionFetcher {
         hashes.retain(|hash| {
             if let Some(entry) = self.hashes_fetch_inflight_and_pending_fetch.get(hash) {
                 entry.fallback_peers_mut().remove(peer_failed_to_serve);
-                return true
+                return true;
             }
             // tx has been seen over broadcast in the time it took for the request to resolve
             false
@@ -377,13 +377,13 @@ impl TransactionFetcher {
         for hash in hashes {
             // hash could have been evicted from bounded lru map
             if self.hashes_fetch_inflight_and_pending_fetch.peek(&hash).is_none() {
-                continue
+                continue;
             }
 
             let Some(TxFetchMetadata { retries, fallback_peers, .. }) =
                 self.hashes_fetch_inflight_and_pending_fetch.get(&hash)
             else {
-                return
+                return;
             };
 
             if let Some(peer_id) = fallback_peer {
@@ -398,7 +398,7 @@ impl TransactionFetcher {
                     );
 
                     max_retried_and_evicted_hashes.push(hash);
-                    continue
+                    continue;
                 }
                 *retries += 1;
             }
@@ -438,7 +438,7 @@ impl TransactionFetcher {
                     budget_find_idle_fallback_peer,
                 ) else {
                     // no peers are idle or budget is depleted
-                    return
+                    return;
                 };
 
                 peer_id
@@ -633,7 +633,7 @@ impl TransactionFetcher {
                 max_inflight_transaction_requests=self.info.max_inflight_requests,
                 "limit for concurrent `GetPooledTransactions` requests reached, dropping request for hashes to peer"
             );
-            return Some(new_announced_hashes)
+            return Some(new_announced_hashes);
         }
 
         let Some(inflight_count) = self.active_peers.get_or_insert(peer_id, || 0) else {
@@ -643,7 +643,7 @@ impl TransactionFetcher {
                 conn_eth_version=%conn_eth_version,
                 "failed to cache active peer in schnellru::LruMap, dropping request to peer"
             );
-            return Some(new_announced_hashes)
+            return Some(new_announced_hashes);
         };
 
         if *inflight_count >= DEFAULT_MAX_COUNT_CONCURRENT_REQUESTS_PER_PEER {
@@ -654,7 +654,7 @@ impl TransactionFetcher {
                 max_concurrent_tx_reqs_per_peer=DEFAULT_MAX_COUNT_CONCURRENT_REQUESTS_PER_PEER,
                 "limit for concurrent `GetPooledTransactions` requests per peer reached"
             );
-            return Some(new_announced_hashes)
+            return Some(new_announced_hashes);
         }
 
         *inflight_count += 1;
@@ -691,7 +691,7 @@ impl TransactionFetcher {
                     self.metrics.egress_peer_channel_full.increment(1);
                     Some(new_announced_hashes)
                 }
-            }
+            };
         } else {
             // stores a new request future for the request
             self.inflight_requests.push(GetPooledTxRequestFut::new(
@@ -738,10 +738,10 @@ impl TransactionFetcher {
             .unwrap_or(AVERAGE_BYTE_SIZE_TX_ENCODED);
 
         // if request full enough already, we're satisfied, send request for single tx
-        if acc_size_response >=
-            DEFAULT_SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESPONSE_ON_FETCH_PENDING_HASHES
+        if acc_size_response
+            >= DEFAULT_SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESPONSE_ON_FETCH_PENDING_HASHES
         {
-            return
+            return;
         }
 
         // try to fill request by checking if any other hashes pending fetch (in lru order) are
@@ -749,7 +749,7 @@ impl TransactionFetcher {
         for hash in self.hashes_pending_fetch.iter() {
             // 1. Check if a hash pending fetch is seen by peer.
             if !seen_hashes.contains(hash) {
-                continue
+                continue;
             };
 
             // 2. Optimistically include the hash in the request.
@@ -778,7 +778,7 @@ impl TransactionFetcher {
             if let Some(ref mut bud) = budget_fill_request {
                 *bud = bud.saturating_sub(1);
                 if *bud == 0 {
-                    return
+                    return;
                 }
             }
         }
@@ -814,8 +814,8 @@ impl TransactionFetcher {
         let info = &self.info;
 
         let tx_fetcher_has_capacity = self.has_capacity(
-            info.max_inflight_requests /
-                DEFAULT_DIVISOR_MAX_COUNT_INFLIGHT_REQUESTS_ON_FIND_IDLE_PEER,
+            info.max_inflight_requests
+                / DEFAULT_DIVISOR_MAX_COUNT_INFLIGHT_REQUESTS_ON_FIND_IDLE_PEER,
         );
         let tx_pool_has_capacity = has_capacity_wrt_pending_pool_imports(
             DEFAULT_DIVISOR_MAX_COUNT_PENDING_POOL_IMPORTS_ON_FIND_IDLE_PEER,
@@ -853,8 +853,8 @@ impl TransactionFetcher {
         let info = &self.info;
 
         let tx_fetcher_has_capacity = self.has_capacity(
-            info.max_inflight_requests /
-                DEFAULT_DIVISOR_MAX_COUNT_INFLIGHT_REQUESTS_ON_FIND_INTERSECTION,
+            info.max_inflight_requests
+                / DEFAULT_DIVISOR_MAX_COUNT_INFLIGHT_REQUESTS_ON_FIND_INTERSECTION,
         );
         let tx_pool_has_capacity = has_capacity_wrt_pending_pool_imports(
             DEFAULT_DIVISOR_MAX_COUNT_PENDING_POOL_IMPORTS_ON_FIND_INTERSECTION,
@@ -929,7 +929,7 @@ impl TransactionFetcher {
                         "received empty `PooledTransactions` response from peer, peer failed to serve hashes it announced"
                     );
 
-                    return FetchEvent::EmptyResponse { peer_id }
+                    return FetchEvent::EmptyResponse { peer_id };
                 }
 
                 //
@@ -956,7 +956,7 @@ impl TransactionFetcher {
                 }
                 // peer has only sent hashes that we didn't request
                 if verified_payload.is_empty() {
-                    return FetchEvent::FetchError { peer_id, error: RequestError::BadResponse }
+                    return FetchEvent::FetchError { peer_id, error: RequestError::BadResponse };
                 }
 
                 //
@@ -993,7 +993,7 @@ impl TransactionFetcher {
                     if valid_payload.contains_key(requested_hash) {
                         // hash is now known, stop tracking
                         fetched.push(*requested_hash);
-                        return false
+                        return false;
                     }
                     true
                 });
@@ -1040,11 +1040,11 @@ impl Stream for TransactionFetcher {
         // `FuturesUnordered` doesn't close when `None` is returned. so just return pending.
         // <https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=815be2b6c8003303757c3ced135f363e>
         if self.inflight_requests.is_empty() {
-            return Poll::Pending
+            return Poll::Pending;
         }
 
         if let Some(resp) = ready!(self.inflight_requests.poll_next_unpin(cx)) {
-            return Poll::Ready(Some(self.on_resolved_get_pooled_transactions_request_fut(resp)))
+            return Poll::Ready(Some(self.on_resolved_get_pooled_transactions_request_fut(resp)));
         }
 
         Poll::Pending
@@ -1248,7 +1248,7 @@ impl VerifyPooledTransactionsResponse for UnverifiedPooledTransactions {
                     tx_hashes_not_requested_count += 1;
                 }
 
-                return false
+                return false;
             }
             true
         });

--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -185,13 +185,7 @@ impl TransactionFetcher {
         let TxFetchMetadata { fallback_peers, .. } =
             self.hashes_fetch_inflight_and_pending_fetch.peek(&hash)?;
 
-        for peer_id in fallback_peers.iter() {
-            if self.is_idle(peer_id) && is_session_active(peer_id) {
-                return Some(peer_id);
-            }
-        }
-
-        None
+        fallback_peers.iter().find(|&peer_id| self.is_idle(peer_id) && is_session_active(peer_id))
     }
 
     /// Returns any idle peer for any hash pending fetch. If one is found, the corresponding

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -356,7 +356,7 @@ where
         if let Some(peer) = self.peers.get_mut(&peer_id) {
             if self.network.tx_gossip_disabled() {
                 let _ = response.send(Ok(PooledTransactions::default()));
-                return
+                return;
             }
             let transactions = self.pool.get_pooled_transaction_elements(
                 request.0,
@@ -390,10 +390,10 @@ where
     fn on_new_pending_transactions(&mut self, hashes: Vec<TxHash>) {
         // Nothing to propagate while initially syncing
         if self.network.is_initially_syncing() {
-            return
+            return;
         }
         if self.network.tx_gossip_disabled() {
-            return
+            return;
         }
 
         trace!(target: "net::tx", num_hashes=?hashes.len(), "Start propagating transactions");
@@ -420,7 +420,7 @@ where
     ) -> PropagatedTransactions {
         let mut propagated = PropagatedTransactions::default();
         if self.network.tx_gossip_disabled() {
-            return propagated
+            return propagated;
         }
 
         // send full transactions to a fraction of the connected peers (square root of the total
@@ -449,7 +449,7 @@ where
 
             if builder.is_empty() {
                 trace!(target: "net::tx", ?peer_id, "Nothing to propagate to peer; has seen all transactions");
-                continue
+                continue;
             }
 
             let PropagateTransactions { pooled, full } = builder.build();
@@ -521,7 +521,7 @@ where
 
         if full_transactions.is_empty() {
             // nothing to propagate
-            return None
+            return None;
         }
 
         let PropagateTransactions { pooled, full } = full_transactions.build();
@@ -565,7 +565,7 @@ where
         let propagated = {
             let Some(peer) = self.peers.get_mut(&peer_id) else {
                 // no such peer
-                return
+                return;
             };
 
             let to_propagate: Vec<PropagateTransaction> =
@@ -586,7 +586,7 @@ where
 
             if new_pooled_hashes.is_empty() {
                 // nothing to propagate
-                return
+                return;
             }
 
             for hash in new_pooled_hashes.iter_hashes().copied() {
@@ -616,10 +616,10 @@ where
     ) {
         // If the node is initially syncing, ignore transactions
         if self.network.is_initially_syncing() {
-            return
+            return;
         }
         if self.network.tx_gossip_disabled() {
-            return
+            return;
         }
 
         // get handle to peer's session, if the session is still active
@@ -630,7 +630,7 @@ where
                 "discarding announcement from inactive peer"
             );
 
-            return
+            return;
         };
         let client = peer.client_version.clone();
 
@@ -691,7 +691,7 @@ where
 
         if partially_valid_msg.is_empty() {
             // nothing to request
-            return
+            return;
         }
 
         // 4. filter out invalid entries (spam)
@@ -720,7 +720,7 @@ where
 
         if valid_announcement_data.is_empty() {
             // no valid announcement data
-            return
+            return;
         }
 
         // 5. filter out already seen unknown hashes
@@ -740,7 +740,7 @@ where
 
         if valid_announcement_data.is_empty() {
             // nothing to request
-            return
+            return;
         }
 
         trace!(target: "net::tx::propagation",
@@ -769,7 +769,7 @@ where
 
             self.transaction_fetcher.buffer_hashes(hashes, Some(peer_id));
 
-            return
+            return;
         }
 
         // load message version before announcement data type is destructed in packing
@@ -926,7 +926,7 @@ where
                 // `SOFT_LIMIT_COUNT_HASHES_IN_NEW_POOLED_TRANSACTIONS_BROADCAST_MESSAGE`
                 // transactions in the pool.
                 if self.network.is_initially_syncing() || self.network.tx_gossip_disabled() {
-                    return
+                    return;
                 }
 
                 let pooled_txs = self.pool.pooled_transactions_max(
@@ -934,7 +934,7 @@ where
                 );
                 if pooled_txs.is_empty() {
                     // do not send a message if there are no transactions in the pool
-                    return
+                    return;
                 }
 
                 let mut msg_builder = PooledTransactionsHashesBuilder::new(version);
@@ -959,10 +959,10 @@ where
     ) {
         // If the node is pipeline syncing, ignore transactions
         if self.network.is_initially_syncing() {
-            return
+            return;
         }
         if self.network.tx_gossip_disabled() {
-            return
+            return;
         }
 
         let Some(peer) = self.peers.get_mut(&peer_id) else { return };
@@ -1012,7 +1012,7 @@ where
                             "failed ecrecovery for transaction"
                         );
                         has_bad_transactions = true;
-                        continue
+                        continue;
                     }
                 };
 
@@ -1150,7 +1150,7 @@ where
             RequestError::Timeout => ReputationChangeKind::Timeout,
             RequestError::ChannelClosed | RequestError::ConnectionDropped => {
                 // peer is already disconnected
-                return
+                return;
             }
             RequestError::BadResponse => return self.report_peer_bad_transactions(peer_id),
         };
@@ -1195,7 +1195,7 @@ where
 
         // if we're _currently_ syncing, we ignore a bad transaction
         if !err.is_bad_transaction() || self.network.is_syncing() {
-            return
+            return;
         }
         // otherwise we penalize the peer that sent the bad transaction, with the assumption that
         // the peer should have known that this transaction is bad (e.g. violating consensus rules)
@@ -1212,8 +1212,8 @@ where
     /// `false` if [`TransactionsManager`] is operating close to full capacity.
     fn has_capacity_for_fetching_pending_hashes(&self) -> bool {
         self.pending_pool_imports_info
-            .has_capacity(self.pending_pool_imports_info.max_pending_pool_imports) &&
-            self.transaction_fetcher.has_capacity_for_fetching_pending_hashes()
+            .has_capacity(self.pending_pool_imports_info.max_pending_pool_imports)
+            && self.transaction_fetcher.has_capacity_for_fetching_pending_hashes()
     }
 }
 
@@ -1362,16 +1362,16 @@ where
         this.transaction_fetcher.update_metrics();
 
         // all channels are fully drained and import futures pending
-        if maybe_more_network_events ||
-            maybe_more_commands ||
-            maybe_more_tx_events ||
-            maybe_more_tx_fetch_events ||
-            maybe_more_pool_imports ||
-            maybe_more_pending_txns
+        if maybe_more_network_events
+            || maybe_more_commands
+            || maybe_more_tx_events
+            || maybe_more_tx_fetch_events
+            || maybe_more_pool_imports
+            || maybe_more_pending_txns
         {
             // make sure we're woken up again
             cx.waker().wake_by_ref();
-            return Poll::Pending
+            return Poll::Pending;
         }
 
         this.update_poll_metrics(start, poll_durations);
@@ -1501,16 +1501,16 @@ impl FullTransactionsBuilder {
         // From: <https://eips.ethereum.org/EIPS/eip-4844#networking>
         if transaction.transaction.is_eip4844() {
             self.pooled.push(transaction);
-            return
+            return;
         }
 
         let new_size = self.total_size + transaction.size;
-        if new_size > DEFAULT_SOFT_LIMIT_BYTE_SIZE_TRANSACTIONS_BROADCAST_MESSAGE &&
-            self.total_size > 0
+        if new_size > DEFAULT_SOFT_LIMIT_BYTE_SIZE_TRANSACTIONS_BROADCAST_MESSAGE
+            && self.total_size > 0
         {
             // transaction does not fit into the message
             self.pooled.push(transaction);
-            return
+            return;
         }
 
         self.total_size = new_size;

--- a/crates/net/network/src/transactions/validation.rs
+++ b/crates/net/network/src/transactions/validation.rs
@@ -80,7 +80,7 @@ pub trait PartiallyFilterMessage {
                 msg=?msg,
                 "empty payload"
             );
-            return (FilterOutcome::ReportPeer, PartiallyValidData::empty_eth66())
+            return (FilterOutcome::ReportPeer, PartiallyValidData::empty_eth66());
         }
 
         // 2. checks if announcement is spam packed with duplicate hashes
@@ -179,7 +179,7 @@ impl ValidateTx68 for EthMessageFilter {
                     "invalid tx type in eth68 announcement"
                 );
 
-                return ValidationOutcome::ReportPeer
+                return ValidationOutcome::ReportPeer;
             }
         };
         tx_types_counter.increase_by_tx_type(tx_type);
@@ -201,7 +201,7 @@ impl ValidateTx68 for EthMessageFilter {
                     "invalid tx size in eth68 announcement"
                 );
 
-                return ValidationOutcome::Ignore
+                return ValidationOutcome::Ignore;
             }
         }
         if let Some(reasonable_min_encoded_tx_length) = self.min_encoded_tx_length(tx_type) {

--- a/crates/net/network/tests/it/multiplex.rs
+++ b/crates/net/network/tests/it/multiplex.rs
@@ -101,8 +101,8 @@ mod proto {
             buf.put_u8(self.message_type as u8);
             match &self.message {
                 PingPongProtoMessageKind::Ping | PingPongProtoMessageKind::Pong => {}
-                PingPongProtoMessageKind::PingMessage(msg) |
-                PingPongProtoMessageKind::PongMessage(msg) => {
+                PingPongProtoMessageKind::PingMessage(msg)
+                | PingPongProtoMessageKind::PongMessage(msg) => {
                     buf.put(msg.as_bytes());
                 }
             }
@@ -112,7 +112,7 @@ mod proto {
         /// Decodes a `TestProtoMessage` from the given message buffer.
         pub fn decode_message(buf: &mut &[u8]) -> Option<Self> {
             if buf.is_empty() {
-                return None
+                return None;
             }
             let id = buf[0];
             buf.advance(1);
@@ -236,7 +236,7 @@ impl Stream for PingPongProtoConnection {
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
         if let Some(initial_ping) = this.initial_ping.take() {
-            return Poll::Ready(Some(initial_ping.encoded()))
+            return Poll::Ready(Some(initial_ping.encoded()));
         }
 
         loop {
@@ -246,12 +246,12 @@ impl Stream for PingPongProtoConnection {
                         this.pending_pong = Some(response);
                         Poll::Ready(Some(PingPongProtoMessage::ping_message(msg).encoded()))
                     }
-                }
+                };
             }
             let Some(msg) = ready!(this.conn.poll_next_unpin(cx)) else { return Poll::Ready(None) };
 
             let Some(msg) = PingPongProtoMessage::decode_message(&mut &msg[..]) else {
-                return Poll::Ready(None)
+                return Poll::Ready(None);
             };
 
             match msg.message {
@@ -266,11 +266,11 @@ impl Stream for PingPongProtoConnection {
                     if let Some(sender) = this.pending_pong.take() {
                         sender.send(msg).ok();
                     }
-                    continue
+                    continue;
                 }
             }
 
-            return Poll::Pending
+            return Poll::Pending;
         }
     }
 }

--- a/crates/net/p2p/src/error.rs
+++ b/crates/net/p2p/src/error.rs
@@ -33,7 +33,7 @@ impl EthResponseValidator for RequestResult<Vec<Header>> {
                 let request_length = headers.len() as u64;
 
                 if request_length <= 1 && request.limit != request_length {
-                    return true
+                    return true;
                 }
 
                 match request.start {
@@ -62,10 +62,10 @@ impl EthResponseValidator for RequestResult<Vec<Header>> {
     fn reputation_change_err(&self) -> Option<ReputationChangeKind> {
         if let Err(err) = self {
             match err {
-                RequestError::ChannelClosed |
-                RequestError::ConnectionDropped |
-                RequestError::UnsupportedCapability |
-                RequestError::BadResponse => None,
+                RequestError::ChannelClosed
+                | RequestError::ConnectionDropped
+                | RequestError::UnsupportedCapability
+                | RequestError::BadResponse => None,
                 RequestError::Timeout => Some(ReputationChangeKind::Timeout),
             }
         } else {

--- a/crates/net/p2p/src/full_block.rs
+++ b/crates/net/p2p/src/full_block.rs
@@ -132,7 +132,7 @@ where
     /// Returns the [`SealedBlock`] if the request is complete and valid.
     fn take_block(&mut self) -> Option<SealedBlock> {
         if self.header.is_none() || self.body.is_none() {
-            return None
+            return None;
         }
 
         let header = self.header.take().unwrap();
@@ -146,7 +146,7 @@ where
                     self.client.report_bad_message(resp.peer_id());
                     self.header = Some(header);
                     self.request.body = Some(self.client.get_block_body(self.hash));
-                    return None
+                    return None;
                 }
                 Some(SealedBlock::new(header, resp.into_data()))
             }
@@ -158,10 +158,10 @@ where
             if let Err(err) = ensure_valid_body_response(header, resp.data()) {
                 debug!(target: "downloaders", %err, hash=?header.hash(), "Received wrong body");
                 self.client.report_bad_message(resp.peer_id());
-                return
+                return;
             }
             self.body = Some(BodyResponse::Validated(resp.into_data()));
-            return
+            return;
         }
         self.body = Some(BodyResponse::PendingValidation(resp));
     }
@@ -222,7 +222,7 @@ where
             }
 
             if let Some(res) = this.take_block() {
-                return Poll::Ready(res)
+                return Poll::Ready(res);
             }
         }
     }
@@ -257,14 +257,14 @@ where
         if let Some(fut) = Pin::new(&mut self.header).as_pin_mut() {
             if let Poll::Ready(res) = fut.poll(cx) {
                 self.header = None;
-                return Poll::Ready(ResponseResult::Header(res))
+                return Poll::Ready(ResponseResult::Header(res));
             }
         }
 
         if let Some(fut) = Pin::new(&mut self.body).as_pin_mut() {
             if let Poll::Ready(res) = fut.poll(cx) {
                 self.body = None;
-                return Poll::Ready(ResponseResult::Body(res))
+                return Poll::Ready(ResponseResult::Body(res));
             }
         }
 
@@ -302,14 +302,14 @@ fn ensure_valid_body_response(
     if header.ommers_hash != ommers_hash {
         return Err(ConsensusError::BodyOmmersHashDiff(
             GotExpected { got: ommers_hash, expected: header.ommers_hash }.into(),
-        ))
+        ));
     }
 
     let tx_root = block.calculate_tx_root();
     if header.transactions_root != tx_root {
         return Err(ConsensusError::BodyTransactionRootDiff(
             GotExpected { got: tx_root, expected: header.transactions_root }.into(),
-        ))
+        ));
     }
 
     match (header.withdrawals_root, &block.withdrawals) {
@@ -319,7 +319,7 @@ fn ensure_valid_body_response(
             if withdrawals_root != header_withdrawals_root {
                 return Err(ConsensusError::BodyWithdrawalsRootDiff(
                     GotExpected { got: withdrawals_root, expected: header_withdrawals_root }.into(),
-                ))
+                ));
             }
         }
         (None, None) => {
@@ -335,7 +335,7 @@ fn ensure_valid_body_response(
             if requests_root != header_requests_root {
                 return Err(ConsensusError::BodyRequestsRootDiff(
                     GotExpected { got: requests_root, expected: header_requests_root }.into(),
-                ))
+                ));
             }
         }
         (None, None) => {
@@ -429,7 +429,7 @@ where
     fn take_blocks(&mut self) -> Option<Vec<SealedBlock>> {
         if !self.is_bodies_complete() {
             // not done with bodies yet
-            return None
+            return None;
         }
 
         let headers = self.headers.take()?;
@@ -450,7 +450,7 @@ where
                             // get body that doesn't match, put back into vecdeque, and retry it
                             self.pending_headers.push_back(header.clone());
                             needs_retry = true;
-                            continue
+                            continue;
                         }
 
                         resp.into_data()
@@ -475,7 +475,7 @@ where
             // create response for failing bodies
             let hashes = self.remaining_bodies_hashes();
             self.request.bodies = Some(self.client.get_block_bodies(hashes));
-            return None
+            return None;
         }
 
         Some(valid_responses)
@@ -500,7 +500,7 @@ where
                 if let Err(err) = self.consensus.validate_header_range(&headers_rising) {
                     debug!(target: "downloaders", %err, ?self.start_hash, "Received bad header response");
                     self.client.report_bad_message(peer);
-                    return
+                    return;
                 }
 
                 // get the bodies request so it can be polled later
@@ -628,7 +628,7 @@ where
             }
 
             if let Some(res) = this.take_blocks() {
-                return Poll::Ready(res)
+                return Poll::Ready(res);
             }
         }
     }
@@ -653,14 +653,14 @@ where
         if let Some(fut) = Pin::new(&mut self.headers).as_pin_mut() {
             if let Poll::Ready(res) = fut.poll(cx) {
                 self.headers = None;
-                return Poll::Ready(RangeResponseResult::Header(res))
+                return Poll::Ready(RangeResponseResult::Header(res));
             }
         }
 
         if let Some(fut) = Pin::new(&mut self.bodies).as_pin_mut() {
             if let Poll::Ready(res) = fut.poll(cx) {
                 self.bodies = None;
-                return Poll::Ready(RangeResponseResult::Body(res))
+                return Poll::Ready(RangeResponseResult::Body(res));
             }
         }
 

--- a/crates/net/p2p/src/test_utils/headers.rs
+++ b/crates/net/p2p/src/test_utils/headers.rs
@@ -77,7 +77,7 @@ impl Stream for TestHeaderDownloader {
         let this = self.get_mut();
         loop {
             if this.queued_headers.len() == this.batch_size {
-                return Poll::Ready(Some(Ok(std::mem::take(&mut this.queued_headers))))
+                return Poll::Ready(Some(Ok(std::mem::take(&mut this.queued_headers))));
             }
             if this.download.is_none() {
                 this.download = Some(this.create_download());
@@ -137,9 +137,9 @@ impl Stream for TestDownload {
 
         loop {
             if let Some(header) = this.buffer.pop() {
-                return Poll::Ready(Some(Ok(header)))
+                return Poll::Ready(Some(Ok(header)));
             } else if this.done {
-                return Poll::Ready(None)
+                return Poll::Ready(None);
             }
 
             let empty = SealedHeader::default();
@@ -149,7 +149,7 @@ impl Stream for TestDownload {
                     hash: empty.hash(),
                     number: empty.number,
                     error: Box::new(error),
-                })))
+                })));
             }
 
             match ready!(this.get_or_init_fut().poll_unpin(cx)) {
@@ -166,7 +166,7 @@ impl Stream for TestDownload {
                     return Poll::Ready(Some(Err(match err {
                         RequestError::Timeout => DownloadError::Timeout,
                         _ => DownloadError::RequestError(err),
-                    })))
+                    })));
                 }
             }
         }
@@ -231,7 +231,7 @@ impl HeadersClient for TestHeadersClient {
 
         Box::pin(async move {
             if let Some(err) = &mut *error.lock().await {
-                return Err(err.clone())
+                return Err(err.clone());
             }
 
             let mut lock = responses.lock().await;

--- a/crates/net/peers/src/lib.rs
+++ b/crates/net/peers/src/lib.rs
@@ -168,17 +168,17 @@ impl FromStr for AnyNode {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if let Some(rem) = s.strip_prefix("enode://") {
             if let Ok(record) = NodeRecord::from_str(s) {
-                return Ok(Self::NodeRecord(record))
+                return Ok(Self::NodeRecord(record));
             }
             // incomplete enode
             if let Ok(peer_id) = PeerId::from_str(rem) {
-                return Ok(Self::PeerId(peer_id))
+                return Ok(Self::PeerId(peer_id));
             }
-            return Err(format!("invalid public key: {rem}"))
+            return Err(format!("invalid public key: {rem}"));
         }
         #[cfg(feature = "secp256k1")]
         if s.starts_with("enr:") {
-            return Enr::from_str(s).map(AnyNode::Enr)
+            return Enr::from_str(s).map(AnyNode::Enr);
         }
         Err("missing 'enr:' prefix for base64-encoded record".to_string())
     }

--- a/crates/net/peers/src/node_record.rs
+++ b/crates/net/peers/src/node_record.rs
@@ -63,7 +63,7 @@ impl NodeRecord {
         if let IpAddr::V6(v6) = self.address {
             if let Some(v4) = v6.to_ipv4_mapped() {
                 self.address = v4.into();
-                return true
+                return true;
             }
         }
         false
@@ -203,15 +203,15 @@ impl TryFrom<&Enr<secp256k1::SecretKey>> for NodeRecord {
     fn try_from(enr: &Enr<secp256k1::SecretKey>) -> Result<Self, Self::Error> {
         let Some(address) = enr.ip4().map(IpAddr::from).or_else(|| enr.ip6().map(IpAddr::from))
         else {
-            return Err(NodeRecordParseError::InvalidUrl("ip missing".to_string()))
+            return Err(NodeRecordParseError::InvalidUrl("ip missing".to_string()));
         };
 
         let Some(udp_port) = enr.udp4().or_else(|| enr.udp6()) else {
-            return Err(NodeRecordParseError::InvalidUrl("udp port missing".to_string()))
+            return Err(NodeRecordParseError::InvalidUrl("udp port missing".to_string()));
         };
 
         let Some(tcp_port) = enr.tcp4().or_else(|| enr.tcp6()) else {
-            return Err(NodeRecordParseError::InvalidUrl("tcp port missing".to_string()))
+            return Err(NodeRecordParseError::InvalidUrl("tcp port missing".to_string()));
         };
 
         let id = crate::pk2id(&enr.public_key());

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -813,7 +813,7 @@ where
                     inconsistent_stage_checkpoint = stage_checkpoint,
                     "Pipeline sync progress is inconsistent"
                 );
-                return self.blockchain_db().block_hash(first_stage_checkpoint)
+                return self.blockchain_db().block_hash(first_stage_checkpoint);
             }
         }
 

--- a/crates/node/builder/src/launch/exex.rs
+++ b/crates/node/builder/src/launch/exex.rs
@@ -39,7 +39,7 @@ impl<Node: FullNodeComponents + Clone> ExExLauncher<Node> {
 
         if extensions.is_empty() {
             // nothing to launch
-            return None
+            return None;
         }
 
         let mut exex_handles = Vec::with_capacity(extensions.len());

--- a/crates/node/core/src/args/payload_builder.rs
+++ b/crates/node/core/src/args/payload_builder.rs
@@ -93,7 +93,7 @@ impl TypedValueParser for ExtradataValueParser {
                 format!(
                     "Payload builder extradata size exceeds {MAXIMUM_EXTRA_DATA_SIZE}-byte limit"
                 ),
-            ))
+            ));
         }
         Ok(val.to_string())
     }

--- a/crates/node/core/src/args/pruning.rs
+++ b/crates/node/core/src/args/pruning.rs
@@ -19,7 +19,7 @@ impl PruningArgs {
     /// Returns pruning configuration.
     pub fn prune_config(&self, chain_spec: &ChainSpec) -> Option<PruneConfig> {
         if !self.full {
-            return None
+            return None;
         }
 
         Some(PruneConfig {

--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -320,7 +320,7 @@ impl NodeConfig {
         // try to look up the header in the database
         if let Some(header) = header {
             info!(target: "reth::cli", ?tip, "Successfully looked up tip block in the database");
-            return Ok(header.number)
+            return Ok(header.number);
         }
 
         Ok(self.fetch_tip_from_network(client, tip.into()).await.number)
@@ -343,7 +343,7 @@ impl NodeConfig {
             match get_single_header(&client, tip).await {
                 Ok(tip_header) => {
                     info!(target: "reth::cli", ?tip, "Successfully fetched tip");
-                    return tip_header
+                    return tip_header;
                 }
                 Err(error) => {
                     fetch_failures += 1;

--- a/crates/node/events/src/cl.rs
+++ b/crates/node/events/src/cl.rs
@@ -52,14 +52,14 @@ impl Stream for ConsensusLayerHealthEvents {
             if let Some(fork_choice) = this.canon_chain.last_received_update_timestamp() {
                 if fork_choice.elapsed() <= NO_FORKCHOICE_UPDATE_RECEIVED_PERIOD {
                     // We had an FCU, and it's recent. CL is healthy.
-                    continue
+                    continue;
                 } else {
                     // We had an FCU, but it's too old.
                     return Poll::Ready(Some(
                         ConsensusLayerHealthEvent::HaveNotReceivedUpdatesForAWhile(
                             fork_choice.elapsed(),
                         ),
-                    ))
+                    ));
                 }
             }
 
@@ -74,11 +74,11 @@ impl Stream for ConsensusLayerHealthEvents {
                     Poll::Ready(Some(ConsensusLayerHealthEvent::HasNotBeenSeenForAWhile(
                         transition_config.elapsed(),
                     )))
-                }
+                };
             }
 
             // We never had both FCU and transition config exchange.
-            return Poll::Ready(Some(ConsensusLayerHealthEvent::NeverSeen))
+            return Poll::Ready(Some(ConsensusLayerHealthEvent::NeverSeen));
         }
     }
 }

--- a/crates/node/events/src/node.rs
+++ b/crates/node/events/src/node.rs
@@ -223,8 +223,8 @@ impl NodeState {
             BeaconConsensusEngineEvent::ForkchoiceUpdated(state, status) => {
                 let ForkchoiceState { head_block_hash, safe_block_hash, finalized_block_hash } =
                     state;
-                if self.safe_block_hash != Some(safe_block_hash) &&
-                    self.finalized_block_hash != Some(finalized_block_hash)
+                if self.safe_block_hash != Some(safe_block_hash)
+                    && self.finalized_block_hash != Some(finalized_block_hash)
                 {
                     let msg = match status {
                         ForkchoiceStatus::Valid => "Forkchoice updated",
@@ -577,7 +577,7 @@ impl Eta {
             else {
                 self.eta = None;
                 debug!(target: "reth::cli", %stage, ?current, ?self.last_checkpoint, "Failed to calculate the ETA: processed entities is less than the last checkpoint");
-                return
+                return;
             };
             let elapsed = last_checkpoint_time.elapsed();
             let per_second = processed_since_last as f64 / elapsed.as_secs_f64();
@@ -585,7 +585,7 @@ impl Eta {
             let Some(remaining) = current.total.checked_sub(current.processed) else {
                 self.eta = None;
                 debug!(target: "reth::cli", %stage, ?current, "Failed to calculate the ETA: total entities is less than processed entities");
-                return
+                return;
             };
 
             self.eta = Duration::try_from_secs_f64(remaining as f64 / per_second).ok();
@@ -606,8 +606,8 @@ impl Eta {
     /// It's not the case for network-dependent ([`StageId::Headers`] and [`StageId::Bodies`]) and
     /// [`StageId::Execution`] stages.
     fn fmt_for_stage(&self, stage: StageId) -> Option<String> {
-        if !self.is_available() ||
-            matches!(stage, StageId::Headers | StageId::Bodies | StageId::Execution)
+        if !self.is_available()
+            || matches!(stage, StageId::Headers | StageId::Bodies | StageId::Execution)
         {
             None
         } else {
@@ -626,7 +626,7 @@ impl Display for Eta {
                     f,
                     "{}",
                     humantime::format_duration(Duration::from_secs(remaining.as_secs()))
-                )
+                );
             }
         }
 

--- a/crates/node/metrics/src/hooks.rs
+++ b/crates/node/metrics/src/hooks.rs
@@ -53,7 +53,7 @@ fn collect_memory_stats() {
 
     if epoch::advance().map_err(|error| error!(%error, "Failed to advance jemalloc epoch")).is_err()
     {
-        return
+        return;
     }
 
     if let Ok(value) = stats::active::read()
@@ -104,13 +104,13 @@ fn collect_io_stats() {
     let Ok(process) = procfs::process::Process::myself()
         .map_err(|error| error!(%error, "Failed to get currently running process"))
     else {
-        return
+        return;
     };
 
     let Ok(io) = process.io().map_err(
         |error| error!(%error, "Failed to get IO stats for the currently running process"),
     ) else {
-        return
+        return;
     };
 
     counter!("io.rchar").absolute(io.rchar);

--- a/crates/payload/builder/src/events.rs
+++ b/crates/payload/builder/src/events.rs
@@ -69,14 +69,14 @@ impl<T: PayloadTypes + 'static> Stream for BuiltPayloadStream<T> {
                 Some(Ok(Events::BuiltPayload(payload))) => Poll::Ready(Some(payload)),
                 Some(Ok(Events::Attributes(_))) => {
                     // ignoring attributes
-                    continue
+                    continue;
                 }
                 Some(Err(err)) => {
                     debug!(%err, "payload event stream stream lagging behind");
-                    continue
+                    continue;
                 }
                 None => Poll::Ready(None),
-            }
+            };
         }
     }
 }
@@ -99,14 +99,14 @@ impl<T: PayloadTypes + 'static> Stream for PayloadAttributeStream<T> {
                 Some(Ok(Events::Attributes(attr))) => Poll::Ready(Some(attr)),
                 Some(Ok(Events::BuiltPayload(_))) => {
                     // ignoring payloads
-                    continue
+                    continue;
                 }
                 Some(Err(err)) => {
                     debug!(%err, "payload event stream stream lagging behind");
-                    continue
+                    continue;
                 }
                 None => Poll::Ready(None),
-            }
+            };
         }
     }
 }

--- a/crates/payload/builder/src/noop.rs
+++ b/crates/payload/builder/src/noop.rs
@@ -42,7 +42,7 @@ where
         let this = self.get_mut();
         loop {
             let Some(cmd) = ready!(this.command_rx.poll_next_unpin(cx)) else {
-                return Poll::Ready(())
+                return Poll::Ready(());
             };
             match cmd {
                 PayloadServiceCommand::BuildNewPayload(attr, tx) => {

--- a/crates/payload/primitives/src/lib.rs
+++ b/crates/payload/primitives/src/lib.rs
@@ -66,7 +66,7 @@ pub fn validate_payload_timestamp(
         //
         // 1. Client software **MUST** return `-38005: Unsupported fork` error if the `timestamp` of
         //    payload or payloadAttributes is greater or equal to the Cancun activation timestamp.
-        return Err(EngineObjectValidationError::UnsupportedFork)
+        return Err(EngineObjectValidationError::UnsupportedFork);
     }
 
     if version == EngineApiMessageVersion::V3 && !is_cancun {
@@ -88,7 +88,7 @@ pub fn validate_payload_timestamp(
         //
         // 2. Client software **MUST** return `-38005: Unsupported fork` error if the `timestamp` of
         //    the payload does not fall within the time frame of the Cancun fork.
-        return Err(EngineObjectValidationError::UnsupportedFork)
+        return Err(EngineObjectValidationError::UnsupportedFork);
     }
 
     let is_prague = chain_spec.is_prague_active_at_timestamp(timestamp);
@@ -111,7 +111,7 @@ pub fn validate_payload_timestamp(
         //
         // 2. Client software **MUST** return `-38005: Unsupported fork` error if the `timestamp` of
         //    the payload does not fall within the time frame of the Prague fork.
-        return Err(EngineObjectValidationError::UnsupportedFork)
+        return Err(EngineObjectValidationError::UnsupportedFork);
     }
     Ok(())
 }
@@ -132,17 +132,17 @@ pub fn validate_withdrawals_presence(
         EngineApiMessageVersion::V1 => {
             if has_withdrawals {
                 return Err(message_validation_kind
-                    .to_error(VersionSpecificValidationError::WithdrawalsNotSupportedInV1))
+                    .to_error(VersionSpecificValidationError::WithdrawalsNotSupportedInV1));
             }
         }
         EngineApiMessageVersion::V2 | EngineApiMessageVersion::V3 | EngineApiMessageVersion::V4 => {
             if is_shanghai_active && !has_withdrawals {
                 return Err(message_validation_kind
-                    .to_error(VersionSpecificValidationError::NoWithdrawalsPostShanghai))
+                    .to_error(VersionSpecificValidationError::NoWithdrawalsPostShanghai));
             }
             if !is_shanghai_active && has_withdrawals {
                 return Err(message_validation_kind
-                    .to_error(VersionSpecificValidationError::HasWithdrawalsPreShanghai))
+                    .to_error(VersionSpecificValidationError::HasWithdrawalsPreShanghai));
             }
         }
     };
@@ -233,13 +233,13 @@ pub fn validate_parent_beacon_block_root_presence(
             if has_parent_beacon_block_root {
                 return Err(validation_kind.to_error(
                     VersionSpecificValidationError::ParentBeaconBlockRootNotSupportedBeforeV3,
-                ))
+                ));
             }
         }
         EngineApiMessageVersion::V3 | EngineApiMessageVersion::V4 => {
             if !has_parent_beacon_block_root {
                 return Err(validation_kind
-                    .to_error(VersionSpecificValidationError::NoParentBeaconBlockRootPostCancun))
+                    .to_error(VersionSpecificValidationError::NoParentBeaconBlockRootPostCancun));
             }
         }
     };

--- a/crates/payload/validator/src/lib.rs
+++ b/crates/payload/validator/src/lib.rs
@@ -65,20 +65,20 @@ impl ExecutionPayloadValidator {
         if let Some(versioned_hashes) = cancun_fields.versioned_hashes() {
             if num_blob_versioned_hashes != versioned_hashes.len() {
                 // Number of blob versioned hashes does not match
-                return Err(PayloadError::InvalidVersionedHashes)
+                return Err(PayloadError::InvalidVersionedHashes);
             }
             // we can use `zip` safely here because we already compared their length
             for (payload_versioned_hash, block_versioned_hash) in
                 versioned_hashes.iter().zip(sealed_block.blob_versioned_hashes_iter())
             {
                 if payload_versioned_hash != block_versioned_hash {
-                    return Err(PayloadError::InvalidVersionedHashes)
+                    return Err(PayloadError::InvalidVersionedHashes);
                 }
             }
         } else {
             // No Cancun fields, if block includes any blobs, this is an error
             if num_blob_versioned_hashes > 0 {
-                return Err(PayloadError::InvalidVersionedHashes)
+                return Err(PayloadError::InvalidVersionedHashes);
             }
         }
 
@@ -124,51 +124,51 @@ impl ExecutionPayloadValidator {
             return Err(PayloadError::BlockHash {
                 execution: sealed_block.hash(),
                 consensus: expected_hash,
-            })
+            });
         }
 
         if self.is_cancun_active_at_timestamp(sealed_block.timestamp) {
             if sealed_block.header.blob_gas_used.is_none() {
                 // cancun active but blob gas used not present
-                return Err(PayloadError::PostCancunBlockWithoutBlobGasUsed)
+                return Err(PayloadError::PostCancunBlockWithoutBlobGasUsed);
             }
             if sealed_block.header.excess_blob_gas.is_none() {
                 // cancun active but excess blob gas not present
-                return Err(PayloadError::PostCancunBlockWithoutExcessBlobGas)
+                return Err(PayloadError::PostCancunBlockWithoutExcessBlobGas);
             }
             if cancun_fields.as_ref().is_none() {
                 // cancun active but cancun fields not present
-                return Err(PayloadError::PostCancunWithoutCancunFields)
+                return Err(PayloadError::PostCancunWithoutCancunFields);
             }
         } else {
             if sealed_block.has_blob_transactions() {
                 // cancun not active but blob transactions present
-                return Err(PayloadError::PreCancunBlockWithBlobTransactions)
+                return Err(PayloadError::PreCancunBlockWithBlobTransactions);
             }
             if sealed_block.header.blob_gas_used.is_some() {
                 // cancun not active but blob gas used present
-                return Err(PayloadError::PreCancunBlockWithBlobGasUsed)
+                return Err(PayloadError::PreCancunBlockWithBlobGasUsed);
             }
             if sealed_block.header.excess_blob_gas.is_some() {
                 // cancun not active but excess blob gas present
-                return Err(PayloadError::PreCancunBlockWithExcessBlobGas)
+                return Err(PayloadError::PreCancunBlockWithExcessBlobGas);
             }
             if cancun_fields.as_ref().is_some() {
                 // cancun not active but cancun fields present
-                return Err(PayloadError::PreCancunWithCancunFields)
+                return Err(PayloadError::PreCancunWithCancunFields);
             }
         }
 
         let shanghai_active = self.is_shanghai_active_at_timestamp(sealed_block.timestamp);
         if !shanghai_active && sealed_block.withdrawals.is_some() {
             // shanghai not active but withdrawals present
-            return Err(PayloadError::PreShanghaiBlockWithWitdrawals)
+            return Err(PayloadError::PreShanghaiBlockWithWitdrawals);
         }
 
-        if !self.is_prague_active_at_timestamp(sealed_block.timestamp) &&
-            sealed_block.has_eip7702_transactions()
+        if !self.is_prague_active_at_timestamp(sealed_block.timestamp)
+            && sealed_block.has_eip7702_transactions()
         {
-            return Err(PayloadError::PrePragueBlockWithEip7702Transactions)
+            return Err(PayloadError::PrePragueBlockWithEip7702Transactions);
         }
 
         // EIP-4844 checks

--- a/crates/primitives-traits/src/account.rs
+++ b/crates/primitives-traits/src/account.rs
@@ -30,9 +30,9 @@ impl Account {
     /// After `SpuriousDragon` empty account is defined as account with nonce == 0 && balance == 0
     /// && bytecode = None (or hash is [`KECCAK_EMPTY`]).
     pub fn is_empty(&self) -> bool {
-        self.nonce == 0 &&
-            self.balance.is_zero() &&
-            self.bytecode_hash.map_or(true, |hash| hash == KECCAK_EMPTY)
+        self.nonce == 0
+            && self.balance.is_zero()
+            && self.bytecode_hash.map_or(true, |hash| hash == KECCAK_EMPTY)
     }
 
     /// Returns an account bytecode's hash.

--- a/crates/primitives-traits/src/header/mod.rs
+++ b/crates/primitives-traits/src/header/mod.rs
@@ -218,9 +218,9 @@ impl Header {
 
     /// Checks if the header is empty - has no transactions and no ommers
     pub fn is_empty(&self) -> bool {
-        self.transaction_root_is_empty() &&
-            self.ommers_hash_is_empty() &&
-            self.withdrawals_root.map_or(true, |root| root == EMPTY_ROOT_HASH)
+        self.transaction_root_is_empty()
+            && self.ommers_hash_is_empty()
+            && self.withdrawals_root.map_or(true, |root| root == EMPTY_ROOT_HASH)
     }
 
     /// Check if the ommers hash equals to empty hash list.

--- a/crates/primitives-traits/src/withdrawal.rs
+++ b/crates/primitives-traits/src/withdrawal.rs
@@ -125,10 +125,10 @@ mod tests {
 
     impl PartialEq<Withdrawal> for RethWithdrawal {
         fn eq(&self, other: &Withdrawal) -> bool {
-            self.index == other.index &&
-                self.validator_index == other.validator_index &&
-                self.address == other.address &&
-                self.amount == other.amount
+            self.index == other.index
+                && self.validator_index == other.validator_index
+                && self.address == other.address
+                && self.amount == other.amount
         }
     }
 

--- a/crates/primitives/src/alloy_compat.rs
+++ b/crates/primitives/src/alloy_compat.rs
@@ -38,8 +38,8 @@ impl TryFrom<alloy_rpc_types::Block> for Block {
                         ))
                     })
                     .collect(),
-                alloy_rpc_types::BlockTransactions::Hashes(_) |
-                alloy_rpc_types::BlockTransactions::Uncle => {
+                alloy_rpc_types::BlockTransactions::Hashes(_)
+                | alloy_rpc_types::BlockTransactions::Uncle => {
                     // alloy deserializes empty blocks into `BlockTransactions::Hashes`, if the tx
                     // root is the empty root then we can just return an empty vec.
                     if block.header.transactions_root == EMPTY_TRANSACTIONS {
@@ -82,7 +82,7 @@ impl TryFrom<alloy_rpc_types::Transaction> for Transaction {
                     return Err(ConversionError::Eip2718Error(
                         RlpError::Custom("EIP-1559 fields are present in a legacy transaction")
                             .into(),
-                    ))
+                    ));
                 }
 
                 // extract the chain id if possible
@@ -98,7 +98,7 @@ impl TryFrom<alloy_rpc_types::Transaction> for Transaction {
                                 .map_err(|err| ConversionError::Eip2718Error(err.into()))?
                                 .1
                         } else {
-                            return Err(ConversionError::MissingChainId)
+                            return Err(ConversionError::MissingChainId);
                         }
                     }
                 };

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -419,7 +419,7 @@ impl SealedBlock {
             let Some(senders) =
                 TransactionSigned::recover_signers_unchecked(&self.body, self.body.len())
             else {
-                return Err(self)
+                return Err(self);
             };
             senders
         };
@@ -650,11 +650,12 @@ impl BlockBody {
     /// Calculates a heuristic for the in-memory size of the [`BlockBody`].
     #[inline]
     pub fn size(&self) -> usize {
-        self.transactions.iter().map(TransactionSigned::size).sum::<usize>() +
-            self.transactions.capacity() * core::mem::size_of::<TransactionSigned>() +
-            self.ommers.iter().map(Header::size).sum::<usize>() +
-            self.ommers.capacity() * core::mem::size_of::<Header>() +
-            self.withdrawals
+        self.transactions.iter().map(TransactionSigned::size).sum::<usize>()
+            + self.transactions.capacity() * core::mem::size_of::<TransactionSigned>()
+            + self.ommers.iter().map(Header::size).sum::<usize>()
+            + self.ommers.capacity() * core::mem::size_of::<Header>()
+            + self
+                .withdrawals
                 .as_ref()
                 .map_or(core::mem::size_of::<Option<Withdrawals>>(), Withdrawals::total_size)
     }

--- a/crates/primitives/src/botanix/peg_contract.rs
+++ b/crates/primitives/src/botanix/peg_contract.rs
@@ -127,10 +127,10 @@ impl PeginData {
                 .iter()
                 .rev()
                 .skip_while(|h| h.block_hash() != commit_hash)
-                .count() -
-                1; // minus one for the commitment itself
-                   // the latest block height minus the position of the user block in the list is the
-                   // height of the user block
+                .count()
+                - 1; // minus one for the commitment itself
+                     // the latest block height minus the position of the user block in the list is the
+                     // height of the user block
             if bitcoin_commitment.1 - (diff as u32) != self.bitcoin_block_height {
                 return Err(PeginDataError::InvalidBitcoinBlockHeight);
             }

--- a/crates/primitives/src/compression/mod.rs
+++ b/crates/primitives/src/compression/mod.rs
@@ -74,7 +74,7 @@ impl ReusableDecompressor {
                     reserved_upper_bound = true;
                     if let Some(upper_bound) = Decompressor::upper_bound(src) {
                         if let Some(additional) = upper_bound.checked_sub(self.buf.capacity()) {
-                            break 'b additional
+                            break 'b additional;
                         }
                     }
                 }

--- a/crates/primitives/src/header_ext.rs
+++ b/crates/primitives/src/header_ext.rs
@@ -119,14 +119,18 @@ impl HeaderExt for Header {
         let bitcoin_checkpoint_header = match bitcoind.get_block_header(&edh.bitcoin_block_hash) {
             Ok(header) => header,
             Err(e) => {
-                return Err(BotanixConsensusPackageError::FailedToRetrieveBitcoinCheckpointHeader(e))
+                return Err(BotanixConsensusPackageError::FailedToRetrieveBitcoinCheckpointHeader(
+                    e,
+                ))
             }
         };
 
         let bitcoin_checkpoint_height = match bitcoind.get_block_info(&edh.bitcoin_block_hash) {
             Ok(info) => info.height,
             Err(e) => {
-                return Err(BotanixConsensusPackageError::FailedToRetrieveBitcoinCheckpointHeight(e))
+                return Err(BotanixConsensusPackageError::FailedToRetrieveBitcoinCheckpointHeight(
+                    e,
+                ))
             }
         };
 

--- a/crates/primitives/src/proofs.rs
+++ b/crates/primitives/src/proofs.rs
@@ -55,7 +55,7 @@ pub fn calculate_receipt_root_no_memo(receipts: &[&Receipt]) -> B256 {
 pub fn calculate_ommers_root(ommers: &[Header]) -> B256 {
     // Check if `ommers` list is empty
     if ommers.is_empty() {
-        return EMPTY_OMMER_ROOT_HASH
+        return EMPTY_OMMER_ROOT_HASH;
     }
     // RLP Encode
     let mut ommers_rlp = Vec::new();

--- a/crates/primitives/src/receipt.rs
+++ b/crates/primitives/src/receipt.rs
@@ -205,7 +205,7 @@ impl ReceiptWithBloom {
         let b = &mut &**buf;
         let rlp_head = alloy_rlp::Header::decode(b)?;
         if !rlp_head.list {
-            return Err(alloy_rlp::Error::UnexpectedString)
+            return Err(alloy_rlp::Error::UnexpectedString);
         }
         let started_len = b.len();
 
@@ -222,7 +222,7 @@ impl ReceiptWithBloom {
             return Err(alloy_rlp::Error::ListLengthMismatch {
                 expected: rlp_head.payload_length,
                 got: consumed,
-            })
+            });
         }
         *buf = *b;
         Ok(this)
@@ -355,7 +355,7 @@ impl ReceiptWithBloomEncoder<'_> {
     fn encode_inner(&self, out: &mut dyn BufMut, with_header: bool) {
         if matches!(self.receipt.tx_type, TxType::Legacy) {
             self.encode_fields(out);
-            return
+            return;
         }
 
         let mut payload = Vec::new();

--- a/crates/primitives/src/transaction/eip1559.rs
+++ b/crates/primitives/src/transaction/eip1559.rs
@@ -128,15 +128,15 @@ impl TxEip1559 {
 
     /// Encodes only the transaction's fields into the desired buffer, without a RLP header.
     pub(crate) fn fields_len(&self) -> usize {
-        self.chain_id.length() +
-            self.nonce.length() +
-            self.max_priority_fee_per_gas.length() +
-            self.max_fee_per_gas.length() +
-            self.gas_limit.length() +
-            self.to.length() +
-            self.value.length() +
-            self.input.0.length() +
-            self.access_list.length()
+        self.chain_id.length()
+            + self.nonce.length()
+            + self.max_priority_fee_per_gas.length()
+            + self.max_fee_per_gas.length()
+            + self.gas_limit.length()
+            + self.to.length()
+            + self.value.length()
+            + self.input.0.length()
+            + self.access_list.length()
     }
 
     /// Encodes only the transaction's fields into the desired buffer, without a RLP header.

--- a/crates/primitives/src/transaction/eip2930.rs
+++ b/crates/primitives/src/transaction/eip2930.rs
@@ -108,14 +108,14 @@ impl TxEip2930 {
 
     /// Outputs the length of the transaction's fields, without a RLP header.
     pub(crate) fn fields_len(&self) -> usize {
-        self.chain_id.length() +
-            self.nonce.length() +
-            self.gas_price.length() +
-            self.gas_limit.length() +
-            self.to.length() +
-            self.value.length() +
-            self.input.0.length() +
-            self.access_list.length()
+        self.chain_id.length()
+            + self.nonce.length()
+            + self.gas_price.length()
+            + self.gas_limit.length()
+            + self.to.length()
+            + self.value.length()
+            + self.input.0.length()
+            + self.access_list.length()
     }
 
     /// Encodes only the transaction's fields into the desired buffer, without a RLP header.

--- a/crates/primitives/src/transaction/eip4844.rs
+++ b/crates/primitives/src/transaction/eip4844.rs
@@ -192,17 +192,17 @@ impl TxEip4844 {
 
     /// Outputs the length of the transaction's fields, without a RLP header.
     pub(crate) fn fields_len(&self) -> usize {
-        self.chain_id.length() +
-            self.nonce.length() +
-            self.gas_limit.length() +
-            self.max_fee_per_gas.length() +
-            self.max_priority_fee_per_gas.length() +
-            self.to.length() +
-            self.value.length() +
-            self.access_list.length() +
-            self.blob_versioned_hashes.length() +
-            self.max_fee_per_blob_gas.length() +
-            self.input.0.length()
+        self.chain_id.length()
+            + self.nonce.length()
+            + self.gas_limit.length()
+            + self.max_fee_per_gas.length()
+            + self.max_priority_fee_per_gas.length()
+            + self.to.length()
+            + self.value.length()
+            + self.access_list.length()
+            + self.blob_versioned_hashes.length()
+            + self.max_fee_per_blob_gas.length()
+            + self.input.0.length()
     }
 
     /// Encodes only the transaction's fields into the desired buffer, without a RLP header.

--- a/crates/primitives/src/transaction/eip7702.rs
+++ b/crates/primitives/src/transaction/eip7702.rs
@@ -146,16 +146,16 @@ impl TxEip7702 {
 
     /// Outputs the length of the transaction's fields, without a RLP header.
     pub(crate) fn fields_len(&self) -> usize {
-        self.chain_id.length() +
-            self.nonce.length() +
-            self.max_priority_fee_per_gas.length() +
-            self.max_fee_per_gas.length() +
-            self.gas_limit.length() +
-            self.to.length() +
-            self.value.length() +
-            self.input.0.length() +
-            self.access_list.length() +
-            self.authorization_list.length()
+        self.chain_id.length()
+            + self.nonce.length()
+            + self.max_priority_fee_per_gas.length()
+            + self.max_fee_per_gas.length()
+            + self.gas_limit.length()
+            + self.to.length()
+            + self.value.length()
+            + self.input.0.length()
+            + self.access_list.length()
+            + self.authorization_list.length()
     }
 
     /// Encodes only the transaction's fields into the desired buffer, without a RLP header.

--- a/crates/primitives/src/transaction/legacy.rs
+++ b/crates/primitives/src/transaction/legacy.rs
@@ -65,12 +65,12 @@ impl TxLegacy {
     /// Outputs the length of the transaction's fields, without a RLP header or length of the
     /// eip155 fields.
     pub(crate) fn fields_len(&self) -> usize {
-        self.nonce.length() +
-            self.gas_price.length() +
-            self.gas_limit.length() +
-            self.to.length() +
-            self.value.length() +
-            self.input.0.length()
+        self.nonce.length()
+            + self.gas_price.length()
+            + self.gas_limit.length()
+            + self.to.length()
+            + self.value.length()
+            + self.input.0.length()
     }
 
     /// Encodes only the transaction's fields into the desired buffer, without a RLP header or

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -148,10 +148,10 @@ impl Transaction {
     pub const fn chain_id(&self) -> Option<u64> {
         match self {
             Self::Legacy(TxLegacy { chain_id, .. }) => *chain_id,
-            Self::Eip2930(TxEip2930 { chain_id, .. }) |
-            Self::Eip1559(TxEip1559 { chain_id, .. }) |
-            Self::Eip4844(TxEip4844 { chain_id, .. }) |
-            Self::Eip7702(TxEip7702 { chain_id, .. }) => Some(*chain_id),
+            Self::Eip2930(TxEip2930 { chain_id, .. })
+            | Self::Eip1559(TxEip1559 { chain_id, .. })
+            | Self::Eip4844(TxEip4844 { chain_id, .. })
+            | Self::Eip7702(TxEip7702 { chain_id, .. }) => Some(*chain_id),
         }
     }
 
@@ -159,10 +159,10 @@ impl Transaction {
     pub fn set_chain_id(&mut self, chain_id: u64) {
         match self {
             Self::Legacy(TxLegacy { chain_id: ref mut c, .. }) => *c = Some(chain_id),
-            Self::Eip2930(TxEip2930 { chain_id: ref mut c, .. }) |
-            Self::Eip1559(TxEip1559 { chain_id: ref mut c, .. }) |
-            Self::Eip4844(TxEip4844 { chain_id: ref mut c, .. }) |
-            Self::Eip7702(TxEip7702 { chain_id: ref mut c, .. }) => *c = chain_id,
+            Self::Eip2930(TxEip2930 { chain_id: ref mut c, .. })
+            | Self::Eip1559(TxEip1559 { chain_id: ref mut c, .. })
+            | Self::Eip4844(TxEip4844 { chain_id: ref mut c, .. })
+            | Self::Eip7702(TxEip7702 { chain_id: ref mut c, .. }) => *c = chain_id,
         }
     }
 
@@ -170,10 +170,10 @@ impl Transaction {
     /// [`TxKind::Create`] if the transaction is a contract creation.
     pub const fn kind(&self) -> TxKind {
         match self {
-            Self::Legacy(TxLegacy { to, .. }) |
-            Self::Eip2930(TxEip2930 { to, .. }) |
-            Self::Eip1559(TxEip1559 { to, .. }) |
-            Self::Eip7702(TxEip7702 { to, .. }) => *to,
+            Self::Legacy(TxLegacy { to, .. })
+            | Self::Eip2930(TxEip2930 { to, .. })
+            | Self::Eip1559(TxEip1559 { to, .. })
+            | Self::Eip7702(TxEip7702 { to, .. }) => *to,
             Self::Eip4844(TxEip4844 { to, .. }) => TxKind::Call(*to),
         }
     }
@@ -200,22 +200,22 @@ impl Transaction {
     /// Gets the transaction's value field.
     pub const fn value(&self) -> U256 {
         *match self {
-            Self::Legacy(TxLegacy { value, .. }) |
-            Self::Eip2930(TxEip2930 { value, .. }) |
-            Self::Eip1559(TxEip1559 { value, .. }) |
-            Self::Eip4844(TxEip4844 { value, .. }) |
-            Self::Eip7702(TxEip7702 { value, .. }) => value,
+            Self::Legacy(TxLegacy { value, .. })
+            | Self::Eip2930(TxEip2930 { value, .. })
+            | Self::Eip1559(TxEip1559 { value, .. })
+            | Self::Eip4844(TxEip4844 { value, .. })
+            | Self::Eip7702(TxEip7702 { value, .. }) => value,
         }
     }
 
     /// Get the transaction's nonce.
     pub const fn nonce(&self) -> u64 {
         match self {
-            Self::Legacy(TxLegacy { nonce, .. }) |
-            Self::Eip2930(TxEip2930 { nonce, .. }) |
-            Self::Eip1559(TxEip1559 { nonce, .. }) |
-            Self::Eip4844(TxEip4844 { nonce, .. }) |
-            Self::Eip7702(TxEip7702 { nonce, .. }) => *nonce,
+            Self::Legacy(TxLegacy { nonce, .. })
+            | Self::Eip2930(TxEip2930 { nonce, .. })
+            | Self::Eip1559(TxEip1559 { nonce, .. })
+            | Self::Eip4844(TxEip4844 { nonce, .. })
+            | Self::Eip7702(TxEip7702 { nonce, .. }) => *nonce,
         }
     }
 
@@ -245,11 +245,11 @@ impl Transaction {
     /// Get the gas limit of the transaction.
     pub const fn gas_limit(&self) -> u64 {
         match self {
-            Self::Legacy(TxLegacy { gas_limit, .. }) |
-            Self::Eip2930(TxEip2930 { gas_limit, .. }) |
-            Self::Eip1559(TxEip1559 { gas_limit, .. }) |
-            Self::Eip4844(TxEip4844 { gas_limit, .. }) |
-            Self::Eip7702(TxEip7702 { gas_limit, .. }) => *gas_limit,
+            Self::Legacy(TxLegacy { gas_limit, .. })
+            | Self::Eip2930(TxEip2930 { gas_limit, .. })
+            | Self::Eip1559(TxEip1559 { gas_limit, .. })
+            | Self::Eip4844(TxEip4844 { gas_limit, .. })
+            | Self::Eip7702(TxEip7702 { gas_limit, .. }) => *gas_limit,
         }
     }
 
@@ -266,11 +266,11 @@ impl Transaction {
     /// This is also commonly referred to as the "Gas Fee Cap" (`GasFeeCap`).
     pub const fn max_fee_per_gas(&self) -> u128 {
         match self {
-            Self::Legacy(TxLegacy { gas_price, .. }) |
-            Self::Eip2930(TxEip2930 { gas_price, .. }) => *gas_price,
-            Self::Eip1559(TxEip1559 { max_fee_per_gas, .. }) |
-            Self::Eip4844(TxEip4844 { max_fee_per_gas, .. }) |
-            Self::Eip7702(TxEip7702 { max_fee_per_gas, .. }) => *max_fee_per_gas,
+            Self::Legacy(TxLegacy { gas_price, .. })
+            | Self::Eip2930(TxEip2930 { gas_price, .. }) => *gas_price,
+            Self::Eip1559(TxEip1559 { max_fee_per_gas, .. })
+            | Self::Eip4844(TxEip4844 { max_fee_per_gas, .. })
+            | Self::Eip7702(TxEip7702 { max_fee_per_gas, .. }) => *max_fee_per_gas,
         }
     }
 
@@ -281,9 +281,9 @@ impl Transaction {
     pub const fn max_priority_fee_per_gas(&self) -> Option<u128> {
         match self {
             Self::Legacy(_) | Self::Eip2930(_) => None,
-            Self::Eip1559(TxEip1559 { max_priority_fee_per_gas, .. }) |
-            Self::Eip4844(TxEip4844 { max_priority_fee_per_gas, .. }) |
-            Self::Eip7702(TxEip7702 { max_priority_fee_per_gas, .. }) => {
+            Self::Eip1559(TxEip1559 { max_priority_fee_per_gas, .. })
+            | Self::Eip4844(TxEip4844 { max_priority_fee_per_gas, .. })
+            | Self::Eip7702(TxEip7702 { max_priority_fee_per_gas, .. }) => {
                 Some(*max_priority_fee_per_gas)
             }
         }
@@ -332,11 +332,13 @@ impl Transaction {
     /// non-EIP-1559 transactions.
     pub const fn priority_fee_or_price(&self) -> u128 {
         match self {
-            Self::Legacy(TxLegacy { gas_price, .. }) |
-            Self::Eip2930(TxEip2930 { gas_price, .. }) => *gas_price,
-            Self::Eip1559(TxEip1559 { max_priority_fee_per_gas, .. }) |
-            Self::Eip4844(TxEip4844 { max_priority_fee_per_gas, .. }) |
-            Self::Eip7702(TxEip7702 { max_priority_fee_per_gas, .. }) => *max_priority_fee_per_gas,
+            Self::Legacy(TxLegacy { gas_price, .. })
+            | Self::Eip2930(TxEip2930 { gas_price, .. }) => *gas_price,
+            Self::Eip1559(TxEip1559 { max_priority_fee_per_gas, .. })
+            | Self::Eip4844(TxEip4844 { max_priority_fee_per_gas, .. })
+            | Self::Eip7702(TxEip7702 { max_priority_fee_per_gas, .. }) => {
+                *max_priority_fee_per_gas
+            }
         }
     }
 
@@ -388,11 +390,11 @@ impl Transaction {
     /// Get the transaction's input field.
     pub const fn input(&self) -> &Bytes {
         match self {
-            Self::Legacy(TxLegacy { input, .. }) |
-            Self::Eip2930(TxEip2930 { input, .. }) |
-            Self::Eip1559(TxEip1559 { input, .. }) |
-            Self::Eip4844(TxEip4844 { input, .. }) |
-            Self::Eip7702(TxEip7702 { input, .. }) => input,
+            Self::Legacy(TxLegacy { input, .. })
+            | Self::Eip2930(TxEip2930 { input, .. })
+            | Self::Eip1559(TxEip1559 { input, .. })
+            | Self::Eip4844(TxEip4844 { input, .. })
+            | Self::Eip7702(TxEip7702 { input, .. }) => input,
         }
     }
 
@@ -1199,7 +1201,7 @@ impl TransactionSigned {
     /// of bytes in input data.
     pub fn decode_enveloped(input_data: &mut &[u8]) -> alloy_rlp::Result<Self> {
         if input_data.is_empty() {
-            return Err(RlpError::InputTooShort)
+            return Err(RlpError::InputTooShort);
         }
 
         // Check if the tx is a list
@@ -1211,7 +1213,7 @@ impl TransactionSigned {
         };
 
         if !input_data.is_empty() {
-            return Err(RlpError::UnexpectedLength)
+            return Err(RlpError::UnexpectedLength);
         }
 
         Ok(output_data)
@@ -1290,7 +1292,7 @@ impl Decodable for TransactionSigned {
     /// string header if the first byte is less than `0xf7`.
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
         if buf.is_empty() {
-            return Err(RlpError::InputTooShort)
+            return Err(RlpError::InputTooShort);
         }
 
         // decode header

--- a/crates/primitives/src/transaction/pooled.rs
+++ b/crates/primitives/src/transaction/pooled.rs
@@ -121,10 +121,10 @@ impl PooledTransactionsElement {
     /// Reference to transaction hash. Used to identify transaction.
     pub const fn hash(&self) -> &TxHash {
         match self {
-            Self::Legacy { hash, .. } |
-            Self::Eip2930 { hash, .. } |
-            Self::Eip1559 { hash, .. } |
-            Self::Eip7702 { hash, .. } => hash,
+            Self::Legacy { hash, .. }
+            | Self::Eip2930 { hash, .. }
+            | Self::Eip1559 { hash, .. }
+            | Self::Eip7702 { hash, .. } => hash,
             Self::BlobTransaction(tx) => &tx.hash,
         }
     }
@@ -132,10 +132,10 @@ impl PooledTransactionsElement {
     /// Returns the signature of the transaction.
     pub const fn signature(&self) -> &Signature {
         match self {
-            Self::Legacy { signature, .. } |
-            Self::Eip2930 { signature, .. } |
-            Self::Eip1559 { signature, .. } |
-            Self::Eip7702 { signature, .. } => signature,
+            Self::Legacy { signature, .. }
+            | Self::Eip2930 { signature, .. }
+            | Self::Eip1559 { signature, .. }
+            | Self::Eip7702 { signature, .. } => signature,
             Self::BlobTransaction(blob_tx) => &blob_tx.signature,
         }
     }

--- a/crates/primitives/src/transaction/sidecar.rs
+++ b/crates/primitives/src/transaction/sidecar.rs
@@ -216,7 +216,7 @@ impl BlobTransaction {
         // decode the _first_ list header for the rest of the transaction
         let outer_header = Header::decode(data)?;
         if !outer_header.list {
-            return Err(RlpError::Custom("PooledTransactions blob tx must be encoded as a list"))
+            return Err(RlpError::Custom("PooledTransactions blob tx must be encoded as a list"));
         }
 
         let outer_remaining_len = data.len();
@@ -228,7 +228,7 @@ impl BlobTransaction {
         if !inner_header.list {
             return Err(RlpError::Custom(
                 "PooledTransactions inner blob tx must be encoded as a list",
-            ))
+            ));
         }
 
         let inner_remaining_len = data.len();
@@ -242,7 +242,7 @@ impl BlobTransaction {
         // the inner header only decodes the transaction and signature, so we check the length here
         let inner_consumed = inner_remaining_len - data.len();
         if inner_consumed != inner_header.payload_length {
-            return Err(RlpError::UnexpectedLength)
+            return Err(RlpError::UnexpectedLength);
         }
 
         // All that's left are the blobs, commitments, and proofs
@@ -271,7 +271,7 @@ impl BlobTransaction {
         // the outer header is for the entire transaction, so we check the length here
         let outer_consumed = outer_remaining_len - data.len();
         if outer_consumed != outer_header.payload_length {
-            return Err(RlpError::UnexpectedLength)
+            return Err(RlpError::UnexpectedLength);
         }
 
         Ok(Self { transaction, hash, signature, sidecar })
@@ -359,7 +359,7 @@ mod tests {
 
             // Ensure the entry is a file and not a directory
             if !file_path.is_file() || file_path.extension().unwrap_or_default() != "json" {
-                continue
+                continue;
             }
 
             // Read the contents of the JSON file into a string.

--- a/crates/primitives/src/transaction/signature.rs
+++ b/crates/primitives/src/transaction/signature.rs
@@ -144,7 +144,7 @@ impl Signature {
     /// If the S value is too large, then this will return `None`
     pub fn recover_signer(&self, hash: B256) -> Option<Address> {
         if self.s > SECP256K1N_HALF {
-            return None
+            return None;
         }
 
         self.recover_signer_unchecked(hash)
@@ -186,7 +186,7 @@ pub const fn extract_chain_id(v: u64) -> alloy_rlp::Result<(bool, Option<u64>)> 
     if v < 35 {
         // non-EIP-155 legacy scheme, v = 27 for even y-parity, v = 28 for odd y-parity
         if v != 27 && v != 28 {
-            return Err(RlpError::Custom("invalid Ethereum signature (V is not 27 or 28)"))
+            return Err(RlpError::Custom("invalid Ethereum signature (V is not 27 or 28)"));
         }
         Ok((v == 28, None))
     } else {

--- a/crates/primitives/src/transaction/tx_type.rs
+++ b/crates/primitives/src/transaction/tx_type.rs
@@ -89,15 +89,15 @@ impl TryFrom<u8> for TxType {
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         if value == Self::Legacy {
-            return Ok(Self::Legacy)
+            return Ok(Self::Legacy);
         } else if value == Self::Eip2930 {
-            return Ok(Self::Eip2930)
+            return Ok(Self::Eip2930);
         } else if value == Self::Eip1559 {
-            return Ok(Self::Eip1559)
+            return Ok(Self::Eip1559);
         } else if value == Self::Eip4844 {
-            return Ok(Self::Eip4844)
+            return Ok(Self::Eip4844);
         } else if value == Self::Eip7702 {
-            return Ok(Self::Eip7702)
+            return Ok(Self::Eip7702);
         }
 
         Err("invalid tx type")

--- a/crates/prune/prune/src/pruner.rs
+++ b/crates/prune/prune/src/pruner.rs
@@ -107,13 +107,13 @@ impl<DB: Database, S> Pruner<DB, S> {
         let Some(tip_block_number) =
             self.adjust_tip_block_number_to_finished_exex_height(tip_block_number)
         else {
-            return Ok(PruneProgress::Finished.into())
+            return Ok(PruneProgress::Finished.into());
         };
         if tip_block_number == 0 {
             self.previous_tip_block_number = Some(tip_block_number);
 
             debug!(target: "pruner", %tip_block_number, "Nothing to prune yet");
-            return Ok(PruneProgress::Finished.into())
+            return Ok(PruneProgress::Finished.into());
         }
 
         self.event_sender.notify(PrunerEvent::Started { tip_block_number });
@@ -175,7 +175,7 @@ impl<DB: Database, S> Pruner<DB, S> {
 
         for segment in &self.segments {
             if limiter.is_limit_reached() {
-                break
+                break;
             }
 
             if let Some((to_block, prune_mode)) = segment
@@ -250,14 +250,14 @@ impl<DB: Database, S> Pruner<DB, S> {
         let Some(tip_block_number) =
             self.adjust_tip_block_number_to_finished_exex_height(tip_block_number)
         else {
-            return false
+            return false;
         };
 
         // Saturating subtraction is needed for the case when the chain was reverted, meaning
         // current block number might be less than the previous tip block number.
         // If that's the case, no pruning is needed as outdated data is also reverted.
-        if tip_block_number.saturating_sub(self.previous_tip_block_number.unwrap_or_default()) >=
-            self.min_block_interval as u64
+        if tip_block_number.saturating_sub(self.previous_tip_block_number.unwrap_or_default())
+            >= self.min_block_interval as u64
         {
             debug!(
                 target: "pruner",

--- a/crates/prune/prune/src/segments/mod.rs
+++ b/crates/prune/prune/src/segments/mod.rs
@@ -101,7 +101,7 @@ impl PruneInput {
                     // Prevents a scenario where the pruner correctly starts at a finalized block,
                     // but the first transaction (tx_num = 0) only appears on an non-finalized one.
                     // Should only happen on a test/hive scenario.
-                    return Ok(None)
+                    return Ok(None);
                 }
                 last_tx
             }
@@ -110,7 +110,7 @@ impl PruneInput {
 
         let range = from_tx_number..=to_tx_number;
         if range.is_empty() {
-            return Ok(None)
+            return Ok(None);
         }
 
         Ok(Some(range))
@@ -128,7 +128,7 @@ impl PruneInput {
         let from_block = self.get_start_next_block_range();
         let range = from_block..=self.to_block;
         if range.is_empty() {
-            return None
+            return None;
         }
 
         Some(range)

--- a/crates/prune/prune/src/segments/receipts.rs
+++ b/crates/prune/prune/src/segments/receipts.rs
@@ -25,7 +25,7 @@ pub(crate) fn prune<DB: Database>(
         Some(range) => range,
         None => {
             trace!(target: "pruner", "No receipts to prune");
-            return Ok(SegmentOutput::done())
+            return Ok(SegmentOutput::done());
         }
     };
     let tx_range_end = *tx_range.end();
@@ -150,8 +150,8 @@ mod tests {
                 .map(|block| block.body.len())
                 .sum::<usize>()
                 .min(
-                    next_tx_number_to_prune as usize +
-                        input.limiter.deleted_entries_limit().unwrap(),
+                    next_tx_number_to_prune as usize
+                        + input.limiter.deleted_entries_limit().unwrap(),
                 )
                 .sub(1);
 

--- a/crates/prune/prune/src/segments/set.rs
+++ b/crates/prune/prune/src/segments/set.rs
@@ -29,7 +29,7 @@ impl<DB: Database> SegmentSet<DB> {
     /// Adds new [Segment] to collection if it's [Some].
     pub fn segment_opt<S: Segment<DB> + 'static>(self, segment: Option<S>) -> Self {
         if let Some(segment) = segment {
-            return self.segment(segment)
+            return self.segment(segment);
         }
         self
     }

--- a/crates/prune/prune/src/segments/static_file/headers.rs
+++ b/crates/prune/prune/src/segments/static_file/headers.rs
@@ -58,7 +58,7 @@ impl<DB: Database> Segment<DB> for Headers {
             Some(range) => (*range.start(), *range.end()),
             None => {
                 trace!(target: "pruner", "No headers to prune");
-                return Ok(SegmentOutput::done())
+                return Ok(SegmentOutput::done());
             }
         };
 
@@ -147,7 +147,7 @@ where
     type Item = Result<HeaderTablesIterItem, PrunerError>;
     fn next(&mut self) -> Option<Self::Item> {
         if self.limiter.is_limit_reached() {
-            return None
+            return None;
         }
 
         let mut pruned_block_headers = None;
@@ -160,7 +160,7 @@ where
             &mut |_| false,
             &mut |row| pruned_block_headers = Some(row.0),
         ) {
-            return Some(Err(err.into()))
+            return Some(Err(err.into()));
         }
 
         if let Err(err) = self.provider.prune_table_with_range_step(
@@ -169,7 +169,7 @@ where
             &mut |_| false,
             &mut |row| pruned_block_td = Some(row.0),
         ) {
-            return Some(Err(err.into()))
+            return Some(Err(err.into()));
         }
 
         if let Err(err) = self.provider.prune_table_with_range_step(
@@ -178,13 +178,13 @@ where
             &mut |_| false,
             &mut |row| pruned_block_canonical = Some(row.0),
         ) {
-            return Some(Err(err.into()))
+            return Some(Err(err.into()));
         }
 
         if ![pruned_block_headers, pruned_block_td, pruned_block_canonical].iter().all_equal() {
             return Some(Err(PrunerError::InconsistentData(
                 "All headers-related tables should be pruned up to the same height",
-            )))
+            )));
         }
 
         pruned_block_headers.map(move |block| {
@@ -278,8 +278,8 @@ mod tests {
             provider.commit().expect("commit");
 
             let last_pruned_block_number = to_block.min(
-                next_block_number_to_prune +
-                    (input.limiter.deleted_entries_limit().unwrap() / HEADER_TABLES_TO_PRUNE - 1)
+                next_block_number_to_prune
+                    + (input.limiter.deleted_entries_limit().unwrap() / HEADER_TABLES_TO_PRUNE - 1)
                         as u64,
             );
 

--- a/crates/prune/prune/src/segments/static_file/transactions.rs
+++ b/crates/prune/prune/src/segments/static_file/transactions.rs
@@ -46,7 +46,7 @@ impl<DB: Database> Segment<DB> for Transactions {
             Some(range) => range,
             None => {
                 trace!(target: "pruner", "No transactions to prune");
-                return Ok(SegmentOutput::done())
+                return Ok(SegmentOutput::done());
             }
         };
 
@@ -161,8 +161,8 @@ mod tests {
                 .map(|block| block.body.len())
                 .sum::<usize>()
                 .min(
-                    next_tx_number_to_prune as usize +
-                        input.limiter.deleted_entries_limit().unwrap(),
+                    next_tx_number_to_prune as usize
+                        + input.limiter.deleted_entries_limit().unwrap(),
                 )
                 .sub(1);
 

--- a/crates/prune/prune/src/segments/user/account_history.rs
+++ b/crates/prune/prune/src/segments/user/account_history.rs
@@ -53,7 +53,7 @@ impl<DB: Database> Segment<DB> for AccountHistory {
             Some(range) => range,
             None => {
                 trace!(target: "pruner", "No account history to prune");
-                return Ok(SegmentOutput::done())
+                return Ok(SegmentOutput::done());
             }
         };
         let range_end = *range.end();
@@ -67,7 +67,7 @@ impl<DB: Database> Segment<DB> for AccountHistory {
             return Ok(SegmentOutput::not_done(
                 PruneInterruptReason::new(&limiter),
                 input.previous_checkpoint.map(SegmentOutputCheckpoint::from_prune_checkpoint),
-            ))
+            ));
         }
 
         let mut last_changeset_pruned_block = None;
@@ -231,8 +231,8 @@ mod tests {
                     .iter()
                     .enumerate()
                     .skip_while(|(i, (block_number, _))| {
-                        *i < deleted_entries_limit / ACCOUNT_HISTORY_TABLES_TO_PRUNE * run &&
-                            *block_number <= to_block as usize
+                        *i < deleted_entries_limit / ACCOUNT_HISTORY_TABLES_TO_PRUNE * run
+                            && *block_number <= to_block as usize
                     })
                     .next()
                     .map(|(i, _)| i)

--- a/crates/prune/prune/src/segments/user/history.rs
+++ b/crates/prune/prune/src/segments/user/history.rs
@@ -51,7 +51,7 @@ where
             let Some((key, block_nums)) =
                 shard.map(|(k, v)| Result::<_, DatabaseError>::Ok((k.key()?, v))).transpose()?
             else {
-                break
+                break;
             };
 
             if key_matches(&key, &sharded_key) {
@@ -62,7 +62,7 @@ where
                 }
             } else {
                 // If such shard doesn't exist, skip to the next sharded key
-                break 'shard
+                break 'shard;
             }
 
             shard = cursor.next()?;

--- a/crates/prune/prune/src/segments/user/receipts_by_logs.rs
+++ b/crates/prune/prune/src/segments/user/receipts_by_logs.rs
@@ -135,7 +135,7 @@ impl<DB: Database> Segment<DB> for ReceiptsByLogs {
                         ?block_range,
                         "No receipts to prune."
                     );
-                    continue
+                    continue;
                 }
             };
             let tx_range = from_tx_number..=tx_range_end;
@@ -147,10 +147,11 @@ impl<DB: Database> Segment<DB> for ReceiptsByLogs {
                 tx_range,
                 &mut limiter,
                 |(tx_num, receipt)| {
-                    let skip = num_addresses > 0 &&
-                        receipt.logs.iter().any(|log| {
-                            filtered_addresses[..num_addresses].contains(&&log.address)
-                        });
+                    let skip = num_addresses > 0
+                        && receipt
+                            .logs
+                            .iter()
+                            .any(|log| filtered_addresses[..num_addresses].contains(&&log.address));
 
                     if skip {
                         last_skipped_transaction = *tx_num;
@@ -182,7 +183,7 @@ impl<DB: Database> Segment<DB> for ReceiptsByLogs {
 
             if limiter.is_limit_reached() {
                 done &= end_block == to_block;
-                break
+                break;
             }
 
             from_tx_number = last_pruned_transaction + 1;
@@ -316,8 +317,8 @@ mod tests {
 
             assert_eq!(
                 db.table::<tables::Receipts>().unwrap().len(),
-                blocks.iter().map(|block| block.body.len()).sum::<usize>() -
-                    ((pruned_tx + 1) - unprunable) as usize
+                blocks.iter().map(|block| block.body.len()).sum::<usize>()
+                    - ((pruned_tx + 1) - unprunable) as usize
             );
 
             output.progress.is_finished()
@@ -334,8 +335,8 @@ mod tests {
             // Either we only find our contract, or the receipt is part of the unprunable receipts
             // set by tip - 128
             assert!(
-                receipt.logs.iter().any(|l| l.address == deposit_contract_addr) ||
-                    provider.transaction_block(tx_num).unwrap().unwrap() > tip - 128,
+                receipt.logs.iter().any(|l| l.address == deposit_contract_addr)
+                    || provider.transaction_block(tx_num).unwrap().unwrap() > tip - 128,
             );
         }
     }

--- a/crates/prune/prune/src/segments/user/sender_recovery.rs
+++ b/crates/prune/prune/src/segments/user/sender_recovery.rs
@@ -44,7 +44,7 @@ impl<DB: Database> Segment<DB> for SenderRecovery {
             Some(range) => range,
             None => {
                 trace!(target: "pruner", "No transaction senders to prune");
-                return Ok(SegmentOutput::done())
+                return Ok(SegmentOutput::done());
             }
         };
         let tx_range_end = *tx_range.end();
@@ -156,8 +156,8 @@ mod tests {
                 .map(|block| block.body.len())
                 .sum::<usize>()
                 .min(
-                    next_tx_number_to_prune as usize +
-                        input.limiter.deleted_entries_limit().unwrap(),
+                    next_tx_number_to_prune as usize
+                        + input.limiter.deleted_entries_limit().unwrap(),
                 )
                 .sub(1);
 

--- a/crates/prune/prune/src/segments/user/storage_history.rs
+++ b/crates/prune/prune/src/segments/user/storage_history.rs
@@ -56,7 +56,7 @@ impl<DB: Database> Segment<DB> for StorageHistory {
             Some(range) => range,
             None => {
                 trace!(target: "pruner", "No storage history to prune");
-                return Ok(SegmentOutput::done())
+                return Ok(SegmentOutput::done());
             }
         };
         let range_end = *range.end();
@@ -70,7 +70,7 @@ impl<DB: Database> Segment<DB> for StorageHistory {
             return Ok(SegmentOutput::not_done(
                 PruneInterruptReason::new(&limiter),
                 input.previous_checkpoint.map(SegmentOutputCheckpoint::from_prune_checkpoint),
-            ))
+            ));
         }
 
         let mut last_changeset_pruned_block = None;
@@ -240,8 +240,8 @@ mod tests {
                 .iter()
                 .enumerate()
                 .skip_while(|(i, (block_number, _, _))| {
-                    *i < deleted_entries_limit / STORAGE_HISTORY_TABLES_TO_PRUNE * run &&
-                        *block_number <= to_block as usize
+                    *i < deleted_entries_limit / STORAGE_HISTORY_TABLES_TO_PRUNE * run
+                        && *block_number <= to_block as usize
                 })
                 .next()
                 .map(|(i, _)| i)

--- a/crates/prune/prune/src/segments/user/transaction_lookup.rs
+++ b/crates/prune/prune/src/segments/user/transaction_lookup.rs
@@ -45,12 +45,12 @@ impl<DB: Database> Segment<DB> for TransactionLookup {
             Some(range) => range,
             None => {
                 trace!(target: "pruner", "No transaction lookup entries to prune");
-                return Ok(SegmentOutput::done())
+                return Ok(SegmentOutput::done());
             }
         }
         .into_inner();
-        let tx_range = start..=
-            Some(end)
+        let tx_range = start
+            ..=Some(end)
                 .min(input.limiter.deleted_entries_limit_left().map(|left| start + left as u64 - 1))
                 .unwrap();
         let tx_range_end = *tx_range.end();
@@ -67,7 +67,7 @@ impl<DB: Database> Segment<DB> for TransactionLookup {
         if hashes.len() != tx_count {
             return Err(PrunerError::InconsistentData(
                 "Unexpected number of transaction hashes retrieved by transaction number range",
-            ))
+            ));
         }
 
         let mut limiter = input.limiter;
@@ -181,8 +181,8 @@ mod tests {
                 .map(|block| block.body.len())
                 .sum::<usize>()
                 .min(
-                    next_tx_number_to_prune as usize +
-                        input.limiter.deleted_entries_limit().unwrap(),
+                    next_tx_number_to_prune as usize
+                        + input.limiter.deleted_entries_limit().unwrap(),
                 )
                 .sub(1);
 

--- a/crates/prune/types/src/lib.rs
+++ b/crates/prune/types/src/lib.rs
@@ -72,8 +72,8 @@ impl ReceiptsLogPruneConfig {
             let block = (pruned_block + 1).max(
                 mode.prune_target_block(tip, PruneSegment::ContractLogs, PrunePurpose::User)?
                     .map(|(block, _)| block)
-                    .unwrap_or_default() +
-                    1,
+                    .unwrap_or_default()
+                    + 1,
             );
 
             map.entry(block).or_insert_with(Vec::new).push(address)

--- a/crates/prune/types/src/mode.rs
+++ b/crates/prune/types/src/mode.rs
@@ -55,7 +55,7 @@ impl PruneMode {
             Self::Full => true,
             Self::Distance(distance) => {
                 if *distance > tip {
-                    return false
+                    return false;
                 }
                 block < tip - *distance
             }

--- a/crates/revm/src/batch.rs
+++ b/crates/revm/src/batch.rs
@@ -102,8 +102,8 @@ impl BlockBatchRecord {
             !self
                 .prune_modes
                 .account_history
-                .is_some_and(|mode| mode.should_prune(block_number, tip)) &&
-                !self
+                .is_some_and(|mode| mode.should_prune(block_number, tip))
+                && !self
                     .prune_modes
                     .storage_history
                     .is_some_and(|mode| mode.should_prune(block_number, tip))
@@ -139,7 +139,7 @@ impl BlockBatchRecord {
             self.prune_modes.receipts.is_some_and(|mode| mode.should_prune(block_number, tip))
         {
             receipts.clear();
-            return Ok(())
+            return Ok(());
         }
 
         // All receipts from the last 128 blocks are required for blockchain tree, even with
@@ -147,7 +147,7 @@ impl BlockBatchRecord {
         let prunable_receipts =
             PruneMode::Distance(MINIMUM_PRUNING_DISTANCE).should_prune(block_number, tip);
         if !prunable_receipts {
-            return Ok(())
+            return Ok(());
         }
 
         let contract_log_pruner = self.prune_modes.receipts_log_filter.group_by_block(tip, None)?;

--- a/crates/revm/src/state_change.rs
+++ b/crates/revm/src/state_change.rs
@@ -50,10 +50,10 @@ pub fn post_block_balance_increments(
     let fees = total_block_fees.unwrap_or(0);
     let block_fee_recipient = block_fee_recipient_address.unwrap_or(Address::ZERO);
 
-    if fees > 0 &&
-        block_fee_recipient != Address::ZERO &&
-        chain_spec.botanix_fee_recipient.is_some() &&
-        chain_spec.lst_fee_receiver.is_some()
+    if fees > 0
+        && block_fee_recipient != Address::ZERO
+        && chain_spec.botanix_fee_recipient.is_some()
+        && chain_spec.lst_fee_receiver.is_some()
     {
         let (lst_fee_receiver_fees, botanix_fees, block_fee_recipient_fees) =
             utils::block_fees_split(fees);

--- a/crates/rpc/ipc/src/server/connection.rs
+++ b/crates/rpc/ipc/src/server/connection.rs
@@ -102,7 +102,7 @@ where
             if budget == 0 {
                 // make sure we're woken up again
                 cx.waker().wake_by_ref();
-                return Poll::Pending
+                return Poll::Pending;
             }
 
             // write all responses to the sink
@@ -110,10 +110,10 @@ where
                 if let Some(item) = this.items.pop_front() {
                     if let Err(err) = this.conn.as_mut().start_send(item) {
                         tracing::warn!("IPC response failed: {:?}", err);
-                        return Poll::Ready(())
+                        return Poll::Ready(());
                     }
                 } else {
-                    break
+                    break;
                 }
             }
 
@@ -128,7 +128,7 @@ where
                             Err(err) => err.into().to_string(),
                         };
                         this.items.push_back(item);
-                        continue 'outer
+                        continue 'outer;
                     } else {
                         drained = true;
                     }
@@ -147,7 +147,7 @@ where
                                         Err(err) => err.into().to_string(),
                                     };
                                     this.items.push_back(item);
-                                    continue 'outer
+                                    continue 'outer;
                                 }
                                 Poll::Pending => {
                                     this.pending_calls.push(call);
@@ -157,14 +157,14 @@ where
                         Some(Err(err)) => {
                             // this can happen if the client closes the connection
                             tracing::debug!("IPC request failed: {:?}", err);
-                            return Poll::Ready(())
+                            return Poll::Ready(());
                         }
                         None => return Poll::Ready(()),
                     },
                     Poll::Pending => {
                         if drained || this.pending_calls.is_empty() {
                             // at this point all things are pending
-                            return Poll::Pending
+                            return Poll::Pending;
                         }
                     }
                 }

--- a/crates/rpc/ipc/src/server/ipc.rs
+++ b/crates/rpc/ipc/src/server/ipc.rs
@@ -70,7 +70,7 @@ where
 
         while let Some(response) = pending_calls.next().await {
             if let Err(too_large) = batch_response.append(&response) {
-                return Some(too_large.to_result())
+                return Some(too_large.to_result());
             }
         }
 
@@ -151,7 +151,7 @@ where
         return Some(batch_response_error(
             Id::Null,
             reject_too_big_request(max_request_body_size as u32),
-        ))
+        ));
     }
 
     // Single request or notification

--- a/crates/rpc/ipc/src/stream_codec.rs
+++ b/crates/rpc/ipc/src/stream_codec.rs
@@ -117,7 +117,7 @@ impl tokio_util::codec::Decoder for StreamCodec {
                     return match String::from_utf8(bts.into()) {
                         Ok(val) => Ok(Some(val)),
                         Err(_) => Ok(None),
-                    }
+                    };
                 }
             }
             Ok(None)

--- a/crates/rpc/rpc-builder/src/cors.rs
+++ b/crates/rpc/rpc-builder/src/cors.rs
@@ -31,7 +31,7 @@ pub(crate) fn create_cors_layer(http_cors_domains: &str) -> Result<CorsLayer, Co
             if iter.clone().any(|o| o == "*") {
                 return Err(CorsDomainError::WildCardNotAllowed {
                     input: http_cors_domains.to_string(),
-                })
+                });
             }
 
             let origins = iter

--- a/crates/rpc/rpc-builder/src/error.rs
+++ b/crates/rpc/rpc-builder/src/error.rs
@@ -79,7 +79,7 @@ impl RpcError {
     /// Converts an [`io::Error`] to a more descriptive `RpcError`.
     pub fn server_error(io_error: io::Error, kind: ServerKind) -> Self {
         if io_error.kind() == ErrorKind::AddrInUse {
-            return Self::AddressAlreadyInUse { kind, error: io_error }
+            return Self::AddressAlreadyInUse { kind, error: io_error };
         }
         Self::ServerError { kind, error: io_error }
     }

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -1243,9 +1243,9 @@ impl<RpcMiddleware> RpcServerConfig<RpcMiddleware> {
     ///
     /// If no server is configured, no server will be launched on [`RpcServerConfig::start`].
     pub const fn has_server(&self) -> bool {
-        self.http_server_config.is_some() ||
-            self.ws_server_config.is_some() ||
-            self.ipc_server_config.is_some()
+        self.http_server_config.is_some()
+            || self.ws_server_config.is_some()
+            || self.ipc_server_config.is_some()
     }
 
     /// Returns the [`SocketAddr`] of the http server
@@ -1310,9 +1310,9 @@ impl<RpcMiddleware> RpcServerConfig<RpcMiddleware> {
         }
 
         // If both are configured on the same port, we combine them into one server.
-        if self.http_addr == self.ws_addr &&
-            self.http_server_config.is_some() &&
-            self.ws_server_config.is_some()
+        if self.http_addr == self.ws_addr
+            && self.http_server_config.is_some()
+            && self.ws_server_config.is_some()
         {
             let cors = match (self.ws_cors_domains.as_ref(), self.http_cors_domains.as_ref()) {
                 (Some(ws_cors), Some(http_cors)) => {
@@ -1676,8 +1676,8 @@ impl RpcServerHandle {
                 "Bearer {}",
                 secret
                     .encode(&Claims {
-                        iat: (SystemTime::now().duration_since(UNIX_EPOCH).unwrap() +
-                            Duration::from_secs(60))
+                        iat: (SystemTime::now().duration_since(UNIX_EPOCH).unwrap()
+                            + Duration::from_secs(60))
                         .as_secs(),
                         exp: None,
                     })

--- a/crates/rpc/rpc-builder/tests/it/http.rs
+++ b/crates/rpc/rpc-builder/tests/it/http.rs
@@ -31,8 +31,8 @@ use std::collections::HashSet;
 fn is_unimplemented(err: jsonrpsee::core::client::Error) -> bool {
     match err {
         jsonrpsee::core::client::Error::Call(error_obj) => {
-            error_obj.code() == ErrorCode::InternalError.code() &&
-                error_obj.message() == "unimplemented"
+            error_obj.code() == ErrorCode::InternalError.code()
+                && error_obj.message() == "unimplemented"
         }
         _ => false,
     }

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -476,7 +476,7 @@ where
     {
         let len = hashes.len() as u64;
         if len > MAX_PAYLOAD_BODIES_LIMIT {
-            return Err(EngineApiError::PayloadRequestTooLarge { len })
+            return Err(EngineApiError::PayloadRequestTooLarge { len });
         }
 
         let mut result = Vec::with_capacity(hashes.len());
@@ -534,7 +534,7 @@ where
             return Err(EngineApiError::TerminalTD {
                 execution: merge_terminal_td,
                 consensus: terminal_total_difficulty,
-            })
+            });
         }
 
         self.inner.beacon_consensus.transition_configuration_exchanged();
@@ -544,7 +544,7 @@ where
             return Ok(TransitionConfiguration {
                 terminal_total_difficulty: merge_terminal_td,
                 ..Default::default()
-            })
+            });
         }
 
         // Attempt to look up terminal block hash
@@ -609,9 +609,9 @@ where
                 // TODO: decide if we want this branch - the FCU INVALID response might be more
                 // useful than the payload attributes INVALID response
                 if fcu_res.is_invalid() {
-                    return Ok(fcu_res)
+                    return Ok(fcu_res);
                 }
-                return Err(err.into())
+                return Err(err.into());
             }
         }
 
@@ -1083,8 +1083,8 @@ mod tests {
                 blocks
                     .iter()
                     .filter(|b| {
-                        !first_missing_range.contains(&b.number) &&
-                            !second_missing_range.contains(&b.number)
+                        !first_missing_range.contains(&b.number)
+                            && !second_missing_range.contains(&b.number)
                     })
                     .map(|b| (b.hash(), b.clone().unseal())),
             );
@@ -1113,8 +1113,8 @@ mod tests {
                 // ensure we still return trailing `None`s here because by-hash will not be aware
                 // of the missing block's number, and cannot compare it to the current best block
                 .map(|b| {
-                    if first_missing_range.contains(&b.number) ||
-                        second_missing_range.contains(&b.number)
+                    if first_missing_range.contains(&b.number)
+                        || second_missing_range.contains(&b.number)
                     {
                         None
                     } else {
@@ -1144,8 +1144,8 @@ mod tests {
                     .chain_spec
                     .fork(EthereumHardfork::Paris)
                     .ttd()
-                    .unwrap() +
-                    U256::from(1),
+                    .unwrap()
+                    + U256::from(1),
                 ..Default::default()
             };
 

--- a/crates/rpc/rpc-engine-api/src/error.rs
+++ b/crates/rpc/rpc-engine-api/src/error.rs
@@ -116,11 +116,11 @@ impl ErrorData {
 impl From<EngineApiError> for jsonrpsee_types::error::ErrorObject<'static> {
     fn from(error: EngineApiError) -> Self {
         match error {
-            EngineApiError::InvalidBodiesRange { .. } |
-            EngineApiError::EngineObjectValidationError(EngineObjectValidationError::Payload(
+            EngineApiError::InvalidBodiesRange { .. }
+            | EngineApiError::EngineObjectValidationError(EngineObjectValidationError::Payload(
                 _,
-            )) |
-            EngineApiError::EngineObjectValidationError(
+            ))
+            | EngineApiError::EngineObjectValidationError(
                 EngineObjectValidationError::InvalidParams(_),
             ) => {
                 // Note: the data field is not required by the spec, but is also included by other
@@ -164,8 +164,8 @@ impl From<EngineApiError> for jsonrpsee_types::error::ErrorObject<'static> {
             // Error responses from the consensus engine
             EngineApiError::ForkChoiceUpdate(ref err) => match err {
                 BeaconForkChoiceUpdateError::ForkchoiceUpdateError(err) => (*err).into(),
-                BeaconForkChoiceUpdateError::EngineUnavailable |
-                BeaconForkChoiceUpdateError::Internal(_) => {
+                BeaconForkChoiceUpdateError::EngineUnavailable
+                | BeaconForkChoiceUpdateError::Internal(_) => {
                     jsonrpsee_types::error::ErrorObject::owned(
                         INTERNAL_ERROR_CODE,
                         SERVER_ERROR_MSG,
@@ -174,11 +174,11 @@ impl From<EngineApiError> for jsonrpsee_types::error::ErrorObject<'static> {
                 }
             },
             // Any other server error
-            EngineApiError::TerminalTD { .. } |
-            EngineApiError::TerminalBlockHash { .. } |
-            EngineApiError::NewPayload(_) |
-            EngineApiError::Internal(_) |
-            EngineApiError::GetPayloadError(_) => jsonrpsee_types::error::ErrorObject::owned(
+            EngineApiError::TerminalTD { .. }
+            | EngineApiError::TerminalBlockHash { .. }
+            | EngineApiError::NewPayload(_)
+            | EngineApiError::Internal(_)
+            | EngineApiError::GetPayloadError(_) => jsonrpsee_types::error::ErrorObject::owned(
                 INTERNAL_ERROR_CODE,
                 SERVER_ERROR_MSG,
                 Some(ErrorData::new(error)),

--- a/crates/rpc/rpc-eth-api/src/helpers/block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/block.rs
@@ -75,7 +75,7 @@ pub trait EthBlocks: LoadBlock {
                 return Ok(LoadBlock::provider(self)
                     .pending_block()
                     .map_err(Self::Error::from_eth_err)?
-                    .map(|block| block.body.len()))
+                    .map(|block| block.body.len()));
             }
 
             let block_hash = match LoadBlock::provider(self)
@@ -135,7 +135,7 @@ pub trait EthBlocks: LoadBlock {
                             .map_err(Self::Error::from_eth_err)
                     })
                     .collect::<Result<Vec<_>, Self::Error>>();
-                return receipts.map(Some)
+                return receipts.map(Some);
             }
 
             Ok(None)
@@ -155,7 +155,7 @@ pub trait EthBlocks: LoadBlock {
                 return Ok(LoadBlock::provider(self)
                     .pending_block_and_receipts()
                     .map_err(Self::Error::from_eth_err)?
-                    .map(|(sb, receipts)| (sb, Arc::new(receipts))))
+                    .map(|(sb, receipts)| (sb, Arc::new(receipts))));
             }
 
             if let Some(block_hash) = LoadBlock::provider(self)
@@ -165,7 +165,7 @@ pub trait EthBlocks: LoadBlock {
                 return LoadReceipt::cache(self)
                     .get_block_and_receipts(block_hash)
                     .await
-                    .map_err(Self::Error::from_eth_err)
+                    .map_err(Self::Error::from_eth_err);
             }
 
             Ok(None)
@@ -250,7 +250,7 @@ pub trait LoadBlock: LoadPendingBlock + SpawnBlocking {
                     Ok(maybe_pending)
                 } else {
                     self.local_pending_block().await
-                }
+                };
             }
 
             let block_hash = match LoadPendingBlock::provider(self)

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -93,7 +93,7 @@ pub trait EthCall: Call + LoadPendingBlock {
             if transactions.is_empty() {
                 return Err(
                     EthApiError::InvalidParams(String::from("transactions are empty.")).into()
-                )
+                );
             }
 
             let StateContext { transaction_index, block_number } =
@@ -264,11 +264,11 @@ pub trait EthCall: Call + LoadPendingBlock {
             ExecutionResult::Halt { reason, gas_used } => {
                 let error =
                     Some(RpcInvalidTransactionError::halt(reason, env.tx.gas_limit).to_string());
-                return Ok(AccessListResult { access_list, gas_used: U256::from(gas_used), error })
+                return Ok(AccessListResult { access_list, gas_used: U256::from(gas_used), error });
             }
             ExecutionResult::Revert { output, gas_used } => {
                 let error = Some(RevertError::new(output).to_string());
-                return Ok(AccessListResult { access_list, gas_used: U256::from(gas_used), error })
+                return Ok(AccessListResult { access_list, gas_used: U256::from(gas_used), error });
             }
             ExecutionResult::Success { .. } => {}
         };
@@ -483,7 +483,7 @@ pub trait Call: LoadState + SpawnBlocking {
         for tx in transactions {
             if tx.hash() == target_tx_hash {
                 // reached the target transaction
-                break
+                break;
             }
 
             let sender = tx.signer();
@@ -584,7 +584,7 @@ pub trait Call: LoadState + SpawnBlocking {
                         env.tx.gas_limit = MIN_TRANSACTION_GAS;
                         if let Ok((res, _)) = self.transact(&mut db, env) {
                             if res.result.is_success() {
-                                return Ok(U256::from(MIN_TRANSACTION_GAS))
+                                return Ok(U256::from(MIN_TRANSACTION_GAS));
                             }
                         }
                     }
@@ -617,8 +617,8 @@ pub trait Call: LoadState + SpawnBlocking {
             // with the block's gas limit to determine if the failure was due to
             // insufficient gas.
             Err(err)
-                if err.is_gas_too_high() &&
-                    (tx_request_gas_limit.is_some() || tx_request_gas_price.is_some()) =>
+                if err.is_gas_too_high()
+                    && (tx_request_gas_limit.is_some() || tx_request_gas_price.is_some()) =>
             {
                 return Err(self.map_out_of_gas_err(block_env_gas_limit, env, &mut db))
             }
@@ -631,7 +631,7 @@ pub trait Call: LoadState + SpawnBlocking {
             ExecutionResult::Halt { reason, gas_used } => {
                 // here we don't check for invalid opcode because already executed with highest gas
                 // limit
-                return Err(RpcInvalidTransactionError::halt(reason, gas_used).into_eth_err())
+                return Err(RpcInvalidTransactionError::halt(reason, gas_used).into_eth_err());
             }
             ExecutionResult::Revert { output, .. } => {
                 // if price or limit was included in the request then we can execute the request
@@ -641,7 +641,7 @@ pub trait Call: LoadState + SpawnBlocking {
                 } else {
                     // the transaction did revert
                     Err(RpcInvalidTransactionError::Revert(RevertError::new(output)).into_eth_err())
-                }
+                };
             }
         };
 
@@ -696,10 +696,10 @@ pub trait Call: LoadState + SpawnBlocking {
             // An estimation error is allowed once the current gas limit range used in the binary
             // search is small enough (less than 1.5% of the highest gas limit)
             // <https://github.com/ethereum/go-ethereum/blob/a5a4fa7032bb248f5a7c40f4e8df2b131c4186a4/eth/gasestimator/gasestimator.go#L152
-            if (highest_gas_limit - lowest_gas_limit) as f64 / (highest_gas_limit as f64) <
-                ESTIMATE_GAS_ERROR_RATIO
+            if (highest_gas_limit - lowest_gas_limit) as f64 / (highest_gas_limit as f64)
+                < ESTIMATE_GAS_ERROR_RATIO
             {
-                break
+                break;
             };
 
             env.tx.gas_limit = mid_gas_limit;
@@ -771,7 +771,7 @@ pub trait Call: LoadState + SpawnBlocking {
                         // These cases should be unreachable because we know the transaction
                         // succeeds, but if they occur, treat them as an
                         // error.
-                        return Err(RpcInvalidTransactionError::EvmHalt(err).into_eth_err())
+                        return Err(RpcInvalidTransactionError::EvmHalt(err).into_eth_err());
                     }
                 }
             }
@@ -825,7 +825,7 @@ pub trait Call: LoadState + SpawnBlocking {
     ) -> Result<TxEnv, Self::Error> {
         // Ensure that if versioned hashes are set, they're not empty
         if request.blob_versioned_hashes.as_ref().is_some_and(|hashes| hashes.is_empty()) {
-            return Err(RpcInvalidTransactionError::BlobTransactionMissingBlobHashes.into_eth_err())
+            return Err(RpcInvalidTransactionError::BlobTransactionMissingBlobHashes.into_eth_err());
         }
 
         let TransactionRequest {

--- a/crates/rpc/rpc-eth-api/src/helpers/error.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/error.rs
@@ -54,7 +54,7 @@ pub trait AsEthApiError {
     /// [`RpcInvalidTransactionError::GasTooHigh`](reth_rpc_eth_types::RpcInvalidTransactionError::GasTooHigh).
     fn is_gas_too_high(&self) -> bool {
         if let Some(err) = self.as_err() {
-            return err.is_gas_too_high()
+            return err.is_gas_too_high();
         }
 
         false

--- a/crates/rpc/rpc-eth-api/src/helpers/fee.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/fee.rs
@@ -56,7 +56,7 @@ pub trait EthFees: LoadFee {
     ) -> impl Future<Output = Result<FeeHistory, Self::Error>> + Send {
         async move {
             if block_count == 0 {
-                return Ok(FeeHistory::default())
+                return Ok(FeeHistory::default());
             }
 
             // See https://github.com/ethereum/go-ethereum/blob/2754b197c935ee63101cbbca2752338246384fec/eth/gasprice/feehistory.go#L218C8-L225
@@ -86,7 +86,7 @@ pub trait EthFees: LoadFee {
                 .block_number_for_id(newest_block.into())
                 .map_err(Self::Error::from_eth_err)?
             else {
-                return Err(EthApiError::UnknownBlockNumber.into())
+                return Err(EthApiError::UnknownBlockNumber.into());
             };
 
             // need to add 1 to the end block to get the correct (inclusive) range
@@ -102,7 +102,7 @@ pub trait EthFees: LoadFee {
             // Note: The types used ensure that the percentiles are never < 0
             if let Some(percentiles) = &reward_percentiles {
                 if percentiles.windows(2).any(|w| w[0] > w[1] || w[0] > 100.) {
-                    return Err(EthApiError::InvalidRewardPercentiles.into())
+                    return Err(EthApiError::InvalidRewardPercentiles.into());
                 }
             }
 
@@ -127,7 +127,7 @@ pub trait EthFees: LoadFee {
 
             if let Some(fee_entries) = fee_entries {
                 if fee_entries.len() != block_count as usize {
-                    return Err(EthApiError::InvalidBlockRange.into())
+                    return Err(EthApiError::InvalidBlockRange.into());
                 }
 
                 for entry in &fee_entries {
@@ -154,58 +154,64 @@ pub trait EthFees: LoadFee {
 
                 base_fee_per_blob_gas.push(last_entry.next_block_blob_fee().unwrap_or_default());
             } else {
-            // read the requested header range
-            let headers = LoadFee::provider(self).sealed_headers_range(start_block..=end_block).map_err(Self::Error::from_eth_err)?;
-            if headers.len() != block_count as usize {
-                return Err(EthApiError::InvalidBlockRange.into())
-            }
+                // read the requested header range
+                let headers = LoadFee::provider(self)
+                    .sealed_headers_range(start_block..=end_block)
+                    .map_err(Self::Error::from_eth_err)?;
+                if headers.len() != block_count as usize {
+                    return Err(EthApiError::InvalidBlockRange.into());
+                }
 
-            for header in &headers {
-                base_fee_per_gas.push(header.base_fee_per_gas.unwrap_or_default() as u128);
-                gas_used_ratio.push(header.gas_used as f64 / header.gas_limit as f64);
-                base_fee_per_blob_gas.push(header.blob_fee().unwrap_or_default());
-                blob_gas_used_ratio.push(
-                    header.blob_gas_used.unwrap_or_default() as f64 /
-                        reth_primitives::constants::eip4844::MAX_DATA_GAS_PER_BLOCK as f64,
+                for header in &headers {
+                    base_fee_per_gas.push(header.base_fee_per_gas.unwrap_or_default() as u128);
+                    gas_used_ratio.push(header.gas_used as f64 / header.gas_limit as f64);
+                    base_fee_per_blob_gas.push(header.blob_fee().unwrap_or_default());
+                    blob_gas_used_ratio.push(
+                        header.blob_gas_used.unwrap_or_default() as f64
+                            / reth_primitives::constants::eip4844::MAX_DATA_GAS_PER_BLOCK as f64,
+                    );
+
+                    // Percentiles were specified, so we need to collect reward percentile ino
+                    if let Some(percentiles) = &reward_percentiles {
+                        let (transactions, receipts) = LoadFee::cache(self)
+                            .get_transactions_and_receipts(header.hash())
+                            .await
+                            .map_err(Self::Error::from_eth_err)?
+                            .ok_or(EthApiError::InvalidBlockRange)?;
+                        rewards.push(
+                            calculate_reward_percentiles_for_block(
+                                percentiles,
+                                header.gas_used,
+                                header.base_fee_per_gas.unwrap_or_default(),
+                                &transactions,
+                                &receipts,
+                            )
+                            .unwrap_or_default(),
+                        );
+                    }
+                }
+
+                // The spec states that `base_fee_per_gas` "[..] includes the next block after the
+                // newest of the returned range, because this value can be derived from the
+                // newest block"
+                //
+                // The unwrap is safe since we checked earlier that we got at least 1 header.
+                let last_header = headers.last().expect("is present");
+                base_fee_per_gas.push(
+                    LoadFee::provider(self)
+                        .chain_spec()
+                        .base_fee_params_at_timestamp(last_header.timestamp)
+                        .next_block_base_fee(
+                            last_header.gas_used as u128,
+                            last_header.gas_limit as u128,
+                            last_header.base_fee_per_gas.unwrap_or_default() as u128,
+                        ),
                 );
 
-                // Percentiles were specified, so we need to collect reward percentile ino
-                if let Some(percentiles) = &reward_percentiles {
-                    let (transactions, receipts) = LoadFee::cache(self)
-                        .get_transactions_and_receipts(header.hash())
-                        .await.map_err(Self::Error::from_eth_err)?
-                        .ok_or(EthApiError::InvalidBlockRange)?;
-                    rewards.push(
-                        calculate_reward_percentiles_for_block(
-                            percentiles,
-                            header.gas_used,
-                            header.base_fee_per_gas.unwrap_or_default(),
-                            &transactions,
-                            &receipts,
-                        )
-                        .unwrap_or_default(),
-                    );
-                }
-            }
-
-            // The spec states that `base_fee_per_gas` "[..] includes the next block after the
-            // newest of the returned range, because this value can be derived from the
-            // newest block"
-            //
-            // The unwrap is safe since we checked earlier that we got at least 1 header.
-            let last_header = headers.last().expect("is present");
-            base_fee_per_gas.push(
-                LoadFee::provider(self).chain_spec().base_fee_params_at_timestamp(last_header.timestamp).next_block_base_fee(
-                    last_header.gas_used as u128,
-                    last_header.gas_limit as u128,
-                    last_header.base_fee_per_gas.unwrap_or_default() as u128,
-                ));
-
-            // Same goes for the `base_fee_per_blob_gas`:
-            // > "[..] includes the next block after the newest of the returned range, because this value can be derived from the newest block.
-            base_fee_per_blob_gas
-                .push(last_header.next_block_blob_fee().unwrap_or_default());
-        };
+                // Same goes for the `base_fee_per_blob_gas`:
+                // > "[..] includes the next block after the newest of the returned range, because this value can be derived from the newest block.
+                base_fee_per_blob_gas.push(last_header.next_block_blob_fee().unwrap_or_default());
+            };
 
             Ok(FeeHistory {
                 base_fee_per_gas,

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -132,7 +132,7 @@ pub trait LoadPendingBlock: EthApiTypes {
         async move {
             let pending = self.pending_block_env_and_cfg()?;
             if pending.origin.is_actual_pending() {
-                return Ok(pending.origin.into_actual_pending())
+                return Ok(pending.origin.into_actual_pending());
             }
 
             let mut lock = self.pending_block().lock().await;
@@ -142,11 +142,11 @@ pub trait LoadPendingBlock: EthApiTypes {
             // check if the block is still good
             if let Some(pending_block) = lock.as_ref() {
                 // this is guaranteed to be the `latest` header
-                if pending.block_env.number.to::<u64>() == pending_block.block.number &&
-                    pending.origin.header().hash() == pending_block.block.parent_hash &&
-                    now <= pending_block.expires_at
+                if pending.block_env.number.to::<u64>() == pending_block.block.number
+                    && pending.origin.header().hash() == pending_block.block.parent_hash
+                    && now <= pending_block.expires_at
                 {
-                    return Ok(Some(pending_block.block.clone()))
+                    return Ok(Some(pending_block.block.clone()));
                 }
             }
 
@@ -161,7 +161,7 @@ pub trait LoadPendingBlock: EthApiTypes {
                 Ok(block) => block,
                 Err(err) => {
                     debug!(target: "rpc", "Failed to build pending block: {:?}", err);
-                    return Ok(None)
+                    return Ok(None);
                 }
             };
 
@@ -279,7 +279,7 @@ pub trait LoadPendingBlock: EthApiTypes {
                 // which also removes all dependent transaction from the iterator before we can
                 // continue
                 best_txs.mark_invalid(&pool_tx);
-                continue
+                continue;
             }
 
             if pool_tx.origin.is_private() {
@@ -287,7 +287,7 @@ pub trait LoadPendingBlock: EthApiTypes {
                 // them as invalid here which removes all dependent transactions from the iterator
                 // before we can continue
                 best_txs.mark_invalid(&pool_tx);
-                continue
+                continue;
             }
 
             // convert tx to a signed transaction
@@ -303,7 +303,7 @@ pub trait LoadPendingBlock: EthApiTypes {
                     // the iterator. This is similar to the gas limit condition
                     // for regular transactions above.
                     best_txs.mark_invalid(&pool_tx);
-                    continue
+                    continue;
                 }
             }
 
@@ -328,11 +328,11 @@ pub trait LoadPendingBlock: EthApiTypes {
                                 // descendants
                                 best_txs.mark_invalid(&pool_tx);
                             }
-                            continue
+                            continue;
                         }
                         err => {
                             // this is an error that we should treat as fatal for this attempt
-                            return Err(Self::Error::from_evm_err(err))
+                            return Err(Self::Error::from_evm_err(err));
                         }
                     }
                 }

--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -110,7 +110,7 @@ pub trait EthState: LoadState + SpawnBlocking {
             .ok_or(EthApiError::UnknownBlockNumber)?;
         let max_window = self.max_proof_window();
         if chain_info.best_number.saturating_sub(block_number) > max_window {
-            return Err(EthApiError::ExceedsMaxProofWindow.into())
+            return Err(EthApiError::ExceedsMaxProofWindow.into());
         }
 
         Ok(async move {
@@ -284,7 +284,7 @@ pub trait LoadState: EthApiTypes {
                     let tx_count = highest_nonce.checked_add(1).ok_or(Self::Error::from(
                         EthApiError::InvalidTransaction(RpcInvalidTransactionError::NonceMaxValue),
                     ))?;
-                    return Ok(U256::from(tx_count))
+                    return Ok(U256::from(tx_count));
                 }
             }
 

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -292,7 +292,7 @@ pub trait Trace: LoadState {
 
             if block.body.is_empty() {
                 // nothing to trace
-                return Ok(Some(Vec::new()))
+                return Ok(Some(Vec::new()));
             }
 
             // replay all transactions of the block

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -109,7 +109,7 @@ pub trait EthTransactions: LoadTransaction {
             if let Some(tx) =
                 self.pool().get_pooled_transaction_element(hash).map(|tx| tx.envelope_encoded())
             {
-                return Ok(Some(tx))
+                return Ok(Some(tx));
             }
 
             self.spawn_blocking_io(move |ref this| {
@@ -211,7 +211,7 @@ pub trait EthTransactions: LoadTransaction {
                         block_number,
                         base_fee_per_gas,
                         index,
-                    )))
+                    )));
                 }
             }
 
@@ -233,7 +233,7 @@ pub trait EthTransactions: LoadTransaction {
         async move {
             if let Some(block) = self.block_with_senders(block_id).await? {
                 if let Some(tx) = block.transactions().nth(index) {
-                    return Ok(Some(tx.envelope_encoded()))
+                    return Ok(Some(tx.envelope_encoded()));
                 }
             }
 
@@ -496,7 +496,7 @@ pub trait EthTransactions: LoadTransaction {
                 return match signer.sign_transaction(request, from) {
                     Ok(tx) => Ok(tx),
                     Err(e) => Err(e.into_eth_err()),
-                }
+                };
             }
         }
         Err(EthApiError::InvalidTransactionSignature.into())

--- a/crates/rpc/rpc-eth-types/src/cache/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/mod.rs
@@ -419,7 +419,7 @@ where
                         CacheAction::GetBlockWithSenders { block_hash, response_tx } => {
                             if let Some(block) = this.full_block_cache.get(&block_hash).cloned() {
                                 let _ = response_tx.send(Ok(Some(block)));
-                                continue
+                                continue;
                             }
 
                             // block is not in the cache, request it if this is the first consumer
@@ -447,7 +447,7 @@ where
                             // check if block is cached
                             if let Some(block) = this.full_block_cache.get(&block_hash) {
                                 let _ = response_tx.send(Ok(Some(block.body.clone())));
-                                continue
+                                continue;
                             }
 
                             // block is not in the cache, request it if this is the first consumer
@@ -475,7 +475,7 @@ where
                             // check if block is cached
                             if let Some(receipts) = this.receipts_cache.get(&block_hash).cloned() {
                                 let _ = response_tx.send(Ok(Some(receipts)));
-                                continue
+                                continue;
                             }
 
                             // block is not in the cache, request it if this is the first consumer
@@ -499,7 +499,7 @@ where
                             // check if env data is cached
                             if let Some(env) = this.evm_env_cache.get(&block_hash).cloned() {
                                 let _ = response_tx.send(Ok(env));
-                                continue
+                                continue;
                             }
 
                             // env data is not in the cache, request it if this is the first

--- a/crates/rpc/rpc-eth-types/src/error.rs
+++ b/crates/rpc/rpc-eth-types/src/error.rs
@@ -160,30 +160,30 @@ impl EthApiError {
 impl From<EthApiError> for jsonrpsee_types::error::ErrorObject<'static> {
     fn from(error: EthApiError) -> Self {
         match error {
-            EthApiError::FailedToDecodeSignedTransaction |
-            EthApiError::InvalidTransactionSignature |
-            EthApiError::EmptyRawTransactionData |
-            EthApiError::InvalidBlockRange |
-            EthApiError::ExceedsMaxProofWindow |
-            EthApiError::ConflictingFeeFieldsInRequest |
-            EthApiError::Signing(_) |
-            EthApiError::BothStateAndStateDiffInOverride(_) |
-            EthApiError::InvalidTracerConfig |
-            EthApiError::TransactionConversionError => invalid_params_rpc_err(error.to_string()),
+            EthApiError::FailedToDecodeSignedTransaction
+            | EthApiError::InvalidTransactionSignature
+            | EthApiError::EmptyRawTransactionData
+            | EthApiError::InvalidBlockRange
+            | EthApiError::ExceedsMaxProofWindow
+            | EthApiError::ConflictingFeeFieldsInRequest
+            | EthApiError::Signing(_)
+            | EthApiError::BothStateAndStateDiffInOverride(_)
+            | EthApiError::InvalidTracerConfig
+            | EthApiError::TransactionConversionError => invalid_params_rpc_err(error.to_string()),
             EthApiError::InvalidTransaction(err) => err.into(),
             EthApiError::PoolError(err) => err.into(),
-            EthApiError::PrevrandaoNotSet |
-            EthApiError::ExcessBlobGasNotSet |
-            EthApiError::InvalidBlockData(_) |
-            EthApiError::Internal(_) |
-            EthApiError::TransactionNotFound |
-            EthApiError::EvmCustom(_) |
-            EthApiError::EvmPrecompile(_) |
-            EthApiError::InvalidRewardPercentiles |
-            EthApiError::GatewayAddress |
-            EthApiError::GetMerkleProof |
-            EthApiError::GetBtcFee |
-            EthApiError::GetAggregatePublicKey => internal_rpc_err(error.to_string()),
+            EthApiError::PrevrandaoNotSet
+            | EthApiError::ExcessBlobGasNotSet
+            | EthApiError::InvalidBlockData(_)
+            | EthApiError::Internal(_)
+            | EthApiError::TransactionNotFound
+            | EthApiError::EvmCustom(_)
+            | EthApiError::EvmPrecompile(_)
+            | EthApiError::InvalidRewardPercentiles
+            | EthApiError::GatewayAddress
+            | EthApiError::GetMerkleProof
+            | EthApiError::GetBtcFee
+            | EthApiError::GetAggregatePublicKey => internal_rpc_err(error.to_string()),
             EthApiError::UnknownBlockNumber | EthApiError::UnknownBlockOrTxIndex => {
                 rpc_error_with_code(EthRpcErrorCode::ResourceNotFound.code(), error.to_string())
             }
@@ -232,12 +232,12 @@ impl From<reth_errors::ProviderError> for EthApiError {
     fn from(error: reth_errors::ProviderError) -> Self {
         use reth_errors::ProviderError;
         match error {
-            ProviderError::HeaderNotFound(_) |
-            ProviderError::BlockHashNotFound(_) |
-            ProviderError::BestBlockNotFound |
-            ProviderError::BlockNumberForTransactionIndexNotFound |
-            ProviderError::TotalDifficultyNotFound { .. } |
-            ProviderError::UnknownBlockHash(_) => Self::UnknownBlockNumber,
+            ProviderError::HeaderNotFound(_)
+            | ProviderError::BlockHashNotFound(_)
+            | ProviderError::BestBlockNotFound
+            | ProviderError::BlockNumberForTransactionIndexNotFound
+            | ProviderError::TotalDifficultyNotFound { .. }
+            | ProviderError::UnknownBlockHash(_) => Self::UnknownBlockNumber,
             ProviderError::FinalizedBlockNotFound | ProviderError::SafeBlockNotFound => {
                 Self::UnknownSafeOrFinalizedBlock
             }
@@ -464,8 +464,8 @@ impl From<revm::primitives::InvalidTransaction> for RpcInvalidTransactionError {
             InvalidTransaction::InvalidChainId => Self::InvalidChainId,
             InvalidTransaction::PriorityFeeGreaterThanMaxFee => Self::TipAboveFeeCap,
             InvalidTransaction::GasPriceLessThanBasefee => Self::FeeCapTooLow,
-            InvalidTransaction::CallerGasLimitMoreThanBlock |
-            InvalidTransaction::CallGasCostMoreThanGasLimit => Self::GasTooHigh,
+            InvalidTransaction::CallerGasLimitMoreThanBlock
+            | InvalidTransaction::CallGasCostMoreThanGasLimit => Self::GasTooHigh,
             InvalidTransaction::RejectCallerWithCode => Self::SenderNoEOA,
             InvalidTransaction::LackOfFundForMaxFee { .. } => Self::InsufficientFunds,
             InvalidTransaction::OverflowPaymentInTransaction => Self::GasUintOverflow,
@@ -516,11 +516,11 @@ impl From<reth_primitives::InvalidTransactionError> for RpcInvalidTransactionErr
                 Self::OldLegacyChainId
             }
             InvalidTransactionError::ChainIdMismatch => Self::InvalidChainId,
-            InvalidTransactionError::Eip2930Disabled |
-            InvalidTransactionError::Eip1559Disabled |
-            InvalidTransactionError::Eip4844Disabled |
-            InvalidTransactionError::Eip7702Disabled |
-            InvalidTransactionError::TxTypeNotSupported => Self::TxTypeNotSupported,
+            InvalidTransactionError::Eip2930Disabled
+            | InvalidTransactionError::Eip1559Disabled
+            | InvalidTransactionError::Eip4844Disabled
+            | InvalidTransactionError::Eip7702Disabled
+            | InvalidTransactionError::TxTypeNotSupported => Self::TxTypeNotSupported,
             InvalidTransactionError::GasUintOverflow => Self::GasUintOverflow,
             InvalidTransactionError::GasTooLow => Self::GasTooLow,
             InvalidTransactionError::GasTooHigh => Self::GasTooHigh,

--- a/crates/rpc/rpc-eth-types/src/fee_history.rs
+++ b/crates/rpc/rpc-eth-types/src/fee_history.rs
@@ -103,7 +103,7 @@ impl FeeHistoryCache {
         if entries.is_empty() {
             self.inner.upper_bound.store(0, SeqCst);
             self.inner.lower_bound.store(0, SeqCst);
-            return
+            return;
         }
 
         let upper_bound = *entries.last_entry().expect("Contains at least one entry").key();
@@ -150,7 +150,7 @@ impl FeeHistoryCache {
                 .collect::<Vec<_>>();
 
             if result.is_empty() {
-                return None
+                return None;
             }
 
             Some(result)
@@ -308,7 +308,7 @@ pub fn calculate_reward_percentiles_for_block(
         // Empty blocks should return in a zero row
         if transactions.is_empty() {
             rewards_in_block.push(0);
-            continue
+            continue;
         }
 
         let threshold = (gas_used as f64 * percentile / 100.) as u64;
@@ -363,8 +363,8 @@ impl FeeHistoryEntry {
             base_fee_per_gas: block.base_fee_per_gas.unwrap_or_default(),
             gas_used_ratio: block.gas_used as f64 / block.gas_limit as f64,
             base_fee_per_blob_gas: block.blob_fee(),
-            blob_gas_used_ratio: block.blob_gas_used() as f64 /
-                reth_primitives::constants::eip4844::MAX_DATA_GAS_PER_BLOCK as f64,
+            blob_gas_used_ratio: block.blob_gas_used() as f64
+                / reth_primitives::constants::eip4844::MAX_DATA_GAS_PER_BLOCK as f64,
             excess_blob_gas: block.excess_blob_gas,
             blob_gas_used: block.blob_gas_used,
             gas_used: block.gas_used,

--- a/crates/rpc/rpc-eth-types/src/gas_oracle.rs
+++ b/crates/rpc/rpc-eth-types/src/gas_oracle.rs
@@ -124,7 +124,7 @@ where
 
         // if we have stored a last price, then we check whether or not it was for the same head
         if inner.last_price.block_hash == header.hash() {
-            return Ok(inner.last_price.price)
+            return Ok(inner.last_price.price);
         }
 
         // if all responses are empty, then we can return a maximum of 2*check_block blocks' worth
@@ -169,7 +169,7 @@ where
 
             // break when we have enough populated blocks
             if populated_blocks >= self.oracle_config.blocks {
-                break
+                break;
             }
 
             current_hash = parent_hash;
@@ -230,14 +230,14 @@ where
                 let tip = tx.effective_tip_per_gas(base_fee_per_gas);
                 effective_gas_tip = Some(tip);
                 if tip < Some(ignore_under) {
-                    continue
+                    continue;
                 }
             }
 
             // check if the sender was the coinbase, if so, ignore
             if let Some(sender) = tx.recover_signer() {
                 if sender == block.beneficiary {
-                    continue
+                    continue;
                 }
             }
 
@@ -251,7 +251,7 @@ where
 
             // we have enough entries
             if prices.len() >= limit {
-                break
+                break;
             }
         }
 

--- a/crates/rpc/rpc-eth-types/src/id_provider.rs
+++ b/crates/rpc/rpc-eth-types/src/id_provider.rs
@@ -29,7 +29,7 @@ fn to_quantity(val: u128) -> SubscriptionId<'static> {
     let non_zero = b.iter().take_while(|b| **b == 0).count();
     let b = &b[non_zero..];
     if b.is_empty() {
-        return SubscriptionId::Str("0x0".into())
+        return SubscriptionId::Str("0x0".into());
     }
 
     let mut id = String::with_capacity(2 * b.len() + 2);

--- a/crates/rpc/rpc-eth-types/src/logs_utils.rs
+++ b/crates/rpc/rpc-eth-types/src/logs_utils.rs
@@ -45,9 +45,9 @@ impl From<EthFilterError> for jsonrpsee_types::error::ErrorObject<'static> {
                 rpc_error_with_code(jsonrpsee_types::error::INTERNAL_ERROR_CODE, err.to_string())
             }
             EthFilterError::EthAPIError(err) => err.into(),
-            err @ EthFilterError::InvalidBlockRangeParams |
-            err @ EthFilterError::QueryExceedsMaxBlocks(_) |
-            err @ EthFilterError::QueryExceedsMaxResults(_) => {
+            err @ EthFilterError::InvalidBlockRangeParams
+            | err @ EthFilterError::QueryExceedsMaxBlocks(_)
+            | err @ EthFilterError::QueryExceedsMaxResults(_) => {
                 rpc_error_with_code(jsonrpsee_types::error::INVALID_PARAMS_CODE, err.to_string())
             }
         }
@@ -170,13 +170,13 @@ pub fn log_matches_filter(
     log: &reth_primitives::Log,
     params: &FilteredParams,
 ) -> bool {
-    if params.filter.is_some() &&
-        (!params.filter_block_range(block.number) ||
-            !params.filter_block_hash(block.hash) ||
-            !params.filter_address(&log.address) ||
-            !params.filter_topics(log.topics()))
+    if params.filter.is_some()
+        && (!params.filter_block_range(block.number)
+            || !params.filter_block_hash(block.hash)
+            || !params.filter_address(&log.address)
+            || !params.filter_topics(log.topics()))
     {
-        return false
+        return false;
     }
     true
 }

--- a/crates/rpc/rpc-eth-types/src/revm_utils.rs
+++ b/crates/rpc/rpc-eth-types/src/revm_utils.rs
@@ -121,17 +121,17 @@ impl CallFees {
                     let max_priority_fee_per_gas = max_priority_fee_per_gas.unwrap_or(U256::ZERO);
 
                     // only enforce the fee cap if provided input is not zero
-                    if !(max_fee.is_zero() && max_priority_fee_per_gas.is_zero()) &&
-                        max_fee < block_base_fee
+                    if !(max_fee.is_zero() && max_priority_fee_per_gas.is_zero())
+                        && max_fee < block_base_fee
                     {
                         // `base_fee_per_gas` is greater than the `max_fee_per_gas`
-                        return Err(RpcInvalidTransactionError::FeeCapTooLow.into())
+                        return Err(RpcInvalidTransactionError::FeeCapTooLow.into());
                     }
                     if max_fee < max_priority_fee_per_gas {
                         return Err(
                             // `max_priority_fee_per_gas` is greater than the `max_fee_per_gas`
                             RpcInvalidTransactionError::TipAboveFeeCap.into(),
-                        )
+                        );
                     }
                     Ok(min(
                         max_fee,
@@ -185,7 +185,7 @@ impl CallFees {
                 // Ensure blob_hashes are present
                 if !has_blob_hashes {
                     // Blob transaction but no blob hashes
-                    return Err(RpcInvalidTransactionError::BlobTransactionMissingBlobHashes.into())
+                    return Err(RpcInvalidTransactionError::BlobTransactionMissingBlobHashes.into());
                 }
 
                 Ok(Self {

--- a/crates/rpc/rpc-eth-types/src/utils.rs
+++ b/crates/rpc/rpc-eth-types/src/utils.rs
@@ -9,7 +9,7 @@ use super::{EthApiError, EthResult};
 /// See [`PooledTransactionsElement::decode_enveloped`]
 pub fn recover_raw_transaction(data: Bytes) -> EthResult<PooledTransactionsElementEcRecovered> {
     if data.is_empty() {
-        return Err(EthApiError::EmptyRawTransactionData)
+        return Err(EthApiError::EmptyRawTransactionData);
     }
 
     let transaction = PooledTransactionsElement::decode_enveloped(&mut data.as_ref())

--- a/crates/rpc/rpc-layer/src/auth_client_layer.rs
+++ b/crates/rpc/rpc-layer/src/auth_client_layer.rs
@@ -66,8 +66,8 @@ pub fn secret_to_bearer_header(secret: &JwtSecret) -> HeaderValue {
         "Bearer {}",
         secret
             .encode(&Claims {
-                iat: (SystemTime::now().duration_since(UNIX_EPOCH).unwrap() +
-                    Duration::from_secs(60))
+                iat: (SystemTime::now().duration_since(UNIX_EPOCH).unwrap()
+                    + Duration::from_secs(60))
                 .as_secs(),
                 exp: None,
             })

--- a/crates/rpc/rpc-server-types/src/module.rs
+++ b/crates/rpc/rpc-server-types/src/module.rs
@@ -195,7 +195,7 @@ impl FromStr for RpcModuleSelection {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.is_empty() {
-            return Ok(Self::Selection(Default::default()))
+            return Ok(Self::Selection(Default::default()));
         }
         let mut modules = s.split(',').map(str::trim).peekable();
         let first = modules.peek().copied().ok_or(ParseError::VariantNotFound)?;

--- a/crates/rpc/rpc-testing-util/tests/it/trace.rs
+++ b/crates/rpc/rpc-testing-util/tests/it/trace.rs
@@ -14,7 +14,7 @@ use std::{collections::HashSet, time::Instant};
 async fn trace_many_blocks() {
     let url = parse_env_url("RETH_RPC_TEST_NODE_URL");
     if url.is_err() {
-        return
+        return;
     }
     let url = url.unwrap();
 
@@ -101,7 +101,7 @@ async fn trace_call() {
 async fn debug_trace_block_entire_chain() {
     let url = parse_env_url("RETH_RPC_TEST_NODE_URL");
     if url.is_err() {
-        return
+        return;
     }
     let url = url.unwrap();
 

--- a/crates/rpc/rpc-types-compat/src/engine/payload.rs
+++ b/crates/rpc/rpc-types-compat/src/engine/payload.rs
@@ -20,7 +20,7 @@ pub fn try_payload_v1_to_block(payload: ExecutionPayloadV1) -> Result<Block, Pay
     // }
 
     if payload.base_fee_per_gas.is_zero() {
-        return Err(PayloadError::BaseFee(payload.base_fee_per_gas))
+        return Err(PayloadError::BaseFee(payload.base_fee_per_gas));
     }
 
     let transactions = payload
@@ -356,7 +356,7 @@ pub fn validate_block_hash(
         return Err(PayloadError::BlockHash {
             execution: sealed_block.hash(),
             consensus: expected_block_hash,
-        })
+        });
     }
 
     Ok(sealed_block)

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -90,7 +90,7 @@ where
     ) -> Result<Vec<TraceResult>, Eth::Error> {
         if transactions.is_empty() {
             // nothing to trace
-            return Ok(Vec::new())
+            return Ok(Vec::new());
         }
 
         // replay all transactions of the block
@@ -306,7 +306,7 @@ where
                                 Ok(inspector)
                             })
                             .await?;
-                        return Ok(FourByteFrame::from(inspector).into())
+                        return Ok(FourByteFrame::from(inspector).into());
                     }
                     GethDebugBuiltInTracerType::CallTracer => {
                         let call_config = tracer_config
@@ -329,7 +329,7 @@ where
                                 Ok(frame.into())
                             })
                             .await?;
-                        return Ok(frame)
+                        return Ok(frame);
                     }
                     GethDebugBuiltInTracerType::PreStateTracer => {
                         let prestate_config = tracer_config
@@ -357,7 +357,7 @@ where
                                 Ok(frame)
                             })
                             .await?;
-                        return Ok(frame.into())
+                        return Ok(frame.into());
                     }
                     GethDebugBuiltInTracerType::NoopTracer => Ok(NoopFrame::default().into()),
                     GethDebugBuiltInTracerType::MuxTracer => {
@@ -384,7 +384,7 @@ where
                                 Ok(frame.into())
                             })
                             .await?;
-                        return Ok(frame)
+                        return Ok(frame);
                     }
                 },
                 #[cfg(not(feature = "js-tracer"))]
@@ -416,7 +416,7 @@ where
 
                     Ok(GethTrace::JS(res))
                 }
-            }
+            };
         }
 
         // default structlog tracer
@@ -452,7 +452,7 @@ where
         opts: Option<GethDebugTracingCallOptions>,
     ) -> Result<Vec<Vec<GethTrace>>, Eth::Error> {
         if bundles.is_empty() {
-            return Err(EthApiError::InvalidParams(String::from("bundles are empty.")).into())
+            return Err(EthApiError::InvalidParams(String::from("bundles are empty.")).into());
         }
 
         let StateContext { transaction_index, block_number } = state_context.unwrap_or_default();
@@ -687,7 +687,7 @@ where
                     GethDebugBuiltInTracerType::FourByteTracer => {
                         let mut inspector = FourByteInspector::default();
                         let (res, _) = self.eth_api().inspect(db, env, &mut inspector)?;
-                        return Ok((FourByteFrame::from(inspector).into(), res.state))
+                        return Ok((FourByteFrame::from(inspector).into(), res.state));
                     }
                     GethDebugBuiltInTracerType::CallTracer => {
                         let call_config = tracer_config
@@ -705,7 +705,7 @@ where
                             .into_geth_builder()
                             .geth_call_traces(call_config, res.result.gas_used());
 
-                        return Ok((frame.into(), res.state))
+                        return Ok((frame.into(), res.state));
                     }
                     GethDebugBuiltInTracerType::PreStateTracer => {
                         let prestate_config = tracer_config
@@ -723,7 +723,7 @@ where
                             .geth_prestate_traces(&res, prestate_config, db)
                             .map_err(Eth::Error::from_eth_err)?;
 
-                        return Ok((frame.into(), res.state))
+                        return Ok((frame.into(), res.state));
                     }
                     GethDebugBuiltInTracerType::NoopTracer => {
                         Ok((NoopFrame::default().into(), Default::default()))
@@ -740,7 +740,7 @@ where
                         let frame = inspector
                             .try_into_mux_frame(&res, db)
                             .map_err(Eth::Error::from_eth_err)?;
-                        return Ok((frame.into(), res.state))
+                        return Ok((frame.into(), res.state));
                     }
                 },
                 #[cfg(not(feature = "js-tracer"))]
@@ -764,7 +764,7 @@ where
                         inspector.json_result(res, &env, db).map_err(Eth::Error::from_eth_err)?;
                     Ok((GethTrace::JS(result), state))
                 }
-            }
+            };
         }
 
         // default structlog tracer

--- a/crates/rpc/rpc/src/eth/bundle.rs
+++ b/crates/rpc/rpc/src/eth/bundle.rs
@@ -64,13 +64,13 @@ where
             return Err(EthApiError::InvalidParams(
                 EthBundleError::EmptyBundleTransactions.to_string(),
             )
-            .into())
+            .into());
         }
         if block_number == 0 {
             return Err(EthApiError::InvalidParams(
                 EthBundleError::BundleMissingBlockNumber.to_string(),
             )
-            .into())
+            .into());
         }
 
         let transactions = txs
@@ -92,13 +92,13 @@ where
                     None
                 }
             })
-            .sum::<u64>() >
-            MAX_BLOB_GAS_PER_BLOCK
+            .sum::<u64>()
+            > MAX_BLOB_GAS_PER_BLOCK
         {
             return Err(EthApiError::InvalidParams(
                 EthBundleError::Eip4844BlobGasExceeded.to_string(),
             )
-            .into())
+            .into());
         }
 
         let block_id: reth_rpc_types::BlockId = state_block_number.into();

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -141,7 +141,7 @@ where
 
             if filter.block > best_number {
                 // no new blocks since the last poll
-                return Ok(FilterChanges::Empty)
+                return Ok(FilterChanges::Empty);
             }
 
             // update filter
@@ -210,7 +210,7 @@ where
                 *filter.clone()
             } else {
                 // Not a log filter
-                return Err(EthFilterError::FilterNotFound(id))
+                return Err(EthFilterError::FilterNotFound(id));
             }
         };
 
@@ -430,11 +430,11 @@ where
         let best_number = chain_info.best_number;
 
         if to_block < from_block {
-            return Err(EthFilterError::InvalidBlockRangeParams)
+            return Err(EthFilterError::InvalidBlockRangeParams);
         }
 
         if to_block - from_block > self.max_blocks_per_filter {
-            return Err(EthFilterError::QueryExceedsMaxBlocks(self.max_blocks_per_filter))
+            return Err(EthFilterError::QueryExceedsMaxBlocks(self.max_blocks_per_filter));
         }
 
         let mut all_logs = Vec::new();
@@ -458,7 +458,7 @@ where
                     block.header.timestamp,
                 )?;
             }
-            return Ok(all_logs)
+            return Ok(all_logs);
         }
 
         // derive bloom filters from filter input, so we can check headers for matching logs
@@ -474,8 +474,8 @@ where
 
             for (idx, header) in headers.iter().enumerate() {
                 // only if filter matches
-                if FilteredParams::matches_address(header.logs_bloom, &address_filter) &&
-                    FilteredParams::matches_topics(header.logs_bloom, &topics_filter)
+                if FilteredParams::matches_address(header.logs_bloom, &address_filter)
+                    && FilteredParams::matches_topics(header.logs_bloom, &topics_filter)
                 {
                     // these are consecutive headers, so we can use the parent hash of the next
                     // block to get the current header's hash
@@ -504,7 +504,7 @@ where
                         if is_multi_block_range && all_logs.len() > self.max_logs_per_response {
                             return Err(EthFilterError::QueryExceedsMaxResults(
                                 self.max_logs_per_response,
-                            ))
+                            ));
                         }
                     }
                 }
@@ -650,7 +650,7 @@ impl Iterator for BlockRangeInclusiveIter {
         let start = self.iter.next()?;
         let end = (start + self.step).min(self.end);
         if start > end {
-            return None
+            return None;
         }
         Some((start, end))
     }

--- a/crates/rpc/rpc/src/eth/pubsub.rs
+++ b/crates/rpc/rpc/src/eth/pubsub.rs
@@ -138,7 +138,7 @@ where
                                 ),
                             ))
                         });
-                        return pipe_from_stream(accepted_sink, stream).await
+                        return pipe_from_stream(accepted_sink, stream).await;
                     }
                     Params::Bool(false) | Params::None => {
                         // only hashes requested
@@ -168,7 +168,7 @@ where
             let msg = SubscriptionMessage::from_json(&current_sub_res)
                 .map_err(SubscriptionSerializeError::new)?;
             if accepted_sink.send(msg).await.is_err() {
-                return Ok(())
+                return Ok(());
             }
 
             while canon_state.next().await.is_some() {
@@ -183,7 +183,7 @@ where
                     let msg = SubscriptionMessage::from_json(&sync_status)
                         .map_err(SubscriptionSerializeError::new)?;
                     if accepted_sink.send(msg).await.is_err() {
-                        break
+                        break;
                     }
                 }
             }

--- a/crates/rpc/rpc/src/otterscan.rs
+++ b/crates/rpc/rpc/src/otterscan.rs
@@ -189,7 +189,7 @@ where
         if tx_len != receipts.len() {
             return Err(internal_rpc_err(
                 "the number of transactions does not match the number of receipts",
-            ))
+            ));
         }
 
         // make sure the block is full
@@ -268,7 +268,7 @@ where
     ) -> RpcResult<Option<TxHash>> {
         // Check if the sender is a contract
         if self.has_code(sender, None).await? {
-            return Ok(None)
+            return Ok(None);
         }
 
         let highest =
@@ -277,7 +277,7 @@ where
         // If the nonce is higher or equal to the highest nonce, the transaction is pending or not
         // exists.
         if nonce >= highest {
-            return Ok(None)
+            return Ok(None);
         }
 
         // perform a binary search over the block range to find the block in which the sender's

--- a/crates/rpc/rpc/src/reth.rs
+++ b/crates/rpc/rpc/src/reth.rs
@@ -64,7 +64,7 @@ where
 
     fn try_balance_changes_in_block(&self, block_id: BlockId) -> EthResult<HashMap<Address, U256>> {
         let Some(block_number) = self.provider().block_number_for_id(block_id)? else {
-            return Err(EthApiError::UnknownBlockNumber)
+            return Err(EthApiError::UnknownBlockNumber);
         };
 
         let state = self.provider().state_by_block_id(block_id)?;

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -229,7 +229,7 @@ where
     ) -> Result<Option<LocalizedTransactionTrace>, Eth::Error> {
         if indices.len() != 1 {
             // The OG impl failed if it gets more than a single index
-            return Ok(None)
+            return Ok(None);
         }
         self.trace_get_index(hash, indices[0]).await
     }
@@ -266,7 +266,7 @@ where
             return Err(EthApiError::InvalidParams(
                 "invalid parameters: fromBlock cannot be greater than toBlock".to_string(),
             )
-            .into())
+            .into());
         }
 
         // ensure that the range is not too large, since we need to fetch all blocks in the range
@@ -275,7 +275,7 @@ where
             return Err(EthApiError::InvalidParams(
                 "Block range too large; currently limited to 100 blocks".to_string(),
             )
-            .into())
+            .into());
         }
 
         // fetch all blocks in that range
@@ -316,7 +316,7 @@ where
             } else {
                 // no block reward, means we're past the Paris hardfork and don't expect any rewards
                 // because the blocks in ascending order
-                break
+                break;
             }
         }
 

--- a/crates/stages/api/src/error.rs
+++ b/crates/stages/api/src/error.rs
@@ -146,17 +146,17 @@ impl StageError {
     pub const fn is_fatal(&self) -> bool {
         matches!(
             self,
-            Self::Database(_) |
-                Self::Download(_) |
-                Self::DatabaseIntegrity(_) |
-                Self::StageCheckpoint(_) |
-                Self::MissingDownloadBuffer |
-                Self::MissingSyncGap |
-                Self::ChannelClosed |
-                Self::InconsistentBlockNumber { .. } |
-                Self::InconsistentTxNumber { .. } |
-                Self::Internal(_) |
-                Self::Fatal(_)
+            Self::Database(_)
+                | Self::Download(_)
+                | Self::DatabaseIntegrity(_)
+                | Self::StageCheckpoint(_)
+                | Self::MissingDownloadBuffer
+                | Self::MissingSyncGap
+                | Self::ChannelClosed
+                | Self::InconsistentBlockNumber { .. }
+                | Self::InconsistentTxNumber { .. }
+                | Self::Internal(_)
+                | Self::Fatal(_)
         )
     }
 }

--- a/crates/stages/api/src/metrics/listener.rs
+++ b/crates/stages/api/src/metrics/listener.rs
@@ -99,7 +99,7 @@ impl Future for MetricsListener {
         loop {
             let Some(event) = ready!(this.events_rx.poll_recv(cx)) else {
                 // Channel has closed
-                return Poll::Ready(())
+                return Poll::Ready(());
             };
 
             this.handle_event(event);

--- a/crates/stages/api/src/pipeline/mod.rs
+++ b/crates/stages/api/src/pipeline/mod.rs
@@ -138,14 +138,14 @@ where
                     PipelineTarget::Sync(tip) => self.set_tip(tip),
                     PipelineTarget::Unwind(target) => {
                         if let Err(err) = self.move_to_static_files() {
-                            return (self, Err(err.into()))
+                            return (self, Err(err.into()));
                         }
                         if let Err(err) = self.unwind(target, None) {
-                            return (self, Err(err))
+                            return (self, Err(err));
                         }
                         self.progress.update(target);
 
-                        return (self, Ok(ControlFlow::Continue { block_number: target }))
+                        return (self, Ok(ControlFlow::Continue { block_number: target }));
                     }
                 }
             }
@@ -166,8 +166,9 @@ where
 
             // Terminate the loop early if it's reached the maximum user
             // configured block.
-            if next_action.should_continue() &&
-                self.progress
+            if next_action.should_continue()
+                && self
+                    .progress
                     .minimum_block_number
                     .zip(self.max_block)
                     .is_some_and(|(progress, target)| progress >= target)
@@ -179,7 +180,7 @@ where
                     max_block = ?self.max_block,
                     "Terminating pipeline."
                 );
-                return Ok(())
+                return Ok(());
             }
         }
     }
@@ -217,7 +218,7 @@ where
                 ControlFlow::Continue { block_number } => self.progress.update(block_number),
                 ControlFlow::Unwind { target, bad_block } => {
                     self.unwind(target, Some(bad_block.number))?;
-                    return Ok(ControlFlow::Unwind { target, bad_block })
+                    return Ok(ControlFlow::Unwind { target, bad_block });
                 }
             }
 
@@ -293,7 +294,7 @@ where
                 );
                 self.event_sender.notify(PipelineEvent::Skipped { stage_id });
 
-                continue
+                continue;
             }
 
             info!(
@@ -339,8 +340,8 @@ where
 
                         // If None, that means the finalized block is not written so we should
                         // always save in that case
-                        if last_saved_finalized_block_number.is_none() ||
-                            Some(checkpoint.block_number) < last_saved_finalized_block_number
+                        if last_saved_finalized_block_number.is_none()
+                            || Some(checkpoint.block_number) < last_saved_finalized_block_number
                         {
                             provider_rw.save_finalized_block_number(BlockNumber::from(
                                 checkpoint.block_number,
@@ -359,7 +360,7 @@ where
                     Err(err) => {
                         self.event_sender.notify(PipelineEvent::Error { stage_id });
 
-                        return Err(PipelineError::Stage(StageError::Fatal(Box::new(err))))
+                        return Err(PipelineError::Stage(StageError::Fatal(Box::new(err))));
                     }
                 }
             }
@@ -399,7 +400,7 @@ where
                 // We reached the maximum block, so we skip the stage
                 return Ok(ControlFlow::NoProgress {
                     block_number: prev_checkpoint.map(|progress| progress.block_number),
-                })
+                });
             }
 
             let exec_input = ExecInput { target, checkpoint: prev_checkpoint };
@@ -469,7 +470,7 @@ where
                             ControlFlow::Continue { block_number }
                         } else {
                             ControlFlow::NoProgress { block_number: Some(block_number) }
-                        })
+                        });
                     }
                 }
                 Err(err) => {
@@ -479,7 +480,7 @@ where
                     if let Some(ctrl) =
                         on_stage_error(&self.provider_factory, stage_id, prev_checkpoint, err)?
                     {
-                        return Ok(ctrl)
+                        return Ok(ctrl);
                     }
                 }
             }

--- a/crates/stages/api/src/pipeline/set.rs
+++ b/crates/stages/api/src/pipeline/set.rs
@@ -220,7 +220,7 @@ where
         F: FnOnce() -> bool,
     {
         if f() {
-            return self.disable(stage_id)
+            return self.disable(stage_id);
         }
         self
     }
@@ -234,7 +234,7 @@ where
         F: FnOnce() -> bool,
     {
         if f() {
-            return self.disable_all(stages)
+            return self.disable_all(stages);
         }
         self
     }

--- a/crates/stages/api/src/stage.rs
+++ b/crates/stages/api/src/stage.rs
@@ -93,7 +93,7 @@ impl ExecInput {
 
         if all_tx_cnt == 0 {
             // if there is no more transaction return back.
-            return Ok((first_tx_num..first_tx_num, start_block..=target_block, true))
+            return Ok((first_tx_num..first_tx_num, start_block..=target_block, true));
         }
 
         // get block of this tx

--- a/crates/stages/stages/src/stages/bodies.rs
+++ b/crates/stages/stages/src/stages/bodies.rs
@@ -82,7 +82,7 @@ impl<DB: Database, D: BodyDownloader> Stage<DB> for BodyStage<D> {
         input: ExecInput,
     ) -> Poll<Result<(), StageError>> {
         if input.target_reached() || self.buffer.is_some() {
-            return Poll::Ready(Ok(()))
+            return Poll::Ready(Ok(()));
         }
 
         // Update the header range on the downloader
@@ -112,7 +112,7 @@ impl<DB: Database, D: BodyDownloader> Stage<DB> for BodyStage<D> {
         input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         if input.target_reached() {
-            return Ok(ExecOutput::done(input.checkpoint()))
+            return Ok(ExecOutput::done(input.checkpoint()));
         }
         let (from_block, to_block) = input.next_block_range().into_inner();
 
@@ -190,7 +190,7 @@ impl<DB: Database, D: BodyDownloader> Stage<DB> for BodyStage<D> {
                         segment: StaticFileSegment::Transactions,
                         database: block_number,
                         static_file: appended_block_number,
-                    })
+                    });
                 }
             }
 
@@ -213,7 +213,7 @@ impl<DB: Database, D: BodyDownloader> Stage<DB> for BodyStage<D> {
                                 segment: StaticFileSegment::Transactions,
                                 database: next_tx_num,
                                 static_file: appended_tx_number,
-                            })
+                            });
                         }
 
                         // Increment transaction id for each transaction.
@@ -282,7 +282,7 @@ impl<DB: Database, D: BodyDownloader> Stage<DB> for BodyStage<D> {
         let mut rev_walker = body_cursor.walk_back(None)?;
         while let Some((number, block_meta)) = rev_walker.next().transpose()? {
             if number <= input.unwind_to {
-                break
+                break;
             }
 
             // Delete the ommers entry if any
@@ -301,8 +301,8 @@ impl<DB: Database, D: BodyDownloader> Stage<DB> for BodyStage<D> {
             }
 
             // Delete all transaction to block values.
-            if !block_meta.is_empty() &&
-                tx_block_cursor.seek_exact(block_meta.last_tx_num())?.is_some()
+            if !block_meta.is_empty()
+                && tx_block_cursor.seek_exact(block_meta.last_tx_num())?.is_some()
             {
                 tx_block_cursor.delete_current()?;
             }
@@ -329,7 +329,7 @@ impl<DB: Database, D: BodyDownloader> Stage<DB> for BodyStage<D> {
                 static_file_tx_num,
                 static_file_provider,
                 provider,
-            )?)
+            )?);
         }
 
         // Unwinds static file
@@ -357,11 +357,11 @@ fn missing_static_data_error<DB: Database>(
     loop {
         if let Some(indices) = provider.block_body_indices(last_block)? {
             if indices.last_tx_num() <= last_tx_num {
-                break
+                break;
             }
         }
         if last_block == 0 {
-            break
+            break;
         }
         last_block -= 1;
     }
@@ -927,7 +927,7 @@ mod tests {
                 let this = self.get_mut();
 
                 if this.headers.is_empty() {
-                    return Poll::Ready(None)
+                    return Poll::Ready(None);
                 }
 
                 let mut response = Vec::default();
@@ -947,12 +947,12 @@ mod tests {
                     }
 
                     if response.len() as u64 >= this.batch_size {
-                        break
+                        break;
                     }
                 }
 
                 if !response.is_empty() {
-                    return Poll::Ready(Some(Ok(response)))
+                    return Poll::Ready(Some(Ok(response)));
                 }
 
                 panic!("requested bodies without setting headers")

--- a/crates/stages/stages/src/stages/execution.rs
+++ b/crates/stages/stages/src/stages/execution.rs
@@ -161,8 +161,8 @@ impl<E> ExecutionStage<E> {
 
         // If we're not executing MerkleStage from scratch (by threshold or first-sync), then erase
         // changeset related pruning configurations
-        if !(max_block - start_block > self.external_clean_threshold ||
-            provider.count_entries::<tables::AccountsTrie>()?.is_zero())
+        if !(max_block - start_block > self.external_clean_threshold
+            || provider.count_entries::<tables::AccountsTrie>()?.is_zero())
         {
             prune_modes.account_history = None;
             prune_modes.storage_history = None;
@@ -207,8 +207,8 @@ where
         let static_file_provider = provider.static_file_provider();
 
         // We only use static files for Receipts, if there is no receipt pruning of any kind.
-        let static_file_producer = if self.prune_modes.receipts.is_none() &&
-            self.prune_modes.receipts_log_filter.is_empty()
+        let static_file_producer = if self.prune_modes.receipts.is_none()
+            && self.prune_modes.receipts_log_filter.is_empty()
         {
             debug!(target: "sync::stages::execution", start = start_block, "Preparing static file producer");
             let mut producer = prepare_static_file_producer(provider, start_block)?;
@@ -538,8 +538,8 @@ fn execution_checkpoint(
                 block_range: CheckpointBlockRange { from: start_block, to: max_block },
                 progress: EntitiesCheckpoint {
                     processed,
-                    total: processed +
-                        calculate_gas_used_from_headers(provider, start_block..=max_block)?,
+                    total: processed
+                        + calculate_gas_used_from_headers(provider, start_block..=max_block)?,
                 },
             }
         }

--- a/crates/stages/stages/src/stages/finish.rs
+++ b/crates/stages/stages/src/stages/finish.rs
@@ -80,7 +80,7 @@ mod tests {
             let end = input.target.unwrap_or_default() + 1;
 
             if start + 1 >= end {
-                return Ok(Vec::default())
+                return Ok(Vec::default());
             }
 
             let mut headers = random_header_range(&mut rng, start + 1..end, head.hash());

--- a/crates/stages/stages/src/stages/hashing_account.rs
+++ b/crates/stages/stages/src/stages/hashing_account.rs
@@ -134,7 +134,7 @@ impl<DB: Database> Stage<DB> for AccountHashingStage {
         input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         if input.target_reached() {
-            return Ok(ExecOutput::done(input.checkpoint()))
+            return Ok(ExecOutput::done(input.checkpoint()));
         }
 
         let (from_block, to_block) = input.next_block_range().into_inner();
@@ -459,7 +459,7 @@ mod tests {
                     let start_block = input.next_block();
                     let end_block = output.checkpoint.block_number;
                     if start_block > end_block {
-                        return Ok(())
+                        return Ok(());
                     }
                 }
                 self.check_hashed_accounts()

--- a/crates/stages/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/stages/src/stages/hashing_storage.rs
@@ -76,7 +76,7 @@ impl<DB: Database> Stage<DB> for StorageHashingStage {
     ) -> Result<ExecOutput, StageError> {
         let tx = provider.tx_ref();
         if input.target_reached() {
-            return Ok(ExecOutput::done(input.checkpoint()))
+            return Ok(ExecOutput::done(input.checkpoint()));
         }
 
         let (from_block, to_block) = input.next_block_range().into_inner();
@@ -272,7 +272,7 @@ mod tests {
 
                     // Continue from checkpoint
                     input.checkpoint = Some(checkpoint);
-                    continue
+                    continue;
                 } else {
                     assert_eq!(checkpoint.block_number, previous_stage);
                     assert_matches!(checkpoint.storage_hashing_stage_checkpoint(), Some(StorageHashingCheckpoint {
@@ -290,7 +290,7 @@ mod tests {
                         "execution validation"
                     );
 
-                    break
+                    break;
                 }
             }
             panic!("Failed execution");
@@ -423,7 +423,7 @@ mod tests {
                 let start_block = input.checkpoint().block_number + 1;
                 let end_block = output.checkpoint.block_number;
                 if start_block > end_block {
-                    return Ok(())
+                    return Ok(());
                 }
             }
             self.check_hashed_storage()
@@ -524,7 +524,7 @@ mod tests {
 
                 while let Some((bn_address, entry)) = rev_changeset_walker.next().transpose()? {
                     if bn_address.block_number() < target_block {
-                        break
+                        break;
                     }
 
                     if storage_cursor

--- a/crates/stages/stages/src/stages/headers.rs
+++ b/crates/stages/stages/src/stages/headers.rs
@@ -122,7 +122,7 @@ where
             let (sealed_header, _) = SealedHeader::from_compact(&header_buf, header_buf.len());
             let (header, header_hash) = sealed_header.split();
             if header.number == 0 {
-                continue
+                continue;
             }
             last_header_number = header.number;
 
@@ -203,7 +203,7 @@ where
 
         // Return if stage has already completed the gap on the ETL files
         if self.is_etl_ready {
-            return Poll::Ready(Ok(()))
+            return Poll::Ready(Ok(()));
         }
 
         // Lookup the head and tip of the sync range
@@ -220,7 +220,7 @@ where
                 "Target block already reached"
             );
             self.is_etl_ready = true;
-            return Poll::Ready(Ok(()))
+            return Poll::Ready(Ok(()));
         }
 
         debug!(target: "sync::stages::headers", ?tip, head = ?gap.local_head.hash(), "Commencing sync");
@@ -244,13 +244,17 @@ where
                         // filled the gap.
                         if header_number == local_head_number + 1 {
                             self.is_etl_ready = true;
-                            return Poll::Ready(Ok(()))
+                            return Poll::Ready(Ok(()));
                         }
                     }
                 }
                 Some(Err(HeadersDownloaderError::DetachedHead { local_head, header, error })) => {
                     error!(target: "sync::stages::headers", %error, "Cannot attach header to head");
-                    return Poll::Ready(Err(StageError::DetachedHead { local_head, header, error }))
+                    return Poll::Ready(Err(StageError::DetachedHead {
+                        local_head,
+                        header,
+                        error,
+                    }));
                 }
                 None => return Poll::Ready(Err(StageError::ChannelClosed)),
             }
@@ -268,12 +272,12 @@ where
 
         if self.sync_gap.as_ref().ok_or(StageError::MissingSyncGap)?.is_closed() {
             self.is_etl_ready = false;
-            return Ok(ExecOutput::done(current_checkpoint))
+            return Ok(ExecOutput::done(current_checkpoint));
         }
 
         // We should be here only after we have downloaded all headers into the disk buffer (ETL).
         if !self.is_etl_ready {
-            return Err(StageError::MissingDownloadBuffer)
+            return Err(StageError::MissingDownloadBuffer);
         }
 
         // Reset flag
@@ -457,7 +461,7 @@ mod tests {
                 let end = input.target.unwrap_or_default() + 1;
 
                 if start + 1 >= end {
-                    return Ok(Vec::default())
+                    return Ok(Vec::default());
                 }
 
                 let mut headers = random_header_range(&mut rng, start + 1..end, head.hash());

--- a/crates/stages/stages/src/stages/index_account_history.rs
+++ b/crates/stages/stages/src/stages/index_account_history.rs
@@ -87,7 +87,7 @@ impl<DB: Database> Stage<DB> for IndexAccountHistoryStage {
         }
 
         if input.target_reached() {
-            return Ok(ExecOutput::done(input.checkpoint()))
+            return Ok(ExecOutput::done(input.checkpoint()));
         }
 
         let mut range = input.next_block_range();
@@ -563,7 +563,7 @@ mod tests {
                 let start_block = input.next_block();
                 let end_block = output.checkpoint.block_number;
                 if start_block > end_block {
-                    return Ok(())
+                    return Ok(());
                 }
 
                 assert_eq!(

--- a/crates/stages/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/stages/src/stages/index_storage_history.rs
@@ -90,7 +90,7 @@ impl<DB: Database> Stage<DB> for IndexStorageHistoryStage {
         }
 
         if input.target_reached() {
-            return Ok(ExecOutput::done(input.checkpoint()))
+            return Ok(ExecOutput::done(input.checkpoint()));
         }
 
         let mut range = input.next_block_range();
@@ -585,7 +585,7 @@ mod tests {
                 let start_block = input.next_block();
                 let end_block = output.checkpoint.block_number;
                 if start_block > end_block {
-                    return Ok(())
+                    return Ok(());
                 }
 
                 assert_eq!(

--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -106,7 +106,7 @@ impl MerkleStage {
             provider.get_stage_checkpoint_progress(StageId::MerkleExecute)?.unwrap_or_default();
 
         if buf.is_empty() {
-            return Ok(None)
+            return Ok(None);
         }
 
         let (checkpoint, _) = MerkleCheckpoint::from_compact(&buf, buf.len());
@@ -152,7 +152,7 @@ impl<DB: Database> Stage<DB> for MerkleStage {
         let threshold = match self {
             Self::Unwind => {
                 info!(target: "sync::stages::merkle::unwind", "Stage is always skipped");
-                return Ok(ExecOutput::done(StageCheckpoint::new(input.target())))
+                return Ok(ExecOutput::done(StageCheckpoint::new(input.target())));
             }
             Self::Execution { clean_threshold } => *clean_threshold,
             #[cfg(any(test, feature = "test-utils"))]
@@ -203,8 +203,8 @@ impl<DB: Database> Stage<DB> for MerkleStage {
             }
             .unwrap_or(EntitiesCheckpoint {
                 processed: 0,
-                total: (provider.count_entries::<tables::HashedAccounts>()? +
-                    provider.count_entries::<tables::HashedStorages>()?)
+                total: (provider.count_entries::<tables::HashedAccounts>()?
+                    + provider.count_entries::<tables::HashedStorages>()?)
                     as u64,
             });
 
@@ -235,7 +235,7 @@ impl<DB: Database> Stage<DB> for MerkleStage {
                             .checkpoint()
                             .with_entities_stage_checkpoint(entities_checkpoint),
                         done: false,
-                    })
+                    });
                 }
                 StateRootProgress::Complete(root, hashed_entries_walked, updates) => {
                     provider.write_trie_updates(&updates)?;
@@ -256,8 +256,8 @@ impl<DB: Database> Stage<DB> for MerkleStage {
 
             provider.write_trie_updates(&updates)?;
 
-            let total_hashed_entries = (provider.count_entries::<tables::HashedAccounts>()? +
-                provider.count_entries::<tables::HashedStorages>()?)
+            let total_hashed_entries = (provider.count_entries::<tables::HashedAccounts>()?
+                + provider.count_entries::<tables::HashedStorages>()?)
                 as u64;
 
             let entities_checkpoint = EntitiesCheckpoint {
@@ -293,14 +293,14 @@ impl<DB: Database> Stage<DB> for MerkleStage {
         let range = input.unwind_block_range();
         if matches!(self, Self::Execution { .. }) {
             info!(target: "sync::stages::merkle::unwind", "Stage is always skipped");
-            return Ok(UnwindOutput { checkpoint: StageCheckpoint::new(input.unwind_to) })
+            return Ok(UnwindOutput { checkpoint: StageCheckpoint::new(input.unwind_to) });
         }
 
         let mut entities_checkpoint =
             input.checkpoint.entities_stage_checkpoint().unwrap_or(EntitiesCheckpoint {
                 processed: 0,
-                total: (tx.entries::<tables::HashedAccounts>()? +
-                    tx.entries::<tables::HashedStorages>()?) as u64,
+                total: (tx.entries::<tables::HashedAccounts>()?
+                    + tx.entries::<tables::HashedStorages>()?) as u64,
             });
 
         if input.unwind_to == 0 {
@@ -312,7 +312,7 @@ impl<DB: Database> Stage<DB> for MerkleStage {
             return Ok(UnwindOutput {
                 checkpoint: StageCheckpoint::new(input.unwind_to)
                     .with_entities_stage_checkpoint(entities_checkpoint),
-            })
+            });
         }
 
         // Unwind trie only if there are transitions
@@ -624,7 +624,7 @@ mod tests {
                         rev_changeset_walker.next().transpose().unwrap()
                     {
                         if bn_address.block_number() < target_block {
-                            break
+                            break;
                         }
 
                         tree.entry(keccak256(bn_address.address()))
@@ -655,7 +655,7 @@ mod tests {
                         rev_changeset_walker.next().transpose().unwrap()
                     {
                         if block_number < target_block {
-                            break
+                            break;
                         }
 
                         if let Some(acc) = account_before_tx.info {

--- a/crates/stages/stages/src/stages/prune.rs
+++ b/crates/stages/stages/src/stages/prune.rs
@@ -223,7 +223,7 @@ mod tests {
                 let end_block = output.checkpoint.block_number;
 
                 if start_block > end_block {
-                    return Ok(())
+                    return Ok(());
                 }
 
                 let provider = self.db.factory.provider()?;

--- a/crates/stages/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/stages/src/stages/sender_recovery.rs
@@ -67,7 +67,7 @@ impl<DB: Database> Stage<DB> for SenderRecoveryStage {
         input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         if input.target_reached() {
-            return Ok(ExecOutput::done(input.checkpoint()))
+            return Ok(ExecOutput::done(input.checkpoint()));
         }
 
         let (tx_range, block_range, is_final_range) =
@@ -81,7 +81,7 @@ impl<DB: Database> Stage<DB> for SenderRecoveryStage {
                 checkpoint: StageCheckpoint::new(end_block)
                     .with_entities_stage_checkpoint(stage_checkpoint(provider)?),
                 done: is_final_range,
-            })
+            });
         }
 
         // Acquire the cursor for inserting elements
@@ -213,7 +213,7 @@ where
                             })
                         }
                         SenderRecoveryStageError::StageError(err) => Err(err),
-                    }
+                    };
                 }
             };
             senders_cursor.append(tx_id, sender)?;
@@ -571,7 +571,7 @@ mod tests {
                     let end_block = output.checkpoint.block_number;
 
                     if start_block > end_block {
-                        return Ok(())
+                        return Ok(());
                     }
 
                     let mut body_cursor =

--- a/crates/stages/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/stages/src/stages/tx_lookup.rs
@@ -101,7 +101,7 @@ impl<DB: Database> Stage<DB> for TransactionLookupStage {
             }
         }
         if input.target_reached() {
-            return Ok(ExecOutput::done(input.checkpoint()))
+            return Ok(ExecOutput::done(input.checkpoint()));
         }
 
         // 500MB temporary files
@@ -164,7 +164,7 @@ impl<DB: Database> Stage<DB> for TransactionLookupStage {
                     "Transaction hashes inserted"
                 );
 
-                break
+                break;
             }
         }
 
@@ -191,7 +191,7 @@ impl<DB: Database> Stage<DB> for TransactionLookupStage {
         let mut rev_walker = body_cursor.walk_back(Some(*range.end()))?;
         while let Some((number, body)) = rev_walker.next().transpose()? {
             if number <= unwind_to {
-                break
+                break;
             }
 
             // Delete all transactions that belong to this block
@@ -225,8 +225,8 @@ fn stage_checkpoint<DB: Database>(
         // If `TransactionHashNumbers` table was pruned, we will have a number of entries in it not
         // matching the actual number of processed transactions. To fix that, we add the
         // number of pruned `TransactionHashNumbers` entries.
-        processed: provider.count_entries::<tables::TransactionHashNumbers>()? as u64 +
-            pruned_entries,
+        processed: provider.count_entries::<tables::TransactionHashNumbers>()? as u64
+            + pruned_entries,
         // Count only static files entries. If we count the database entries too, we may have
         // duplicates. We're sure that the static files have all entries that database has,
         // because we run the `StaticFileProducer` before starting the pipeline.
@@ -521,7 +521,7 @@ mod tests {
                     let end_block = output.checkpoint.block_number;
 
                     if start_block > end_block {
-                        return Ok(())
+                        return Ok(());
                     }
 
                     let mut body_cursor =

--- a/crates/stages/stages/src/test_utils/test_db.rs
+++ b/crates/stages/stages/src/test_utils/test_db.rs
@@ -278,8 +278,8 @@ impl TestStageDB {
                     // Backfill: some tests start at a forward block number, but static files
                     // require no gaps.
                     let segment_header = txs_writer.user_header();
-                    if segment_header.block_end().is_none() &&
-                        segment_header.expected_block_start() == 0
+                    if segment_header.block_end().is_none()
+                        && segment_header.expected_block_start() == 0
                     {
                         for block in 0..block.number {
                             txs_writer.increment_block(block)?;
@@ -490,7 +490,7 @@ impl StorageKind {
 
     fn tx_offset(&self) -> u64 {
         if let Self::Database(offset) = self {
-            return offset.unwrap_or_default()
+            return offset.unwrap_or_default();
         }
         0
     }

--- a/crates/stages/types/src/checkpoints.rs
+++ b/crates/stages/types/src/checkpoints.rs
@@ -152,7 +152,7 @@ impl EntitiesCheckpoint {
     /// Return [None] if `total == 0`.
     pub fn fmt_percentage(&self) -> Option<String> {
         if self.total == 0 {
-            return None
+            return None;
         }
 
         // Calculate percentage with 2 decimal places.
@@ -237,14 +237,14 @@ impl StageCheckpoint {
         match stage_checkpoint {
             StageUnitCheckpoint::Account(AccountHashingCheckpoint {
                 progress: entities, ..
-            }) |
-            StageUnitCheckpoint::Storage(StorageHashingCheckpoint {
+            })
+            | StageUnitCheckpoint::Storage(StorageHashingCheckpoint {
                 progress: entities, ..
-            }) |
-            StageUnitCheckpoint::Entities(entities) |
-            StageUnitCheckpoint::Execution(ExecutionCheckpoint { progress: entities, .. }) |
-            StageUnitCheckpoint::Headers(HeadersCheckpoint { progress: entities, .. }) |
-            StageUnitCheckpoint::IndexHistory(IndexHistoryCheckpoint {
+            })
+            | StageUnitCheckpoint::Entities(entities)
+            | StageUnitCheckpoint::Execution(ExecutionCheckpoint { progress: entities, .. })
+            | StageUnitCheckpoint::Headers(HeadersCheckpoint { progress: entities, .. })
+            | StageUnitCheckpoint::IndexHistory(IndexHistoryCheckpoint {
                 progress: entities,
                 ..
             }) => Some(entities),
@@ -278,10 +278,10 @@ impl StageUnitCheckpoint {
     /// range.
     pub fn set_block_range(&mut self, from: u64, to: u64) -> Option<CheckpointBlockRange> {
         match self {
-            Self::Account(AccountHashingCheckpoint { ref mut block_range, .. }) |
-            Self::Storage(StorageHashingCheckpoint { ref mut block_range, .. }) |
-            Self::Execution(ExecutionCheckpoint { ref mut block_range, .. }) |
-            Self::IndexHistory(IndexHistoryCheckpoint { ref mut block_range, .. }) => {
+            Self::Account(AccountHashingCheckpoint { ref mut block_range, .. })
+            | Self::Storage(StorageHashingCheckpoint { ref mut block_range, .. })
+            | Self::Execution(ExecutionCheckpoint { ref mut block_range, .. })
+            | Self::IndexHistory(IndexHistoryCheckpoint { ref mut block_range, .. }) => {
                 let old_range = *block_range;
                 *block_range = CheckpointBlockRange { from, to };
 

--- a/crates/stages/types/src/execution.rs
+++ b/crates/stages/types/src/execution.rs
@@ -42,9 +42,9 @@ impl ExecutionStageThresholds {
         cumulative_gas_used: u64,
         elapsed: Duration,
     ) -> bool {
-        blocks_processed >= self.max_blocks.unwrap_or(u64::MAX) ||
-            changes_processed >= self.max_changes.unwrap_or(u64::MAX) ||
-            cumulative_gas_used >= self.max_cumulative_gas.unwrap_or(u64::MAX) ||
-            elapsed >= self.max_duration.unwrap_or(Duration::MAX)
+        blocks_processed >= self.max_blocks.unwrap_or(u64::MAX)
+            || changes_processed >= self.max_changes.unwrap_or(u64::MAX)
+            || cumulative_gas_used >= self.max_cumulative_gas.unwrap_or(u64::MAX)
+            || elapsed >= self.max_duration.unwrap_or(Duration::MAX)
     }
 }

--- a/crates/static-file/static-file/src/static_file_producer.rs
+++ b/crates/static-file/static-file/src/static_file_producer.rs
@@ -85,10 +85,9 @@ impl StaticFileTargets {
         .iter()
         .all(|(target_block_range, highest_static_fileted_block)| {
             target_block_range.map_or(true, |target_block_range| {
-                *target_block_range.start() ==
-                    highest_static_fileted_block.map_or(0, |highest_static_fileted_block| {
-                        highest_static_fileted_block + 1
-                    })
+                *target_block_range.start()
+                    == highest_static_fileted_block
+                        .map_or(0, |highest_static_fileted_block| highest_static_fileted_block + 1)
             })
         })
     }
@@ -116,7 +115,7 @@ impl<DB: Database> StaticFileProducerInner<DB> {
     pub fn run(&self, targets: StaticFileTargets) -> StaticFileProducerResult {
         // If there are no targets, do not produce any static files and return early
         if !targets.any() {
-            return Ok(targets)
+            return Ok(targets);
         }
 
         debug_assert!(targets.is_contiguous_to_highest_static_files(
@@ -208,8 +207,8 @@ impl<DB: Database> StaticFileProducerInner<DB> {
                 self.get_static_file_target(highest_static_files.headers, finalized_block_number)
             }),
             // StaticFile receipts only if they're not pruned according to the user configuration
-            receipts: if self.prune_modes.receipts.is_none() &&
-                self.prune_modes.receipts_log_filter.is_empty()
+            receipts: if self.prune_modes.receipts.is_none()
+                && self.prune_modes.receipts_log_filter.is_empty()
             {
                 finalized_block_numbers.receipts.and_then(|finalized_block_number| {
                     self.get_static_file_target(

--- a/crates/static-file/types/src/segment.rs
+++ b/crates/static-file/types/src/segment.rs
@@ -116,14 +116,14 @@ impl StaticFileSegment {
     pub fn parse_filename(name: &str) -> Option<(Self, SegmentRangeInclusive)> {
         let mut parts = name.split('_');
         if !(parts.next() == Some("static") && parts.next() == Some("file")) {
-            return None
+            return None;
         }
 
         let segment = Self::from_str(parts.next()?).ok()?;
         let (block_start, block_end) = (parts.next()?.parse().ok()?, parts.next()?.parse().ok()?);
 
         if block_start > block_end {
-            return None
+            return None;
         }
 
         Some((segment, SegmentRangeInclusive::new(block_start, block_end)))

--- a/crates/storage/codecs/derive/src/compact/flags.rs
+++ b/crates/storage/codecs/derive/src/compact/flags.rs
@@ -26,7 +26,7 @@ pub(crate) fn generate_flag_struct(
                 .iter()
                 .filter_map(|f| {
                     if let FieldTypes::StructField(f) = f {
-                        return Some(f)
+                        return Some(f);
                     }
                     None
                 })
@@ -37,7 +37,7 @@ pub(crate) fn generate_flag_struct(
     };
 
     if total_bits == 0 {
-        return placeholder_flag_struct(ident, &flags_ident)
+        return placeholder_flag_struct(ident, &flags_ident);
     }
 
     let (total_bytes, unused_bits) = pad_flag_struct(total_bits, &mut field_flags);

--- a/crates/storage/codecs/derive/src/compact/generator.rs
+++ b/crates/storage/codecs/derive/src/compact/generator.rs
@@ -125,7 +125,7 @@ fn generate_from_compact(fields: &FieldList, ident: &Ident, is_zstd: bool) -> To
                     let ident = format_ident!("{name}");
                     return Some(quote! {
                         #ident: #ident,
-                    })
+                    });
                 }
                 None
             });

--- a/crates/storage/codecs/derive/src/compact/mod.rs
+++ b/crates/storage/codecs/derive/src/compact/mod.rs
@@ -143,10 +143,11 @@ fn load_field_from_segments(
         if is_enum {
             fields.push(FieldTypes::EnumUnnamedField((ftype.to_string(), use_alt_impl)));
         } else {
-            let should_compact = is_flag_type(&ftype) ||
-                field.attrs.iter().any(|attr| {
-                    attr.path().segments.iter().any(|path| path.ident == "maybe_zero")
-                });
+            let should_compact = is_flag_type(&ftype)
+                || field
+                    .attrs
+                    .iter()
+                    .any(|attr| attr.path().segments.iter().any(|path| path.ident == "maybe_zero"));
 
             fields.push(FieldTypes::StructField((
                 field.ident.as_ref().map(|i| i.to_string()).unwrap_or_default(),
@@ -180,7 +181,7 @@ fn should_use_alt_impl(ftype: &String, segment: &syn::PathSegment) -> bool {
                     ]
                     .contains(&path.ident.to_string().as_str())
                     {
-                        return true
+                        return true;
                     }
                 }
             }

--- a/crates/storage/codecs/derive/src/compact/structs.rs
+++ b/crates/storage/codecs/derive/src/compact/structs.rs
@@ -66,7 +66,7 @@ impl<'a> StructHandler<'a> {
                 })
             }
 
-            return
+            return;
         }
 
         let name = format_ident!("{name}");

--- a/crates/storage/codecs/src/lib.rs
+++ b/crates/storage/codecs/src/lib.rs
@@ -289,7 +289,7 @@ where
     #[inline]
     fn from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {
         if len == 0 {
-            return (None, buf)
+            return (None, buf);
         }
 
         let (len, mut buf) = decode_varuint(buf);
@@ -318,7 +318,7 @@ where
     #[inline]
     fn specialized_from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {
         if len == 0 {
-            return (None, buf)
+            return (None, buf);
         }
 
         let (element, buf) = T::from_compact(buf, len);
@@ -341,7 +341,7 @@ impl Compact for U256 {
     #[inline]
     fn from_compact(mut buf: &[u8], len: usize) -> (Self, &[u8]) {
         if len == 0 {
-            return (Self::ZERO, buf)
+            return (Self::ZERO, buf);
         }
 
         let mut arr = [0; 32];
@@ -381,7 +381,7 @@ impl<const N: usize> Compact for [u8; N] {
     #[inline]
     fn from_compact(mut buf: &[u8], len: usize) -> (Self, &[u8]) {
         if len == 0 {
-            return ([0; N], buf)
+            return ([0; N], buf);
         }
 
         let v = buf[..N].try_into().unwrap();
@@ -466,7 +466,7 @@ fn decode_varuint(buf: &[u8]) -> (usize, &[u8]) {
         let byte = buf[i];
         value |= usize::from(byte & 0x7F) << (i * 7);
         if byte < 0x80 {
-            return (value, &buf[i + 1..])
+            return (value, &buf[i + 1..]);
         }
     }
 

--- a/crates/storage/db-api/src/cursor.rs
+++ b/crates/storage/db-api/src/cursor.rs
@@ -158,7 +158,7 @@ impl<T: Table, CURSOR: DbCursorRO<T>> Iterator for Walker<'_, T, CURSOR> {
     fn next(&mut self) -> Option<Self::Item> {
         let start = self.start.take();
         if start.is_some() {
-            return start
+            return start;
         }
 
         self.cursor.next().transpose()
@@ -235,7 +235,7 @@ impl<T: Table, CURSOR: DbCursorRO<T>> Iterator for ReverseWalker<'_, T, CURSOR> 
     fn next(&mut self) -> Option<Self::Item> {
         let start = self.start.take();
         if start.is_some() {
-            return start
+            return start;
         }
 
         self.cursor.prev().transpose()
@@ -275,7 +275,7 @@ impl<T: Table, CURSOR: DbCursorRO<T>> Iterator for RangeWalker<'_, T, CURSOR> {
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.is_done {
-            return None
+            return None;
         }
 
         let next_item = self.start.take().or_else(|| self.cursor.next().transpose());
@@ -366,7 +366,7 @@ impl<T: DupSort, CURSOR: DbDupCursorRO<T>> Iterator for DupWalker<'_, T, CURSOR>
     fn next(&mut self) -> Option<Self::Item> {
         let start = self.start.take();
         if start.is_some() {
-            return start
+            return start;
         }
         self.cursor.next_dup().transpose()
     }

--- a/crates/storage/db-common/src/db_tool/mod.rs
+++ b/crates/storage/db-common/src/db_tool/mod.rs
@@ -59,18 +59,18 @@ impl<DB: Database> DbTool<DB> {
                     let (key, value) = (k.into_key(), v.into_value());
 
                     if key.len() + value.len() < filter.min_row_size {
-                        return None
+                        return None;
                     }
                     if key.len() < filter.min_key_size {
-                        return None
+                        return None;
                     }
                     if value.len() < filter.min_value_size {
-                        return None
+                        return None;
                     }
 
                     let result = || {
                         if filter.only_count {
-                            return None
+                            return None;
                         }
                         Some((
                             <T as Table>::Key::decode(&key).unwrap(),
@@ -80,16 +80,16 @@ impl<DB: Database> DbTool<DB> {
 
                     match &*bmb {
                         Some(searcher) => {
-                            if searcher.find_first_in(&value).is_some() ||
-                                searcher.find_first_in(&key).is_some()
+                            if searcher.find_first_in(&value).is_some()
+                                || searcher.find_first_in(&key).is_some()
                             {
                                 hits += 1;
-                                return result()
+                                return result();
                             }
                         }
                         None => {
                             hits += 1;
-                            return result()
+                            return result();
                         }
                     }
                 }

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -384,7 +384,7 @@ fn parse_accounts(
 
     while let Ok(n) = reader.read_line(&mut line) {
         if n == 0 {
-            break
+            break;
         }
 
         let GenesisAccountWithAddress { genesis_account, address } = serde_json::from_str(&line)?;
@@ -420,8 +420,8 @@ fn dump_state<DB: Database>(
 
         accounts.push((address, account));
 
-        if (index > 0 && index % AVERAGE_COUNT_ACCOUNTS_PER_GB_STATE_DUMP == 0) ||
-            index == accounts_len - 1
+        if (index > 0 && index % AVERAGE_COUNT_ACCOUNTS_PER_GB_STATE_DUMP == 0)
+            || index == accounts_len - 1
         {
             total_inserted_accounts += accounts.len();
 

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -394,7 +394,7 @@ impl DatabaseEnv {
                     LogLevel::Extra => 7,
                 });
             } else {
-                return Err(DatabaseError::LogLevelUnavailable(log_level))
+                return Err(DatabaseError::LogLevelUnavailable(log_level));
             }
         }
 
@@ -439,7 +439,7 @@ impl DatabaseEnv {
     /// Records version that accesses the database with write privileges.
     pub fn record_client_version(&self, version: ClientVersion) -> Result<(), DatabaseError> {
         if version.is_empty() {
-            return Ok(())
+            return Ok(());
         }
 
         let tx = self.tx_mut()?;

--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -225,9 +225,9 @@ impl<K: TransactionKind> MetricsHandler<K> {
     /// NOTE: Backtrace is recorded using [`Backtrace::force_capture`], so `RUST_BACKTRACE` env var
     /// is not needed.
     fn log_backtrace_on_long_read_transaction(&self) {
-        if self.record_backtrace &&
-            !self.backtrace_recorded.load(Ordering::Relaxed) &&
-            self.transaction_mode().is_read_only()
+        if self.record_backtrace
+            && !self.backtrace_recorded.load(Ordering::Relaxed)
+            && self.transaction_mode().is_read_only()
         {
             let open_duration = self.start.elapsed();
             if open_duration >= self.long_transaction_duration {

--- a/crates/storage/db/src/lockfile.rs
+++ b/crates/storage/db/src/lockfile.rs
@@ -49,7 +49,7 @@ impl StorageLock {
                         start_time = process_lock.start_time,
                         "Storage lock already taken."
                     );
-                    return Err(StorageLockError::Taken(process_lock.pid))
+                    return Err(StorageLockError::Taken(process_lock.pid));
                 }
             }
 

--- a/crates/storage/db/src/static_file/cursor.rs
+++ b/crates/storage/db/src/static_file/cursor.rs
@@ -35,7 +35,7 @@ impl<'a> StaticFileCursor<'a> {
         mask: usize,
     ) -> ProviderResult<Option<Vec<&'_ [u8]>>> {
         if self.jar().rows() == 0 {
-            return Ok(None)
+            return Ok(None);
         }
 
         let row = match key_or_num {
@@ -43,7 +43,7 @@ impl<'a> StaticFileCursor<'a> {
             KeyOrNumber::Number(n) => match self.jar().user_header().start() {
                 Some(offset) => {
                     if offset > n {
-                        return Ok(None)
+                        return Ok(None);
                     }
                     self.row_by_number_with_cols((n - offset) as usize, mask)
                 }

--- a/crates/storage/db/src/tables/codecs/fuzz/inputs.rs
+++ b/crates/storage/db/src/tables/codecs/fuzz/inputs.rs
@@ -13,7 +13,7 @@ impl From<IntegerListInput> for IntegerList {
 
         // Empty lists are not supported by `IntegerList`, so we want to skip these cases.
         if v.is_empty() {
-            return vec![1u64].into()
+            return vec![1u64].into();
         }
         v.sort();
         v.into()

--- a/crates/storage/db/src/version.rs
+++ b/crates/storage/db/src/version.rs
@@ -48,7 +48,7 @@ pub enum DatabaseVersionError {
 pub fn check_db_version_file<P: AsRef<Path>>(db_path: P) -> Result<(), DatabaseVersionError> {
     let version = get_db_version(db_path)?;
     if version != DB_VERSION {
-        return Err(DatabaseVersionError::VersionMismatch { version })
+        return Err(DatabaseVersionError::VersionMismatch { version });
     }
 
     Ok(())

--- a/crates/storage/libmdbx-rs/mdbx-sys/build.rs
+++ b/crates/storage/libmdbx-rs/mdbx-sys/build.rs
@@ -32,8 +32,8 @@ fn main() {
 
     // Propagate `-C target-cpu=native`
     let rustflags = env::var("CARGO_ENCODED_RUSTFLAGS").unwrap();
-    if rustflags.contains("target-cpu=native") &&
-        env::var("CARGO_CFG_TARGET_ENV").unwrap() != "msvc"
+    if rustflags.contains("target-cpu=native")
+        && env::var("CARGO_CFG_TARGET_ENV").unwrap() != "msvc"
     {
         cc.flag("-march=native");
     }
@@ -53,42 +53,42 @@ fn generate_bindings(mdbx: &Path, out_file: &Path) {
     impl ParseCallbacks for Callbacks {
         fn int_macro(&self, name: &str, _value: i64) -> Option<IntKind> {
             match name {
-                "MDBX_SUCCESS" |
-                "MDBX_KEYEXIST" |
-                "MDBX_NOTFOUND" |
-                "MDBX_PAGE_NOTFOUND" |
-                "MDBX_CORRUPTED" |
-                "MDBX_PANIC" |
-                "MDBX_VERSION_MISMATCH" |
-                "MDBX_INVALID" |
-                "MDBX_MAP_FULL" |
-                "MDBX_DBS_FULL" |
-                "MDBX_READERS_FULL" |
-                "MDBX_TLS_FULL" |
-                "MDBX_TXN_FULL" |
-                "MDBX_CURSOR_FULL" |
-                "MDBX_PAGE_FULL" |
-                "MDBX_MAP_RESIZED" |
-                "MDBX_INCOMPATIBLE" |
-                "MDBX_BAD_RSLOT" |
-                "MDBX_BAD_TXN" |
-                "MDBX_BAD_VALSIZE" |
-                "MDBX_BAD_DBI" |
-                "MDBX_LOG_DONTCHANGE" |
-                "MDBX_DBG_DONTCHANGE" |
-                "MDBX_RESULT_TRUE" |
-                "MDBX_UNABLE_EXTEND_MAPSIZE" |
-                "MDBX_PROBLEM" |
-                "MDBX_LAST_LMDB_ERRCODE" |
-                "MDBX_BUSY" |
-                "MDBX_EMULTIVAL" |
-                "MDBX_EBADSIGN" |
-                "MDBX_WANNA_RECOVERY" |
-                "MDBX_EKEYMISMATCH" |
-                "MDBX_TOO_LARGE" |
-                "MDBX_THREAD_MISMATCH" |
-                "MDBX_TXN_OVERLAPPING" |
-                "MDBX_LAST_ERRCODE" => Some(IntKind::Int),
+                "MDBX_SUCCESS"
+                | "MDBX_KEYEXIST"
+                | "MDBX_NOTFOUND"
+                | "MDBX_PAGE_NOTFOUND"
+                | "MDBX_CORRUPTED"
+                | "MDBX_PANIC"
+                | "MDBX_VERSION_MISMATCH"
+                | "MDBX_INVALID"
+                | "MDBX_MAP_FULL"
+                | "MDBX_DBS_FULL"
+                | "MDBX_READERS_FULL"
+                | "MDBX_TLS_FULL"
+                | "MDBX_TXN_FULL"
+                | "MDBX_CURSOR_FULL"
+                | "MDBX_PAGE_FULL"
+                | "MDBX_MAP_RESIZED"
+                | "MDBX_INCOMPATIBLE"
+                | "MDBX_BAD_RSLOT"
+                | "MDBX_BAD_TXN"
+                | "MDBX_BAD_VALSIZE"
+                | "MDBX_BAD_DBI"
+                | "MDBX_LOG_DONTCHANGE"
+                | "MDBX_DBG_DONTCHANGE"
+                | "MDBX_RESULT_TRUE"
+                | "MDBX_UNABLE_EXTEND_MAPSIZE"
+                | "MDBX_PROBLEM"
+                | "MDBX_LAST_LMDB_ERRCODE"
+                | "MDBX_BUSY"
+                | "MDBX_EMULTIVAL"
+                | "MDBX_EBADSIGN"
+                | "MDBX_WANNA_RECOVERY"
+                | "MDBX_EKEYMISMATCH"
+                | "MDBX_TOO_LARGE"
+                | "MDBX_THREAD_MISMATCH"
+                | "MDBX_TXN_OVERLAPPING"
+                | "MDBX_LAST_ERRCODE" => Some(IntKind::Int),
                 _ => Some(IntKind::UInt),
             }
         }

--- a/crates/storage/libmdbx-rs/src/codec.rs
+++ b/crates/storage/libmdbx-rs/src/codec.rs
@@ -41,8 +41,8 @@ impl TableObject for Cow<'_, [u8]> {
 
         #[cfg(not(feature = "return-borrowed"))]
         {
-            let is_dirty = (!K::IS_READ_ONLY) &&
-                crate::error::mdbx_result(ffi::mdbx_is_dirty(_txn, data_val.iov_base))?;
+            let is_dirty = (!K::IS_READ_ONLY)
+                && crate::error::mdbx_result(ffi::mdbx_is_dirty(_txn, data_val.iov_base))?;
 
             Ok(if is_dirty { Cow::Owned(s.to_vec()) } else { Cow::Borrowed(s) })
         }
@@ -81,7 +81,7 @@ impl TableObject for ObjectLength {
 impl<const LEN: usize> TableObject for [u8; LEN] {
     fn decode(data_val: &[u8]) -> Result<Self, Error> {
         if data_val.len() != LEN {
-            return Err(Error::DecodeErrorLenDiff)
+            return Err(Error::DecodeErrorLenDiff);
         }
         let mut a = [0; LEN];
         a[..].copy_from_slice(data_val);

--- a/crates/storage/libmdbx-rs/src/cursor.rs
+++ b/crates/storage/libmdbx-rs/src/cursor.rs
@@ -372,7 +372,7 @@ where
     {
         let res: Result<Option<((), ())>> = self.set_range(key);
         if let Err(error) = res {
-            return Iter::Err(Some(error))
+            return Iter::Err(Some(error));
         };
         Iter::new(self, ffi::MDBX_GET_CURRENT, ffi::MDBX_NEXT)
     }
@@ -407,7 +407,7 @@ where
     {
         let res: Result<Option<((), ())>> = self.set_range(key);
         if let Err(error) = res {
-            return IterDup::Err(Some(error))
+            return IterDup::Err(Some(error));
         };
         IterDup::new(self, ffi::MDBX_GET_CURRENT)
     }
@@ -423,7 +423,7 @@ where
             Ok(Some(_)) => (),
             Ok(None) => {
                 let _: Result<Option<((), ())>> = self.last();
-                return Iter::new(self, ffi::MDBX_NEXT, ffi::MDBX_NEXT)
+                return Iter::new(self, ffi::MDBX_NEXT, ffi::MDBX_NEXT);
             }
             Err(error) => return Iter::Err(Some(error)),
         };

--- a/crates/storage/libmdbx-rs/src/error.rs
+++ b/crates/storage/libmdbx-rs/src/error.rs
@@ -192,9 +192,9 @@ impl Error {
             Self::DecodeErrorLenDiff | Self::DecodeError => ffi::MDBX_EINVAL,
             Self::TooLarge => ffi::MDBX_TOO_LARGE,
             Self::BadSignature => ffi::MDBX_EBADSIGN,
-            Self::Access |
-            Self::WriteTransactionUnsupportedInReadOnlyMode |
-            Self::NestedTransactionsUnsupportedWithWriteMap => ffi::MDBX_EACCESS,
+            Self::Access
+            | Self::WriteTransactionUnsupportedInReadOnlyMode
+            | Self::NestedTransactionsUnsupportedWithWriteMap => ffi::MDBX_EACCESS,
             Self::ReadTransactionTimeout => -96000, // Custom non-MDBX error code
             Self::Other(err_code) => *err_code,
         }

--- a/crates/storage/libmdbx-rs/src/transaction.rs
+++ b/crates/storage/libmdbx-rs/src/transaction.rs
@@ -503,7 +503,7 @@ impl Transaction<RW> {
     /// Begins a new nested transaction inside of this transaction.
     pub fn begin_nested_txn(&mut self) -> Result<Self> {
         if self.inner.env.is_write_map() {
-            return Err(Error::NestedTransactionsUnsupportedWithWriteMap)
+            return Err(Error::NestedTransactionsUnsupportedWithWriteMap);
         }
         self.txn_execute(|txn| {
             let (tx, rx) = sync_channel(0);
@@ -584,7 +584,7 @@ impl TransactionPtr {
         // to the `mdbx_txn_reset`.
         #[cfg(feature = "read-tx-timeouts")]
         if self.is_timed_out() {
-            return Err(Error::ReadTransactionTimeout)
+            return Err(Error::ReadTransactionTimeout);
         }
 
         Ok((f)(self.txn))

--- a/crates/storage/nippy-jar/src/compression/lz4.rs
+++ b/crates/storage/nippy-jar/src/compression/lz4.rs
@@ -43,7 +43,7 @@ impl Compression for Lz4 {
                 Err(err) => {
                     multiplier *= 2;
                     if multiplier == 16 {
-                        return Err(NippyJarError::Custom(err.to_string()))
+                        return Err(NippyJarError::Custom(err.to_string()));
                     }
                 }
             }

--- a/crates/storage/nippy-jar/src/compression/zstd.rs
+++ b/crates/storage/nippy-jar/src/compression/zstd.rs
@@ -60,7 +60,7 @@ impl Zstd {
     pub fn decompressors(&self) -> Result<Vec<Decompressor<'_>>, NippyJarError> {
         if let Some(dictionaries) = &self.dictionaries {
             debug_assert!(dictionaries.len() == self.columns);
-            return dictionaries.decompressors()
+            return dictionaries.decompressors();
         }
 
         Ok(vec![])
@@ -72,12 +72,12 @@ impl Zstd {
             ZstdState::PendingDictionary => Err(NippyJarError::CompressorNotReady),
             ZstdState::Ready => {
                 if !self.use_dict {
-                    return Ok(None)
+                    return Ok(None);
                 }
 
                 if let Some(dictionaries) = &self.dictionaries {
                     debug!(target: "nippy-jar", count=?dictionaries.len(), "Generating ZSTD compressor dictionaries.");
-                    return Ok(Some(dictionaries.compressors()?))
+                    return Ok(Some(dictionaries.compressors()?));
                 }
                 Ok(None)
             }
@@ -102,7 +102,7 @@ impl Zstd {
                 buffer.reserve(column_value.len() * multiplier);
                 multiplier += 1;
                 if multiplier == 5 {
-                    return Err(NippyJarError::Disconnect(err))
+                    return Err(NippyJarError::Disconnect(err));
                 }
             }
 
@@ -192,7 +192,7 @@ impl Compression for Zstd {
         columns: Vec<impl IntoIterator<Item = Vec<u8>>>,
     ) -> Result<(), NippyJarError> {
         if !self.use_dict {
-            return Ok(())
+            return Ok(());
         }
 
         // There's a per 2GB hard limit on each column data set for training
@@ -206,7 +206,7 @@ impl Compression for Zstd {
         // ```
 
         if columns.len() != self.columns {
-            return Err(NippyJarError::ColumnLenMismatch(self.columns, columns.len()))
+            return Err(NippyJarError::ColumnLenMismatch(self.columns, columns.len()));
         }
 
         let mut dictionaries = vec![];
@@ -365,7 +365,7 @@ impl Serialize for ZstdDictionary<'_> {
 impl<'a> PartialEq for ZstdDictionary<'a> {
     fn eq(&self, other: &Self) -> bool {
         if let (Self::Raw(a), Self::Raw(b)) = (self, &other) {
-            return a == b
+            return a == b;
         }
         unimplemented!("`DecoderDictionary` can't be compared. So comparison should be done after decompressing a value.");
     }

--- a/crates/storage/nippy-jar/src/cursor.rs
+++ b/crates/storage/nippy-jar/src/cursor.rs
@@ -86,11 +86,11 @@ impl<'a, H: NippyJarHeader> NippyJarCursor<'a, H> {
                         .offsets_index
                         .access(row_index as usize)
                         .expect("built from same set") as u64;
-                    return self.next_row()
+                    return self.next_row();
                 }
             }
         } else {
-            return Err(NippyJarError::UnsupportedFilterQuery)
+            return Err(NippyJarError::UnsupportedFilterQuery);
         }
 
         Ok(None)
@@ -108,7 +108,7 @@ impl<'a, H: NippyJarHeader> NippyJarCursor<'a, H> {
 
         if self.row as usize >= self.jar.rows {
             // Has reached the end
-            return Ok(None)
+            return Ok(None);
         }
 
         let mut row = Vec::with_capacity(self.jar.columns);
@@ -154,11 +154,11 @@ impl<'a, H: NippyJarHeader> NippyJarCursor<'a, H> {
                         .offsets_index
                         .access(row_index as usize)
                         .expect("built from same set") as u64;
-                    return self.next_row_with_cols(mask)
+                    return self.next_row_with_cols(mask);
                 }
             }
         } else {
-            return Err(NippyJarError::UnsupportedFilterQuery)
+            return Err(NippyJarError::UnsupportedFilterQuery);
         }
 
         Ok(None)
@@ -182,7 +182,7 @@ impl<'a, H: NippyJarHeader> NippyJarCursor<'a, H> {
 
         if self.row as usize >= self.jar.rows {
             // Has reached the end
-            return Ok(None)
+            return Ok(None);
         }
 
         let columns = self.jar.columns;

--- a/crates/storage/nippy-jar/src/filter/cuckoo.rs
+++ b/crates/storage/nippy-jar/src/filter/cuckoo.rs
@@ -28,7 +28,7 @@ impl Cuckoo {
 impl InclusionFilter for Cuckoo {
     fn add(&mut self, element: &[u8]) -> Result<(), NippyJarError> {
         if self.remaining == 0 {
-            return Err(NippyJarError::FilterMaxCapacity)
+            return Err(NippyJarError::FilterMaxCapacity);
         }
 
         self.remaining -= 1;

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -465,12 +465,12 @@ impl<H: NippyJarHeader> NippyJar<H> {
         columns: &[impl IntoIterator<Item = ColumnResult<Vec<u8>>>],
     ) -> Result<(), NippyJarError> {
         if columns.len() != self.columns {
-            return Err(NippyJarError::ColumnLenMismatch(self.columns, columns.len()))
+            return Err(NippyJarError::ColumnLenMismatch(self.columns, columns.len()));
         }
 
         if let Some(compression) = &self.compressor {
             if !compression.is_ready() {
-                return Err(NippyJarError::CompressorNotReady)
+                return Err(NippyJarError::CompressorNotReady);
             }
         }
 
@@ -518,9 +518,9 @@ impl DataReader {
 
         // Ensure that the size of an offset is at most 8 bytes.
         if offset_size > 8 {
-            return Err(NippyJarError::OffsetSizeTooBig { offset_size })
+            return Err(NippyJarError::OffsetSizeTooBig { offset_size });
         } else if offset_size == 0 {
-            return Err(NippyJarError::OffsetSizeTooSmall { offset_size })
+            return Err(NippyJarError::OffsetSizeTooSmall { offset_size });
         }
 
         Ok(Self { data_file, data_mmap, offset_file, offset_size, offset_mmap })
@@ -560,7 +560,7 @@ impl DataReader {
 
         let offset_end = index.saturating_add(self.offset_size as usize);
         if offset_end > self.offset_mmap.len() {
-            return Err(NippyJarError::OffsetOutOfBounds { index })
+            return Err(NippyJarError::OffsetOutOfBounds { index });
         }
 
         buffer[..self.offset_size as usize].copy_from_slice(&self.offset_mmap[index..offset_end]);

--- a/crates/storage/nippy-jar/src/phf/fmph.rs
+++ b/crates/storage/nippy-jar/src/phf/fmph.rs
@@ -28,7 +28,7 @@ impl PerfectHashingFunction for Fmph {
 
     fn get_index(&self, key: &[u8]) -> Result<Option<u64>, NippyJarError> {
         if let Some(f) = &self.function {
-            return Ok(f.get(key))
+            return Ok(f.get(key));
         }
         Err(NippyJarError::PHFMissingKeys)
     }
@@ -39,9 +39,9 @@ impl PartialEq for Fmph {
     fn eq(&self, _other: &Self) -> bool {
         match (&self.function, &_other.function) {
             (Some(func1), Some(func2)) => {
-                func1.level_sizes() == func2.level_sizes() &&
-                    func1.write_bytes() == func2.write_bytes() &&
-                    {
+                func1.level_sizes() == func2.level_sizes()
+                    && func1.write_bytes() == func2.write_bytes()
+                    && {
                         let mut f1 = Vec::with_capacity(func1.write_bytes());
                         func1.write(&mut f1).expect("enough capacity");
 
@@ -92,7 +92,7 @@ impl<'de> Deserialize<'de> for Fmph {
                 function: Some(
                     Function::read(&mut std::io::Cursor::new(buffer)).map_err(D::Error::custom)?,
                 ),
-            })
+            });
         }
         Ok(Self { function: None })
     }

--- a/crates/storage/nippy-jar/src/phf/go_fmph.rs
+++ b/crates/storage/nippy-jar/src/phf/go_fmph.rs
@@ -28,7 +28,7 @@ impl PerfectHashingFunction for GoFmph {
 
     fn get_index(&self, key: &[u8]) -> Result<Option<u64>, NippyJarError> {
         if let Some(f) = &self.function {
-            return Ok(f.get(key))
+            return Ok(f.get(key));
         }
         Err(NippyJarError::PHFMissingKeys)
     }
@@ -39,9 +39,9 @@ impl PartialEq for GoFmph {
     fn eq(&self, other: &Self) -> bool {
         match (&self.function, &other.function) {
             (Some(func1), Some(func2)) => {
-                func1.level_sizes() == func2.level_sizes() &&
-                    func1.write_bytes() == func2.write_bytes() &&
-                    {
+                func1.level_sizes() == func2.level_sizes()
+                    && func1.write_bytes() == func2.write_bytes()
+                    && {
                         let mut f1 = Vec::with_capacity(func1.write_bytes());
                         func1.write(&mut f1).expect("enough capacity");
 
@@ -93,7 +93,7 @@ impl<'de> Deserialize<'de> for GoFmph {
                     GOFunction::read(&mut std::io::Cursor::new(buffer))
                         .map_err(D::Error::custom)?,
                 ),
-            })
+            });
         }
         Ok(Self { function: None })
     }

--- a/crates/storage/nippy-jar/src/writer.rs
+++ b/crates/storage/nippy-jar/src/writer.rs
@@ -163,7 +163,7 @@ impl<H: NippyJarHeader> NippyJarWriter<H> {
         // When an offset size is smaller than the initial (8), we are dealing with immutable
         // data.
         if reader.offset_size() != OFFSET_SIZE_BYTES {
-            return Err(NippyJarError::FrozenJar)
+            return Err(NippyJarError::FrozenJar);
         }
 
         let expected_offsets_file_size: u64 = (1 + // first byte is the size of one offset
@@ -171,10 +171,10 @@ impl<H: NippyJarHeader> NippyJarWriter<H> {
             OFFSET_SIZE_BYTES as usize) as u64; // expected size of the data file
         let actual_offsets_file_size = self.offsets_file.get_ref().metadata()?.len();
 
-        if check_mode.should_err() &&
-            expected_offsets_file_size.cmp(&actual_offsets_file_size) != Ordering::Equal
+        if check_mode.should_err()
+            && expected_offsets_file_size.cmp(&actual_offsets_file_size) != Ordering::Equal
         {
-            return Err(NippyJarError::InconsistentState)
+            return Err(NippyJarError::InconsistentState);
         }
 
         // Offsets configuration wasn't properly committed
@@ -191,8 +191,8 @@ impl<H: NippyJarHeader> NippyJarWriter<H> {
                 self.jar.rows = ((actual_offsets_file_size.
                     saturating_sub(1). // first byte is the size of one offset
                     saturating_sub(OFFSET_SIZE_BYTES as u64) / // expected size of the data file
-                    (self.jar.columns as u64)) /
-                    OFFSET_SIZE_BYTES as u64) as usize;
+                    (self.jar.columns as u64))
+                    / OFFSET_SIZE_BYTES as u64) as usize;
 
                 // Freeze row count changed
                 self.jar.freeze_config()?;
@@ -205,7 +205,7 @@ impl<H: NippyJarHeader> NippyJarWriter<H> {
         let data_file_len = self.data_file.get_ref().metadata()?.len();
 
         if check_mode.should_err() && last_offset.cmp(&data_file_len) != Ordering::Equal {
-            return Err(NippyJarError::InconsistentState)
+            return Err(NippyJarError::InconsistentState);
         }
 
         // Offset list wasn't properly committed
@@ -235,7 +235,7 @@ impl<H: NippyJarHeader> NippyJarWriter<H> {
                         // Since we decrease the offset list, we need to check the consistency of
                         // `self.jar.rows` again
                         self.ensure_file_consistency(ConsistencyFailStrategy::Heal)?;
-                        break
+                        break;
                     }
                 }
             }
@@ -372,7 +372,7 @@ impl<H: NippyJarHeader> NippyJarWriter<H> {
                     return Err(NippyJarError::InvalidPruning(
                         num_offsets,
                         remaining_to_prune as u64,
-                    ))
+                    ));
                 }
 
                 let new_num_offsets = num_offsets.saturating_sub(remaining_to_prune as u64);
@@ -398,7 +398,7 @@ impl<H: NippyJarHeader> NippyJarWriter<H> {
                     self.data_file.get_mut().set_len(last_offset)?;
                 }
             } else {
-                return Err(NippyJarError::InvalidPruning(0, remaining_to_prune as u64))
+                return Err(NippyJarError::InvalidPruning(0, remaining_to_prune as u64));
             }
         }
 
@@ -490,7 +490,7 @@ impl<H: NippyJarHeader> NippyJarWriter<H> {
         for offset in self.offsets.drain(..) {
             if let Some(last_offset_ondisk) = last_offset_ondisk.take() {
                 if last_offset_ondisk == offset {
-                    continue
+                    continue;
                 }
             }
             self.offsets_file.write_all(&offset.to_le_bytes())?;

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -169,7 +169,7 @@ where
             // database lookup
             let Some(block_number) = provider.transaction_block(id)? else { return Ok(None) };
             let Some(body_index) = provider.block_body_indices(block_number)? else {
-                return Ok(None)
+                return Ok(None);
             };
             let tx_index = id - body_index.last_tx_num();
             Ok(Some((None, tx_index as usize)))
@@ -193,7 +193,7 @@ where
 
                 for tx_index in 0..block.body.len() {
                     if id == in_memory_tx_num {
-                        return Ok(Some((Some(block_state), tx_index)))
+                        return Ok(Some((Some(block_state), tx_index)));
                     }
 
                     in_memory_tx_num += 1;
@@ -312,7 +312,7 @@ where
                 // need to handle that situation.
                 headers.push(block_state.block().block().header.header().clone());
             } else {
-                break
+                break;
             }
         }
 
@@ -352,7 +352,7 @@ where
                 // need to handle that situation.
                 sealed_headers.push(block_state.block().block().header.clone());
             } else {
-                break
+                break;
             }
         }
 
@@ -383,13 +383,13 @@ where
             if let Some(block_state) = self.canonical_in_memory_state.state_by_number(num) {
                 let header = block_state.block().block().header.clone();
                 if !predicate(&header) {
-                    break
+                    break;
                 }
                 // TODO: there might be an update between loop iterations, we
                 // need to handle that situation.
                 sealed_headers.push(header);
             } else {
-                break
+                break;
             }
         }
 
@@ -433,7 +433,7 @@ where
                 // need to handle that situation.
                 hashes.push(block_state.hash());
             } else {
-                break
+                break;
             }
         }
 
@@ -653,7 +653,7 @@ where
                 // need to handle that situation.
                 blocks.push(block_state.block().block().clone().unseal());
             } else {
-                break
+                break;
             }
         }
 
@@ -683,7 +683,7 @@ where
                 // need to handle that situation.
                 blocks.push(BlockWithSenders { block: block.unseal(), senders });
             } else {
-                break
+                break;
             }
         }
 
@@ -713,7 +713,7 @@ where
                 // need to handle that situation.
                 blocks.push(SealedBlockWithSenders { block, senders });
             } else {
-                break
+                break;
             }
         }
 
@@ -728,7 +728,7 @@ where
     fn transaction_id(&self, tx_hash: TxHash) -> ProviderResult<Option<TxNumber>> {
         // First, check the database
         if let Some(id) = self.database.transaction_id(tx_hash)? {
-            return Ok(Some(id))
+            return Ok(Some(id));
         }
 
         // If the transaction is not found in the database, check the in-memory state
@@ -744,8 +744,8 @@ where
         // Find the transaction in the in-memory state with the matching hash, and return its
         // number
         let mut in_memory_tx_id = last_database_tx_id + 1;
-        for block_number in last_database_block_number.saturating_add(1)..=
-            self.canonical_in_memory_state.get_canonical_block_number()
+        for block_number in last_database_block_number.saturating_add(1)
+            ..=self.canonical_in_memory_state.get_canonical_block_number()
         {
             // TODO: there might be an update between loop iterations, we
             // need to handle that situation.
@@ -755,7 +755,7 @@ where
                 .ok_or(ProviderError::StateForNumberNotFound(block_number))?;
             for tx in &block_state.block().block().body {
                 if tx.hash() == tx_hash {
-                    return Ok(Some(in_memory_tx_id))
+                    return Ok(Some(in_memory_tx_id));
                 }
 
                 in_memory_tx_id += 1;
@@ -768,7 +768,7 @@ where
     fn transaction_by_id(&self, id: TxNumber) -> ProviderResult<Option<TransactionSigned>> {
         let provider = self.database.provider()?;
         let Some((block_state, tx_index)) = self.block_state_by_tx_id(&provider, id)? else {
-            return Ok(None)
+            return Ok(None);
         };
 
         if let Some(block_state) = block_state {
@@ -785,7 +785,7 @@ where
     ) -> ProviderResult<Option<TransactionSignedNoHash>> {
         let provider = self.database.provider()?;
         let Some((block_state, tx_index)) = self.block_state_by_tx_id(&provider, id)? else {
-            return Ok(None)
+            return Ok(None);
         };
 
         if let Some(block_state) = block_state {
@@ -799,7 +799,7 @@ where
 
     fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<TransactionSigned>> {
         if let Some(tx) = self.canonical_in_memory_state.transaction_by_hash(hash) {
-            return Ok(Some(tx))
+            return Ok(Some(tx));
         }
 
         self.database.transaction_by_hash(hash)
@@ -812,7 +812,7 @@ where
         if let Some((tx, meta)) =
             self.canonical_in_memory_state.transaction_by_hash_with_meta(tx_hash)
         {
-            return Ok(Some((tx, meta)))
+            return Ok(Some((tx, meta)));
         }
 
         self.database.transaction_by_hash_with_meta(tx_hash)
@@ -863,7 +863,7 @@ where
                 transactions.push(block_state.block().block().body.clone());
                 last_in_memory_block = Some(number);
             } else {
-                break
+                break;
             }
         }
 
@@ -897,7 +897,7 @@ where
     fn transaction_sender(&self, id: TxNumber) -> ProviderResult<Option<Address>> {
         let provider = self.database.provider()?;
         let Some((block_state, tx_index)) = self.block_state_by_tx_id(&provider, id)? else {
-            return Ok(None)
+            return Ok(None);
         };
 
         if let Some(block_state) = block_state {
@@ -921,7 +921,7 @@ where
     fn receipt(&self, id: TxNumber) -> ProviderResult<Option<Receipt>> {
         let provider = self.database.provider()?;
         let Some((block_state, tx_index)) = self.block_state_by_tx_id(&provider, id)? else {
-            return Ok(None)
+            return Ok(None);
         };
 
         if let Some(block_state) = block_state {
@@ -1023,7 +1023,7 @@ where
         timestamp: u64,
     ) -> ProviderResult<Option<Withdrawals>> {
         if !self.database.chain_spec().is_shanghai_active_at_timestamp(timestamp) {
-            return Ok(None)
+            return Ok(None);
         }
 
         let Some(number) = self.convert_hash_or_number(id)? else { return Ok(None) };
@@ -1058,7 +1058,7 @@ where
         timestamp: u64,
     ) -> ProviderResult<Option<reth_primitives::Requests>> {
         if !self.database.chain_spec().is_prague_active_at_timestamp(timestamp) {
-            return Ok(None)
+            return Ok(None);
         }
         let Some(number) = self.convert_hash_or_number(id)? else { return Ok(None) };
         if let Some(block) = self.canonical_in_memory_state.state_by_number(number) {
@@ -1270,7 +1270,7 @@ where
                 let pending_provider =
                     self.canonical_in_memory_state.state_provider(block_hash, historical);
 
-                return Ok(Some(Box::new(pending_provider)))
+                return Ok(Some(Box::new(pending_provider)));
             }
         }
         Ok(None)

--- a/crates/storage/provider/src/providers/bundle_state_provider.rs
+++ b/crates/storage/provider/src/providers/bundle_state_provider.rs
@@ -40,7 +40,7 @@ impl<SP: StateProvider, EDP: ExecutionDataProvider> BlockHashReader
     fn block_hash(&self, block_number: BlockNumber) -> ProviderResult<Option<B256>> {
         let block_hash = self.block_execution_data_provider.block_hash(block_number);
         if block_hash.is_some() {
-            return Ok(block_hash)
+            return Ok(block_hash);
         }
         self.state_provider.block_hash(block_number)
     }
@@ -182,7 +182,7 @@ impl<SP: StateProvider, EDP: ExecutionDataProvider> StateProvider for BundleStat
             .execution_outcome()
             .storage(&account, u256_storage_key)
         {
-            return Ok(Some(value))
+            return Ok(Some(value));
         }
 
         self.state_provider.storage(account, storage_key)
@@ -192,7 +192,7 @@ impl<SP: StateProvider, EDP: ExecutionDataProvider> StateProvider for BundleStat
         if let Some(bytecode) =
             self.block_execution_data_provider.execution_outcome().bytecode(&code_hash)
         {
-            return Ok(Some(bytecode))
+            return Ok(Some(bytecode));
         }
 
         self.state_provider.bytecode_by_hash(code_hash)

--- a/crates/storage/provider/src/providers/consistent_view.rs
+++ b/crates/storage/provider/src/providers/consistent_view.rs
@@ -62,7 +62,7 @@ where
             return Err(ConsistentViewError::Inconsistent {
                 tip: GotExpected { got: tip, expected: self.tip },
             }
-            .into())
+            .into());
         }
 
         // Check that the best block number is the same as the latest stored header.
@@ -73,7 +73,7 @@ where
             return Err(ConsistentViewError::Syncing {
                 best_block: GotExpected { got: best_block_number, expected: last_num },
             }
-            .into())
+            .into());
         }
 
         Ok(provider_ro)

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -219,7 +219,7 @@ impl<DB: Database> HeaderProvider for ProviderFactory<DB> {
         if let Some(td) = self.chain_spec.final_paris_total_difficulty(number) {
             // if this block is higher than the final paris(merge) block, return the final paris
             // difficulty
-            return Ok(Some(td))
+            return Ok(Some(td));
         }
 
         self.static_file_provider.get_with_static_file_or_database(

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -153,10 +153,10 @@ impl<TX: DbTx + 'static> DatabaseProvider<TX> {
         self,
         mut block_number: BlockNumber,
     ) -> ProviderResult<StateProviderBox> {
-        if block_number == self.best_block_number().unwrap_or_default() &&
-            block_number == self.last_block_number().unwrap_or_default()
+        if block_number == self.best_block_number().unwrap_or_default()
+            && block_number == self.last_block_number().unwrap_or_default()
         {
-            return Ok(Box::new(LatestStateProvider::new(self.tx, self.static_file_provider)))
+            return Ok(Box::new(LatestStateProvider::new(self.tx, self.static_file_provider)));
         }
 
         // +1 as the changeset that we want is the one that was applied after this block.
@@ -252,7 +252,7 @@ where
     while let Some((sharded_key, list)) = item {
         // If the shard does not belong to the key, break.
         if !shard_belongs_to_key(&sharded_key) {
-            break
+            break;
         }
         cursor.delete_current()?;
 
@@ -263,9 +263,9 @@ where
             item = cursor.prev()?;
         } else if block_number <= sharded_key.as_ref().highest_block_number {
             // Filter out all elements greater than block number.
-            return Ok(list.iter().take_while(|i| *i < block_number).collect::<Vec<_>>())
+            return Ok(list.iter().take_while(|i| *i < block_number).collect::<Vec<_>>());
         } else {
-            return Ok(list.iter().collect::<Vec<_>>())
+            return Ok(list.iter().collect::<Vec<_>>());
         }
     }
 
@@ -476,7 +476,7 @@ impl<TX: DbTx> DatabaseProvider<TX> {
         ) -> ProviderResult<R>,
     {
         if range.is_empty() {
-            return Ok(Vec::new())
+            return Ok(Vec::new());
         }
 
         let len = range.end().saturating_sub(*range.start()) as usize;
@@ -615,7 +615,7 @@ impl<TX: DbTx> DatabaseProvider<TX> {
         let block_bodies = self.get::<tables::BlockBodyIndices>(range)?;
 
         if block_bodies.is_empty() {
-            return Ok(Vec::new())
+            return Ok(Vec::new());
         }
 
         // Compute the first and last tx ID in the range
@@ -624,7 +624,7 @@ impl<TX: DbTx> DatabaseProvider<TX> {
 
         // If this is the case then all of the blocks in the range are empty
         if last_transaction < first_transaction {
-            return Ok(block_bodies.into_iter().map(|(n, _)| (n, Vec::new())).collect())
+            return Ok(block_bodies.into_iter().map(|(n, _)| (n, Vec::new())).collect());
         }
 
         // Get transactions and senders
@@ -686,7 +686,7 @@ impl<TX: DbTx> DatabaseProvider<TX> {
 
         let block_headers = self.get::<tables::Headers>(range.clone())?;
         if block_headers.is_empty() {
-            return Ok(Vec::new())
+            return Ok(Vec::new());
         }
 
         let block_header_hashes = self.get::<tables::CanonicalHeaders>(range.clone())?;
@@ -788,7 +788,7 @@ impl<TX: DbTx> DatabaseProvider<TX> {
         range: RangeInclusive<BlockNumber>,
     ) -> ProviderResult<ExecutionOutcome> {
         if range.is_empty() {
-            return Ok(ExecutionOutcome::default())
+            return Ok(ExecutionOutcome::default());
         }
         let start_block_number = *range.start();
 
@@ -957,7 +957,7 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
     ///     3. Set the local state to the value in the changeset
     pub fn remove_state(&self, range: RangeInclusive<BlockNumber>) -> ProviderResult<()> {
         if range.is_empty() {
-            return Ok(())
+            return Ok(());
         }
 
         // We are not removing block meta as it is used to get block changesets.
@@ -1052,7 +1052,7 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
         range: RangeInclusive<BlockNumber>,
     ) -> ProviderResult<ExecutionOutcome> {
         if range.is_empty() {
-            return Ok(ExecutionOutcome::default())
+            return Ok(ExecutionOutcome::default());
         }
         let start_block_number = *range.start();
 
@@ -1192,7 +1192,7 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
         let block_bodies = self.take::<tables::BlockBodyIndices>(range)?;
 
         if block_bodies.is_empty() {
-            return Ok(())
+            return Ok(());
         }
 
         // Compute the first and last tx ID in the range
@@ -1201,7 +1201,7 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
 
         // If this is the case then all of the blocks in the range are empty
         if last_transaction < first_transaction {
-            return Ok(())
+            return Ok(());
         }
 
         // Get transactions so we can then remove
@@ -1247,7 +1247,7 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
         let block_bodies = self.get::<tables::BlockBodyIndices>(range)?;
 
         if block_bodies.is_empty() {
-            return Ok(Vec::new())
+            return Ok(Vec::new());
         }
 
         // Compute the first and last tx ID in the range
@@ -1256,7 +1256,7 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
 
         // If this is the case then all of the blocks in the range are empty
         if last_transaction < first_transaction {
-            return Ok(block_bodies.into_iter().map(|(n, _)| (n, Vec::new())).collect())
+            return Ok(block_bodies.into_iter().map(|(n, _)| (n, Vec::new())).collect());
         }
 
         // Get transactions and senders
@@ -1334,7 +1334,7 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
     ) -> ProviderResult<()> {
         let block_headers = self.remove::<tables::Headers>(range.clone())?;
         if block_headers == 0 {
-            return Ok(())
+            return Ok(());
         }
 
         self.unwind_table_by_walker::<tables::CanonicalHeaders, tables::HeaderNumbers>(
@@ -1377,7 +1377,7 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
 
         let block_headers = self.take::<tables::Headers>(range.clone())?;
         if block_headers.is_empty() {
-            return Ok(Vec::new())
+            return Ok(Vec::new());
         }
 
         self.unwind_table_by_walker::<tables::CanonicalHeaders, tables::HeaderNumbers>(
@@ -1491,7 +1491,7 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
 
         while let Some(Ok((entry_key, _))) = reverse_walker.next() {
             if selector(entry_key.clone()) <= key {
-                break
+                break;
             }
             reverse_walker.delete_current()?;
             deleted += 1;
@@ -1541,7 +1541,7 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
                     table = %T::NAME,
                     "Pruning limit reached"
                 );
-                break
+                break;
             }
 
             let row = cursor.seek_exact(key)?;
@@ -1584,7 +1584,7 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
                     table = %T::NAME,
                     "Pruning limit reached"
                 );
-                break false
+                break false;
             }
 
             let done = self.prune_table_with_range_step(
@@ -1595,7 +1595,7 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
             )?;
 
             if done {
-                break true
+                break true;
             } else {
                 deleted_entries += 1;
             }
@@ -1643,7 +1643,7 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
             // delete old shard so new one can be inserted.
             self.tx.delete::<T>(shard_key, None)?;
             let list = list.iter().collect::<Vec<_>>();
-            return Ok(list)
+            return Ok(list);
         }
         Ok(Vec::new())
     }
@@ -1788,7 +1788,7 @@ impl<TX: DbTx> HeaderSyncGapProvider for DatabaseProvider<TX> {
             }
             Ordering::Less => {
                 // There's either missing or corrupted files.
-                return Err(ProviderError::HeaderNotFound(next_static_file_block_num.into()))
+                return Err(ProviderError::HeaderNotFound(next_static_file_block_num.into()));
             }
             Ordering::Equal => {}
         }
@@ -1833,7 +1833,7 @@ impl<TX: DbTx> HeaderProvider for DatabaseProvider<TX> {
         if let Some(td) = self.chain_spec.final_paris_total_difficulty(number) {
             // if this block is higher than the final paris(merge) block, return the final paris
             // difficulty
-            return Ok(Some(td))
+            return Ok(Some(td));
         }
 
         self.static_file_provider.get_with_static_file_or_database(
@@ -1890,7 +1890,7 @@ impl<TX: DbTx> HeaderProvider for DatabaseProvider<TX> {
                         .ok_or_else(|| ProviderError::HeaderNotFound(number.into()))?;
                     let sealed = header.seal(hash);
                     if !predicate(&sealed) {
-                        break
+                        break;
                     }
                     headers.push(sealed);
                 }
@@ -1986,7 +1986,13 @@ impl<TX: DbTx> BlockReader for DatabaseProvider<TX> {
                     None => return Ok(None),
                 };
 
-                return Ok(Some(Block { header, body: transactions, ommers, withdrawals, requests }))
+                return Ok(Some(Block {
+                    header,
+                    body: transactions,
+                    ommers,
+                    withdrawals,
+                    requests,
+                }));
             }
         }
 
@@ -2014,11 +2020,11 @@ impl<TX: DbTx> BlockReader for DatabaseProvider<TX> {
             // If the Paris (Merge) hardfork block is known and block is after it, return empty
             // ommers.
             if self.chain_spec.final_paris_total_difficulty(number).is_some() {
-                return Ok(Some(Vec::new()))
+                return Ok(Some(Vec::new()));
             }
 
             let ommers = self.tx.get::<tables::BlockOmmers>(number)?.map(|o| o.ommers);
-            return Ok(ommers)
+            return Ok(ommers);
         }
 
         Ok(None)
@@ -2270,7 +2276,7 @@ impl<TX: DbTx> TransactionsProvider for DatabaseProvider<TX> {
                                 timestamp: header.timestamp,
                             };
 
-                            return Ok(Some((transaction, meta)))
+                            return Ok(Some((transaction, meta)));
                         }
                     }
                 }
@@ -2303,7 +2309,7 @@ impl<TX: DbTx> TransactionsProvider for DatabaseProvider<TX> {
                             .map(Into::into)
                             .collect(),
                     ))
-                }
+                };
             }
         }
         Ok(None)
@@ -2381,7 +2387,7 @@ impl<TX: DbTx> ReceiptProvider for DatabaseProvider<TX> {
                     Ok(Some(Vec::new()))
                 } else {
                     self.receipts_by_tx_range(tx_range).map(Some)
-                }
+                };
             }
         }
         Ok(None)
@@ -2416,7 +2422,7 @@ impl<TX: DbTx> WithdrawalsProvider for DatabaseProvider<TX> {
                     .get::<tables::BlockWithdrawals>(number)
                     .map(|w| w.map(|w| w.withdrawals))?
                     .unwrap_or_default();
-                return Ok(Some(withdrawals))
+                return Ok(Some(withdrawals));
             }
         }
         Ok(None)
@@ -2440,7 +2446,7 @@ impl<TX: DbTx> RequestsProvider for DatabaseProvider<TX> {
                 // If we are past Prague, then all blocks should have a requests list, even if
                 // empty
                 let requests = self.tx.get::<tables::BlockRequests>(number)?.unwrap_or_default();
-                return Ok(Some(requests))
+                return Ok(Some(requests));
             }
         }
         Ok(None)
@@ -2814,7 +2820,7 @@ impl<TX: DbTxMut + DbTx> TrieWriter for DatabaseProvider<TX> {
     /// Writes trie updates. Returns the number of entries modified.
     fn write_trie_updates(&self, trie_updates: &TrieUpdates) -> ProviderResult<usize> {
         if trie_updates.is_empty() {
-            return Ok(0)
+            return Ok(0);
         }
 
         // Track the number of inserted entries.
@@ -2888,7 +2894,7 @@ impl<TX: DbTxMut + DbTx> StorageTrieWriter for DatabaseProvider<TX> {
         updates: &StorageTrieUpdates,
     ) -> ProviderResult<usize> {
         if updates.is_empty() {
-            return Ok(0)
+            return Ok(0);
         }
 
         let cursor = self.tx_ref().cursor_dup_write::<tables::StoragesTrie>()?;
@@ -3090,7 +3096,7 @@ impl<TX: DbTxMut + DbTx> HashingWriter for DatabaseProvider<TX> {
                     root: GotExpected { got: state_root, expected: expected_state_root },
                     block_number: *range.end(),
                     block_hash: end_block_hash,
-                })))
+                })));
             }
             self.write_trie_updates(&trie_updates)?;
         }
@@ -3170,8 +3176,8 @@ impl<TX: DbTxMut + DbTx> HistoryWriter for DatabaseProvider<TX> {
                 StorageShardedKey::last(address, storage_key),
                 rem_index,
                 |storage_sharded_key| {
-                    storage_sharded_key.address == address &&
-                        storage_sharded_key.sharded_key.key == storage_key
+                    storage_sharded_key.address == address
+                        && storage_sharded_key.sharded_key.key == storage_key
                 },
             )?;
 
@@ -3299,7 +3305,7 @@ impl<TX: DbTxMut + DbTx> BlockExecutionWriter for DatabaseProvider<TX> {
                 root: GotExpected { got: new_state_root, expected: parent_state_root },
                 block_number: parent_number,
                 block_hash: parent_hash,
-            })))
+            })));
         }
         self.write_trie_updates(&trie_updates)?;
 
@@ -3387,7 +3393,7 @@ impl<TX: DbTxMut + DbTx> BlockExecutionWriter for DatabaseProvider<TX> {
                 root: GotExpected { got: new_state_root, expected: parent_state_root },
                 block_number: parent_number,
                 block_hash: parent_hash,
-            })))
+            })));
         }
         self.write_trie_updates(&trie_updates)?;
 
@@ -3586,7 +3592,7 @@ impl<TX: DbTxMut + DbTx> BlockWriter for DatabaseProvider<TX> {
     ) -> ProviderResult<()> {
         if blocks.is_empty() {
             debug!(target: "providers::db", "Attempted to append empty block range");
-            return Ok(())
+            return Ok(());
         }
 
         let first_number = blocks.first().unwrap().number;
@@ -3795,8 +3801,8 @@ impl<TX: DbTx> SnapshotReader for DatabaseProvider<TX> {
             self.tx
                 .cursor_read::<tables::Chunks>()?
                 .walk_range(
-                    chunk_ids.first().cloned().unwrap_or_default()..=
-                        chunk_ids.last().cloned().unwrap_or_default(),
+                    chunk_ids.first().cloned().unwrap_or_default()
+                        ..=chunk_ids.last().cloned().unwrap_or_default(),
                 )?
                 .collect::<Result<HashMap<_, _>, _>>()?
                 .values()
@@ -3878,8 +3884,8 @@ impl<TX: DbTx> WalletStateSyncReader for DatabaseProvider<TX> {
             .walk(None)?
             .filter_map(|item| match item {
                 Ok((peer_id, wallet_state_sync_record)) => {
-                    if wallet_state_sync_record.get_data().len() as u64 >=
-                        wallet_state_sync_record.get_chunks_count()
+                    if wallet_state_sync_record.get_data().len() as u64
+                        >= wallet_state_sync_record.get_chunks_count()
                     {
                         return Some((peer_id, wallet_state_sync_record));
                     }
@@ -3992,7 +3998,7 @@ impl<TX: DbTxMut + DbTx> SnapshotWriter for DatabaseProvider<TX> {
 
     fn remove_snapshots(&self, range: RangeInclusive<SnapshotId>) -> ProviderResult<()> {
         if range.is_empty() {
-            return Ok(())
+            return Ok(());
         }
         self.remove::<tables::Snapshots>(*range.start()..=*range.end())?;
         Ok(())
@@ -4004,7 +4010,7 @@ impl<TX: DbTxMut + DbTx> SnapshotWriter for DatabaseProvider<TX> {
             self.remove_snapshots(RangeInclusive::new(snapshot_id, snapshot_id))?;
             let cids = snapshot.chunk_ids().to_vec();
             if cids.is_empty() {
-                return Ok(())
+                return Ok(());
             }
             let range_to_delete = RangeInclusive::new(
                 cids.first().copied().unwrap_or_default(),
@@ -4018,7 +4024,7 @@ impl<TX: DbTxMut + DbTx> SnapshotWriter for DatabaseProvider<TX> {
 
     fn remove_chunks(&self, range: RangeInclusive<ChunkId>) -> ProviderResult<()> {
         if range.is_empty() {
-            return Ok(())
+            return Ok(());
         }
         self.remove::<tables::Chunks>(*range.start()..=*range.end())?;
         Ok(())
@@ -4042,7 +4048,7 @@ impl<TX: DbTxMut + DbTx> SnapshotWriter for DatabaseProvider<TX> {
 
     fn delete_chunks_in_blocks(&self, range: RangeInclusive<ChunkId>) -> ProviderResult<()> {
         if range.is_empty() {
-            return Ok(())
+            return Ok(());
         }
         Ok(self.tx.cursor_write::<tables::ChunkBlocks>()?.walk_range(range)?.delete_current()?)
     }

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -80,7 +80,7 @@ impl<'b, TX: DbTx> HistoricalStateProviderRef<'b, TX> {
     /// Lookup an account in the `AccountsHistory` table
     pub fn account_history_lookup(&self, address: Address) -> ProviderResult<HistoryInfo> {
         if !self.lowest_available_blocks.is_account_history_available(self.block_number) {
-            return Err(ProviderError::StateAtBlockPruned(self.block_number))
+            return Err(ProviderError::StateAtBlockPruned(self.block_number));
         }
 
         // history key to search IntegerList of block number changesets.
@@ -99,7 +99,7 @@ impl<'b, TX: DbTx> HistoricalStateProviderRef<'b, TX> {
         storage_key: StorageKey,
     ) -> ProviderResult<HistoryInfo> {
         if !self.lowest_available_blocks.is_storage_history_available(self.block_number) {
-            return Err(ProviderError::StateAtBlockPruned(self.block_number))
+            return Err(ProviderError::StateAtBlockPruned(self.block_number));
         }
 
         // history key to search IntegerList of block number changesets.
@@ -113,10 +113,10 @@ impl<'b, TX: DbTx> HistoricalStateProviderRef<'b, TX> {
 
     /// Retrieve revert hashed state for this history provider.
     fn revert_state(&self) -> ProviderResult<HashedPostState> {
-        if !self.lowest_available_blocks.is_account_history_available(self.block_number) ||
-            !self.lowest_available_blocks.is_storage_history_available(self.block_number)
+        if !self.lowest_available_blocks.is_account_history_available(self.block_number)
+            || !self.lowest_available_blocks.is_storage_history_available(self.block_number)
         {
-            return Err(ProviderError::StateAtBlockPruned(self.block_number))
+            return Err(ProviderError::StateAtBlockPruned(self.block_number));
         }
 
         let tip = self
@@ -172,9 +172,9 @@ impl<'b, TX: DbTx> HistoricalStateProviderRef<'b, TX> {
             // This check is worth it, the `cursor.prev()` check is rarely triggered (the if will
             // short-circuit) and when it passes we save a full seek into the changeset/plain state
             // table.
-            if rank == 0 &&
-                block_number != Some(self.block_number) &&
-                !cursor.prev()?.is_some_and(|(key, _)| key_filter(&key))
+            if rank == 0
+                && block_number != Some(self.block_number)
+                && !cursor.prev()?.is_some_and(|(key, _)| key_filter(&key))
             {
                 if let (Some(_), Some(block_number)) = (lowest_available_block_number, block_number)
                 {

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -151,7 +151,7 @@ impl<TX: DbTx> StateProvider for LatestStateProviderRef<'_, TX> {
         let mut cursor = self.tx.cursor_dup_read::<tables::PlainStorageState>()?;
         if let Some(entry) = cursor.seek_by_key_subkey(account, storage_key)? {
             if entry.key == storage_key {
-                return Ok(Some(entry.value))
+                return Ok(Some(entry.value));
             }
         }
         Ok(None)

--- a/crates/storage/provider/src/providers/static_file/jar.rs
+++ b/crates/storage/provider/src/providers/static_file/jar.rs
@@ -137,7 +137,7 @@ impl HeaderProvider for StaticFileJarProvider<'_> {
             {
                 let sealed = header.seal(hash);
                 if !predicate(&sealed) {
-                    break
+                    break;
                 }
                 headers.push(sealed);
             }
@@ -297,7 +297,7 @@ impl ReceiptProvider for StaticFileJarProvider<'_> {
     fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Receipt>> {
         if let Some(tx_static_file) = &self.auxiliary_jar {
             if let Some(num) = tx_static_file.transaction_id(hash)? {
-                return self.receipt(num)
+                return self.receipt(num);
             }
         }
         Ok(None)

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -269,7 +269,7 @@ impl StaticFileProvider {
             )
             .and_then(|(parsed_segment, block_range)| {
                 if parsed_segment == segment {
-                    return Some(block_range)
+                    return Some(block_range);
                 }
                 None
             }),
@@ -278,7 +278,7 @@ impl StaticFileProvider {
 
         // Return cached `LoadedJar` or insert it for the first time, and then, return it.
         if let Some(block_range) = block_range {
-            return Ok(Some(self.get_or_create_jar_provider(segment, &block_range)?))
+            return Ok(Some(self.get_or_create_jar_provider(segment, &block_range)?));
         }
 
         Ok(None)
@@ -390,11 +390,11 @@ impl StaticFileProvider {
         while let Some((tx_end, block_range)) = static_files_rev_iter.next() {
             if tx > *tx_end {
                 // request tx is higher than highest static file tx
-                return None
+                return None;
             }
             let tx_start = static_files_rev_iter.peek().map(|(tx_end, _)| *tx_end + 1).unwrap_or(0);
             if tx_start <= tx {
-                return Some(find_fixed_range(block_range.end()))
+                return Some(find_fixed_range(block_range.end()));
             }
         }
         None
@@ -454,8 +454,8 @@ impl StaticFileProvider {
                 } else if tx_index.get(&segment).map(|index| index.len()) == Some(1) {
                     // Only happens if we unwind all the txs/receipts from the first static file.
                     // Should only happen in test scenarios.
-                    if jar.user_header().expected_block_start() == 0 &&
-                        matches!(
+                    if jar.user_header().expected_block_start() == 0
+                        && matches!(
                             segment,
                             StaticFileSegment::Receipts | StaticFileSegment::Transactions
                         )
@@ -567,7 +567,7 @@ impl StaticFileProvider {
         for segment in StaticFileSegment::iter() {
             if has_receipt_pruning && segment.is_receipts() {
                 // Pruned nodes (including full node) do not store receipts as static files.
-                continue
+                continue;
             }
 
             let initial_highest_block = self.get_highest_static_file_block(segment);
@@ -609,16 +609,16 @@ impl StaticFileProvider {
                 loop {
                     if let Some(indices) = provider.block_body_indices(last_block)? {
                         if indices.last_tx_num() <= highest_tx {
-                            break
+                            break;
                         }
                     } else {
                         // If the block body indices can not be found, then it means that static
                         // files is ahead of database, and the `ensure_invariants` check will fix
                         // it by comparing with stage checkpoints.
-                        break
+                        break;
                     }
                     if last_block == 0 {
-                        break
+                        break;
                     }
                     last_block -= 1;
 
@@ -691,8 +691,8 @@ impl StaticFileProvider {
             // If there is a gap between the entry found in static file and
             // database, then we have most likely lost static file data and need to unwind so we can
             // load it again
-            if !(db_first_entry <= highest_static_file_entry ||
-                highest_static_file_entry + 1 == db_first_entry)
+            if !(db_first_entry <= highest_static_file_entry
+                || highest_static_file_entry + 1 == db_first_entry)
             {
                 info!(
                     target: "reth::providers::static_file",
@@ -702,12 +702,12 @@ impl StaticFileProvider {
                     ?segment,
                     "Setting unwind target."
                 );
-                return Ok(Some(highest_static_file_block))
+                return Ok(Some(highest_static_file_block));
             }
 
             if let Some((db_last_entry, _)) = db_cursor.last()? {
                 if db_last_entry > highest_static_file_entry {
-                    return Ok(None)
+                    return Ok(None);
                 }
             }
         }
@@ -732,7 +732,7 @@ impl StaticFileProvider {
                 ?segment,
                 "Setting unwind target."
             );
-            return Ok(Some(highest_static_file_block))
+            return Ok(Some(highest_static_file_block));
         }
 
         // If the checkpoint is behind, then we failed to do a database commit **but committed** to
@@ -800,7 +800,7 @@ impl StaticFileProvider {
             let mut range = find_fixed_range(highest_block);
             while range.end() > 0 {
                 if let Some(res) = func(self.get_or_create_jar_provider(segment, &range)?)? {
-                    return Ok(Some(res))
+                    return Ok(Some(res));
                 }
                 range = SegmentRangeInclusive::new(
                     range.start().saturating_sub(BLOCKS_PER_STATIC_FILE),
@@ -853,10 +853,10 @@ impl StaticFileProvider {
                 match get_fn(&mut cursor, number)? {
                     Some(res) => {
                         if !predicate(&res) {
-                            break 'outer
+                            break 'outer;
                         }
                         result.push(res);
-                        break 'inner
+                        break 'inner;
                     }
                     None => {
                         if retrying {
@@ -872,7 +872,7 @@ impl StaticFileProvider {
                             } else {
                                 ProviderError::MissingStaticFileTx(segment, number)
                             };
-                            return Err(err)
+                            return Err(err);
                         }
                         // There is a very small chance of hitting a deadlock if two consecutive
                         // static files share the same bucket in the
@@ -966,7 +966,7 @@ impl StaticFileProvider {
         if static_file_upper_bound
             .is_some_and(|static_file_upper_bound| static_file_upper_bound >= number)
         {
-            return fetch_from_static_file(self)
+            return fetch_from_static_file(self);
         }
         fetch_from_database()
     }
@@ -1059,7 +1059,7 @@ impl StaticFileWriter for StaticFileProvider {
         segment: StaticFileSegment,
     ) -> ProviderResult<StaticFileProviderRWRefMut<'_>> {
         if self.access.is_read_only() {
-            return Err(ProviderError::ReadOnlyStaticFileAccess)
+            return Err(ProviderError::ReadOnlyStaticFileAccess);
         }
 
         trace!(target: "provider::static_file", ?block, ?segment, "Getting static file writer.");
@@ -1110,7 +1110,7 @@ impl HeaderProvider for StaticFileProvider {
                 .get_two::<HeaderMask<Header, BlockHash>>(block_hash.into())?
                 .and_then(|(header, hash)| {
                     if &hash == block_hash {
-                        return Some(header)
+                        return Some(header);
                     }
                     None
                 }))
@@ -1223,7 +1223,7 @@ impl ReceiptProvider for StaticFileProvider {
 
     fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Receipt>> {
         if let Some(num) = self.transaction_id(hash)? {
-            return self.receipt(num)
+            return self.receipt(num);
         }
         Ok(None)
     }
@@ -1758,9 +1758,9 @@ impl RequestsProvider for StaticFileProvider {
 impl StatsReader for StaticFileProvider {
     fn count_entries<T: Table>(&self) -> ProviderResult<usize> {
         match T::NAME {
-            tables::CanonicalHeaders::NAME |
-            tables::Headers::NAME |
-            tables::HeaderTerminalDifficulties::NAME => Ok(self
+            tables::CanonicalHeaders::NAME
+            | tables::Headers::NAME
+            | tables::HeaderTerminalDifficulties::NAME => Ok(self
                 .get_highest_static_file_block(StaticFileSegment::Headers)
                 .map(|block| block + 1)
                 .unwrap_or_default()

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -199,7 +199,7 @@ impl StaticFileProviderRW {
 
         self.writer.ensure_file_consistency(check_mode).map_err(|error| {
             if matches!(error, NippyJarError::InconsistentState) {
-                return inconsistent_error()
+                return inconsistent_error();
             }
             ProviderError::NippyJar(error.to_string())
         })?;
@@ -213,7 +213,7 @@ impl StaticFileProviderRW {
         let pruned_rows = expected_rows - self.writer.rows() as u64;
         if pruned_rows > 0 {
             if read_only {
-                return Err(inconsistent_error())
+                return Err(inconsistent_error());
             }
             self.user_header_mut().prune(pruned_rows);
         }
@@ -388,7 +388,7 @@ impl StaticFileProviderRW {
                 segment,
                 expected_block_number,
                 next_static_file_block,
-            ))
+            ));
         }
         Ok(())
     }
@@ -430,7 +430,7 @@ impl StaticFileProviderRW {
                     self.writer
                         .prune_rows(len as usize)
                         .map_err(|e| ProviderError::NippyJar(e.to_string()))?;
-                    break
+                    break;
                 }
 
                 remaining_rows -= len;
@@ -697,7 +697,7 @@ impl StaticFileProviderRW {
         if self.prune_on_commit.is_some() {
             return Err(ProviderError::NippyJar(
                 "Pruning should be committed before appending or pruning more data".to_string(),
-            ))
+            ));
         }
         Ok(())
     }

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -262,7 +262,7 @@ impl TransactionsProvider for MockEthProvider {
                         excess_blob_gas: block.header.excess_blob_gas,
                         timestamp: block.header.timestamp,
                     };
-                    return Ok(Some((tx.clone(), meta)))
+                    return Ok(Some((tx.clone(), meta)));
                 }
             }
         }
@@ -274,7 +274,7 @@ impl TransactionsProvider for MockEthProvider {
         let mut current_tx_number: TxNumber = 0;
         for block in lock.values() {
             if current_tx_number + (block.body.len() as TxNumber) > id {
-                return Ok(Some(block.header.number))
+                return Ok(Some(block.header.number));
             }
             current_tx_number += block.body.len() as TxNumber;
         }

--- a/crates/storage/provider/src/writer/mod.rs
+++ b/crates/storage/provider/src/writer/mod.rs
@@ -96,7 +96,7 @@ impl<'a, TX, SF> UnifiedStorageWriter<'a, TX, SF> {
     #[allow(unused)]
     const fn ensure_static_file(&self) -> Result<(), UnifiedStorageWriterError> {
         if self.static_file.is_none() {
-            return Err(UnifiedStorageWriterError::MissingStaticFileWriter)
+            return Err(UnifiedStorageWriterError::MissingStaticFileWriter);
         }
         Ok(())
     }
@@ -146,7 +146,7 @@ where
     pub fn save_blocks(&self, blocks: &[ExecutedBlock]) -> ProviderResult<()> {
         if blocks.is_empty() {
             debug!(target: "provider::storage_writer", "Attempted to write empty block range");
-            return Ok(())
+            return Ok(());
         }
 
         // NOTE: checked non-empty above
@@ -429,8 +429,8 @@ where
         // * If we are in live sync. In this case, `UnifiedStorageWriter` is built without a static
         //   file writer.
         // * If there is any kind of receipt pruning
-        let mut storage_type = if self.static_file.is_none() ||
-            self.database().prune_modes_ref().has_receipts_pruning()
+        let mut storage_type = if self.static_file.is_none()
+            || self.database().prune_modes_ref().has_receipts_pruning()
         {
             StorageType::Database(self.database().tx_ref().cursor_write::<tables::Receipts>()?)
         } else {

--- a/crates/storage/storage-api/src/receipts.rs
+++ b/crates/storage/storage-api/src/receipts.rs
@@ -50,7 +50,7 @@ pub trait ReceiptProviderIdExt: ReceiptProvider + BlockIdReader {
                 if let Some(num) = self.convert_block_number(num_tag)? {
                     BlockHashOrNumber::Number(num)
                 } else {
-                    return Ok(None)
+                    return Ok(None);
                 }
             }
         };

--- a/crates/storage/storage-api/src/state.rs
+++ b/crates/storage/storage-api/src/state.rs
@@ -38,10 +38,10 @@ pub trait StateProvider:
 
         if let Some(code_hash) = acc.bytecode_hash {
             if code_hash == KECCAK_EMPTY {
-                return Ok(None)
+                return Ok(None);
             }
             // Get the code from the code hash
-            return self.bytecode_by_hash(code_hash)
+            return self.bytecode_by_hash(code_hash);
         }
 
         // Return `None` if no code hash is set

--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -223,7 +223,7 @@ impl TaskManager {
         while self.graceful_tasks.load(Ordering::Relaxed) > 0 {
             if when.map(|when| std::time::Instant::now() > when).unwrap_or(false) {
                 debug!("graceful shutdown timed out");
-                return false
+                return false;
             }
             std::hint::spin_loop();
         }

--- a/crates/tokio-util/src/ratelimit.rs
+++ b/crates/tokio-util/src/ratelimit.rs
@@ -38,7 +38,7 @@ impl RateLimit {
             State::Ready { .. } => return Poll::Ready(()),
             State::Limited => {
                 if Pin::new(&mut self.sleep).poll(cx).is_pending() {
-                    return Poll::Pending
+                    return Poll::Pending;
                 }
             }
         }

--- a/crates/transaction-pool/src/blobstore/disk.rs
+++ b/crates/transaction-pool/src/blobstore/disk.rs
@@ -56,7 +56,7 @@ impl BlobStore for DiskFileBlobStore {
 
     fn insert_all(&self, txs: Vec<(B256, BlobTransactionSidecar)>) -> Result<(), BlobStoreError> {
         if txs.is_empty() {
-            return Ok(())
+            return Ok(());
         }
         self.inner.insert_many(txs)
     }
@@ -115,14 +115,14 @@ impl BlobStore for DiskFileBlobStore {
         txs: Vec<B256>,
     ) -> Result<Vec<(B256, BlobTransactionSidecar)>, BlobStoreError> {
         if txs.is_empty() {
-            return Ok(Vec::new())
+            return Ok(Vec::new());
         }
         self.inner.get_all(txs)
     }
 
     fn get_exact(&self, txs: Vec<B256>) -> Result<Vec<BlobTransactionSidecar>, BlobStoreError> {
         if txs.is_empty() {
-            return Ok(Vec::new())
+            return Ok(Vec::new());
         }
         self.inner.get_exact(txs)
     }
@@ -228,7 +228,7 @@ impl DiskFileBlobStoreInner {
     /// Returns true if the blob for the given transaction hash is in the blob cache or on disk.
     fn contains(&self, tx: B256) -> Result<bool, BlobStoreError> {
         if self.blob_cache.lock().get(&tx).is_some() {
-            return Ok(true)
+            return Ok(true);
         }
         // we only check if the file exists and assume it's valid
         Ok(self.blob_disk_file(tx).is_file())
@@ -254,7 +254,7 @@ impl DiskFileBlobStoreInner {
     /// Retrieves the blob for the given transaction hash from the blob cache or disk.
     fn get_one(&self, tx: B256) -> Result<Option<BlobTransactionSidecar>, BlobStoreError> {
         if let Some(blob) = self.blob_cache.lock().get(&tx) {
-            return Ok(Some(blob.clone()))
+            return Ok(Some(blob.clone()));
         }
         let blob = self.read_one(tx)?;
         if let Some(blob) = &blob {
@@ -362,11 +362,11 @@ impl DiskFileBlobStoreInner {
             }
         }
         if cache_miss.is_empty() {
-            return Ok(res)
+            return Ok(res);
         }
         let from_disk = self.read_many_decoded(cache_miss);
         if from_disk.is_empty() {
-            return Ok(res)
+            return Ok(res);
         }
         let mut cache = self.blob_cache.lock();
         for (tx, data) in from_disk {

--- a/crates/transaction-pool/src/blobstore/mem.rs
+++ b/crates/transaction-pool/src/blobstore/mem.rs
@@ -34,7 +34,7 @@ impl BlobStore for InMemoryBlobStore {
 
     fn insert_all(&self, txs: Vec<(B256, BlobTransactionSidecar)>) -> Result<(), BlobStoreError> {
         if txs.is_empty() {
-            return Ok(())
+            return Ok(());
         }
         let mut store = self.inner.store.write();
         let mut total_add = 0;
@@ -57,7 +57,7 @@ impl BlobStore for InMemoryBlobStore {
 
     fn delete_all(&self, txs: Vec<B256>) -> Result<(), BlobStoreError> {
         if txs.is_empty() {
-            return Ok(())
+            return Ok(());
         }
         let mut store = self.inner.store.write();
         let mut total_sub = 0;
@@ -106,7 +106,7 @@ impl BlobStore for InMemoryBlobStore {
             if let Some(item) = store.get(&tx) {
                 items.push(item.clone());
             } else {
-                return Err(BlobStoreError::MissingSidecar(tx))
+                return Err(BlobStoreError::MissingSidecar(tx));
             }
         }
 

--- a/crates/transaction-pool/src/blobstore/mod.rs
+++ b/crates/transaction-pool/src/blobstore/mod.rs
@@ -135,8 +135,8 @@ impl BlobStoreSize {
 
 impl PartialEq for BlobStoreSize {
     fn eq(&self, other: &Self) -> bool {
-        self.data_size.load(Ordering::Relaxed) == other.data_size.load(Ordering::Relaxed) &&
-            self.num_blobs.load(Ordering::Relaxed) == other.num_blobs.load(Ordering::Relaxed)
+        self.data_size.load(Ordering::Relaxed) == other.data_size.load(Ordering::Relaxed)
+            && self.num_blobs.load(Ordering::Relaxed) == other.num_blobs.load(Ordering::Relaxed)
     }
 }
 

--- a/crates/transaction-pool/src/blobstore/noop.rs
+++ b/crates/transaction-pool/src/blobstore/noop.rs
@@ -44,7 +44,7 @@ impl BlobStore for NoopBlobStore {
 
     fn get_exact(&self, txs: Vec<B256>) -> Result<Vec<BlobTransactionSidecar>, BlobStoreError> {
         if txs.is_empty() {
-            return Ok(vec![])
+            return Ok(vec![]);
         }
         Err(BlobStoreError::MissingSidecar(txs[0]))
     }

--- a/crates/transaction-pool/src/blobstore/tracker.rs
+++ b/crates/transaction-pool/src/blobstore/tracker.rs
@@ -55,7 +55,7 @@ impl BlobStoreCanonTracker {
             if *entry.key() <= finalized_block {
                 finalized.extend(entry.remove_entry().1);
             } else {
-                break
+                break;
             }
         }
 

--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -52,10 +52,10 @@ impl PoolConfig {
     /// Returns whether or not the size and amount constraints in any sub-pools are exceeded.
     #[inline]
     pub const fn is_exceeded(&self, pool_size: PoolSize) -> bool {
-        self.blob_limit.is_exceeded(pool_size.blob, pool_size.blob_size) ||
-            self.pending_limit.is_exceeded(pool_size.pending, pool_size.pending_size) ||
-            self.basefee_limit.is_exceeded(pool_size.basefee, pool_size.basefee_size) ||
-            self.queued_limit.is_exceeded(pool_size.queued, pool_size.queued_size)
+        self.blob_limit.is_exceeded(pool_size.blob, pool_size.blob_size)
+            || self.pending_limit.is_exceeded(pool_size.pending, pool_size.pending_size)
+            || self.basefee_limit.is_exceeded(pool_size.basefee, pool_size.basefee_size)
+            || self.queued_limit.is_exceeded(pool_size.queued, pool_size.queued_size)
     }
 }
 
@@ -121,7 +121,7 @@ impl PriceBumpConfig {
     #[inline]
     pub(crate) const fn price_bump(&self, tx_type: u8) -> u128 {
         if tx_type == EIP4844_TX_TYPE_ID {
-            return self.replace_blob_tx_price_bump
+            return self.replace_blob_tx_price_bump;
         }
         self.default_price_bump
     }
@@ -182,7 +182,7 @@ impl LocalTransactionConfig {
     #[inline]
     pub fn is_local(&self, origin: TransactionOrigin, sender: Address) -> bool {
         if self.no_local_exemptions() {
-            return false
+            return false;
         }
         origin.is_local() || self.contains_local_address(sender)
     }

--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -224,14 +224,14 @@ impl InvalidPoolTransactionError {
                 // depend on dynamic environmental conditions and should not be assumed to have been
                 // intentionally caused by the sender
                 match err {
-                    InvalidTransactionError::InsufficientFunds { .. } |
-                    InvalidTransactionError::NonceNotConsistent => {
+                    InvalidTransactionError::InsufficientFunds { .. }
+                    | InvalidTransactionError::NonceNotConsistent => {
                         // transaction could just have arrived late/early
                         false
                     }
-                    InvalidTransactionError::GasTooLow |
-                    InvalidTransactionError::GasTooHigh |
-                    InvalidTransactionError::TipAboveFeeCap => {
+                    InvalidTransactionError::GasTooLow
+                    | InvalidTransactionError::GasTooHigh
+                    | InvalidTransactionError::TipAboveFeeCap => {
                         // these are technically not invalid
                         false
                     }
@@ -239,18 +239,18 @@ impl InvalidPoolTransactionError {
                         // dynamic, but not used during validation
                         false
                     }
-                    InvalidTransactionError::Eip2930Disabled |
-                    InvalidTransactionError::Eip1559Disabled |
-                    InvalidTransactionError::Eip4844Disabled |
-                    InvalidTransactionError::Eip7702Disabled => {
+                    InvalidTransactionError::Eip2930Disabled
+                    | InvalidTransactionError::Eip1559Disabled
+                    | InvalidTransactionError::Eip4844Disabled
+                    | InvalidTransactionError::Eip7702Disabled => {
                         // settings
                         false
                     }
-                    InvalidTransactionError::OldLegacyChainId |
-                    InvalidTransactionError::ChainIdMismatch |
-                    InvalidTransactionError::GasUintOverflow |
-                    InvalidTransactionError::TxTypeNotSupported |
-                    InvalidTransactionError::SignerAccountHasBytecode => true,
+                    InvalidTransactionError::OldLegacyChainId
+                    | InvalidTransactionError::ChainIdMismatch
+                    | InvalidTransactionError::GasUintOverflow
+                    | InvalidTransactionError::TxTypeNotSupported
+                    | InvalidTransactionError::SignerAccountHasBytecode => true,
                 }
             }
             Self::ExceedsGasLimit(_, _) => true,
@@ -294,7 +294,7 @@ impl InvalidPoolTransactionError {
 
     /// Returns `true` if an import failed due to nonce gap.
     pub const fn is_nonce_gap(&self) -> bool {
-        matches!(self, Self::Consensus(InvalidTransactionError::NonceNotConsistent)) ||
-            matches!(self, Self::Eip4844(Eip4844PoolTransactionError::Eip4844NonceGap))
+        matches!(self, Self::Consensus(InvalidTransactionError::NonceNotConsistent))
+            || matches!(self, Self::Eip4844(Eip4844PoolTransactionError::Eip4844NonceGap))
     }
 }

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -359,7 +359,7 @@ where
         transactions: Vec<Self::Transaction>,
     ) -> Vec<PoolResult<TxHash>> {
         if transactions.is_empty() {
-            return Vec::new()
+            return Vec::new();
         }
         let validated = self.validate_all(origin, transactions).await;
 

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -263,8 +263,8 @@ pub async fn maintain_transaction_pool<Client, P, St, Tasks>(
                 let old_first = old_blocks.first();
 
                 // check if the reorg is not canonical with the pool's block
-                if !(old_first.parent_hash == pool_info.last_seen_block_hash ||
-                    new_first.parent_hash == pool_info.last_seen_block_hash)
+                if !(old_first.parent_hash == pool_info.last_seen_block_hash
+                    || new_first.parent_hash == pool_info.last_seen_block_hash)
                 {
                     // the new block points to a higher block than the oldest block in the old chain
                     maintained_state = MaintainedPoolState::Drifted;
@@ -411,7 +411,7 @@ pub async fn maintain_transaction_pool<Client, P, St, Tasks>(
                     // keep track of mined blob transactions
                     blob_store_tracker.add_new_chain_blocks(&blocks);
 
-                    continue
+                    continue;
                 }
 
                 let mut changed_accounts = Vec::with_capacity(state.state().len());
@@ -581,14 +581,14 @@ where
     P: TransactionPool,
 {
     if !file_path.exists() {
-        return Ok(())
+        return Ok(());
     }
 
     debug!(target: "txpool", txs_file =?file_path, "Check local persistent storage for saved transactions");
     let data = reth_fs_util::read(file_path)?;
 
     if data.is_empty() {
-        return Ok(())
+        return Ok(());
     }
 
     let txs_signed: Vec<TransactionSigned> = alloy_rlp::Decodable::decode(&mut data.as_slice())?;
@@ -616,7 +616,7 @@ where
     let local_transactions = pool.get_local_transactions();
     if local_transactions.is_empty() {
         trace!(target: "txpool", "no local transactions to save");
-        return
+        return;
     }
 
     let local_transactions = local_transactions
@@ -665,7 +665,7 @@ pub async fn backup_local_transactions_task<P>(
 {
     let Some(transactions_path) = config.transactions_path else {
         // nothing to do
-        return
+        return;
     };
 
     if let Err(err) = load_and_reinsert_transactions(pool.clone(), &transactions_path).await {

--- a/crates/transaction-pool/src/noop.rs
+++ b/crates/transaction-pool/src/noop.rs
@@ -238,7 +238,7 @@ impl TransactionPool for NoopTransactionPool {
         tx_hashes: Vec<TxHash>,
     ) -> Result<Vec<BlobTransactionSidecar>, BlobStoreError> {
         if tx_hashes.is_empty() {
-            return Ok(vec![])
+            return Ok(vec![]);
         }
         Err(BlobStoreError::MissingSidecar(tx_hashes[0]))
     }

--- a/crates/transaction-pool/src/pool/best.rs
+++ b/crates/transaction-pool/src/pool/best.rs
@@ -51,8 +51,9 @@ impl<T: TransactionOrdering> Iterator for BestTransactionsWithFees<T> {
             let best = self.best.next()?;
             // If both the base fee and blob fee (if applicable for EIP-4844) are satisfied, return
             // the transaction
-            if best.transaction.max_fee_per_gas() >= self.base_fee as u128 &&
-                best.transaction
+            if best.transaction.max_fee_per_gas() >= self.base_fee as u128
+                && best
+                    .transaction
                     .max_fee_per_blob_gas()
                     .map_or(true, |fee| fee >= self.base_fee_per_blob_gas as u128)
             {
@@ -178,7 +179,7 @@ impl<T: TransactionOrdering> Iterator for BestTransactions<T> {
                     "[{:?}] skipping invalid transaction",
                     hash
                 );
-                continue
+                continue;
             }
 
             // Insert transactions that just got unlocked.
@@ -191,7 +192,7 @@ impl<T: TransactionOrdering> Iterator for BestTransactions<T> {
                 // transactions are returned
                 self.mark_invalid(&best.transaction)
             } else {
-                return Some(best.transaction)
+                return Some(best.transaction);
             }
         }
     }
@@ -225,7 +226,7 @@ where
         loop {
             let best = self.best.next()?;
             if (self.predicate)(&best) {
-                return Some(best)
+                return Some(best);
             } else {
                 self.best.mark_invalid(&best);
             }

--- a/crates/transaction-pool/src/pool/blob.rs
+++ b/crates/transaction-pool/src/pool/blob.rs
@@ -96,16 +96,16 @@ impl<T: PoolTransaction> BlobTransactions<T> {
                 let mut iter = self.by_id.iter().peekable();
 
                 while let Some((id, tx)) = iter.next() {
-                    if tx.transaction.max_fee_per_blob_gas().unwrap_or_default() <
-                        blob_fee_to_satisfy ||
-                        tx.transaction.max_fee_per_gas() <
-                            best_transactions_attributes.basefee as u128
+                    if tx.transaction.max_fee_per_blob_gas().unwrap_or_default()
+                        < blob_fee_to_satisfy
+                        || tx.transaction.max_fee_per_gas()
+                            < best_transactions_attributes.basefee as u128
                     {
                         // does not satisfy the blob fee or base fee
                         // still parked in blob pool -> skip descendant transactions
                         'this: while let Some((peek, _)) = iter.peek() {
                             if peek.sender != id.sender {
-                                break 'this
+                                break 'this;
                             }
                             iter.next();
                         }
@@ -150,13 +150,13 @@ impl<T: PoolTransaction> BlobTransactions<T> {
             let mut iter = self.by_id.iter().peekable();
 
             while let Some((id, tx)) = iter.next() {
-                if tx.transaction.max_fee_per_blob_gas() < Some(pending_fees.blob_fee) ||
-                    tx.transaction.max_fee_per_gas() < pending_fees.base_fee as u128
+                if tx.transaction.max_fee_per_blob_gas() < Some(pending_fees.blob_fee)
+                    || tx.transaction.max_fee_per_gas() < pending_fees.base_fee as u128
                 {
                     // still parked in blob pool -> skip descendant transactions
                     'this: while let Some((peek, _)) = iter.peek() {
                         if peek.sender != id.sender {
-                            break 'this
+                            break 'this;
                         }
                         iter.next();
                     }
@@ -351,7 +351,7 @@ const LOG_2_1_125: f64 = 0.16992500144231237;
 pub fn fee_delta(max_tx_fee: u128, current_fee: u128) -> i64 {
     if max_tx_fee == current_fee {
         // if these are equal, then there's no fee jump
-        return 0
+        return 0;
     }
 
     let max_tx_fee_jumps = if max_tx_fee == 0 {

--- a/crates/transaction-pool/src/pool/parked.rs
+++ b/crates/transaction-pool/src/pool/parked.rs
@@ -111,7 +111,7 @@ impl<T: ParkedOrd> ParkedPool<T> {
                 if value.count == 0 {
                     entry.remove()
                 } else {
-                    return
+                    return;
                 }
             }
             Entry::Vacant(_) => {
@@ -190,7 +190,7 @@ impl<T: ParkedOrd> ParkedPool<T> {
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
         if !self.exceeds(&limit) {
             // if we are below the limits, we don't need to drop anything
-            return Vec::new()
+            return Vec::new();
         }
 
         let mut removed = Vec::new();
@@ -208,7 +208,7 @@ impl<T: ParkedOrd> ParkedPool<T> {
                 }
 
                 if !self.exceeds(&limit) {
-                    break
+                    break;
                 }
             }
         }
@@ -296,7 +296,7 @@ impl<T: PoolTransaction> ParkedPool<BasefeeOrd<T>> {
                     // still parked -> skip descendant transactions
                     'this: while let Some((peek, _)) = iter.peek() {
                         if peek.sender != id.sender {
-                            break 'this
+                            break 'this;
                         }
                         iter.next();
                     }

--- a/crates/transaction-pool/src/pool/pending.rs
+++ b/crates/transaction-pool/src/pool/pending.rs
@@ -190,7 +190,7 @@ impl<T: TransactionOrdering> PendingPool<T> {
                 // Remove all dependent transactions.
                 'this: while let Some((next_id, next_tx)) = transactions_iter.peek() {
                     if next_id.sender != id.sender {
-                        break 'this
+                        break 'this;
                     }
                     removed.push(Arc::clone(&next_tx.transaction));
                     transactions_iter.next();
@@ -233,7 +233,7 @@ impl<T: TransactionOrdering> PendingPool<T> {
                 // Remove all dependent transactions.
                 'this: while let Some((next_id, next_tx)) = transactions_iter.peek() {
                     if next_id.sender != id.sender {
-                        break 'this
+                        break 'this;
                     }
                     removed.push(Arc::clone(&next_tx.transaction));
                     transactions_iter.next();
@@ -405,8 +405,8 @@ impl<T: TransactionOrdering> PendingPool<T> {
             // loop through the highest nonces set, removing transactions until we reach the limit
             for tx in &self.highest_nonces {
                 // return early if the pool is under limits
-                if !limit.is_exceeded(original_length - total_removed, original_size - total_size) ||
-                    non_local_senders == 0
+                if !limit.is_exceeded(original_length - total_removed, original_size - total_size)
+                    || non_local_senders == 0
                 {
                     // need to remove remaining transactions before exiting
                     for id in &removed {
@@ -415,12 +415,12 @@ impl<T: TransactionOrdering> PendingPool<T> {
                         }
                     }
 
-                    return
+                    return;
                 }
 
                 if !remove_locals && tx.transaction.is_local() {
                     non_local_senders -= 1;
-                    continue
+                    continue;
                 }
 
                 total_size += tx.transaction.size();
@@ -438,7 +438,7 @@ impl<T: TransactionOrdering> PendingPool<T> {
             // return if either the pool is under limits or there are no more _eligible_
             // transactions to remove
             if !self.exceeds(limit) || non_local_senders == 0 {
-                return
+                return;
             }
         }
     }
@@ -460,13 +460,13 @@ impl<T: TransactionOrdering> PendingPool<T> {
         let mut removed = Vec::new();
         // return early if the pool is already under the limits
         if !self.exceeds(&limit) {
-            return removed
+            return removed;
         }
 
         // first truncate only non-local transactions, returning if the pool end up under the limit
         self.remove_to_limit(&limit, false, &mut removed);
         if !self.exceeds(&limit) {
-            return removed
+            return removed;
         }
 
         // now repeat for local transactions, since local transactions must be removed now for the

--- a/crates/transaction-pool/src/pool/state.rs
+++ b/crates/transaction-pool/src/pool/state.rs
@@ -126,14 +126,14 @@ impl SubPool {
 impl From<TxState> for SubPool {
     fn from(value: TxState) -> Self {
         if value.is_pending() {
-            return Self::Pending
+            return Self::Pending;
         }
         if value.is_blob() {
             // all _non-pending_ blob transactions are in the blob sub-pool
-            return Self::Blob
+            return Self::Blob;
         }
         if value.bits() < TxState::BASE_FEE_POOL_BITS.bits() {
-            return Self::Queued
+            return Self::Queued;
         }
         Self::BaseFee
     }
@@ -165,10 +165,10 @@ mod tests {
         let state = TxState::default();
         assert_eq!(SubPool::Queued, state.into());
 
-        let state = TxState::NO_PARKED_ANCESTORS |
-            TxState::NO_NONCE_GAPS |
-            TxState::NOT_TOO_MUCH_GAS |
-            TxState::ENOUGH_FEE_CAP_BLOCK;
+        let state = TxState::NO_PARKED_ANCESTORS
+            | TxState::NO_NONCE_GAPS
+            | TxState::NOT_TOO_MUCH_GAS
+            | TxState::ENOUGH_FEE_CAP_BLOCK;
         assert_eq!(SubPool::Queued, state.into());
     }
 

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -1363,13 +1363,13 @@ impl<T: PoolTransaction> AllTransactions<T> {
             let Some(ancestor_tx) = self.txs.get(&ancestor) else {
                 // ancestor tx is missing, so we can't insert the new blob
                 self.metrics.blob_transactions_nonce_gaps.increment(1);
-                return Err(InsertErr::BlobTxHasNonceGap { transaction: Arc::new(new_blob_tx) })
+                return Err(InsertErr::BlobTxHasNonceGap { transaction: Arc::new(new_blob_tx) });
             };
             if ancestor_tx.state.has_nonce_gap() {
                 // the ancestor transaction already has a nonce gap, so we can't insert the new
                 // blob
                 self.metrics.blob_transactions_nonce_gaps.increment(1);
-                return Err(InsertErr::BlobTxHasNonceGap { transaction: Arc::new(new_blob_tx) })
+                return Err(InsertErr::BlobTxHasNonceGap { transaction: Arc::new(new_blob_tx) });
             }
 
             // the max cost executing this transaction requires
@@ -1395,7 +1395,9 @@ impl<T: PoolTransaction> AllTransactions<T> {
                         cumulative_cost += tx.transaction.cost();
                         if tx.transaction.is_eip4844() && cumulative_cost > on_chain_balance {
                             // the transaction would shift
-                            return Err(InsertErr::Overdraft { transaction: Arc::new(new_blob_tx) });
+                            return Err(InsertErr::Overdraft {
+                                transaction: Arc::new(new_blob_tx),
+                            });
                         }
                     }
                 }
@@ -1418,8 +1420,8 @@ impl<T: PoolTransaction> AllTransactions<T> {
     ) -> bool {
         let price_bump = price_bumps.price_bump(existing_transaction.tx_type());
 
-        if maybe_replacement.max_fee_per_gas() <=
-            existing_transaction.max_fee_per_gas() * (100 + price_bump) / 100
+        if maybe_replacement.max_fee_per_gas()
+            <= existing_transaction.max_fee_per_gas() * (100 + price_bump) / 100
         {
             return true;
         }
@@ -1429,10 +1431,10 @@ impl<T: PoolTransaction> AllTransactions<T> {
         let replacement_max_priority_fee_per_gas =
             maybe_replacement.transaction.max_priority_fee_per_gas().unwrap_or(0);
 
-        if replacement_max_priority_fee_per_gas <=
-            existing_max_priority_fee_per_gas * (100 + price_bump) / 100 &&
-            existing_max_priority_fee_per_gas != 0 &&
-            replacement_max_priority_fee_per_gas != 0
+        if replacement_max_priority_fee_per_gas
+            <= existing_max_priority_fee_per_gas * (100 + price_bump) / 100
+            && existing_max_priority_fee_per_gas != 0
+            && replacement_max_priority_fee_per_gas != 0
         {
             return true;
         }
@@ -1444,8 +1446,8 @@ impl<T: PoolTransaction> AllTransactions<T> {
             // this enforces that blob txs can only be replaced by blob txs
             let replacement_max_blob_fee_per_gas =
                 maybe_replacement.transaction.max_fee_per_blob_gas().unwrap_or(0);
-            if replacement_max_blob_fee_per_gas <=
-                existing_max_blob_fee_per_gas * (100 + price_bump) / 100
+            if replacement_max_blob_fee_per_gas
+                <= existing_max_blob_fee_per_gas * (100 + price_bump) / 100
             {
                 return true;
             }

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -44,10 +44,10 @@ macro_rules! set_value {
     ($this:ident => $field:ident) => {
         let new_value = $field;
         match $this {
-            MockTransaction::Legacy { ref mut $field, .. } |
-            MockTransaction::Eip1559 { ref mut $field, .. } |
-            MockTransaction::Eip4844 { ref mut $field, .. } |
-            MockTransaction::Eip2930 { ref mut $field, .. } => {
+            MockTransaction::Legacy { ref mut $field, .. }
+            | MockTransaction::Eip1559 { ref mut $field, .. }
+            | MockTransaction::Eip4844 { ref mut $field, .. }
+            | MockTransaction::Eip2930 { ref mut $field, .. } => {
                 *$field = new_value;
             }
         }
@@ -58,10 +58,10 @@ macro_rules! set_value {
 macro_rules! get_value {
     ($this:tt => $field:ident) => {
         match $this {
-            MockTransaction::Legacy { $field, .. } |
-            MockTransaction::Eip1559 { $field, .. } |
-            MockTransaction::Eip4844 { $field, .. } |
-            MockTransaction::Eip2930 { $field, .. } => $field.clone(),
+            MockTransaction::Legacy { $field, .. }
+            | MockTransaction::Eip1559 { $field, .. }
+            | MockTransaction::Eip4844 { $field, .. }
+            | MockTransaction::Eip2930 { $field, .. } => $field.clone(),
         }
     };
 }
@@ -333,8 +333,8 @@ impl MockTransaction {
 
     /// Sets the priority fee for dynamic fee transactions (EIP-1559 and EIP-4844)
     pub fn set_priority_fee(&mut self, val: u128) -> &mut Self {
-        if let Self::Eip1559 { max_priority_fee_per_gas, .. } |
-        Self::Eip4844 { max_priority_fee_per_gas, .. } = self
+        if let Self::Eip1559 { max_priority_fee_per_gas, .. }
+        | Self::Eip4844 { max_priority_fee_per_gas, .. } = self
         {
             *max_priority_fee_per_gas = val;
         }
@@ -350,8 +350,8 @@ impl MockTransaction {
     /// Gets the priority fee for dynamic fee transactions (EIP-1559 and EIP-4844)
     pub const fn get_priority_fee(&self) -> Option<u128> {
         match self {
-            Self::Eip1559 { max_priority_fee_per_gas, .. } |
-            Self::Eip4844 { max_priority_fee_per_gas, .. } => Some(*max_priority_fee_per_gas),
+            Self::Eip1559 { max_priority_fee_per_gas, .. }
+            | Self::Eip4844 { max_priority_fee_per_gas, .. } => Some(*max_priority_fee_per_gas),
             _ => None,
         }
     }
@@ -385,9 +385,9 @@ impl MockTransaction {
     pub fn set_accesslist(&mut self, list: AccessList) -> &mut Self {
         match self {
             Self::Legacy { .. } => {}
-            Self::Eip1559 { access_list: accesslist, .. } |
-            Self::Eip4844 { access_list: accesslist, .. } |
-            Self::Eip2930 { access_list: accesslist, .. } => {
+            Self::Eip1559 { access_list: accesslist, .. }
+            | Self::Eip4844 { access_list: accesslist, .. }
+            | Self::Eip2930 { access_list: accesslist, .. } => {
                 *accesslist = list;
             }
         }
@@ -400,8 +400,8 @@ impl MockTransaction {
             Self::Legacy { gas_price, .. } | Self::Eip2930 { gas_price, .. } => {
                 *gas_price = val;
             }
-            Self::Eip1559 { max_fee_per_gas, max_priority_fee_per_gas, .. } |
-            Self::Eip4844 { max_fee_per_gas, max_priority_fee_per_gas, .. } => {
+            Self::Eip1559 { max_fee_per_gas, max_priority_fee_per_gas, .. }
+            | Self::Eip4844 { max_fee_per_gas, max_priority_fee_per_gas, .. } => {
                 *max_fee_per_gas = val;
                 *max_priority_fee_per_gas = val;
             }
@@ -415,8 +415,8 @@ impl MockTransaction {
             Self::Legacy { ref mut gas_price, .. } | Self::Eip2930 { ref mut gas_price, .. } => {
                 *gas_price = val;
             }
-            Self::Eip1559 { ref mut max_fee_per_gas, ref mut max_priority_fee_per_gas, .. } |
-            Self::Eip4844 { ref mut max_fee_per_gas, ref mut max_priority_fee_per_gas, .. } => {
+            Self::Eip1559 { ref mut max_fee_per_gas, ref mut max_priority_fee_per_gas, .. }
+            | Self::Eip4844 { ref mut max_fee_per_gas, ref mut max_priority_fee_per_gas, .. } => {
                 *max_fee_per_gas = val;
                 *max_priority_fee_per_gas = val;
             }
@@ -568,39 +568,39 @@ impl PoolTransaction for MockTransaction {
 
     fn hash(&self) -> &TxHash {
         match self {
-            Self::Legacy { hash, .. } |
-            Self::Eip1559 { hash, .. } |
-            Self::Eip4844 { hash, .. } |
-            Self::Eip2930 { hash, .. } => hash,
+            Self::Legacy { hash, .. }
+            | Self::Eip1559 { hash, .. }
+            | Self::Eip4844 { hash, .. }
+            | Self::Eip2930 { hash, .. } => hash,
         }
     }
 
     fn sender(&self) -> Address {
         match self {
-            Self::Legacy { sender, .. } |
-            Self::Eip1559 { sender, .. } |
-            Self::Eip4844 { sender, .. } |
-            Self::Eip2930 { sender, .. } => *sender,
+            Self::Legacy { sender, .. }
+            | Self::Eip1559 { sender, .. }
+            | Self::Eip4844 { sender, .. }
+            | Self::Eip2930 { sender, .. } => *sender,
         }
     }
 
     fn nonce(&self) -> u64 {
         match self {
-            Self::Legacy { nonce, .. } |
-            Self::Eip1559 { nonce, .. } |
-            Self::Eip4844 { nonce, .. } |
-            Self::Eip2930 { nonce, .. } => *nonce,
+            Self::Legacy { nonce, .. }
+            | Self::Eip1559 { nonce, .. }
+            | Self::Eip4844 { nonce, .. }
+            | Self::Eip2930 { nonce, .. } => *nonce,
         }
     }
 
     fn cost(&self) -> U256 {
         match self {
-            Self::Legacy { gas_price, value, gas_limit, .. } |
-            Self::Eip2930 { gas_limit, gas_price, value, .. } => {
+            Self::Legacy { gas_price, value, gas_limit, .. }
+            | Self::Eip2930 { gas_limit, gas_price, value, .. } => {
                 U256::from(*gas_limit) * U256::from(*gas_price) + *value
             }
-            Self::Eip1559 { max_fee_per_gas, value, gas_limit, .. } |
-            Self::Eip4844 { max_fee_per_gas, value, gas_limit, .. } => {
+            Self::Eip1559 { max_fee_per_gas, value, gas_limit, .. }
+            | Self::Eip4844 { max_fee_per_gas, value, gas_limit, .. } => {
                 U256::from(*gas_limit) * U256::from(*max_fee_per_gas) + *value
             }
         }
@@ -622,17 +622,17 @@ impl PoolTransaction for MockTransaction {
     fn access_list(&self) -> Option<&AccessList> {
         match self {
             Self::Legacy { .. } => None,
-            Self::Eip1559 { access_list: accesslist, .. } |
-            Self::Eip4844 { access_list: accesslist, .. } |
-            Self::Eip2930 { access_list: accesslist, .. } => Some(accesslist),
+            Self::Eip1559 { access_list: accesslist, .. }
+            | Self::Eip4844 { access_list: accesslist, .. }
+            | Self::Eip2930 { access_list: accesslist, .. } => Some(accesslist),
         }
     }
 
     fn max_priority_fee_per_gas(&self) -> Option<u128> {
         match self {
             Self::Legacy { .. } | Self::Eip2930 { .. } => None,
-            Self::Eip1559 { max_priority_fee_per_gas, .. } |
-            Self::Eip4844 { max_priority_fee_per_gas, .. } => Some(*max_priority_fee_per_gas),
+            Self::Eip1559 { max_priority_fee_per_gas, .. }
+            | Self::Eip4844 { max_priority_fee_per_gas, .. } => Some(*max_priority_fee_per_gas),
         }
     }
 
@@ -673,8 +673,8 @@ impl PoolTransaction for MockTransaction {
     fn priority_fee_or_price(&self) -> u128 {
         match self {
             Self::Legacy { gas_price, .. } | Self::Eip2930 { gas_price, .. } => *gas_price,
-            Self::Eip1559 { max_priority_fee_per_gas, .. } |
-            Self::Eip4844 { max_priority_fee_per_gas, .. } => *max_priority_fee_per_gas,
+            Self::Eip1559 { max_priority_fee_per_gas, .. }
+            | Self::Eip4844 { max_priority_fee_per_gas, .. } => *max_priority_fee_per_gas,
         }
     }
 
@@ -690,19 +690,19 @@ impl PoolTransaction for MockTransaction {
     fn input(&self) -> &[u8] {
         match self {
             Self::Legacy { .. } => &[],
-            Self::Eip1559 { input, .. } |
-            Self::Eip4844 { input, .. } |
-            Self::Eip2930 { input, .. } => input,
+            Self::Eip1559 { input, .. }
+            | Self::Eip4844 { input, .. }
+            | Self::Eip2930 { input, .. } => input,
         }
     }
 
     /// Returns the size of the transaction.
     fn size(&self) -> usize {
         match self {
-            Self::Legacy { size, .. } |
-            Self::Eip1559 { size, .. } |
-            Self::Eip4844 { size, .. } |
-            Self::Eip2930 { size, .. } => *size,
+            Self::Legacy { size, .. }
+            | Self::Eip1559 { size, .. }
+            | Self::Eip4844 { size, .. }
+            | Self::Eip2930 { size, .. } => *size,
         }
     }
 
@@ -725,9 +725,9 @@ impl PoolTransaction for MockTransaction {
     fn chain_id(&self) -> Option<u64> {
         match self {
             Self::Legacy { chain_id, .. } => *chain_id,
-            Self::Eip1559 { chain_id, .. } |
-            Self::Eip4844 { chain_id, .. } |
-            Self::Eip2930 { chain_id, .. } => Some(*chain_id),
+            Self::Eip1559 { chain_id, .. }
+            | Self::Eip4844 { chain_id, .. }
+            | Self::Eip2930 { chain_id, .. } => Some(*chain_id),
         }
     }
 }

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -1207,13 +1207,13 @@ impl TryFrom<TransactionSignedEcRecovered> for EthPooledTransaction {
             }
             EIP4844_TX_TYPE_ID => {
                 // doesn't have a blob sidecar
-                return Err(TryFromRecoveredTransactionError::BlobSidecarMissing)
+                return Err(TryFromRecoveredTransactionError::BlobSidecarMissing);
             }
             unsupported => {
                 // unsupported transaction type
                 return Err(TryFromRecoveredTransactionError::UnsupportedTransactionType(
                     unsupported,
-                ))
+                ));
             }
         };
 
@@ -1327,7 +1327,7 @@ impl<Tx: PoolTransaction> NewSubpoolTransactionStream<Tx> {
             match self.st.try_recv() {
                 Ok(event) => {
                     if event.subpool == self.subpool {
-                        return Ok(event)
+                        return Ok(event);
                     }
                 }
                 Err(e) => return Err(e),
@@ -1344,7 +1344,7 @@ impl<Tx: PoolTransaction> Stream for NewSubpoolTransactionStream<Tx> {
             match ready!(self.st.poll_recv(cx)) {
                 Some(event) => {
                     if event.subpool == self.subpool {
-                        return Poll::Ready(Some(event))
+                        return Poll::Ready(Some(event));
                     }
                 }
                 None => return Poll::Ready(None),

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -166,7 +166,7 @@ where
                     return TransactionValidationOutcome::Invalid(
                         transaction,
                         InvalidTransactionError::Eip2930Disabled.into(),
-                    )
+                    );
                 }
             }
             EIP1559_TX_TYPE_ID => {
@@ -175,7 +175,7 @@ where
                     return TransactionValidationOutcome::Invalid(
                         transaction,
                         InvalidTransactionError::Eip1559Disabled.into(),
-                    )
+                    );
                 }
             }
             EIP4844_TX_TYPE_ID => {
@@ -184,7 +184,7 @@ where
                     return TransactionValidationOutcome::Invalid(
                         transaction,
                         InvalidTransactionError::Eip4844Disabled.into(),
-                    )
+                    );
                 }
             }
             EIP7702_TX_TYPE_ID => {
@@ -193,7 +193,7 @@ where
                     return TransactionValidationOutcome::Invalid(
                         transaction,
                         InvalidTransactionError::Eip7702Disabled.into(),
-                    )
+                    );
                 }
             }
 
@@ -214,13 +214,13 @@ where
                     transaction_size,
                     self.max_tx_input_bytes,
                 ),
-            )
+            );
         }
 
         // Check whether the init code size has been exceeded.
         if self.fork_tracker.is_shanghai_activated() {
             if let Err(err) = ensure_max_init_code_size(&transaction, MAX_INIT_CODE_BYTE_SIZE) {
-                return TransactionValidationOutcome::Invalid(transaction, err)
+                return TransactionValidationOutcome::Invalid(transaction, err);
             }
         }
 
@@ -233,7 +233,7 @@ where
                     transaction_gas_limit,
                     self.block_gas_limit,
                 ),
-            )
+            );
         }
 
         // Ensure max_priority_fee_per_gas (if EIP1559) is less than max_fee_per_gas if any.
@@ -241,19 +241,19 @@ where
             return TransactionValidationOutcome::Invalid(
                 transaction,
                 InvalidTransactionError::TipAboveFeeCap.into(),
-            )
+            );
         }
 
         // Drop non-local transactions with a fee lower than the configured fee for acceptance into
         // the pool.
-        if !self.local_transactions_config.is_local(origin, transaction.sender()) &&
-            transaction.is_eip1559() &&
-            transaction.max_priority_fee_per_gas() < self.minimum_priority_fee
+        if !self.local_transactions_config.is_local(origin, transaction.sender())
+            && transaction.is_eip1559()
+            && transaction.max_priority_fee_per_gas() < self.minimum_priority_fee
         {
             return TransactionValidationOutcome::Invalid(
                 transaction,
                 InvalidPoolTransactionError::Underpriced,
-            )
+            );
         }
 
         // Checks for chainid
@@ -262,7 +262,7 @@ where
                 return TransactionValidationOutcome::Invalid(
                     transaction,
                     InvalidTransactionError::ChainIdMismatch.into(),
-                )
+                );
             }
         }
 
@@ -272,12 +272,12 @@ where
                 return TransactionValidationOutcome::Invalid(
                     transaction,
                     InvalidTransactionError::TxTypeNotSupported.into(),
-                )
+                );
             }
         }
 
         if let Err(err) = ensure_intrinsic_gas(&transaction, &self.fork_tracker) {
-            return TransactionValidationOutcome::Invalid(transaction, err)
+            return TransactionValidationOutcome::Invalid(transaction, err);
         }
 
         // light blob tx pre-checks
@@ -287,7 +287,7 @@ where
                 return TransactionValidationOutcome::Invalid(
                     transaction,
                     InvalidTransactionError::TxTypeNotSupported.into(),
-                )
+                );
             }
 
             let blob_count = transaction.blob_count();
@@ -298,7 +298,7 @@ where
                     InvalidPoolTransactionError::Eip4844(
                         Eip4844PoolTransactionError::NoEip4844Blobs,
                     ),
-                )
+                );
             }
 
             if blob_count > MAX_BLOBS_PER_BLOCK {
@@ -311,7 +311,7 @@ where
                             permitted: MAX_BLOBS_PER_BLOCK,
                         },
                     ),
-                )
+                );
             }
         }
 
@@ -332,7 +332,7 @@ where
             return TransactionValidationOutcome::Invalid(
                 transaction,
                 InvalidTransactionError::SignerAccountHasBytecode.into(),
-            )
+            );
         }
 
         // Checks for nonce
@@ -340,7 +340,7 @@ where
             return TransactionValidationOutcome::Invalid(
                 transaction,
                 InvalidTransactionError::NonceNotConsistent.into(),
-            )
+            );
         }
 
         let cost = transaction.cost();
@@ -353,7 +353,7 @@ where
                     GotExpected { got: account.balance, expected: cost }.into(),
                 )
                 .into(),
-            )
+            );
         }
 
         let mut maybe_blob_sidecar = None;
@@ -367,7 +367,7 @@ where
                     return TransactionValidationOutcome::Invalid(
                         transaction,
                         InvalidTransactionError::TxTypeNotSupported.into(),
-                    )
+                    );
                 }
                 EthBlobTransactionSidecar::Missing => {
                     // This can happen for re-injected blob transactions (on re-org), since the blob
@@ -382,7 +382,7 @@ where
                             InvalidPoolTransactionError::Eip4844(
                                 Eip4844PoolTransactionError::MissingEip4844BlobSidecar,
                             ),
-                        )
+                        );
                     }
                 }
                 EthBlobTransactionSidecar::Present(blob) => {
@@ -393,7 +393,7 @@ where
                             InvalidPoolTransactionError::Eip4844(
                                 Eip4844PoolTransactionError::InvalidEip4844Blob(err),
                             ),
-                        )
+                        );
                     }
                     // store the extracted blob
                     maybe_blob_sidecar = Some(blob);

--- a/crates/transaction-pool/src/validate/task.rs
+++ b/crates/transaction-pool/src/validate/task.rs
@@ -196,7 +196,7 @@ where
                 return TransactionValidationOutcome::Error(
                     hash,
                     Box::new(TransactionValidatorError::ValidationServiceUnreachable),
-                )
+                );
             }
         }
 

--- a/crates/trie/common/src/proofs.rs
+++ b/crates/trie/common/src/proofs.rs
@@ -51,7 +51,7 @@ impl MultiProof {
                             nonce: account.nonce,
                             bytecode_hash: (account.code_hash != KECCAK_EMPTY)
                                 .then_some(account.code_hash),
-                        })
+                        });
                     }
                 }
             }
@@ -108,7 +108,7 @@ impl StorageMultiProof {
             if let Some(last) = proof.last() {
                 if let TrieNode::Leaf(leaf) = TrieNode::decode(&mut &last[..])? {
                     if nibbles.ends_with(&leaf.key) {
-                        break 'value U256::decode(&mut &leaf.value[..])?
+                        break 'value U256::decode(&mut &leaf.value[..])?;
                     }
                 }
             }

--- a/crates/trie/trie/benches/prefix_set.rs
+++ b/crates/trie/trie/benches/prefix_set.rs
@@ -150,12 +150,12 @@ mod implementations {
             for key in self.keys.range::<Nibbles, _>(range) {
                 if key.has_prefix(&prefix) {
                     self.last_checked = Some(prefix);
-                    return true
+                    return true;
                 }
 
                 if key > &prefix {
                     self.last_checked = Some(prefix);
-                    return false
+                    return false;
                 }
             }
 
@@ -219,12 +219,12 @@ mod implementations {
             for (idx, key) in self.keys[self.index..].iter().enumerate() {
                 if key.has_prefix(&prefix) {
                     self.index += idx;
-                    return true
+                    return true;
                 }
 
                 if key > &prefix {
                     self.index += idx;
-                    return false
+                    return false;
                 }
             }
 

--- a/crates/trie/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/trie/src/hashed_cursor/post_state.rs
@@ -82,7 +82,7 @@ where
         // It's an exact match, return the account from post state without looking up in the
         // database.
         if post_state_entry.is_some_and(|entry| entry.0 == key) {
-            return Ok(post_state_entry)
+            return Ok(post_state_entry);
         }
 
         // It's not an exact match, reposition to the first greater or equal account that wasn't
@@ -217,7 +217,7 @@ where
         // If database storage was wiped or it's an exact match,
         // return the storage slot from post state without looking up in the database.
         if self.storage_wiped || post_state_entry.is_some_and(|entry| entry.0 == subkey) {
-            return Ok(post_state_entry)
+            return Ok(post_state_entry);
         }
 
         // It's not an exact match and storage was not wiped,
@@ -239,7 +239,7 @@ where
 
         // Return post state entry immediately if database was wiped.
         if self.storage_wiped {
-            return Ok(post_state_entry)
+            return Ok(post_state_entry);
         }
 
         // If post state was given precedence, move the cursor forward.

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -97,7 +97,7 @@ where
                             key.clone(),
                             self.walker.hash().unwrap(),
                             self.walker.children_are_in_trie(),
-                        ))))
+                        ))));
                     }
                 }
             }
@@ -108,12 +108,12 @@ where
                 // reset the checked status and continue
                 if self.walker.key().is_some_and(|key| key < &Nibbles::unpack(hashed_key)) {
                     self.current_walker_key_checked = false;
-                    continue
+                    continue;
                 }
 
                 // Set the next hashed entry as a leaf node and return
                 self.current_hashed_entry = self.hashed_cursor.next()?;
-                return Ok(Some(TrieElement::Leaf(hashed_key, value)))
+                return Ok(Some(TrieElement::Leaf(hashed_key, value)));
             }
 
             // Handle seeking and advancing based on the previous hashed key

--- a/crates/trie/trie/src/prefix_set.rs
+++ b/crates/trie/trie/src/prefix_set.rs
@@ -119,12 +119,12 @@ impl PrefixSetMut {
         for (idx, key) in self.keys[self.index..].iter().enumerate() {
             if key.has_prefix(prefix) {
                 self.index += idx;
-                return true
+                return true;
             }
 
             if *key > *prefix {
                 self.index += idx;
-                return false
+                return false;
             }
         }
 
@@ -193,12 +193,12 @@ impl PrefixSet {
         for (idx, key) in self.keys[self.index..].iter().enumerate() {
             if key.has_prefix(prefix) {
                 self.index += idx;
-                return true
+                return true;
             }
 
             if key > prefix {
                 self.index += idx;
-                return false
+                return false;
             }
         }
 

--- a/crates/trie/trie/src/proof.rs
+++ b/crates/trie/trie/src/proof.rs
@@ -134,7 +134,7 @@ where
 
         // short circuit on empty storage
         if hashed_storage_cursor.is_storage_empty()? {
-            return Ok(StorageMultiProof::default())
+            return Ok(StorageMultiProof::default());
         }
 
         let target_nibbles = self

--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -230,9 +230,9 @@ where
                     hash_builder.add_leaf(Nibbles::unpack(hashed_address), &account_rlp);
 
                     // Decide if we need to return intermediate progress.
-                    let total_updates_len = updated_storage_nodes +
-                        account_node_iter.walker.removed_keys_len() +
-                        hash_builder.updates_len();
+                    let total_updates_len = updated_storage_nodes
+                        + account_node_iter.walker.removed_keys_len()
+                        + hash_builder.updates_len();
                     if retain_updates && total_updates_len as u64 >= self.threshold {
                         let (walker_stack, walker_deleted_keys) = account_node_iter.walker.split();
                         trie_updates.removed_nodes.extend(walker_deleted_keys);
@@ -249,7 +249,7 @@ where
                             Box::new(state),
                             hashed_entries_walked,
                             trie_updates,
-                        ))
+                        ));
                     }
                 }
             }
@@ -403,7 +403,7 @@ where
 
         // short circuit on empty storage
         if hashed_storage_cursor.is_storage_empty()? {
-            return Ok((EMPTY_ROOT_HASH, 0, StorageTrieUpdates::deleted()))
+            return Ok((EMPTY_ROOT_HASH, 0, StorageTrieUpdates::deleted()));
         }
 
         let mut tracker = TrieTracker::default();

--- a/crates/trie/trie/src/trie_cursor/in_memory.rs
+++ b/crates/trie/trie/src/trie_cursor/in_memory.rs
@@ -79,7 +79,7 @@ impl<'a, C: TrieCursor> InMemoryAccountTrieCursor<'a, C> {
     ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
         let in_memory = self.in_memory_cursor.seek(&key);
         if exact && in_memory.as_ref().is_some_and(|entry| entry.0 == key) {
-            return Ok(in_memory)
+            return Ok(in_memory);
         }
 
         // Reposition the cursor to the first greater or equal node that wasn't removed.
@@ -196,10 +196,10 @@ impl<C: TrieCursor> InMemoryStorageTrieCursor<'_, C> {
         exact: bool,
     ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
         let in_memory = self.in_memory_cursor.as_mut().and_then(|c| c.seek(&key));
-        if self.storage_trie_cleared ||
-            (exact && in_memory.as_ref().is_some_and(|entry| entry.0 == key))
+        if self.storage_trie_cleared
+            || (exact && in_memory.as_ref().is_some_and(|entry| entry.0 == key))
         {
-            return Ok(in_memory.filter(|(nibbles, _)| !exact || nibbles == &key))
+            return Ok(in_memory.filter(|(nibbles, _)| !exact || nibbles == &key));
         }
 
         // Reposition the cursor to the first greater or equal node that wasn't removed.
@@ -223,7 +223,7 @@ impl<C: TrieCursor> InMemoryStorageTrieCursor<'_, C> {
     ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
         let in_memory = self.in_memory_cursor.as_mut().and_then(|c| c.first_after(&last));
         if self.storage_trie_cleared {
-            return Ok(in_memory)
+            return Ok(in_memory);
         }
 
         // Reposition the cursor to the first greater or equal node that wasn't removed.

--- a/crates/trie/trie/src/updates.rs
+++ b/crates/trie/trie/src/updates.rs
@@ -14,9 +14,9 @@ pub struct TrieUpdates {
 impl TrieUpdates {
     /// Returns `true` if the updates are empty.
     pub fn is_empty(&self) -> bool {
-        self.account_nodes.is_empty() &&
-            self.removed_nodes.is_empty() &&
-            self.storage_tries.is_empty()
+        self.account_nodes.is_empty()
+            && self.removed_nodes.is_empty()
+            && self.storage_tries.is_empty()
     }
 
     /// Returns reference to updated account nodes.
@@ -252,7 +252,7 @@ impl<I: Iterator<Item = Nibbles>> Iterator for ExcludeEmpty<I> {
         loop {
             let next = self.0.next()?;
             if !next.is_empty() {
-                return Some(next)
+                return Some(next);
             }
         }
     }
@@ -274,7 +274,7 @@ impl<V, I: Iterator<Item = (Nibbles, V)>> Iterator for ExcludeEmptyFromPair<I> {
         loop {
             let next = self.0.next()?;
             if !next.0.is_empty() {
-                return Some(next)
+                return Some(next);
             }
         }
     }

--- a/crates/trie/trie/src/walker.rs
+++ b/crates/trie/trie/src/walker.rs
@@ -169,7 +169,7 @@ impl<C: TrieCursor> TrieWalker<C> {
         let Some((key, node)) = self.node(false)? else {
             // If no next node is found, clear the stack.
             self.stack.clear();
-            return Ok(())
+            return Ok(());
         };
 
         // Overwrite the root node's first nibble
@@ -208,22 +208,22 @@ impl<C: TrieCursor> TrieWalker<C> {
         if subnode.nibble() >= 0xf || (subnode.nibble() < 0 && !allow_root_to_child_nibble) {
             self.stack.pop();
             self.move_to_next_sibling(false)?;
-            return Ok(())
+            return Ok(());
         }
 
         subnode.inc_nibble();
 
         if subnode.node.is_none() {
-            return self.consume_node()
+            return self.consume_node();
         }
 
         // Find the next sibling with state.
         loop {
             if subnode.state_flag() {
-                return Ok(())
+                return Ok(());
             }
             if subnode.nibble() == 0xf {
-                break
+                break;
             }
             subnode.inc_nibble();
         }

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -229,8 +229,8 @@ where
             match value {
                 Either::Left(branch_hash) => {
                     let parent_branch_path = path.slice(..path.len() - 1);
-                    if hash_builder.key.starts_with(&parent_branch_path) ||
-                        trie_nodes
+                    if hash_builder.key.starts_with(&parent_branch_path)
+                        || trie_nodes
                             .peek()
                             .is_some_and(|next| next.0.starts_with(&parent_branch_path))
                     {
@@ -246,13 +246,13 @@ where
                                     for (child_path, branch_hash) in children {
                                         hash_builder.add_branch(child_path, branch_hash, false);
                                     }
-                                    break
+                                    break;
                                 }
                                 TrieNode::Leaf(leaf) => {
                                     let mut child_path = path;
                                     child_path.extend_from_slice(&leaf.key);
                                     hash_builder.add_leaf(child_path, &leaf.value);
-                                    break
+                                    break;
                                 }
                                 TrieNode::Extension(ext) => {
                                     path.extend_from_slice(&ext.key);

--- a/docs/docker_setup.md
+++ b/docs/docker_setup.md
@@ -9,7 +9,7 @@
 
 To run the stack locally, please go through the following steps to ensure you have all necessary prerequisites:
 
-1. Install `rust` (best way to install it is through the rustup toolchain: [rust](https://rustup.rs/) - depending on your OS). Default to nightly version. Minimum required version is `1.75`.
+1. Install `rust` (best way to install it is through the rustup toolchain: [rust](https://rustup.rs/) - depending on your OS). Default to nightly version. Minimum required version is `1.85`.
 1. Install `docker` on your OS - simply follow the instructions here: [docker](https://docs.docker.com/engine/install/)
 1. Install `foundry/forge` on your system - simply follow the instructions here: [foundry](https://book.getfoundry.sh/getting-started/installation)
 1. Install and set up `git` to use ssh.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "1.85.0"
+
+# Extra components that must be present
+components = ["rustc", "rust-std", "cargo", "rustfmt", "clippy"]

--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -71,13 +71,13 @@ impl Case for BlockchainTestCase {
             .filter(|case| {
                 !matches!(
                     case.network,
-                    ForkSpec::ByzantiumToConstantinopleAt5 |
-                        ForkSpec::Constantinople |
-                        ForkSpec::ConstantinopleFix |
-                        ForkSpec::MergeEOF |
-                        ForkSpec::MergeMeterInitCode |
-                        ForkSpec::MergePush0 |
-                        ForkSpec::Unknown
+                    ForkSpec::ByzantiumToConstantinopleAt5
+                        | ForkSpec::Constantinople
+                        | ForkSpec::ConstantinopleFix
+                        | ForkSpec::MergeEOF
+                        | ForkSpec::MergeMeterInitCode
+                        | ForkSpec::MergePush0
+                        | ForkSpec::Unknown
                 )
             })
             .par_bridge()

--- a/testing/ef-tests/src/models.rs
+++ b/testing/ef-tests/src/models.rs
@@ -243,12 +243,12 @@ impl Account {
                 } else {
                     return Err(Error::Assertion(format!(
                         "Slot {slot:?} is missing from the database. Expected {value:?}"
-                    )))
+                    )));
                 }
             } else {
                 return Err(Error::Assertion(format!(
                     "Slot {slot:?} is missing from the database. Expected {value:?}"
-                )))
+                )));
             }
         }
 
@@ -326,17 +326,17 @@ impl From<ForkSpec> for ChainSpec {
                 spec_builder.tangerine_whistle_activated()
             }
             ForkSpec::EIP158 => spec_builder.spurious_dragon_activated(),
-            ForkSpec::Byzantium |
-            ForkSpec::EIP158ToByzantiumAt5 |
-            ForkSpec::ConstantinopleFix |
-            ForkSpec::ByzantiumToConstantinopleFixAt5 => spec_builder.byzantium_activated(),
+            ForkSpec::Byzantium
+            | ForkSpec::EIP158ToByzantiumAt5
+            | ForkSpec::ConstantinopleFix
+            | ForkSpec::ByzantiumToConstantinopleFixAt5 => spec_builder.byzantium_activated(),
             ForkSpec::Istanbul => spec_builder.istanbul_activated(),
             ForkSpec::Berlin => spec_builder.berlin_activated(),
             ForkSpec::London | ForkSpec::BerlinToLondonAt5 => spec_builder.london_activated(),
-            ForkSpec::Merge |
-            ForkSpec::MergeEOF |
-            ForkSpec::MergeMeterInitCode |
-            ForkSpec::MergePush0 => spec_builder.paris_activated(),
+            ForkSpec::Merge
+            | ForkSpec::MergeEOF
+            | ForkSpec::MergeMeterInitCode
+            | ForkSpec::MergePush0 => spec_builder.paris_activated(),
             ForkSpec::Shanghai => spec_builder.shanghai_activated(),
             ForkSpec::Cancun => spec_builder.cancun_activated(),
             ForkSpec::ByzantiumToConstantinopleAt5 | ForkSpec::Constantinople => {

--- a/testing/testing-utils/src/generators.rs
+++ b/testing/testing-utils/src/generators.rs
@@ -263,7 +263,7 @@ where
                 } else {
                     let old = storage.remove(&entry.key);
                     if matches!(old, Some(U256::ZERO)) {
-                        return None
+                        return None;
                     }
                     old
                 };


### PR DESCRIPTION
Now, we are using nightly builds for formatting. Since we all could have a different nightly version installed, we got different formatting, which is overriding from PR to PR.

This PR sets a specific version in `rust-toolchain.toml` and `cargo fmt` uses it.