### PR TITLE
improve(DKG): Implement automatic session reset mechanism w/ verification

### DIFF
--- a/bin/btc-server/src/bin/main.rs
+++ b/bin/btc-server/src/bin/main.rs
@@ -183,8 +183,47 @@ impl<T> ToStatus<T> for Result<T, hex::FromHexError> {
     }
 }
 
+/// Print logs about the DKG state machine, for informal or debugging purposes.
+fn print_dkg_state_log(dkg: &mut DkgState) {
+    // Check session changes.
+    if let Some(current) = dkg.machine.session_nonce() {
+        if let Some(tracked) = dkg.session_nonce {
+            if tracked != current {
+                info!("DKG session nonce changed to: {}", current);
+                dkg.session_nonce = Some(current);
+                dkg.stage = None;
+            }
+        } else {
+            info!("DKG session nonce set to: {}", current);
+            dkg.session_nonce = Some(current);
+        }
+    }
+
+    // Check DKG state changes.
+    let stage = dkg.machine.stage();
+    if let Some(tracked) = dkg.stage {
+        if tracked != stage {
+            info!("DKG stage changed to: {}", stage);
+            dkg.stage = Some(stage);
+        }
+    } else {
+        info!("DKG stage set to: {}", stage);
+        dkg.stage = Some(stage);
+    }
+}
+
 type SigningNoncesCommitmentsMap =
     Arc<Mutex<Option<Vec<(frost::round1::SigningNonces, frost::round1::SigningCommitments)>>>>;
+
+/// The DKG state machine is responsible for managing the DKG process.
+struct DkgState {
+    // The DKG state machine
+    machine: dkg::DkgStateMachine,
+    // The current stage of the DKG process, used for logging purposes.
+    stage: Option<dkg::Stage>,
+    // The current session nonce, used for logging purposes.
+    session_nonce: Option<u64>,
+}
 
 struct App<BitcoinRpcApi> {
     db: database::Db,
@@ -197,7 +236,7 @@ struct App<BitcoinRpcApi> {
     #[cfg(test)]
     max_signers: u16,
     min_signers: u16,
-    dkg: Mutex<Option<dkg::DkgStateMachine>>,
+    dkg: Mutex<Option<DkgState>>,
     /// The signing nonces for the current signing session
     /// We will replace this value in the case of a new signing session
     frost_round1_nonces: SigningNoncesCommitmentsMap,
@@ -377,6 +416,8 @@ where
                 round1_package_timeout: Duration::from_secs(3),
                 round2_package_timeout: Duration::from_secs(3),
                 round3_package_timeout: Duration::from_secs(3),
+                // Start a new DKG session if not completed in 5 minutes.
+                pending_session_timeout: Some(Duration::from_secs(60 * 5)),
             };
 
             let mut members = BTreeMap::new();
@@ -389,15 +430,35 @@ where
                 members.insert(id, pubkey);
             }
 
-            let dkg = dkg::DkgStateMachine::new(
+            // As the coordinator, we simply use the system time as the session
+            // nonce. This value doesn't need to be precisely synchronized - it
+            // simply ensures that each server restart produces a higher nonce
+            // than previous sessions, removing the need to persist this value
+            // in the database.
+            //
+            // Non-coordinators automatically discard this value and use `None`,
+            // and let the coordinator dictate the nonce.
+            #[cfg(not(test))]
+            let session_nonce = SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .expect("bad system time")
+                .as_secs();
+
+            #[cfg(test)]
+            let session_nonce = 0;
+
+            let machine = dkg::DkgStateMachine::new(
                 frost_identifier,
                 secret_key,
                 coordinator,
                 members,
                 dkg_config,
+                Some(session_nonce),
             )?;
 
-            Mutex::new(Some(dkg))
+            let state = DkgState { machine, stage: None, session_nonce: None };
+
+            Mutex::new(Some(state))
         } else {
             Mutex::new(None)
         };
@@ -1360,11 +1421,14 @@ where
 
         // Generate responses on potential timeout events; if no timers expired,
         // then this is simply a no-op call.
-        dkg.on_timeout(Instant::now());
+        dkg.machine.on_timeout(Instant::now());
+
+        // Logging DKG state.
+        print_dkg_state_log(dkg);
 
         // Process response (or initial) payloads.
         let mut payloads = vec![];
-        while let Some(p) = dkg.send(Instant::now()) {
+        while let Some(p) = dkg.machine.send(Instant::now()) {
             // Encode the payload.
             let mut bytes = vec![];
             ciborium::into_writer(&p.msg, &mut bytes).expect("failed to encode Dkg payload");
@@ -1376,10 +1440,8 @@ where
             });
         }
 
-        debug_assert!(dkg.aggregate_key_packages().is_none());
-
         // Set any timers, and retrieve next timeout event.
-        let timeout = dkg.timeout(Instant::now());
+        let timeout = dkg.machine.timeout(Instant::now());
 
         let resp = rpc::DkgPayloads {
             // TODO (lamafab): Option?
@@ -1417,11 +1479,14 @@ where
         };
 
         // Process the payload.
-        dkg.recv(payload).to_status()?;
+        dkg.machine.recv(payload).to_status()?;
+
+        // Logging DKG state.
+        print_dkg_state_log(dkg);
 
         // Process response (or initial) payloads.
         let mut payloads = vec![];
-        while let Some(p) = dkg.send(Instant::now()) {
+        while let Some(p) = dkg.machine.send(Instant::now()) {
             // Encode the payload.
             let mut bytes = vec![];
             ciborium::into_writer(&p.msg, &mut bytes).expect("failed to encode Dkg payload");
@@ -1433,7 +1498,7 @@ where
             });
         }
 
