### PR TITLE
improve(NDD): deprecate version 0 and make deserialization forward compatible

### DIFF
--- a/crates/consensus/authority/src/comet_bft/abci.rs
+++ b/crates/consensus/authority/src/comet_bft/abci.rs
@@ -2,7 +2,7 @@
 //! state
 use alloy_rpc_types_engine::ForkchoiceState;
 use reth_chain_state::ExecutedBlock;
-use reth_chainspec::{ChainSpec, BOTANIX_TESTNET_CHAIN_ID};
+use reth_chainspec::ChainSpec;
 use reth_db::{
     models::{SnapshotSync, SnapshotSyncId},
     Database, DatabaseEnv,
@@ -108,7 +108,8 @@ use super::proto_debug::{
 use crate::{
     builder::BitcoinCheckpoint,
     comet_bft::{
-        non_deterministic_data::NonDeterministicData, utils::transactions_signed_from_bytes,
+        non_deterministic_data::{NonDeterministicData, VERSION_1 as LATEST_NDD_VERSION},
+        utils::transactions_signed_from_bytes,
     },
     excecution_utils::authority_execution_utils::{batch_execute, build_and_execute},
     metrics::AuthorityMetrics,
@@ -350,7 +351,6 @@ pub(crate) struct ABCIClient<EF, BF, DB, Pool> {
     snapshot_sync_state_lock: Option<Arc<RwLock<SnapshotSyncStateLock>>>,
     snapshot_format: u32,
     block_fee_recipient_address: Option<reth_primitives::Address>,
-    is_testnet: bool,
 }
 
 impl<EF, BF, DB, Pool> ABCIClient<EF, BF, DB, Pool>
@@ -402,7 +402,6 @@ where
             snapshot_sync_state_lock,
             snapshot_format,
             block_fee_recipient_address,
-            is_testnet: storage.chain_spec.chain.id() == BOTANIX_TESTNET_CHAIN_ID,
         }
     }
 
@@ -453,9 +452,7 @@ where
             .block_fee_recipient_address
             .ok_or(ConsensusError::MissingBlockFeeRecipientAddress)?;
 
-        // Only v1 is supported for block production
-        // v0 is only used for historical syncing in testnet
-        let ndd = NonDeterministicData::new_v1(
+        let ndd = NonDeterministicData::new(
             self.bitcoin_blockhash()?,
             aggregate_public_key,
             block_fee_recipient_address,
@@ -1563,39 +1560,14 @@ where
             }
         };
 
+        if non_deterministic_data.version() != LATEST_NDD_VERSION {
+            warn!(
+                ?non_deterministic_data,
+                "processing block with unknown non-deterministic data version"
+            );
+        }
+
         trace!("non_deterministic_data={:?}", non_deterministic_data);
-
-        // Only NDD V1 is supported for block production so validate `block_fee_recipient_address`
-        // exists
-        let block_fee_recipient_address = match non_deterministic_data.block_fee_recipient_address {
-            Some(address) => address,
-            None => {
-                warn!("Block fee recipient address is not set in process proposal");
-
-                if tracing::enabled!(tracing::Level::WARN) {
-                    let execution_time = execution_start_time.elapsed().as_secs_f32();
-                    let app_hash = match self.application_hash(&self.storage.client) {
-                        Ok(app_hash) => app_hash,
-                        Err(e) => {
-                            panic!("failed to get application hash on process proposal: {:?}", e);
-                        }
-                    };
-
-                    warn!(
-                        app_hash = hex::encode(&app_hash),
-                        block_time = block_time.seconds,
-                        execution_time,
-                        cbft_transactions_count = txs_len,
-                        eth_transactions_count = txs_len - 1,
-                        "A proposal with {} transactions is rejected in {} seconds",
-                        txs_len,
-                        execution_time
-                    );
-                }
-
-                return ResponseProcessProposal { status: VERIFY_REJECT };
-            }
-        };
 
         let bitcoin_checkpoint_block_hash = match self
             .bitcoin_checkpoint
@@ -1727,7 +1699,7 @@ where
         match build_and_execute(
             txs,
             self.storage.chain_spec.clone(),
-            &block_fee_recipient_address,
+            &non_deterministic_data.block_fee_recipient_address,
             self.storage.evm_config,
             &self.provider_factory,
             &self.storage.bitcoind_factory,
@@ -1919,36 +1891,6 @@ where
                     }
                 };
 
