### PR TITLE
improve(ABCI): track hash of block to be finalized before committing

### DIFF
--- a/crates/consensus/authority/src/comet_bft/abci.rs
+++ b/crates/consensus/authority/src/comet_bft/abci.rs
@@ -331,12 +331,21 @@ enum PayloadBuilderError {
     ParentBlockDoesNotExist,
 }
 
+struct BlockCache {
+    /// Cached blocks, inserted after execution in either `process_proposal` or
+    /// `finalize_block`.
+    cache: LruMap<BlockHash, BlockWithContext>,
+    /// The finalized block hash tracked by `finalize_block`, and then consumed
+    /// by `commit`.
+    tracked_final: Option<BlockHash>,
+}
+
 #[derive(Clone)]
 pub(crate) struct ABCIClient<EF, BF, DB, Pool> {
     storage: Storage<EF, BF, DB>,
     pool: Pool,
     bitcoin_checkpoint: BitcoinCheckpoint,
-    block_cache: Arc<RwLock<LruMap<BlockHash, BlockWithContext>>>,
+    block_cache: Arc<RwLock<BlockCache>>,
     driver_tx: tokio::sync::mpsc::Sender<ABCIDriverMessage>,
     #[allow(dead_code)]
     cbft_rpc_provider: HttpCometBFTRpcClientFactory,
@@ -384,12 +393,18 @@ where
         snapshot_format: u32,
         block_fee_recipient_address: Option<reth_primitives::Address>,
     ) -> Self {
+        // Saving the last 5 blocks that were proposed
+        let block_cache = Arc::new(RwLock::new(BlockCache {
+            cache: LruMap::new(ByLength::new(5)),
+            tracked_final: None,
+        }));
+
         Self {
             storage: storage.clone(),
             pool,
             bitcoin_checkpoint,
             // Saving the last 5 blocks that were proposed
-            block_cache: Arc::new(RwLock::new(LruMap::new(ByLength::new(5)))),
+            block_cache,
             driver_tx,
             cbft_rpc_provider,
             authority_consensus,
@@ -1525,9 +1540,11 @@ where
                 return ResponseProcessProposal { status: VERIFY_REJECT };
             }
         };
+
         let reader_inner: Vec<u8> =
             vec![non_deterministic_data_bytes].into_iter().flatten().collect();
         let reader = &mut io::Cursor::new(reader_inner);
+
         let non_deterministic_data = match NonDeterministicData::deserialize(reader) {
             Ok(data) => data,
             Err(e) => {
@@ -1774,7 +1791,7 @@ where
                 }
 
                 match self.block_cache.write() {
-                    Ok(mut cache) => {
+                    Ok(mut block_cache_write) => {
                         let eth_block_hash = block.hash();
 
                         debug!(
@@ -1783,7 +1800,7 @@ where
                             "update eth block cache",
                         );
 
-                        cache.insert(cbft_block_hash, block_with_context);
+                        block_cache_write.cache.insert(cbft_block_hash, block_with_context);
 
                         self.metrics.commet_processed_proposals.increment(1);
 
@@ -1880,7 +1897,8 @@ where
                 panic!("Error getting eth block cache write lock: {:?}", e);
             }
         };
-        let block_with_context = match block_cache_write.get(&cbft_block_hash) {
+
+        let block_with_context = match block_cache_write.cache.get(&cbft_block_hash) {
             Some(block_with_context) => {
                 debug!(
                     cbft_block_hash = hex::encode(cbft_block_hash),
@@ -1982,7 +2000,7 @@ where
                     block_time,
                 ) {
                     Ok(block_with_context) => {
-                        block_cache_write.insert(cbft_block_hash, block_with_context.clone());
+                        block_cache_write.cache.insert(cbft_block_hash, block_with_context.clone());
 
                         debug!(
                             cbft_block_hash = hex::encode(cbft_block_hash),
@@ -2000,6 +2018,9 @@ where
                 }
             }
         };
+
+        // Track the finalized block hash for the commit stage.
+        block_cache_write.tracked_final = Some(cbft_block_hash);
 
         // Rpc node needs to store aggregate public key from block height 1
         let block_height = block_with_context.sealed_block_with_peg.block().number;
@@ -2033,6 +2054,7 @@ where
                 panic!("failed to finalize block {} without NDD", request.height);
             }
         };
+
         let first_exec_tx_result =
             ExecTxResult { code: SUCCESS, data: non_deterministic_data_tx, ..Default::default() };
         exec_results.push(first_exec_tx_result);
@@ -2090,21 +2112,17 @@ where
     fn commit(&self) -> ResponseCommit {
         let execution_start_time = std::time::Instant::now();
 
-        let candidate_blocks = match self.block_cache.write() {
-            Ok(candidate_blocks) => candidate_blocks,
-            Err(e) => {
-                panic!("Error getting eth block cache write lock: {:?}", e);
-            }
+        let Ok(mut block_cache_write) = self.block_cache.write() else {
+            panic!("Error getting block cache write lock");
         };
 
-        // We want to explicitly panic since we cannot get the lock and send the commit message
-        let (cbft_block_hash, sealed_block_with_context) = match candidate_blocks.peek_newest() {
-            Some((cbft_block_hash, sealed_block_with_context)) => {
-                (cbft_block_hash, sealed_block_with_context)
-            }
-            None => {
-                panic!("Error getting eth block from cache");
-            }
+        // Retrieve the finalized block via hash.
+        let cbft_block_hash =
+            block_cache_write.tracked_final.take().expect("No tracked final block hash");
+
+        let Some(sealed_block_with_context) = block_cache_write.cache.remove(&cbft_block_hash)
+        else {
+            panic!("Error getting block from cache");
         };
 
         let block = sealed_block_with_context.sealed_block_with_peg.block();
@@ -2120,8 +2138,6 @@ where
 
         trace!("eth_block_header={:?}", block.header());
 
-        // need to clone since `sealed_block_with_context` is behind a lock
-        let sealed_block_with_context = sealed_block_with_context.clone();
         let eth_block_height = sealed_block_with_context.sealed_block_with_peg.block().number;
 
         // We want to explicitly panic if we cannot send the commit message
@@ -2631,7 +2647,7 @@ mod tests {
 
         // get newly made block from cache to recreate expected app hash
         let mut rw_lock = abci_client.block_cache.write().expect("should get lock");
-        let sealed_block_with_context = rw_lock.pop_newest().expect("to have block").1;
+        let sealed_block_with_context = rw_lock.cache.pop_newest().expect("to have block").1;
         let expected_app_hash = prost::bytes::Bytes::copy_from_slice(
             &sealed_block_with_context.sealed_block_with_peg.block().hash().0,
         );


### PR DESCRIPTION
Currently, we simply call [`peek_newest`](https://docs.rs/schnellru/0.2.4/schnellru/struct.LruMap.html#method.peek_newest) on the block cache before committing that returned block, which sounds kind of shaky.

> Returns the most recently used **(inserted or accessed)** element of the map. Does not change the order of the elements.


While this is _probably_ fine - considering that the Comet client will call `commit` immediately after a successful `finalize_block` call - this change explicitly tracks the finalized block hash, which is then used to retrieve the sealed block from cache. This would handle an edge-case where (for some reason) `process_proposal` is called between the expected `finalize_block` and `commit` calls, which would result in us committing a non-finalized block candidate. This is unlikely to happen, but then again, this is external behavior.

Additionally, this reverts the cache-insert skip [as introduced yesterday](https://github.com/botanix-labs/Macbeth/releases/tag/v.1.1.1) for our debugging session.