### PR TITLE
refactor(snapshot_size): reduce prod snapshot size

### DIFF
--- a/crates/consensus/authority/src/snapshot_manager.rs
+++ b/crates/consensus/authority/src/snapshot_manager.rs
@@ -47,8 +47,8 @@ pub const SNAPSHOT_SIZE_LIMITS_TEST: SnapshotSizeLimits = SnapshotSizeLimits {
 
 /// Snapshot size limits for state sync prod
 pub const SNAPSHOT_SIZE_LIMITS_PROD: SnapshotSizeLimits = SnapshotSizeLimits {
-    snapshot_max_size: 1024 * 1024 * 100,  // 100 MB
-    snapshot_chunk_size: 1024 * 1024 * 10, // 10 MB
+    snapshot_max_size: 1024 * 1024 * 15,  // ~15 MB
+    snapshot_chunk_size: 1024 * 1024 * 3, // ~3 MB
 };
 
 /// Snapshot Manager State Lock


### PR DESCRIPTION
I need to reduce the snapshot size for prod again in an attempt to sync the rpc nodes to a good state.

I'm going to detail some general info about cometbft snapshots and my approach to getting rpcs in a good state for **testnet**

Overview of **CometBFT State Sync(uses snapshots)**
**Comet has two syncing mechanisms: block sync and state sync**
- block sync is for syncing one block at a time and is intended for full/archival nodes that need the entire chain history (aka fed nodes)
- state sync is for syncing  a fresh node (no chain state) from a trusted height
  - these are nodes that do not need the entire chain history and will have a gap in their chain
  - we do not support this in reth currently: the chain history cannot have any gaps
  - state sync only ever serves **1** snapshot
    - this single snapshot is the most recent one above the `trust_height` in the comet `config.toml`
    - for example, syncing node sets `trust_height = 1` and the latest snapshot has the block range of `5_000 - 10_000`. 
      - the peers will give the syncing node that snapshot and the node will start syncing from block `5_000`
      - this is not allowed by reth (we'd have to add this future)
  
RPC nodes (in our sytem) are archival nodes: they need the full chain history and do not support gaps in the chain.

How can we use state sync to get the external RPC nodes into a good state where they can follow the chain (and get around the current apphash mismatch issue)?

They will wipe their dbs and sync from the genesis block which means:
- the rpc node will **only** recieve **1** snapshot from peers and that would be the **latest snapshot**
- this snapshot needs to be the first and only sealed snapshot available for syncing

Currently, testnet has about 20MB worth of snapshot data.
So this pr reduces the snapshot size to 15MB to get us into the state where we have only 1 sealed snapshot for syncing. This should allow RPC nodes to sync from the genesis block to the height of the snapshot then switch to normal block sync