-                // NDD V0 (no block_fee_recipient_address) is supported only for historical sync on
-                // testnet
-                let block_fee_recipient_address = match non_deterministic_data
-                    .block_fee_recipient_address
-                {
-                    Some(address) => {
-                        debug!(%address, "use proposed block fee recipient address");
-                        address
-                    }
-                    // Need to extract from `request.proposer_address` which is legacy block
-                    // building behavior
-                    None if self.is_testnet => {
-                        let address = Address::new(
-                            FixedBytes::<20>::from_slice(
-                                request.proposer_address.to_vec().as_slice(),
-                            )
-                            .0,
-                        );
-
-                        debug!(%address, "use a proposer address as the block fee recipient address (testnet)");
-
-                        address
-                    }
-                    None => {
-                        panic!(
-                            "Block fee recipient address is not set in finalize block for mainnet"
-                        );
-                    }
-                };
-
                 let block_time = match request.time {
                     Some(time) => time,
                     None => {
@@ -1972,7 +1914,7 @@ where
                 match build_and_execute(
                     txs,
                     self.storage.chain_spec.clone(),
-                    &block_fee_recipient_address,
+                    &non_deterministic_data.block_fee_recipient_address,
                     self.storage.evm_config,
                     &self.provider_factory,
                     &self.storage.bitcoind_factory,
@@ -2508,7 +2450,7 @@ mod tests {
 
         let response = abci_client.prepare_proposal(request);
 
-        let expected_ndd = NonDeterministicData::new_v1(
+        let expected_ndd = NonDeterministicData::new(
             abci_client.bitcoin_blockhash().expect("to have bitcoin blockhash"),
             abci_client.aggregate_public_key().expect("to have agg pk"),
             Address::ZERO,
@@ -2545,7 +2487,7 @@ mod tests {
         let request = RequestPrepareProposal::default();
         let response = abci_client.prepare_proposal(request);
 
-        let expected_ndd = NonDeterministicData::new_v1(
+        let expected_ndd = NonDeterministicData::new(
             abci_client.bitcoin_blockhash().expect("to have agg bitcoin blockhash"),
             abci_client.aggregate_public_key().expect("to have agg pk"),
             Address::ZERO,

--- a/crates/consensus/authority/src/comet_bft/non_deterministic_data.rs
+++ b/crates/consensus/authority/src/comet_bft/non_deterministic_data.rs
@@ -151,14 +151,19 @@ mod tests {
                 .as_slice(),
         )
         .unwrap();
-        let ndd = NonDeterministicData::new(bitcoin_block_hash, pk);
-        assert_eq!(ndd.version, VERSION_0);
+        let block_fee_recipient_address =
+            Address::parse_checksummed("0x43C8bDCb9AFeBB1D834A7de18CC214a6FD1632d9", None)
+                .expect("valid address");
+
+        let ndd = NonDeterministicData::new(bitcoin_block_hash, pk, block_fee_recipient_address);
+        assert_eq!(ndd.version, VERSION_1);
         assert_eq!(ndd.bitcoin_block_hash, bitcoin_block_hash);
         assert_eq!(ndd.aggregated_public_key, pk);
+        assert_eq!(ndd.block_fee_recipient_address, block_fee_recipient_address);
     }
 
     #[test]
-    fn test_non_deterministic_data_new_v1() {
+    fn test_non_deterministic_data_serde() {
         let bitcoin_block_hash = BlockHash::all_zeros();
         let pk = secp256k1::PublicKey::from_slice(
             hex::decode("039bef292b80427d355cecb89eda8a50a7d2196a93d73dade5a0c4a07cd334815d")
@@ -169,33 +174,22 @@ mod tests {
         let block_fee_recipient_address =
             Address::parse_checksummed("0x43C8bDCb9AFeBB1D834A7de18CC214a6FD1632d9", None)
                 .expect("valid address");
-        let ndd = NonDeterministicData::new_v1(bitcoin_block_hash, pk, block_fee_recipient_address);
-        assert_eq!(ndd.version, VERSION_1);
-        assert_eq!(ndd.bitcoin_block_hash, bitcoin_block_hash);
-        assert_eq!(ndd.aggregated_public_key, pk);
-        assert_eq!(ndd.block_fee_recipient_address, Some(block_fee_recipient_address));
-    }
 
-    #[test]
-    fn test_non_deterministic_data_serde_v0() {
-        let bitcoin_block_hash = BlockHash::all_zeros();
-        let pk: secp256k1::PublicKey = secp256k1::PublicKey::from_slice(
-            hex::decode("039bef292b80427d355cecb89eda8a50a7d2196a93d73dade5a0c4a07cd334815d")
-                .unwrap()
-                .as_slice(),
-        )
-        .unwrap();
-        let ndd = NonDeterministicData::new(bitcoin_block_hash, pk);
+        let ndd = NonDeterministicData::new(bitcoin_block_hash, pk, block_fee_recipient_address);
         let res = ndd.serialize().unwrap();
         let mut reader = io::Cursor::new(res);
+
         let deserialized = NonDeterministicData::deserialize(&mut reader).unwrap();
         assert_eq!(deserialized.version, ndd.version);
         assert_eq!(deserialized.bitcoin_block_hash, ndd.bitcoin_block_hash);
         assert_eq!(deserialized.aggregated_public_key, ndd.aggregated_public_key);
+        assert_eq!(deserialized.block_fee_recipient_address, ndd.block_fee_recipient_address);
     }
 
     #[test]
-    fn test_non_deterministic_data_serde_v1() {
+    /// Attempts to deserialize a NDD with an unknown version containing some
+    /// tailing data.
+    fn test_non_deterministic_data_serde_unknown_version() {
         let bitcoin_block_hash = BlockHash::all_zeros();
         let pk: secp256k1::PublicKey = secp256k1::PublicKey::from_slice(
             hex::decode("039bef292b80427d355cecb89eda8a50a7d2196a93d73dade5a0c4a07cd334815d")
@@ -206,13 +200,53 @@ mod tests {
         let block_fee_recipient_address =
             Address::parse_checksummed("0x43C8bDCb9AFeBB1D834A7de18CC214a6FD1632d9", None)
                 .expect("valid address");
-        let ndd = NonDeterministicData::new_v1(bitcoin_block_hash, pk, block_fee_recipient_address);
-        let res = ndd.serialize().unwrap();
-        let mut reader = io::Cursor::new(res);
-        let deserialized = NonDeterministicData::deserialize(&mut reader).unwrap();
-        assert_eq!(deserialized.version, ndd.version);
-        assert_eq!(deserialized.bitcoin_block_hash, ndd.bitcoin_block_hash);
-        assert_eq!(deserialized.aggregated_public_key, ndd.aggregated_public_key);
-        assert_eq!(deserialized.block_fee_recipient_address, ndd.block_fee_recipient_address);
+
+        // NOTE: The last 32 bytes (all 1's) are ignored.
+        let bytes = hex::decode(
+            "0000000000000000000000000000000000000000000000000000000000000000\
+             039bef292b80427d355cecb89eda8a50a7d2196a93d73dade5a0c4a07cd334815d\
+             6300\
+             43c8bdcb9afebb1d834a7de18cc214a6fd1632d9\
+             1111111111111111111111111111111111111111111111111111111111111111",
+        )
+        .unwrap();
+        let mut reader = io::Cursor::new(bytes);
+        let ndd = NonDeterministicData::deserialize(&mut reader).unwrap();
+
+        assert_eq!(ndd.version, 99); // Version 99 is unknown
+        assert_eq!(ndd.bitcoin_block_hash, bitcoin_block_hash);
+        assert_eq!(ndd.aggregated_public_key, pk);
+        assert_eq!(ndd.block_fee_recipient_address, block_fee_recipient_address);
+    }
+
+    #[test]
+    /// Attempts to deserialize a NDD from a deprecated implementation that
+    /// still used version 0.
+    fn test_non_deterministic_data_serde_from_deprecated_impl() {
+        let bitcoin_block_hash = BlockHash::all_zeros();
+        let pk: secp256k1::PublicKey = secp256k1::PublicKey::from_slice(
+            hex::decode("039bef292b80427d355cecb89eda8a50a7d2196a93d73dade5a0c4a07cd334815d")
+                .unwrap()
+                .as_slice(),
+        )
+        .unwrap();
+        let block_fee_recipient_address =
+            Address::parse_checksummed("0x43C8bDCb9AFeBB1D834A7de18CC214a6FD1632d9", None)
+                .expect("valid address");
+
+        let bytes = hex::decode(
+            "0000000000000000000000000000000000000000000000000000000000000000\
+             039bef292b80427d355cecb89eda8a50a7d2196a93d73dade5a0c4a07cd334815d\
+             0100\
+             43c8bdcb9afebb1d834a7de18cc214a6fd1632d9",
+        )
+        .unwrap();
+        let mut reader = io::Cursor::new(bytes);
+        let ndd = NonDeterministicData::deserialize(&mut reader).unwrap();
+
+        assert_eq!(ndd.version, VERSION_1);
+        assert_eq!(ndd.bitcoin_block_hash, bitcoin_block_hash);
+        assert_eq!(ndd.aggregated_public_key, pk);
+        assert_eq!(ndd.block_fee_recipient_address, block_fee_recipient_address);
     }
 }

--- a/crates/consensus/authority/src/comet_bft/non_deterministic_data.rs
+++ b/crates/consensus/authority/src/comet_bft/non_deterministic_data.rs
@@ -13,55 +13,28 @@ pub(crate) enum NonDeterministicDataDeserializeError {
     #[error("invalid data format")]
     /// Invalid data format
     Decoding(#[from] encode::Error),
-    #[error("invalid version")]
-    /// Invalid NonDeterministicData, version
-    InvalidVersion,
 }
 
-// Does not require `block_fee_recipient_address` to be present in NDD
-// Only supported on testnet for historical syncing purposes
-const VERSION_0: u16 = 0;
-// Requires `block_fee_recipient_address` to be present in NDD
-// Supported on testnet and mainnet
-const VERSION_1: u16 = 1;
+// The default NDD version.
+pub(crate) const VERSION_1: u16 = 1;
 
 /// Type that encapsulates non-deterministic data needed for consensus.
-/// When `block_fee_recipient_address` is `None`, the instance corresponds to VERSION_0.
-/// Otherwise VERSION_1.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct NonDeterministicData {
     pub(crate) version: u16,
     pub(crate) bitcoin_block_hash: bitcoin::hash_types::BlockHash,
     pub(crate) aggregated_public_key: secp256k1::PublicKey,
-    pub(crate) block_fee_recipient_address: Option<Address>,
+    pub(crate) block_fee_recipient_address: Address,
 }
 
 impl NonDeterministicData {
     /// Returns the version based on whether a fee recipient address is present.
     pub(crate) fn version(&self) -> u16 {
-        match self.block_fee_recipient_address {
-            Some(_) => VERSION_1,
-            None => VERSION_0,
-        }
+        self.version
     }
 
-    /// Constructor for version 0 (without a fee recipient).
-    /// Deprecated in favor of `new_v1`.
-    #[allow(dead_code)]
+    /// Constructor for the NDD.
     pub(crate) fn new(
-        bitcoin_block_hash: bitcoin::hash_types::BlockHash,
-        aggregated_public_key: secp256k1::PublicKey,
-    ) -> Self {
-        Self {
-            version: VERSION_0,
-            bitcoin_block_hash,
-            aggregated_public_key,
-            block_fee_recipient_address: None,
-        }
-    }
-
-    /// Constructor for version 1 (with a fee recipient).
-    pub(crate) fn new_v1(
         bitcoin_block_hash: bitcoin::hash_types::BlockHash,
         aggregated_public_key: secp256k1::PublicKey,
         block_fee_recipient_address: Address,
@@ -70,7 +43,7 @@ impl NonDeterministicData {
             version: VERSION_1,
             bitcoin_block_hash,
             aggregated_public_key,
-            block_fee_recipient_address: Some(block_fee_recipient_address),
+            block_fee_recipient_address,
         }
     }
 
@@ -80,10 +53,7 @@ impl NonDeterministicData {
         self.bitcoin_block_hash.consensus_encode(&mut writer)?;
         self.aggregated_public_key.serialize().consensus_encode(&mut writer)?;
         self.version().consensus_encode(&mut writer)?;
-        // Version 1 has a block fee recipient address.
-        if let Some(ref address) = self.block_fee_recipient_address {
-            writer.write_all(address.as_slice())?;
-        }
+        writer.write_all(self.block_fee_recipient_address.as_slice())?;
 
         Ok(writer)
     }
@@ -92,38 +62,53 @@ impl NonDeterministicData {
     pub(crate) fn deserialize(
         reader: &mut impl bitcoin::io::Read,
     ) -> Result<Self, NonDeterministicDataDeserializeError> {
+        // Read the bitcoin block hash.
         let bitcoin_block_hash = Decodable::consensus_decode(reader)?;
 
+        // Read the aggregated public key.
         let pk_bytes = <[u8; 33]>::consensus_decode(reader)?;
         let aggregated_public_key = secp256k1::PublicKey::from_slice(&pk_bytes)
             .map_err(|_e| encode::Error::ParseFailed("malformed aggregate public key"))?;
 
         // Read the version and conditionally read the address.
         let version = u16::consensus_decode(reader)?;
+
+        // Read the block fee recipient address.
+        let mut address_bytes = [0u8; 20];
+        reader
+            .read_exact(&mut address_bytes)
+            .map_err(|_e| encode::Error::ParseFailed("malformed block fee recipient address"))?;
+        let block_fee_recipient_address = Address::from(address_bytes);
+
+        let this = Self {
+            version,
+            bitcoin_block_hash,
+            aggregated_public_key,
+            block_fee_recipient_address,
+        };
+
         match version {
-            VERSION_0 => {
-                // No block fee recipient expected.
-                Ok(Self {
-                    version,
-                    bitcoin_block_hash,
-                    aggregated_public_key,
-                    block_fee_recipient_address: None,
-                })
-            }
             VERSION_1 => {
-                let mut address_bytes = [0u8; 20];
-                reader.read_exact(&mut address_bytes).map_err(|_e| {
-                    encode::Error::ParseFailed("malformed block fee recipient address")
-                })?;
-                let block_fee_recipient_address = Address::from(address_bytes);
-                Ok(Self {
-                    version,
-                    bitcoin_block_hash,
-                    aggregated_public_key,
-                    block_fee_recipient_address: Some(block_fee_recipient_address),
-                })
+                // The expected version 1 NDD.
+                Ok(this)
             }
-            _ => Err(NonDeterministicDataDeserializeError::InvalidVersion),
+            _ => {
+                // IMPORTANT: This is a versioning mechanism designed for
+                // forward compatibility. We want to support new,
+                // backwards-compatible versions with enhanced functionality
+                // without requiring coordinated upgrades or hard-forks.
+                //
+                // When an older node encounters a newer, unknown version:
+                // 1. It extracts the data it can understand based on the known structure
+                // 2. It ignores any trailing data that may be present in newer versions
+                // 3. It continues to function normally despite version differences
+                //
+                // By design, encountering an unknown version alone MUST NEVER
+                // cause an error. The caller is responsible for validating
+                // whether the returned NDD is appropriate for their specific
+                // business logic requirements.
+                Ok(this)
+            }
         }
     }
 }


### PR DESCRIPTION
Preface: historic block sync for testnet is broken, so we have no reason to retain version 0. In this PR we remove version 0 and hence demand that the `block_fee_recipient_address` is always present, which is the case for new blocks - those changes here are backwards compatible.

And most importantly; with this PR the NDD deserialization process **becomes forwards-compatible**. As noted in the disclaimer:

```rust
// IMPORTANT: This is a versioning mechanism designed for
// forward compatibility. We want to support new,
// backwards-compatible versions with enhanced functionality
// without requiring coordinated upgrades or hard-forks.
//
// When an older node encounters a newer, unknown version:
// 1. It extracts the data it can understand based on the known structure
// 2. It ignores any trailing data that may be present in newer versions
// 3. It continues to function normally despite version differences
//
// By design, encountering an unknown version alone MUST NEVER
// cause an error. The caller is responsible for validating
// whether the returned NDD is appropriate for their specific
// business logic requirements.
```

Have a look at the unit tests (the diff makes it look confusing, look at them directly) and let me know what you think, **I'd appreciate some scrutiny** here (cc @0xBEEFCAF3) since we don't want to accidentally shoot ourselves in the foot.

# Changelog

### Breaking Changes
- Removed support for legacy VERSION_0 format in NonDeterministicData
- Changed `block_fee_recipient_address` from `Option<Address>` to required `Address`

### Additions
- Added forward compatibility support for future NDD versions
- Added versioning mechanism that allows older nodes to process newer NDD versions
- Added new test cases for unknown version handling and deprecated implementation compatibility