-        if let Some((sec_key, pub_key)) = dkg.aggregate_key_packages() {
+        if let Some((sec_key, pub_key)) = dkg.machine.aggregate_key_packages() {
             if self.db.get_key_package().to_status()?.is_none() {
                 info!("DKG completed successfully, saving key packages...");
 
@@ -1453,7 +1518,7 @@ where
         }
 
         // Set any timers, and retrieve next timeout event.
-        let timeout = dkg.timeout(Instant::now());
+        let timeout = dkg.machine.timeout(Instant::now());
 
         let resp = rpc::DkgPayloads {
             // TODO (lamafab): Option?
@@ -1731,8 +1796,8 @@ mod tests {
         ];
 
         const SAMPLE_EPH_PUB: &[u8] = &[
-            2, 198, 219, 42, 125, 89, 147, 102, 157, 74, 46, 224, 42, 39, 110, 178, 212, 193, 93,
-            218, 129, 115, 234, 83, 4, 112, 112, 91, 211, 159, 17, 242, 104,
+            3, 132, 131, 44, 133, 229, 63, 171, 246, 209, 196, 34, 121, 0, 121, 231, 3, 132, 160,
+            221, 29, 145, 119, 9, 4, 200, 46, 76, 45, 21, 99, 42, 11,
         ];
 
         // Sample signature generated with private key:
@@ -1743,10 +1808,10 @@ mod tests {
         //
         // Respectively, the second entry in the temporary federation config.
         const SAMPLE_SIG: &[u8] = &[
-            97, 239, 21, 245, 44, 204, 59, 181, 45, 16, 126, 138, 167, 239, 21, 148, 68, 161, 34,
-            248, 114, 159, 47, 193, 213, 231, 26, 188, 130, 189, 194, 170, 81, 206, 79, 29, 88, 63,
-            16, 16, 216, 150, 235, 150, 162, 151, 101, 80, 158, 18, 54, 0, 96, 94, 93, 138, 216,
-            83, 148, 67, 125, 184, 148, 215,
+            82, 169, 233, 140, 210, 93, 174, 189, 154, 236, 130, 97, 121, 221, 140, 74, 98, 56,
+            114, 223, 112, 103, 88, 29, 209, 127, 21, 46, 128, 93, 97, 170, 15, 165, 91, 19, 97,
+            103, 12, 84, 50, 209, 217, 240, 124, 55, 62, 188, 29, 90, 73, 22, 206, 224, 205, 49,
+            218, 85, 134, 54, 192, 124, 24, 125,
         ];
 
         // Setup Alice (coordinator), Bob, and Eve.
@@ -1756,7 +1821,7 @@ mod tests {
         let ephemeral_pub = secp256k1::PublicKey::from_slice(SAMPLE_EPH_PUB).unwrap();
         let signature = secp256k1::ecdsa::Signature::from_compact(SAMPLE_SIG).unwrap();
 
-        // Alice generates two round1 packages, one for Bob and one for Eve.
+        // Alice generates two packages, one for Bob and one for Eve.
         {
             let req = tonic::Request::new(rpc::Empty {});
             let payloads = app.get_dkg_payloads(req).await.unwrap();
@@ -1765,18 +1830,24 @@ mod tests {
 
             let p1 = &inner.payloads[0];
             let msg: DkgMessage = ciborium::from_reader(p1.payload.as_slice()).unwrap();
-            let DkgMessage::Round1 { .. } = msg else {
+            let DkgMessage::Round1 { context, nonce, .. } = msg else {
                 panic!("Expected Round1 message");
             };
+
+            assert_eq!(context, dkg::SESSION_CONTEXT);
+            assert_eq!(nonce, 0);
+            //
+            assert_eq!(p1.sender, frost_id!(0).serialize());
+            assert_eq!(p1.recipient, frost_id!(2).serialize());
 
             let p2 = &inner.payloads[1];
             let msg: DkgMessage = ciborium::from_reader(p2.payload.as_slice()).unwrap();
-            let DkgMessage::Round1 { .. } = msg else {
+            let DkgMessage::Round1 { context, nonce, .. } = msg else {
                 panic!("Expected Round1 message");
             };
 
-            assert_eq!(p1.sender, frost_id!(0).serialize());
-            assert_eq!(p1.recipient, frost_id!(2).serialize());
+            assert_eq!(context, dkg::SESSION_CONTEXT);
+            assert_eq!(nonce, 0);
             //
             assert_eq!(p2.sender, frost_id!(0).serialize());
             assert_eq!(p2.recipient, frost_id!(1).serialize());
@@ -1789,6 +1860,8 @@ mod tests {
             #[derive(serde::Serialize, serde::Deserialize)]
             enum Embedded {
                 Round1 {
+                    context: Vec<u8>,
+                    nonce: u64,
                     initiator: frost::Identifier,
                     ephemeral_pub: secp256k1::PublicKey,
                     signature: secp256k1::ecdsa::Signature,
@@ -1797,7 +1870,9 @@ mod tests {
             }
 
             let msg = Embedded::Round1 {
-                initiator: frost_id!(1).into(),
+                context: dkg::SESSION_CONTEXT.to_vec(),
+                nonce: 0,
+                initiator: frost_id!(1),
                 ephemeral_pub,
                 signature,
                 package: round1_pkg,
@@ -1824,15 +1899,15 @@ mod tests {
                 panic!("Expected AckRound1 message");
             };
 
+            assert_eq!(p1.sender, frost_id!(0).serialize());
+            assert_eq!(p1.recipient, frost_id!(1).serialize());
+
             let p2 = &inner.payloads[1];
             let msg: DkgMessage = ciborium::from_reader(p2.payload.as_slice()).unwrap();
             let DkgMessage::Round1 { .. } = msg else {
                 panic!("Expected Round1 message");
             };
 
-            assert_eq!(p1.sender, frost_id!(0).serialize());
-            assert_eq!(p1.recipient, frost_id!(1).serialize());
-            //
             assert_eq!(p2.sender, frost_id!(0).serialize());
             assert_eq!(p2.recipient, frost_id!(2).serialize());
         }

--- a/bin/btc-server/src/dkg/encryption.rs
+++ b/bin/btc-server/src/dkg/encryption.rs
@@ -110,12 +110,14 @@ impl DkgHandshakeManager {
     ///
     /// # Arguments
     ///
-    /// * `session_id` - Unique identifier for this DKG session
+    /// * `context` - Unique identifier for this DKG session
+    /// * `nonce` - Unique nonce for this DKG session
     /// * `my_frost_id` - The FROST identifier of this participant
     /// * `my_static_sec` - The static secret key of this participant
     /// * `fed_members` - Map of all federation members' FROST IDs to their public keys
     pub fn new(
-        session_id: &[u8],
+        context: &[u8],
+        nonce: u64,
         my_frost_id: frost::Identifier,
         my_static_sec: secp256k1::SecretKey,
         fed_members: BTreeMap<frost::Identifier, secp256k1::PublicKey>,
@@ -124,9 +126,9 @@ impl DkgHandshakeManager {
             return Err(Error::SelfNotInFederation);
         }
 
-        // Setup the base transcript tied to a session Id.
         let mut t = Transcript::new(b"Botanix_Macbeth_DKG_Setup_v1");
-        t.append_message(b"session_id", session_id);
+        t.append_message(b"context", context);
+        t.append_u64(b"nonce", nonce);
 
         let secp = secp256k1::Secp256k1::new();
         let my_eph_sec = secp256k1::SecretKey::new(&mut rand::thread_rng());

--- a/bin/btc-server/src/dkg/mod.rs
+++ b/bin/btc-server/src/dkg/mod.rs
@@ -17,11 +17,15 @@ mod encryption;
 #[cfg(test)]
 mod tests;
 
+// NOTE: As of now, the session context is always the same constant. In
+// the future this may change, and might be handled differently.
+pub const SESSION_CONTEXT: &[u8] = b"static-dkg-session-context";
+
 /// Wrapper type for FROST identifiers used in the DKG protocol.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Initiator(frost::Identifier);
 
-// TODO: Hide behind `#[cfg(test)]`?
+#[cfg(test)]
 impl From<frost::Identifier> for Initiator {
     fn from(id: frost::Identifier) -> Self {
         Initiator(id)
@@ -32,7 +36,7 @@ impl From<frost::Identifier> for Initiator {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Target(frost::Identifier);
 
-// TODO: Hide behind `#[cfg(test)]`?
+#[cfg(test)]
 impl From<frost::Identifier> for Target {
     fn from(id: frost::Identifier) -> Self {
         Target(id)
@@ -84,7 +88,6 @@ mod sealed_pkg {
             initiator: Initiator,
             auth: &mut KeyVerificationManager,
         ) -> Result<secp256k1::ecdsa::Signature, encryption::Error> {
-            // TODO: This should take a reference
             auth.validate_round3(initiator, self.0)?;
             Ok(self.0)
         }
@@ -118,6 +121,10 @@ pub enum DkgMessage {
     Round1 {
         /// The original initiator of this package
         initiator: Initiator,
+        // The session context, dictated by the coordinator
+        context: Vec<u8>,
+        // The session nonce, dictated by the coordinator
+        nonce: u64,
         /// The ephemeral public key
         ephemeral_pub: secp256k1::PublicKey,
         /// The signature of the round1 package
@@ -188,21 +195,41 @@ pub struct Config {
     /// The timeout duration for round3 packages. If an acknowledgment isn't
     /// received within this duration, the package will be resent.
     pub round3_package_timeout: Duration,
+
+    /// The optional timeout duration for the entire DKG session. If the session
+    /// isn't completed within this duration, it will be reset. This increments
+    /// the session nonce and creates new round1 packages.
+    pub pending_session_timeout: Option<Duration>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// Represents the current stage of the DKG protocol.
 pub enum Stage {
+    /// Waiting for the coordinator to initialize the DKG session.
+    AwaitingInit,
     /// Active exchange of round1 packages between participants.
-    RoundOneActive,
+    RoundOne,
     /// Active exchange of round2 packages between participants.
-    RoundTwoActive,
+    RoundTwo,
     /// Active exchange of round3 packages (aggregated public keys).
-    RoundThreeActive,
+    RoundThree,
     /// The DKG process was aborted.
     Aborted,
     /// DKG protocol finalized successfully.
     Finalized,
+}
+
+impl std::fmt::Display for Stage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Stage::AwaitingInit => write!(f, "Awaiting-Initialization"),
+            Stage::RoundOne => write!(f, "Round-One"),
+            Stage::RoundTwo => write!(f, "Round-Two"),
+            Stage::RoundThree => write!(f, "Round-Three"),
+            Stage::Aborted => write!(f, "Aborted"),
+            Stage::Finalized => write!(f, "Finalized"),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -216,7 +243,7 @@ struct OutEntryRoundOne {
 
 #[derive(Debug, Clone)]
 struct OutEntryRoundTwo {
-    nonce: u64,
+    ciphernonce: u64,
     ciphertext: Vec<u8>,
     timer: Option<Instant>,
     attempts: usize,
@@ -232,11 +259,14 @@ struct OutEntryRoundThree {
 #[derive(Debug)]
 /// Represents the current state of the DKG process.
 enum StageState {
+    /// The DKG process is waiting for the coordinator to initialize the session.
+    AwatingInit,
     /// The active stage of round1. Participants are exchanging round1 packages
     /// with each other. The coordinator distributes packages between all
     /// participants.
-    RoundOneActive {
-        pending: bool,
+    RoundOne {
+        context: Vec<u8>,
+        nonce: u64,
         auth: DkgHandshakeManager,
         secret_package: round1::SecretPackage,
         in_round1_packages: BTreeMap<Initiator, round1::Package>,
@@ -246,7 +276,7 @@ enum StageState {
     /// with each other. The coordinator distributes packages between all
     /// participants and tracks which packages have been distributed through the
     /// dist_checklist.
-    RoundTwoActive {
+    RoundTwo {
         pending: bool,
         auth: SecureChannelManager,
         secret_package: round2::SecretPackage,
@@ -257,7 +287,7 @@ enum StageState {
     /// The active stage of round3. Participants are exchanging aggregated
     /// public key packages to ensure everyone has the same final, aggregated
     /// public key.
-    RoundThreeActive {
+    RoundThree {
         pending: bool,
         auth: KeyVerificationManager,
         secret_package: frost::keys::KeyPackage,
@@ -270,24 +300,26 @@ enum StageState {
     /// The DKG process was aborted. This can happen if FROST fails to generate
     /// new rounds, for example if a peer provided an incorrect or malformed
     /// package.
-    // TODO (lamafab): Add a reason and blame indicator for the abort.
     Aborted,
     /// The DKG process completed successfully. All participants have verified
     /// they have the same public key package.
-    Finalized { secret_package: frost::keys::KeyPackage, public_key_package: PublicKeyPackage },
+    Finalized {
+        secret_package: frost::keys::KeyPackage,
+        public_key_package: PublicKeyPackage,
+    },
 }
 
 impl StageState {
     fn did_round_one_finalize(&self) -> bool {
         matches!(
             self,
-            StageState::RoundTwoActive { .. } |
-                StageState::RoundThreeActive { .. } |
+            StageState::RoundTwo { .. } |
+                StageState::RoundThree { .. } |
                 StageState::Finalized { .. }
         )
     }
     fn did_round_two_finalize(&self) -> bool {
-        matches!(self, StageState::RoundThreeActive { .. } | StageState::Finalized { .. })
+        matches!(self, StageState::RoundThree { .. } | StageState::Finalized { .. })
     }
     fn did_round_three_finalize(&self) -> bool {
         matches!(self, StageState::Finalized { .. })
@@ -349,11 +381,14 @@ pub enum Error {
 /// The DKG state machine handles distributed key generation across multiple participants.
 pub struct DkgStateMachine {
     config: Config,
-    members: Vec<frost::Identifier>,
-    coordinator: frost::Identifier,
     my_frost_id: frost::Identifier,
+    my_static_sec: secp256k1::SecretKey,
+    coordinator: frost::Identifier,
+    members: BTreeMap<frost::Identifier, secp256k1::PublicKey>,
     queue: Queue,
     state: StageState,
+    session_nonce: Option<u64>,
+    session_activated: Option<Instant>,
 }
 
 impl DkgStateMachine {
@@ -366,7 +401,7 @@ impl DkgStateMachine {
     /// is the coordinator:
     ///
     /// - If this participant is the coordinator (`my_frost_id == coordinator`), the state machine
-    ///   enters the `RoundOneActive` stage by immediately sending the round1 packages to all other
+    ///   enters the `RoundOne` stage by immediately sending the round1 packages to all other
     ///   participants. These initial packages can be retrieved by calling `send()`.
     ///
     /// - If this participant is not the coordinator, the state machine sets the `pending` flag to
@@ -380,16 +415,17 @@ impl DkgStateMachine {
     /// * `members` - A list of all participant FROST identifiers in the DKG process, including this
     ///   participant and the coordinator.
     /// * `config` - Configuration parameters for the DKG process.
-    ///
-    /// # Returns
-    ///
-    /// A new `DkgStateMachine` instance
+    /// * `session_nonce` - An increasing value that uniquely identifies this DKG session. Only the
+    ///   coordinator should provide this value (typically using Unix time in seconds).
+    ///   Non-coordinators should pass `None` and will accept the nonce from the coordinator's
+    ///   initial message. The nonce increases automatically when sessions timeout and restart.
     pub fn new(
         my_frost_id: frost::Identifier,
         my_static_sec: secp256k1::SecretKey,
         coordinator: frost::Identifier,
         members: BTreeMap<frost::Identifier, secp256k1::PublicKey>,
         config: Config,
+        session_nonce: Option<u64>,
     ) -> Result<Self, Error> {
         if !members.contains_key(&my_frost_id) {
             return Err(Error::BadConfig("my_frost_id not in members".to_string()));
@@ -409,27 +445,74 @@ impl DkgStateMachine {
             return Err(Error::BadConfig("max_signers does not match member size".to_string()));
         }
 
-        // AUTHENTICATION: Setup authentication and encryption layer.
-        let mut auth = DkgHandshakeManager::new(
-            b"CONST-SESSION",
+        if my_frost_id == coordinator && session_nonce.is_none() {
+            return Err(Error::BadConfig("coordinator must provide a session nonce".to_string()));
+        }
+
+        // Setup sending queue.
+        let queue = Queue { i: VecDeque::new(), my_frost_id };
+
+        let mut this = Self {
+            config,
             my_frost_id,
             my_static_sec,
-            members.clone(),
-        )?;
+            coordinator,
+            members,
+            queue,
+            state: StageState::AwatingInit,
+            session_nonce: None,
+            session_activated: None,
+        };
 
-        // Retain only the Frost Ids going forward.
-        let members = members.into_keys().collect::<Vec<_>>();
+        // The coordinator immediately starts the DKG process by sending a
+        // `DkgMessage::NewSession` followed by the actual `DkgMessage::Round1`
+        // package to each participant.
+        //
+        // Non-coordinators wait for the coordinator to send this message, and
+        // initialize the round1 package and authentication layer then.
+        if this.is_coordinator() {
+            let nonce = session_nonce.expect("session nonce must be provided");
+            this.init_new_session(nonce)?;
+
+            debug_assert_eq!(this.stage(), Stage::RoundOne);
+        }
+
+        Ok(this)
+    }
+    /// Initializes a new DKG session with the given nonce by resetting the
+    /// stage, setting up a new authentication layer, generating a new round1
+    /// package, and sending it to all participants.
+    ///
+    /// Only the coordinator must call this method.
+    fn init_new_session(&mut self, nonce: u64) -> Result<(), Error> {
+        debug_assert!(self.is_coordinator());
+
+        let context = SESSION_CONTEXT.to_vec();
+        //
+        self.session_activated = None;
+        self.session_nonce = Some(nonce);
+        self.queue.i.clear();
 
         // Generate the secret package and our round1 package
         let (secret_package, our_round1_package) = frost::keys::dkg::part1(
-            my_frost_id,
-            config.max_signers,
-            config.min_signers,
+            self.my_frost_id,
+            self.config.max_signers,
+            self.config.min_signers,
             thread_rng(),
         )?;
 
+        // AUTHENTICATION: Setup authentication and encryption layer.
+        let mut auth = DkgHandshakeManager::new(
+            &context,
+            nonce,
+            self.my_frost_id,
+            self.my_static_sec,
+            self.members.clone(),
+        )?;
+
+        // Seal our round1 package.
         let (sealed_round1_package, our_eph_pub, our_sig) =
-            sealed_pkg::SealedRoundOnePackage::new(our_round1_package.clone(), &mut auth)?;
+            sealed_pkg::SealedRoundOnePackage::new(our_round1_package, &mut auth)?;
 
         let out_entry = OutEntryRoundOne {
             package: sealed_round1_package.clone(),
@@ -439,101 +522,92 @@ impl DkgStateMachine {
             attempts: 0,
         };
 
-        // Sending queue.
-        let mut queue = Queue { i: VecDeque::new(), my_frost_id };
-
-        let self_is_coordinator = my_frost_id == coordinator;
-        let pending = !self_is_coordinator;
-
         let mut out_round1_packages = BTreeMap::new();
 
-        if self_is_coordinator {
-            // Prepare all outgoing round1 package entries that we need to have
-            // acknowledged, including forwarded messages.
-            //
-            // For example; with three participants Alice (us), Bob, and Eve, we construct:
-            // * Alice -> Bob
-            // * Alice -> Eve
-            // * Bob -> Eve (forwarded)
-            // * Eve -> Bob (forwarded)
-            for initiator in members.iter().cloned() {
-                for recipient in members.iter().cloned() {
-                    // Skip ourself.
-                    if recipient == my_frost_id {
-                        continue;
-                    }
-
-                    if initiator == recipient {
-                        continue;
-                    }
-
-                    // Only set our packages; forwarded packages are set once
-                    // they're received, of course.
-                    let out_entry =
-                        if initiator == my_frost_id { Some(out_entry.clone()) } else { None };
-
-                    // Track outgoing package.
-                    out_round1_packages.insert((Initiator(initiator), recipient), out_entry);
-
-                    if initiator != my_frost_id {
-                        // Skip sending unless it's us.
-                        continue;
-                    }
-
-                    // Push the payload to the queue.
-                    let msg = DkgPayload {
-                        sender: my_frost_id,
-                        recipient,
-                        msg: DkgMessage::Round1 {
-                            initiator: Initiator(my_frost_id),
-                            ephemeral_pub: our_eph_pub,
-                            signature: our_sig,
-                            package: sealed_round1_package.clone(),
-                        },
-                    };
-
-                    queue.i.push_back(msg);
+        // Prepare all outgoing round1 package entries that we need to have
+        // acknowledged, including forwarded messages.
+        //
+        // For example; with three participants Alice (us), Bob, and Eve, we construct:
+        // * Alice -> Bob
+        // * Alice -> Eve
+        // * Bob -> Eve (forwarded)
+        // * Eve -> Bob (forwarded)
+        for initiator in self.members.keys().copied() {
+            for recipient in self.members.keys().copied() {
+                // Skip ourself.
+                if recipient == self.my_frost_id {
+                    continue;
                 }
-            }
-        } else {
-            // Non-coordinators only have one outgoing package to send (to the
-            // coordinator).
-            out_round1_packages.insert((Initiator(my_frost_id), coordinator), Some(out_entry));
-        };
 
-        let state = StageState::RoundOneActive {
-            pending,
+                if initiator == recipient {
+                    continue;
+                }
+
+                // Only set our packages; forwarded packages are set once
+                // they're received, of course.
+                let out_entry =
+                    if initiator == self.my_frost_id { Some(out_entry.clone()) } else { None };
+
+                // Track outgoing package.
+                out_round1_packages.insert((Initiator(initiator), recipient), out_entry);
+
+                if initiator != self.my_frost_id {
+                    // Skip sending unless it's us.
+                    continue;
+                }
+
+                // Push the round1 payload to the queue.
+                let msg = DkgPayload {
+                    sender: self.my_frost_id,
+                    recipient,
+                    msg: DkgMessage::Round1 {
+                        initiator: Initiator(self.my_frost_id),
+                        context: context.clone(),
+                        nonce,
+                        ephemeral_pub: our_eph_pub,
+                        signature: our_sig,
+                        package: sealed_round1_package.clone(),
+                    },
+                };
+
+                self.queue.i.push_back(msg);
+            }
+        }
+
+        self.state = StageState::RoundOne {
+            nonce,
             auth,
             secret_package,
             in_round1_packages: BTreeMap::new(),
             out_round1_packages,
+            context,
         };
 
-        let this = Self { config, members, coordinator, my_frost_id, queue, state };
-        Ok(this)
+        Ok(())
     }
-
     /// Returns the FROST identifier of this participant.
     pub fn frost_id(&self) -> frost::Identifier {
         self.my_frost_id
     }
-
     /// Checks if this participant is the coordinator of the DKG process.
     pub fn is_coordinator(&self) -> bool {
         self.my_frost_id == self.coordinator
     }
-
     /// Returns the current stage of the DKG protocol.
     pub fn stage(&self) -> Stage {
         match &self.state {
-            StageState::RoundOneActive { .. } => Stage::RoundOneActive,
-            StageState::RoundTwoActive { .. } => Stage::RoundTwoActive,
-            StageState::RoundThreeActive { .. } => Stage::RoundThreeActive,
+            StageState::AwatingInit => Stage::AwaitingInit,
+            StageState::RoundOne { .. } => Stage::RoundOne,
+            StageState::RoundTwo { .. } => Stage::RoundTwo,
+            StageState::RoundThree { .. } => Stage::RoundThree,
             StageState::Finalized { .. } => Stage::Finalized,
             StageState::Aborted => Stage::Aborted,
         }
     }
-
+    /// Returns the session nonce, if available.
+    pub fn session_nonce(&self) -> Option<u64> {
+        self.session_nonce
+    }
     /// Returns the final, aggregated key packages if the DKG process has completed successfully.
     pub fn aggregate_key_packages(&self) -> Option<(&KeyPackage, &PublicKeyPackage)> {
         if let StageState::Finalized { secret_package, public_key_package, .. } = &self.state {
@@ -557,26 +631,47 @@ impl DkgStateMachine {
     /// An optional `Duration` until the next timeout event. If `None`, there
     /// are no pending timeout events.
     pub fn timeout(&self, now: Instant) -> Option<Duration> {
-        match &self.state {
-            StageState::RoundOneActive { out_round1_packages, .. } => out_round1_packages
+        let mut session_timeout = None;
+
+        // If we're the coordinator and the DKG session has not been finalized...
+        if self.is_coordinator() && self.stage() != Stage::Finalized {
+            // And if a max session timeout has been configured...
+            if let Some(max) = self.config.pending_session_timeout {
+                // And if a DKG session has started...
+                if let Some(session_activated) = self.session_activated {
+                    let t = (session_activated + max).saturating_duration_since(now);
+                    session_timeout = Some(t);
+                }
+            }
+        }
+
+        let t = match &self.state {
+            StageState::RoundOne { out_round1_packages, .. } => out_round1_packages
                 .values()
-                .filter(|e| e.is_some())
-                .filter_map(|e| e.as_ref().expect("must be available").timer)
+                .filter_map(|e| e.as_ref())
+                .filter_map(|e| e.timer)
                 .map(|t| t.saturating_duration_since(now))
                 .min(),
-            StageState::RoundTwoActive { out_round2_packages, .. } => out_round2_packages
+            StageState::RoundTwo { out_round2_packages, .. } => out_round2_packages
                 .values()
-                .filter(|e| e.is_some())
-                .filter_map(|e| e.as_ref().expect("must be available").timer)
+                .filter_map(|e| e.as_ref())
+                .filter_map(|e| e.timer)
                 .map(|t| t.saturating_duration_since(now))
                 .min(),
-            StageState::RoundThreeActive { out_round3_packages, .. } => out_round3_packages
+            StageState::RoundThree { out_round3_packages, .. } => out_round3_packages
                 .values()
-                .filter(|e| e.is_some())
-                .filter_map(|e| e.as_ref().expect("must be available").timer)
+                .filter_map(|e| e.as_ref())
+                .filter_map(|e| e.timer)
                 .map(|t| t.saturating_duration_since(now))
                 .min(),
             _ => None,
+        };
+
+        match (t, session_timeout) {
+            (Some(t), Some(s)) => Some(t.min(s)),
+            (Some(t), None) => Some(t),
+            (None, Some(x)) => Some(x),
+            (None, None) => None,
         }
     }
     /// Processes timeout events for outgoing messages.
@@ -586,19 +681,33 @@ impl DkgStateMachine {
     /// acknowledged. After calling this method, you should call `send()` in a
     /// loop to get any payloads that need to be re-sent.
     ///
-    /// This implementation uses a small tolerance adjustment of 5 milliseconds
-    /// when checking if timers have expired. This prevents edge cases where
-    /// timing precision might cause a timer to be considered unexpired when it
-    /// should have triggered.
-    ///
     /// # Arguments
     ///
     /// * `now` - The current time
     pub fn on_timeout(&mut self, now: Instant) {
         let self_is_coordinator = self.is_coordinator();
 
+        // If we're the coordinator and the DKG session has not been finalized...
+        if self_is_coordinator && self.stage() != Stage::Finalized {
+            // And if a max session timeout has been configured...
+            if let Some(max) = self.config.pending_session_timeout {
+                // And if a DKG session has started...
+                if let Some(session_activated) = self.session_activated {
+                    // And if the timeout has expired...
+                    if now >= session_activated + max {
+                        // Increment nonce.
+                        let nonce = self.session_nonce.as_ref().expect("nonce tracker must be set");
+                        let nonce = nonce.wrapping_add(1);
+
+                        // Start a new session.
+                        self.init_new_session(nonce).expect("failed to init new session");
+                    }
+                }
+            }
+        }
+
         match &mut self.state {
-            StageState::RoundOneActive { out_round1_packages, .. } => {
+            StageState::RoundOne { context, nonce, out_round1_packages, .. } => {
                 for ((initiator, recipient), entry) in out_round1_packages.iter() {
                     let Some(entry) = entry else {
                         // Package not available.
@@ -612,7 +721,7 @@ impl DkgStateMachine {
 
                     // Check if the timer has expired, with a small tolerance
                     // adjustment.
-                    if timer > now + Duration::from_millis(5) {
+                    if timer > now + Duration::from_millis(1) {
                         continue;
                     }
 
@@ -621,6 +730,8 @@ impl DkgStateMachine {
                         recipient: *recipient,
                         msg: DkgMessage::Round1 {
                             initiator: *initiator,
+                            context: context.clone(),
+                            nonce: *nonce,
                             ephemeral_pub: entry.ephemeral_pub,
                             signature: entry.signature,
                             package: entry.package.clone(),
@@ -630,7 +741,7 @@ impl DkgStateMachine {
                     self.queue.i.push_back(msg);
                 }
             }
-            StageState::RoundTwoActive { out_round2_packages, .. } => {
+            StageState::RoundTwo { out_round2_packages, .. } => {
                 for ((initiator, target), entry) in out_round2_packages.iter() {
                     let Some(entry) = entry else {
                         // Package not available.
@@ -644,7 +755,7 @@ impl DkgStateMachine {
 
                     // Check if the timer has expired, with a small tolerance
                     // adjustment.
-                    if timer > now + Duration::from_millis(5) {
+                    if timer > now + Duration::from_millis(1) {
                         continue;
                     }
 
@@ -656,7 +767,7 @@ impl DkgStateMachine {
                         msg: DkgMessage::Round2 {
                             initiator: *initiator,
                             target: *target,
-                            nonce: entry.nonce,
+                            nonce: entry.ciphernonce,
                             package: entry.ciphertext.clone(),
                         },
                     };
@@ -664,7 +775,7 @@ impl DkgStateMachine {
                     self.queue.i.push_back(msg);
                 }
             }
-            StageState::RoundThreeActive { out_round3_packages, .. } => {
+            StageState::RoundThree { out_round3_packages, .. } => {
                 for ((initiator, recipient), entry) in out_round3_packages.iter() {
                     let Some(entry) = entry else {
                         // Package not available.
@@ -678,7 +789,7 @@ impl DkgStateMachine {
 
                     // Check if the timer has expired, with a small tolerance
                     // adjustment.
-                    if timer > now + Duration::from_millis(5) {
+                    if timer > now + Duration::from_millis(1) {
                         continue;
                     }
 
@@ -716,8 +827,7 @@ impl DkgStateMachine {
 
             match payload.msg {
                 DkgMessage::Round1 { initiator, .. } => {
-                    let StageState::RoundOneActive { out_round1_packages, .. } = &mut self.state
-                    else {
+                    let StageState::RoundOne { out_round1_packages, .. } = &mut self.state else {
                         // Already expired.
                         continue;
                     };
@@ -729,12 +839,16 @@ impl DkgStateMachine {
                         continue;
                     };
 
+                    if self.session_activated.is_none() {
+                        // Track the session start time.
+                        self.session_activated = Some(now);
+                    }
+
                     entry.timer = Some(now + self.config.round1_package_timeout);
                     entry.attempts += 1;
                 }
                 DkgMessage::Round2 { initiator, target, .. } => {
-                    let StageState::RoundTwoActive { out_round2_packages, .. } = &mut self.state
-                    else {
+                    let StageState::RoundTwo { out_round2_packages, .. } = &mut self.state else {
                         // Already expired.
                         continue;
                     };
@@ -749,8 +863,7 @@ impl DkgStateMachine {
                     entry.attempts += 1;
                 }
                 DkgMessage::Round3 { initiator, .. } => {
-                    let StageState::RoundThreeActive { out_round3_packages, .. } = &mut self.state
-                    else {
+                    let StageState::RoundThree { out_round3_packages, .. } = &mut self.state else {
                         // Already expired.
                         continue;
                     };
@@ -787,11 +900,20 @@ impl DkgStateMachine {
             return Ok(());
         }
 
-        let DkgPayload { sender, recipient: _, msg } = payload;
+        let DkgPayload { sender, msg, .. } = payload;
 
         match msg {
-            DkgMessage::Round1 { initiator, ephemeral_pub, signature, package } => {
-                self.on_dkg_msg_round1(initiator, ephemeral_pub, signature, package, sender)?;
+            DkgMessage::Round1 {
+                initiator,
+                context,
+                nonce,
+                ephemeral_pub,
+                signature,
+                package,
+                ..
+            } => {
+                #[rustfmt::skip]
+                self.on_dkg_msg_round1(initiator, context, nonce, ephemeral_pub, signature, package, sender)?;
                 self.transition_stage2_checked()?;
             }
             DkgMessage::AckRound1 { initiator } => {
@@ -823,12 +945,11 @@ impl DkgStateMachine {
         initiator: Initiator,
         sender: frost::Identifier,
     ) -> Result<(), Error> {
-        // Check initiator membership
-        if !self.members.contains(&initiator.0) {
+        if !self.members.contains_key(&initiator.0) {
             return Ok(());
         }
 
-        let StageState::RoundOneActive { out_round1_packages, .. } = &mut self.state else {
+        let StageState::RoundOne { out_round1_packages, .. } = &mut self.state else {
             // Ignore
             return Ok(());
         };
@@ -838,11 +959,11 @@ impl DkgStateMachine {
         Ok(())
     }
     fn on_dkg_msg_ack_round2(&mut self, initiator: Initiator, target: Target) -> Result<(), Error> {
-        if !self.members.contains(&initiator.0) {
+        if !self.members.contains_key(&initiator.0) {
             return Ok(());
         }
 
-        let StageState::RoundTwoActive { out_round2_packages, .. } = &mut self.state else {
+        let StageState::RoundTwo { out_round2_packages, .. } = &mut self.state else {
             // Ignore
             return Ok(());
         };
@@ -856,12 +977,11 @@ impl DkgStateMachine {
         initiator: Initiator,
         sender: frost::Identifier,
     ) -> Result<(), Error> {
-        // Check initiator membership
-        if !self.members.contains(&initiator.0) {
+        if !self.members.contains_key(&initiator.0) {
             return Ok(());
         }
 
-        let StageState::RoundThreeActive { out_round3_packages, .. } = &mut self.state else {
+        let StageState::RoundThree { out_round3_packages, .. } = &mut self.state else {
             // Ignore
             return Ok(());
         };
@@ -870,23 +990,200 @@ impl DkgStateMachine {
 
         Ok(())
     }
+    /// Processes a new session initialization as request by the coordinator by
+    /// validating the request, resetting the stage, setting up a new
+    /// authentication layer, generating a new round1 package, and sending it to
+    /// the coordinator. Returns `true` if the session was successfully
+    /// initialized.
+    ///
+    /// Only non-coordinators should call this method.
+    fn validate_new_session_init(
+        &mut self,
+        initiator: Initiator,
+        their_context: Vec<u8>,
+        their_nonce: u64,
+        their_ephmeral_pub: secp256k1::PublicKey,
+        their_signature: secp256k1::ecdsa::Signature,
+        their_package: sealed_pkg::SealedRoundOnePackage,
+    ) -> Result<bool, Error> {
+        if self.is_coordinator() {
+            return Ok(false);
+        }
+
+        if initiator.0 != self.coordinator {
+            return Ok(false);
+        }
+
+        if their_context != SESSION_CONTEXT {
+            return Ok(false);
+        }
+
+        if let Some(last) = self.session_nonce {
+            if last >= their_nonce {
+                // Outdated or active nonce, ignore.
+                return Ok(false);
+            }
+        }
+
+        // Cannot start a new session if the DKG process has already been
+        // finalized.
+        if self.stage() == Stage::Finalized {
+            return Ok(false);
+        }
+
+        // AUTHENTICATION: Setup new session parameters as-is. We then validate
+        // the coordinators' round1 package, which is inherently tied to those
+        // parameters.
+        let mut auth = DkgHandshakeManager::new(
+            &their_context,
+            their_nonce,
+            self.my_frost_id,
+            self.my_static_sec,
+            self.members.clone(),
+        )?;
+
+        let their_package =
+            their_package.extract(initiator, their_ephmeral_pub, their_signature, &mut auth)?;
+
+        // Verification succeeded, the new session is accepted!
+
+        // Set new session params.
+        let context = their_context;
+        let nonce = their_nonce;
+        //
+        self.session_activated = None;
+        self.session_nonce = Some(nonce);
+        self.queue.i.clear();
+
+        // Track the coordinators' round1 package.
+        let mut in_round1_packages = BTreeMap::new();
+        in_round1_packages.insert(initiator, their_package.clone());
+
+        self.queue.send_round1_ack(initiator, self.coordinator);
+
+        // Generate the new secret package and our round1 package
+        let (secret_package, our_round1_package) = frost::keys::dkg::part1(
+            self.my_frost_id,
+            self.config.max_signers,
+            self.config.min_signers,
+            thread_rng(),
+        )?;
+
+        // Seal our round1 package.
+        let (sealed_round1_package, our_eph_pub, our_sig) =
+            sealed_pkg::SealedRoundOnePackage::new(our_round1_package.clone(), &mut auth)?;
+
+        let out_entry = OutEntryRoundOne {
+            package: sealed_round1_package.clone(),
+            ephemeral_pub: our_eph_pub,
+            signature: our_sig,
+            timer: None,
+            attempts: 0,
+        };
+
+        let mut out_round1_packages = BTreeMap::new();
+
+        // Non-coordinators only have one outgoing package to send (to the
+        // coordinator).
+        out_round1_packages
+            .insert((Initiator(self.my_frost_id), self.coordinator), Some(out_entry));
+
+        // Push the pending, outgoing payload to the queue.
+        let msg = DkgPayload {
+            sender: self.my_frost_id,
+            recipient: self.coordinator,
+            msg: DkgMessage::Round1 {
+                context: context.clone(),
+                nonce,
+                initiator: Initiator(self.my_frost_id),
+                ephemeral_pub: our_eph_pub,
+                signature: our_sig,
+                package: sealed_round1_package,
+            },
+        };
+
+        self.queue.i.push_back(msg);
+
+        self.state = StageState::RoundOne {
+            context,
+            nonce,
+            auth,
+            secret_package,
+            in_round1_packages,
+            out_round1_packages,
+        };
+
+        Ok(true)
+    }
+    #[allow(clippy::too_many_arguments)]
     fn on_dkg_msg_round1(
         &mut self,
         initiator: Initiator,
+        their_context: Vec<u8>,
+        their_nonce: u64,
         their_ephmeral_pub: secp256k1::PublicKey,
         their_signature: secp256k1::ecdsa::Signature,
-        sealed_package: sealed_pkg::SealedRoundOnePackage,
+        their_package: sealed_pkg::SealedRoundOnePackage,
         sender: frost::Identifier,
     ) -> Result<(), Error> {
-        // Check initiator membership
-        if !self.members.contains(&initiator.0) {
+        if !self.members.contains_key(&initiator.0) {
+            return Ok(());
+        }
+
+        if initiator.0 == self.my_frost_id {
+            return Ok(());
+        }
+
+        if their_context != SESSION_CONTEXT {
+            return Ok(());
+        }
+
+        // Do a simple check to determine whether we should start the new
+        // session transition process.
+        let do_new_session_check = if let Some(last) = self.session_nonce {
+            match their_nonce.cmp(&last) {
+                std::cmp::Ordering::Greater => {
+                    // The package is for a new session, do check.
+                    true
+                }
+                std::cmp::Ordering::Equal => {
+                    // The package is for the active session, ignore check.
+                    false
+                }
+                std::cmp::Ordering::Less => {
+                    // Outdated nonce, ignore.
+                    return Ok(());
+                }
+            }
+        } else {
+            // No session active, do check.
+            debug_assert!(!self.is_coordinator());
+            true
+        };
+
+        // Validate the new session request.
+        if do_new_session_check &&
+            self.validate_new_session_init(
+                initiator,
+                their_context,
+                their_nonce,
+                their_ephmeral_pub,
+                their_signature,
+                their_package.clone(),
+            )?
+        {
+            // A coordinator never reaches this point.
+            debug_assert!(!self.is_coordinator());
+
+            // New session accepted!
             return Ok(());
         }
 
         let self_is_coordinator = self.is_coordinator();
 
-        let StageState::RoundOneActive {
-            pending,
+        let StageState::RoundOne {
+            context,
+            nonce,
             auth,
             in_round1_packages,
             out_round1_packages,
@@ -907,46 +1204,15 @@ impl DkgStateMachine {
             return Ok(());
         }
 
-        let their_package =
-            sealed_package.clone().extract(initiator, their_ephmeral_pub, their_signature, auth)?;
+        let extracted_package =
+            their_package.clone().extract(initiator, their_ephmeral_pub, their_signature, auth)?;
 
-        in_round1_packages.insert(initiator, their_package.clone());
+        in_round1_packages.insert(initiator, extracted_package);
         self.queue.send_round1_ack(initiator, sender);
-
-        if *pending {
-            debug_assert!(!self_is_coordinator);
-            debug_assert_eq!(out_round1_packages.len(), 1);
-
-            for ((initiator, recipient), entry) in out_round1_packages.iter() {
-                let Some(entry) = entry else {
-                    // Package not available.
-                    continue;
-                };
-
-                debug_assert_eq!(initiator.0, self.my_frost_id);
-                debug_assert_eq!(recipient, &self.coordinator);
-
-                // Push the pending, outgoing payload to the queue.
-                let msg = DkgPayload {
-                    sender: self.my_frost_id,
-                    recipient: *recipient,
-                    msg: DkgMessage::Round1 {
-                        initiator: *initiator,
-                        ephemeral_pub: entry.ephemeral_pub,
-                        signature: entry.signature,
-                        package: entry.package.clone(),
-                    },
-                };
-
-                self.queue.i.push_back(msg);
-            }
-
-            *pending = false;
-        }
 
         if self_is_coordinator {
             // Forward the round1 package to all other members.
-            for recipient in self.members.iter().cloned() {
+            for recipient in self.members.keys().copied() {
                 if recipient == self.my_frost_id || recipient == sender {
                     continue;
                 }
@@ -957,7 +1223,7 @@ impl DkgStateMachine {
                 };
 
                 *entry = Some(OutEntryRoundOne {
-                    package: sealed_package.clone(),
+                    package: their_package.clone(),
                     ephemeral_pub: their_ephmeral_pub,
                     signature: their_signature,
                     timer: None,
@@ -969,10 +1235,12 @@ impl DkgStateMachine {
                     sender: self.my_frost_id,
                     recipient,
                     msg: DkgMessage::Round1 {
+                        context: context.clone(),
+                        nonce: *nonce,
                         initiator,
                         ephemeral_pub: their_ephmeral_pub,
                         signature: their_signature,
-                        package: sealed_package.clone(),
+                        package: their_package.clone(),
                     },
                 };
 
@@ -986,24 +1254,22 @@ impl DkgStateMachine {
         &mut self,
         initiator: Initiator,
         target: Target,
-        nonce: u64,
+        ciphernonce: u64,
         ciphertext: Vec<u8>,
         sender: frost::Identifier,
     ) -> Result<(), Error> {
-        // Check initiator membership
-        if !self.members.contains(&initiator.0) {
+        if !self.members.contains_key(&initiator.0) {
+            return Ok(());
+        }
+
+        if initiator.0 == self.my_frost_id {
             return Ok(());
         }
 
         let self_is_coordinator = self.is_coordinator();
 
-        let StageState::RoundTwoActive {
-            pending,
-            auth,
-            in_round2_packages,
-            out_round2_packages,
-            ..
-        } = &mut self.state
+        let StageState::RoundTwo { pending, auth, in_round2_packages, out_round2_packages, .. } =
+            &mut self.state
         else {
             if self.state.did_round_two_finalize() {
                 // Send acknowledgments for previous rounds.
@@ -1022,7 +1288,7 @@ impl DkgStateMachine {
                 return Ok(());
             }
 
-            let package = auth.validate_round2(initiator, nonce, &ciphertext)?;
+            let package = auth.validate_round2(initiator, ciphernonce, &ciphertext)?;
 
             // Insert the package.
             in_round2_packages.insert(initiator, package);
@@ -1049,7 +1315,7 @@ impl DkgStateMachine {
                         msg: DkgMessage::Round2 {
                             initiator: *initiator,
                             target: *target,
-                            nonce: entry.nonce,
+                            nonce: entry.ciphernonce,
                             package: entry.ciphertext.clone(),
                         },
                     };
@@ -1075,7 +1341,7 @@ impl DkgStateMachine {
             };
 
             *entry = Some(OutEntryRoundTwo {
-                nonce,
+                ciphernonce,
                 ciphertext: ciphertext.clone(),
                 timer: None,
                 attempts: 0,
@@ -1087,7 +1353,12 @@ impl DkgStateMachine {
             let msg = DkgPayload {
                 sender: self.my_frost_id,
                 recipient: target.0,
-                msg: DkgMessage::Round2 { initiator, target, nonce, package: ciphertext },
+                msg: DkgMessage::Round2 {
+                    initiator,
+                    target,
+                    nonce: ciphernonce,
+                    package: ciphertext,
+                },
             };
 
             self.queue.i.push_back(msg);
@@ -1101,19 +1372,18 @@ impl DkgStateMachine {
         sealed_signature: sealed_pkg::SealedRoundThreeSignature,
         sender: frost::Identifier,
     ) -> Result<(), Error> {
-        // Check initiator membership
-        if !self.members.contains(&initiator.0) {
+        if !self.members.contains_key(&initiator.0) {
+            return Ok(());
+        }
+
+        if initiator.0 == self.my_frost_id {
             return Ok(());
         }
 
         let self_is_coordinator = self.is_coordinator();
 
-        let StageState::RoundThreeActive {
-            pending,
-            auth,
-            in_round3_packages,
-            out_round3_packages,
-            ..
+        let StageState::RoundThree {
+            pending, auth, in_round3_packages, out_round3_packages, ..
         } = &mut self.state
         else {
             if self.state.did_round_three_finalize() {
@@ -1166,7 +1436,7 @@ impl DkgStateMachine {
 
         if self_is_coordinator {
             // Forward the round3 package to all other members.
-            for recipient in self.members.iter().cloned() {
+            for recipient in self.members.keys().copied() {
                 if recipient == self.my_frost_id || recipient == sender {
                     continue;
                 }
@@ -1196,12 +1466,12 @@ impl DkgStateMachine {
         Ok(())
     }
     fn transition_stage2_checked(&mut self) -> Result<(), Error> {
-        let StageState::RoundOneActive {
-            pending,
+        let StageState::RoundOne {
             auth,
             secret_package,
             in_round1_packages,
             out_round1_packages,
+            ..
         } = &mut self.state
         else {
             // Ignore
@@ -1213,8 +1483,6 @@ impl DkgStateMachine {
         if in_round1_packages.len() != self.members.len() - 1 || !out_round1_packages.is_empty() {
             return Ok(());
         }
-
-        debug_assert!(!*pending);
 
         // Start transition.
         let in_round1_packages = std::mem::take(in_round1_packages)
@@ -1230,8 +1498,6 @@ impl DkgStateMachine {
             //
             // TODO (lamafab): We should probably do some extra things here,
             // such as communicating this information to the coordinator/peers.
-            //
-            // TODO (lamafab): Explicitly test this condition.
             self.state = StageState::Aborted;
             return Ok(());
         };
@@ -1248,10 +1514,10 @@ impl DkgStateMachine {
             let target = Target(target);
 
             // AUTHENTICATION: Encrypt the package for the target individually.
-            let (ciphertext, nonce) = auth.commit_round2(&target, &our_package)?;
+            let (ciphertext, ciphernonce) = auth.commit_round2(&target, &our_package)?;
 
             let out_entry = OutEntryRoundTwo {
-                nonce,
+                ciphernonce,
                 ciphertext: ciphertext.clone(),
                 timer: None,
                 attempts: 0,
@@ -1265,7 +1531,12 @@ impl DkgStateMachine {
                 let msg = DkgPayload {
                     sender: self.my_frost_id,
                     recipient: target.0,
-                    msg: DkgMessage::Round2 { initiator, target, nonce, package: ciphertext },
+                    msg: DkgMessage::Round2 {
+                        initiator,
+                        target,
+                        nonce: ciphernonce,
+                        package: ciphertext,
+                    },
                 };
 
                 self.queue.i.push_back(msg);
@@ -1283,13 +1554,13 @@ impl DkgStateMachine {
             // For example; with three participants Alice (us), Bob, and Eve, we construct:
             // * Bob -> Eve (forwarded)
             // * Eve -> Bob (forwarded)
-            for initiator in self.members.iter().cloned() {
+            for initiator in self.members.keys().copied() {
                 // Skip ourself, we set those entries before.
                 if initiator == self.my_frost_id {
                     continue;
                 }
 
-                for target in self.members.iter().cloned() {
+                for target in self.members.keys().copied() {
                     // Skip ourself.
                     if target == self.my_frost_id {
                         continue;
@@ -1306,7 +1577,7 @@ impl DkgStateMachine {
             }
         }
 
-        self.state = StageState::RoundTwoActive {
+        self.state = StageState::RoundTwo {
             auth,
             pending,
             secret_package,
@@ -1318,7 +1589,7 @@ impl DkgStateMachine {
         Ok(())
     }
     fn transition_stage3_checked(&mut self) -> Result<(), Error> {
-        let StageState::RoundTwoActive {
+        let StageState::RoundTwo {
             pending,
             auth,
             secret_package,
@@ -1356,9 +1627,6 @@ impl DkgStateMachine {
             //
             // TODO (lamafab): We should probably do some extra things here,
             // such as communicating this information to the coordinator/peers.
-            //
-            // TODO (lamafab): Explicitly test this condition.
-            self.state = StageState::Aborted;
             return Ok(());
         };
 
@@ -1387,8 +1655,8 @@ impl DkgStateMachine {
             // * Alice -> Eve
             // * Bob -> Eve (forwarded)
             // * Eve -> Bob (forwarded)
-            for initiator in self.members.iter().cloned() {
-                for recipient in self.members.iter().cloned() {
+            for initiator in self.members.keys().copied() {
+                for recipient in self.members.keys().copied() {
                     // Skip ourself.
                     if recipient == self.my_frost_id {
                         continue;
@@ -1429,7 +1697,7 @@ impl DkgStateMachine {
                 .insert((Initiator(self.my_frost_id), self.coordinator), Some(out_entry));
         }
 
-        self.state = StageState::RoundThreeActive {
+        self.state = StageState::RoundThree {
             pending,
             auth,
             public_key_package,
@@ -1443,7 +1711,7 @@ impl DkgStateMachine {
         Ok(())
     }
     fn transition_final_checked(&mut self) -> Result<(), Error> {
-        let StageState::RoundThreeActive {
+        let StageState::RoundThree {
             pending,
             auth,
             public_key_package,
@@ -1467,8 +1735,11 @@ impl DkgStateMachine {
             return Ok(());
         }
 
-        // TODO: Currently unused -> implement a fourth round where this is
-        // signed and verified?
+        // TODO (lamafab): This is currently unused; implement a fourth round
+        // where this is signed and verified? This could be used as a way to
+        // guarantee that the coordinator has reliably forwarded all round3
+        // packages, and that each and every participant has persisted the
+        // aggregated keys on-disk.
         let _auth = auth.finalize()?;
 
         debug_assert!(!*pending);
@@ -1477,6 +1748,10 @@ impl DkgStateMachine {
             secret_package: secret_package.clone(),
             public_key_package: public_key_package.clone(),
         };
+
+        // Reset session parameters.
+        self.session_nonce = None;
+        self.session_activated = None;
 
         Ok(())
     }

--- a/bin/btc-server/src/dkg/mod.rs
+++ b/bin/btc-server/src/dkg/mod.rs
@@ -303,10 +303,7 @@ enum StageState {
     Aborted,
     /// The DKG process completed successfully. All participants have verified
     /// they have the same public key package.
-    Finalized {
-        secret_package: frost::keys::KeyPackage,
-        public_key_package: PublicKeyPackage,
-    },
+    Finalized { secret_package: frost::keys::KeyPackage, public_key_package: PublicKeyPackage },
 }
 
 impl StageState {

--- a/bin/btc-server/src/dkg/tests/encryption.rs
+++ b/bin/btc-server/src/dkg/tests/encryption.rs
@@ -1,10 +1,11 @@
-use crate::dkg::encryption::{DkgHandshakeManager, Error};
+use crate::dkg::{
+    encryption::{DkgHandshakeManager, Error},
+    SESSION_CONTEXT,
+};
 use bitcoin::secp256k1;
 use frost::keys::dkg::{round1, round2};
 use frost_secp256k1_tr as frost;
 use std::collections::BTreeMap;
-
-const SESSION_ID: &[u8] = b"test_session_id";
 
 const ROUND1_DKG: &[u8] = &[
     0, 35, 15, 138, 179, 2, 2, 120, 88, 85, 71, 235, 157, 87, 39, 38, 125, 191, 226, 130, 130, 109,
@@ -72,10 +73,37 @@ fn setup() -> (DkgHandshakeManager, DkgHandshakeManager, DkgHandshakeManager) {
     fed_members.insert(eve_addr, eve_pub);
 
     // Setup encryption layer for round one.
-    let alice =
-        DkgHandshakeManager::new(SESSION_ID, alice_addr, alice_sec, fed_members.clone()).unwrap();
-    let bob = DkgHandshakeManager::new(SESSION_ID, bob_addr, bob_sec, fed_members.clone()).unwrap();
-    let eve = DkgHandshakeManager::new(SESSION_ID, eve_addr, eve_sec, fed_members.clone()).unwrap();
+    let nonce = 0;
+
+    #[rustfmt::skip]
+    let alice = DkgHandshakeManager::new(
+        SESSION_CONTEXT,
+        nonce,
+        alice_addr,
+        alice_sec,
+        fed_members.clone(),
+    )
+    .unwrap();
+
+    #[rustfmt::skip]
+    let bob = DkgHandshakeManager::new(
+        SESSION_CONTEXT,
+        nonce, 
+        bob_addr, 
+        bob_sec,
+        fed_members.clone()
+    )
+    .unwrap();
+
+    #[rustfmt::skip]
+    let eve = DkgHandshakeManager::new(
+        SESSION_CONTEXT,
+        nonce,
+        eve_addr,
+        eve_sec,
+        fed_members.clone()
+    )
+    .unwrap();
 
     (alice, bob, eve)
 }

--- a/bin/btc-server/src/dkg/tests/mod.rs
+++ b/bin/btc-server/src/dkg/tests/mod.rs
@@ -10,13 +10,27 @@ pub use stage_one::complete_stage_one;
 pub use stage_two::complete_stage_two;
 
 mod encryption;
+mod reset;
 mod simulation;
 mod stage_one;
 mod stage_three;
 mod stage_two;
 mod timeout;
 
-fn setup() -> (
+fn test_config() -> Config {
+    Config {
+        max_signers: 3,
+        min_signers: 2,
+        round1_package_timeout: Duration::from_secs(3),
+        round2_package_timeout: Duration::from_secs(4),
+        round3_package_timeout: Duration::from_secs(5),
+        pending_session_timeout: Some(Duration::from_secs(180)),
+    }
+}
+
+fn setup(
+    config: Config,
+) -> (
     frost::Identifier,
     frost::Identifier,
     frost::Identifier,
@@ -45,20 +59,15 @@ fn setup() -> (
     members.insert(bob_addr, bob_pub);
     members.insert(eve_addr, eve_pub);
 
-    let config = Config {
-        max_signers: 3,
-        min_signers: 3,
-        round1_package_timeout: Duration::from_secs(3),
-        round2_package_timeout: Duration::from_secs(4),
-        round3_package_timeout: Duration::from_secs(5),
-    };
-
     let alice =
-        DkgStateMachine::new(alice_addr, alice_sec, alice_addr, members.clone(), config).unwrap();
+        DkgStateMachine::new(alice_addr, alice_sec, alice_addr, members.clone(), config, Some(0))
+            .unwrap();
 
-    let bob = DkgStateMachine::new(bob_addr, bob_sec, alice_addr, members.clone(), config).unwrap();
+    let bob =
+        DkgStateMachine::new(bob_addr, bob_sec, alice_addr, members.clone(), config, None).unwrap();
 
-    let eve = DkgStateMachine::new(eve_addr, eve_sec, alice_addr, members.clone(), config).unwrap();
+    let eve =
+        DkgStateMachine::new(eve_addr, eve_sec, alice_addr, members.clone(), config, None).unwrap();
 
     (alice_addr, bob_addr, eve_addr, alice, bob, eve)
 }

--- a/bin/btc-server/src/dkg/tests/reset.rs
+++ b/bin/btc-server/src/dkg/tests/reset.rs
@@ -1,0 +1,209 @@
+use super::*;
+use crate::dkg::{tests::stage_three::complete_stage_three, Stage};
+
+#[test]
+fn dkg_session_reset_stage_one() {
+    let config = test_config();
+    let pending_session_timeout = config.pending_session_timeout.unwrap();
+    let (alice_addr, bob_addr, eve_addr, mut alice, mut bob, mut eve) = setup(config);
+
+    let mut now = Instant::now();
+
+    assert_eq!(alice.stage(), Stage::RoundOne);
+    assert_eq!(bob.stage(), Stage::AwaitingInit);
+    assert_eq!(eve.stage(), Stage::AwaitingInit);
+
+    // Partially complete round one, with session nonce `0`.
+
+    {
+        let [a1, a2] = CheckedSend::new(&mut alice, now)
+            // round1(Alice) -> Eve
+            .round1(alice_addr, eve_addr)
+            // round1(Alice) -> Bob
+            .round1(alice_addr, bob_addr)
+            .msgs();
+
+        let DkgMessage::Round1 { nonce, .. } = a1.msg else { panic!() };
+        assert_eq!(nonce, 0);
+        let DkgMessage::Round1 { nonce, .. } = a2.msg else { panic!() };
+        assert_eq!(nonce, 0);
+
+        eve.recv(a1).unwrap();
+        bob.recv(a2).unwrap();
+    }
+
+    assert_eq!(alice.stage(), Stage::RoundOne);
+    assert_eq!(bob.stage(), Stage::RoundOne);
+    assert_eq!(eve.stage(), Stage::RoundOne);
+
+    {
+        let [b1, b2] = CheckedSend::new(&mut bob, now)
+            // ack(Alice) -> Alice
+            .ack_round1(alice_addr, alice_addr)
+            // round1(Bob) -> Alice
+            .round1(bob_addr, alice_addr)
+            .msgs();
+
+        let DkgMessage::Round1 { nonce, .. } = b2.msg else { panic!() };
+        assert_eq!(nonce, 0);
+
+        alice.recv(b1).unwrap();
+        alice.recv(b2).unwrap();
+    }
+
+    {
+        let [e1, e2] = CheckedSend::new(&mut eve, now)
+            // ack(Alice) -> Alice
+            .ack_round1(alice_addr, alice_addr)
+            // round1(Eve) -> Alice
+            .round1(eve_addr, alice_addr)
+            .msgs();
+
+        let DkgMessage::Round1 { nonce, .. } = e2.msg else { panic!() };
+        assert_eq!(nonce, 0);
+
+        alice.recv(e1).unwrap();
+        alice.recv(e2).unwrap();
+    }
+
+    // Trigger session reset timeout.
+    now += pending_session_timeout;
+    alice.on_timeout(now);
+
+    // (Re-)start a new session from scratch, with session nonce `1`.
+
+    {
+        let [a1, a2] = CheckedSend::new(&mut alice, now)
+            // round1(Alice) -> Eve
+            .round1(alice_addr, eve_addr)
+            // round1(Alice) -> Bob
+            .round1(alice_addr, bob_addr)
+            .msgs();
+
+        let DkgMessage::Round1 { nonce, .. } = a1.msg else { panic!() };
+        assert_eq!(nonce, 1);
+
+        let DkgMessage::Round1 { nonce, .. } = a2.msg else { panic!() };
+        assert_eq!(nonce, 1);
+
+        eve.recv(a1).unwrap();
+        bob.recv(a2).unwrap();
+    }
+
+    {
+        let [b1, b2] = CheckedSend::new(&mut bob, now)
+            // ack(Alice) -> Alice
+            .ack_round1(alice_addr, alice_addr)
+            // round1(Bob) -> Alice
+            .round1(bob_addr, alice_addr)
+            .msgs();
+
+        let DkgMessage::Round1 { nonce, .. } = b2.msg else { panic!() };
+        assert_eq!(nonce, 1);
+
+        let _ = (b1, b2);
+    }
+
+    {
+        let [e1, e2] = CheckedSend::new(&mut eve, now)
+            // ack(Alice) -> Alice
+            .ack_round1(alice_addr, alice_addr)
+            // round1(Eve) -> Alice
+            .round1(eve_addr, alice_addr)
+            .msgs();
+
+        let DkgMessage::Round1 { nonce, .. } = e2.msg else { panic!() };
+        assert_eq!(nonce, 1);
+
+        let _ = (e1, e2);
+    }
+}
+
+#[test]
+fn dkg_session_reset_stage_two() {
+    let config = test_config();
+    let pending_session_timeout = config.pending_session_timeout.unwrap();
+    let (alice_addr, bob_addr, eve_addr, alice, bob, eve) = setup(config);
+
+    let mut now = Instant::now();
+
+    // Complete round one.
+    let (mut alice, bob, eve) =
+        complete_stage_one(alice_addr, bob_addr, eve_addr, alice, bob, eve, now);
+
+    assert_eq!(alice.stage(), Stage::RoundTwo);
+    assert_eq!(bob.stage(), Stage::RoundTwo);
+    assert_eq!(eve.stage(), Stage::RoundTwo);
+
+    // Trigger session reset timeout.
+    now += pending_session_timeout;
+    alice.on_timeout(now);
+
+    assert_eq!(alice.stage(), Stage::RoundOne); // Alice reset.
+    assert_eq!(bob.stage(), Stage::RoundTwo);
+    assert_eq!(eve.stage(), Stage::RoundTwo);
+
+    // All rounds can be completed again, starting from round one.
+    let (alice, bob, eve) =
+        complete_stage_one(alice_addr, bob_addr, eve_addr, alice, bob, eve, now);
+
+    let (alice, bob, eve) =
+        complete_stage_two(alice_addr, bob_addr, eve_addr, alice, bob, eve, now);
+
+    let (alice, bob, eve) =
+        complete_stage_three(alice_addr, bob_addr, eve_addr, alice, bob, eve, now);
+
+    let (_sec, alice_aggr) = alice.aggregate_key_packages().unwrap();
+    let (_sec, bob_aggr) = bob.aggregate_key_packages().unwrap();
+    let (_sec, eve_aggr) = eve.aggregate_key_packages().unwrap();
+
+    assert_eq!(alice_aggr, bob_aggr);
+    assert_eq!(alice_aggr, eve_aggr);
+    assert_eq!(bob_aggr, eve_aggr);
+}
+
+#[test]
+fn dkg_session_reset_stage_three() {
+    let config = test_config();
+    let pending_session_timeout = config.pending_session_timeout.unwrap();
+    let (alice_addr, bob_addr, eve_addr, alice, bob, eve) = setup(config);
+
+    let mut now = Instant::now();
+
+    // Complete round one and round two.
+    let (alice, bob, eve) =
+        complete_stage_one(alice_addr, bob_addr, eve_addr, alice, bob, eve, now);
+
+    let (mut alice, bob, eve) =
+        complete_stage_two(alice_addr, bob_addr, eve_addr, alice, bob, eve, now);
+
+    assert_eq!(alice.stage(), Stage::RoundThree);
+    assert_eq!(bob.stage(), Stage::RoundThree);
+    assert_eq!(eve.stage(), Stage::RoundThree);
+
+    // Trigger session reset timeout.
+    now += pending_session_timeout;
+    alice.on_timeout(now);
+
+    assert_eq!(alice.stage(), Stage::RoundOne); // Alice reset.
+    assert_eq!(bob.stage(), Stage::RoundThree);
+    assert_eq!(eve.stage(), Stage::RoundThree);
+
+    // All rounds can be completed again, starting from round one.
+    let (alice, bob, eve) =
+        complete_stage_one(alice_addr, bob_addr, eve_addr, alice, bob, eve, now);
+
+    let (alice, bob, eve) =
+        complete_stage_two(alice_addr, bob_addr, eve_addr, alice, bob, eve, now);
+
+    let (alice, bob, eve) =
+        complete_stage_three(alice_addr, bob_addr, eve_addr, alice, bob, eve, now);
+
+    let (_sec, alice_aggr) = alice.aggregate_key_packages().unwrap();
+    let (_sec, bob_aggr) = bob.aggregate_key_packages().unwrap();
+    let (_sec, eve_aggr) = eve.aggregate_key_packages().unwrap();
+
+    assert_eq!(alice_aggr, bob_aggr);
+    assert_eq!(alice_aggr, eve_aggr);
+    assert_eq!(bob_aggr, eve_aggr);
+}

--- a/bin/btc-server/src/dkg/tests/simulation.rs
+++ b/bin/btc-server/src/dkg/tests/simulation.rs
@@ -17,9 +17,29 @@ async fn stage_simulate_random_drops_with_3_members() {
         round1_package_timeout: Duration::from_millis(100),
         round2_package_timeout: Duration::from_millis(100),
         round3_package_timeout: Duration::from_millis(100),
+        pending_session_timeout: None,
     };
 
-    setup_tasks(NUM_MEMBERS, config).await;
+    setup_tasks(NUM_MEMBERS, config, &[]).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn stage_simulate_random_drops_with_one_absent_member() {
+    const NUM_MEMBERS: u16 = 3;
+
+    let config = Config {
+        max_signers: 3,
+        min_signers: 3,
+        round1_package_timeout: Duration::from_millis(100),
+        round2_package_timeout: Duration::from_millis(100),
+        round3_package_timeout: Duration::from_millis(100),
+        // Session resets after 10 seconds.
+        pending_session_timeout: Some(Duration::from_secs(10)),
+    };
+
+    // Id number 2 is absent, the DKG process never completes.
+    setup_tasks(NUM_MEMBERS, config, &[2]).await;
 }
 
 #[tokio::test]
@@ -33,12 +53,13 @@ async fn stage_simulate_random_drops_with_16_members() {
         round1_package_timeout: Duration::from_millis(500),
         round2_package_timeout: Duration::from_millis(500),
         round3_package_timeout: Duration::from_millis(500),
+        pending_session_timeout: None,
     };
 
-    setup_tasks(NUM_MEMBERS, config).await;
+    setup_tasks(NUM_MEMBERS, config, &[]).await;
 }
 
-async fn setup_tasks(num_members: u16, config: Config) {
+async fn setup_tasks(num_members: u16, config: Config, absent_nodes: &[u16]) {
     debug_assert!(config.min_signers <= config.max_signers);
     debug_assert!(config.min_signers <= num_members);
     debug_assert!(config.max_signers == num_members);
@@ -51,6 +72,11 @@ async fn setup_tasks(num_members: u16, config: Config) {
     let mut channels = BTreeMap::new();
     // List of all receiver channels.
     let mut queues = BTreeMap::new();
+
+    let absent_nodes: Vec<frost::Identifier> = absent_nodes
+        .iter()
+        .map(|id| frost::Identifier::derive(id.to_le_bytes().as_slice()).unwrap())
+        .collect();
 
     for num in 0..num_members {
         let id = frost::Identifier::derive(num.to_le_bytes().as_slice()).unwrap();
@@ -69,8 +95,14 @@ async fn setup_tasks(num_members: u16, config: Config) {
 
     // Spawn a task for each member.
     for (id, (static_sec, rx)) in queues {
+        if absent_nodes.contains(&id) {
+            println!("WARNING: Member {} is absent", name_addr(&id));
+            continue;
+        }
+
         let machine =
-            DkgStateMachine::new(id, static_sec, coordinator, members.clone(), config).unwrap();
+            DkgStateMachine::new(id, static_sec, coordinator, members.clone(), config, Some(0))
+                .unwrap();
 
         tokio::spawn(run_dkg(machine, rx, channels.clone(), callback_tx.clone()));
     }
@@ -251,9 +283,10 @@ fn name_payload(msg: &DkgMessage) -> String {
 
 fn name_stage(stage: Stage) -> String {
     match stage {
-        Stage::RoundOneActive => String::from("R1"),
-        Stage::RoundTwoActive => String::from("R2"),
-        Stage::RoundThreeActive => String::from("R3"),
+        Stage::AwaitingInit => String::from("AA"),
+        Stage::RoundOne => String::from("R1"),
+        Stage::RoundTwo => String::from("R2"),
+        Stage::RoundThree => String::from("R3"),
         Stage::Finalized => String::from("FF"),
         Stage::Aborted => String::from("!!"),
     }

--- a/bin/btc-server/src/dkg/tests/stage_one.rs
+++ b/bin/btc-server/src/dkg/tests/stage_one.rs
@@ -12,11 +12,6 @@ pub fn complete_stage_one(
     //
     now: Instant,
 ) -> (DkgStateMachine, DkgStateMachine, DkgStateMachine) {
-    // TODO: check pending state.
-    assert_eq!(alice.stage(), Stage::RoundOneActive);
-    assert_eq!(bob.stage(), Stage::RoundOneActive);
-    assert_eq!(eve.stage(), Stage::RoundOneActive);
-
     // Bob and Eve are waiting for Alice to send the initial message.
     assert!(bob.send(now).is_none());
     assert!(eve.send(now).is_none());
@@ -36,6 +31,14 @@ pub fn complete_stage_one(
         eve.recv(a1).unwrap();
         bob.recv(a2).unwrap();
     }
+
+    assert_eq!(alice.stage(), Stage::RoundOne);
+    assert_eq!(bob.stage(), Stage::RoundOne);
+    assert_eq!(eve.stage(), Stage::RoundOne);
+
+    assert!(alice.timeout(now).is_some());
+    assert!(bob.timeout(now).is_none());
+    assert!(eve.timeout(now).is_none());
 
     {
         let [b1, b2] = CheckedSend::new(&mut bob, now)
@@ -60,6 +63,10 @@ pub fn complete_stage_one(
         alice.recv(e1).unwrap();
         alice.recv(e2).unwrap();
     }
+
+    assert!(alice.timeout(now).is_some());
+    assert!(bob.timeout(now).is_some());
+    assert!(eve.timeout(now).is_some());
 
     {
         let [a1, a2, a3, a4] = CheckedSend::new(&mut alice, now)
@@ -97,16 +104,20 @@ pub fn complete_stage_one(
         alice.recv(e1).unwrap();
     }
 
-    assert_eq!(alice.stage(), Stage::RoundTwoActive);
-    assert_eq!(bob.stage(), Stage::RoundTwoActive);
-    assert_eq!(eve.stage(), Stage::RoundTwoActive);
+    assert_eq!(alice.stage(), Stage::RoundTwo);
+    assert_eq!(bob.stage(), Stage::RoundTwo);
+    assert_eq!(eve.stage(), Stage::RoundTwo);
 
     (alice, bob, eve)
 }
 
 #[test]
-fn test_complete_stage_one() {
-    let (alice_addr, bob_addr, eve_addr, alice, bob, eve) = setup();
+fn dkg_complete_stage_one() {
+    let (alice_addr, bob_addr, eve_addr, alice, bob, eve) = setup(test_config());
+
+    assert_eq!(alice.stage(), Stage::RoundOne);
+    assert_eq!(bob.stage(), Stage::AwaitingInit);
+    assert_eq!(eve.stage(), Stage::AwaitingInit);
 
     let now = Instant::now();
 

--- a/bin/btc-server/src/dkg/tests/stage_three.rs
+++ b/bin/btc-server/src/dkg/tests/stage_three.rs
@@ -12,11 +12,15 @@ pub fn complete_stage_three(
     //
     now: Instant,
 ) -> (DkgStateMachine, DkgStateMachine, DkgStateMachine) {
+    assert_eq!(alice.stage(), Stage::RoundThree);
+    assert_eq!(bob.stage(), Stage::RoundThree);
+    assert_eq!(eve.stage(), Stage::RoundThree);
+
     // Bob and Eve are waiting for Alice to send the initial message.
     assert!(bob.send(now).is_none());
     assert!(eve.send(now).is_none());
 
-    assert!(alice.timeout(now).is_none());
+    assert!(alice.timeout(now).is_some());
     assert!(bob.timeout(now).is_none());
     assert!(eve.timeout(now).is_none());
 
@@ -31,6 +35,10 @@ pub fn complete_stage_three(
         eve.recv(a1).unwrap();
         bob.recv(a2).unwrap();
     }
+
+    assert!(alice.timeout(now).is_some());
+    assert!(bob.timeout(now).is_none());
+    assert!(eve.timeout(now).is_none());
 
     {
         let [b1, b2] = CheckedSend::new(&mut bob, now)
@@ -55,6 +63,10 @@ pub fn complete_stage_three(
         alice.recv(e1).unwrap();
         alice.recv(e2).unwrap();
     }
+
+    assert!(alice.timeout(now).is_some());
+    assert!(bob.timeout(now).is_some());
+    assert!(eve.timeout(now).is_some());
 
     {
         let [a1, a2, a3, a4] = CheckedSend::new(&mut alice, now)
@@ -92,11 +104,17 @@ pub fn complete_stage_three(
         alice.recv(e1).unwrap();
     }
 
-    // TODO: Check that no other messages are sent.
-
     assert_eq!(alice.stage(), Stage::Finalized);
     assert_eq!(bob.stage(), Stage::Finalized);
     assert_eq!(eve.stage(), Stage::Finalized);
+
+    assert!(alice.send(now).is_none());
+    assert!(bob.send(now).is_none());
+    assert!(eve.send(now).is_none());
+
+    assert!(alice.timeout(now).is_none());
+    assert!(bob.timeout(now).is_none());
+    assert!(eve.timeout(now).is_none());
 
     // All member reproduced the same public key!
     let (_, alice_pub) = alice.aggregate_key_packages().unwrap();
@@ -111,8 +129,8 @@ pub fn complete_stage_three(
 }
 
 #[test]
-fn test_complete_stage_three() {
-    let (alice_addr, bob_addr, eve_addr, alice, bob, eve) = setup();
+fn dkg_complete_stage_three() {
+    let (alice_addr, bob_addr, eve_addr, alice, bob, eve) = setup(test_config());
 
     let now = Instant::now();
 

--- a/bin/btc-server/src/dkg/tests/stage_two.rs
+++ b/bin/btc-server/src/dkg/tests/stage_two.rs
@@ -12,11 +12,15 @@ pub fn complete_stage_two(
     //
     now: Instant,
 ) -> (DkgStateMachine, DkgStateMachine, DkgStateMachine) {
+    assert_eq!(alice.stage(), Stage::RoundTwo);
+    assert_eq!(bob.stage(), Stage::RoundTwo);
+    assert_eq!(eve.stage(), Stage::RoundTwo);
+
     // Bob and Eve are waiting for Alice to send the initial message.
     assert!(bob.send(now).is_none());
     assert!(eve.send(now).is_none());
 
-    assert!(alice.timeout(now).is_none());
+    assert!(alice.timeout(now).is_some());
     assert!(bob.timeout(now).is_none());
     assert!(eve.timeout(now).is_none());
 
@@ -31,6 +35,10 @@ pub fn complete_stage_two(
         eve.recv(a1).unwrap();
         bob.recv(a2).unwrap();
     }
+
+    assert!(alice.timeout(now).is_some());
+    assert!(bob.timeout(now).is_none());
+    assert!(eve.timeout(now).is_none());
 
     {
         let [b1, b2, b3] = CheckedSend::new(&mut bob, now)
@@ -61,6 +69,10 @@ pub fn complete_stage_two(
         alice.recv(e2).unwrap();
         alice.recv(e3).unwrap();
     }
+
+    assert!(alice.timeout(now).is_some());
+    assert!(bob.timeout(now).is_some());
+    assert!(eve.timeout(now).is_some());
 
     {
         let [a1, a2, a3, a4, a5, a6] = CheckedSend::new(&mut alice, now)
@@ -105,16 +117,16 @@ pub fn complete_stage_two(
         alice.recv(e1).unwrap();
     }
 
-    assert_eq!(alice.stage(), Stage::RoundThreeActive);
-    assert_eq!(bob.stage(), Stage::RoundThreeActive);
-    assert_eq!(eve.stage(), Stage::RoundThreeActive);
+    assert_eq!(alice.stage(), Stage::RoundThree);
+    assert_eq!(bob.stage(), Stage::RoundThree);
+    assert_eq!(eve.stage(), Stage::RoundThree);
 
     (alice, bob, eve)
 }
 
 #[test]
-fn test_complete_stage_two() {
-    let (alice_addr, bob_addr, eve_addr, alice, bob, eve) = setup();
+fn dkg_complete_stage_two() {
+    let (alice_addr, bob_addr, eve_addr, alice, bob, eve) = setup(test_config());
 
     let now = Instant::now();
 

--- a/bin/btc-server/src/dkg/tests/timeout.rs
+++ b/bin/btc-server/src/dkg/tests/timeout.rs
@@ -36,15 +36,8 @@ fn forward_to_timeout(
 
 #[test]
 fn stage_one_resend_round1_packages_on_timeout() {
-    let (alice_addr, bob_addr, eve_addr, mut alice, mut bob, mut eve) = setup();
-
-    let config = Config {
-        max_signers: 3,
-        min_signers: 3,
-        round1_package_timeout: Duration::from_secs(3),
-        round2_package_timeout: Duration::from_secs(4),
-        round3_package_timeout: Duration::from_secs(5),
-    };
+    let config = test_config();
+    let (alice_addr, bob_addr, eve_addr, mut alice, mut bob, mut eve) = setup(config);
 
     let mut now = Instant::now();
 
@@ -96,6 +89,7 @@ fn stage_one_resend_round1_packages_on_timeout() {
 
     // *** Bob resends his round1 package and an ack to Alice
     {
+        // TODO: Shouldn't this be flipped?
         let [b1, b2] = CheckedSend::new(&mut bob, now)
             // round1(Bob) -> Alice
             .round1(bob_addr, alice_addr)
@@ -148,15 +142,8 @@ fn stage_one_resend_round1_packages_on_timeout() {
 
 #[test]
 fn stage_two_resend_round2_packages_on_timeout() {
-    let (alice_addr, bob_addr, eve_addr, alice, bob, eve) = setup();
-
-    let config = Config {
-        max_signers: 3,
-        min_signers: 3,
-        round1_package_timeout: Duration::from_secs(3),
-        round2_package_timeout: Duration::from_secs(4),
-        round3_package_timeout: Duration::from_secs(5),
-    };
+    let config = test_config();
+    let (alice_addr, bob_addr, eve_addr, alice, bob, eve) = setup(config);
 
     let mut now = Instant::now();
 
@@ -271,15 +258,8 @@ fn stage_two_resend_round2_packages_on_timeout() {
 
 #[test]
 fn stage_three_resend_round3_packages_on_timeout() {
-    let (alice_addr, bob_addr, eve_addr, alice, bob, eve) = setup();
-
-    let config = Config {
-        max_signers: 3,
-        min_signers: 3,
-        round1_package_timeout: Duration::from_secs(3),
-        round2_package_timeout: Duration::from_secs(4),
-        round3_package_timeout: Duration::from_secs(5),
-    };
+    let config = test_config();
+    let (alice_addr, bob_addr, eve_addr, alice, bob, eve) = setup(config);
 
     let mut now = Instant::now();
 


### PR DESCRIPTION
This PR adds a session reset mechanism, allowing the coordinator to cancel an ongoing DKG process and requiring all participants to regenerate the Frost packages.

Notably, the `DkgMessage::Round1` variant now has two extra parameters (`context` and `nonce`):

```rust
pub enum DkgMessage {
    /// A round1 message containing the sender's FROST round1 package.
    Round1 {
        /// The original initiator of this package
        initiator: Initiator,
        // The session context, dictated by the coordinator
        context: Vec<u8>,
        // The session nonce, dictated by the coordinator
        nonce: u64,
        /// The ephemeral public key
        ephemeral_pub: secp256k1::PublicKey,
        /// The signature of the round1 package
        signature: secp256k1::ecdsa::Signature,
        /// The round1 package containing commitments to secret values
        package: sealed_pkg::SealedRoundOnePackage,
    },
// ...
```

The `context` purely serves for multisig context separation; right now it's just a fixed constant, since there's only one federation. The `nonce` indicates the DKG session; whenever the coordinator decides to start a new session - implying that all (partial) Frost packages must be regenerated - it increments that nonce by one.

Important properties:

* When the coordinator wants to reset a session, it simply sends a new `DkgMessage::Round1` package with an incremented nonce. Non-coordinators interpret this as a reset and restart the DKG process.
  * The coordinator uses the system time expressed as Unix seconds for the nonce. That way, we do not need to keep track of that number and we make sure that server restarts always use a nonce larger than the previous (unless time goes backwards, of course).
  * Packages with outdated nonces are simply dropped, avoiding replay attacks.
* Only the coordinator can reset sessions, and those parameters (`context` and `nonce`) are part of the authentication layer.
  * Any resulting signatures and encryption keys in any round and by any participant are inherently tied to those parameters, avoiding replay attacks.
* Sessions can only be reset if the DKG process has not been completed yet.
* The coordinator resets a session automatically if the DKG process has **not been completed within 5 minutes**. Non-coordinators accept a session reset at any time.
  * If we ever need to update this value, we can just release a new version **for the coordinator only**, not being required to upgrade all other participants.

Additionally, the `btc-server` has been expanded to display changes in the DKG process, such as stage and session indicators.

For example:

```
[2025-05-12T11:17:40Z WARN  btc_server] No key package found, starting DKG process...
[2025-05-12T11:17:40Z INFO  btc_server] Grpc server: started successfully on "0.0.0.0:8081"
[2025-05-12T11:17:40Z INFO  btc_server] Grpc server: waiting for a shutdown signal...
[2025-05-12T11:17:40Z INFO  btc_server] Telemetry is disabled. Not starting the http server.
[2025-05-12T11:17:49Z INFO  btc_server] DKG session nonce set to: 1747048660
[2025-05-12T11:17:49Z INFO  btc_server] DKG stage set to: Round-One
[2025-05-12T11:20:49Z INFO  btc_server] DKG session nonce changed to: 1747048661
[2025-05-12T11:20:49Z INFO  btc_server] DKG stage set to: Round-One
[2025-05-12T11:21:00Z INFO  btc_server] DKG stage changed to: Round-Two
[2025-05-12T11:21:01Z INFO  btc_server] DKG stage changed to: Round-Three
[2025-05-12T11:23:49Z INFO  btc_server] DKG session nonce changed to: 1747048662
[2025-05-12T11:23:49Z INFO  btc_server] DKG stage set to: Round-One
[2025-05-12T11:25:42Z INFO  btc_server] DKG stage changed to: Round-Two
[2025-05-12T11:25:44Z INFO  btc_server] DKG stage changed to: Round-Three
[2025-05-12T11:25:45Z INFO  btc_server] DKG stage changed to: Finalized
[2025-05-12T11:25:45Z INFO  btc_server] DKG completed successfully, saving key packages...
```

## Reviewing

This PR is a little big, so I recommend having a look in the following places specifically:

* In `bin/btc-server/src/dkg/mod.rs`:
  * `fn init_new_session`, and where it gets called.
  * `fn validate_new_session_init`, and where it gets called.

I would like to add some extra unit tests for specific (edge) cases, but I will probably follow up with those in a separate PR since there are other priorities I have to take care off right now. **This PR is production ready**.