### PR TITLE
chore(abci): missing response logging

### DIFF
--- a/crates/consensus/authority/src/comet_bft/abci.rs
+++ b/crates/consensus/authority/src/comet_bft/abci.rs
@@ -988,7 +988,12 @@ where
                                     "Requested chunk with index {:?} not found in snapshot {:?}",
                                     request.chunk, snapshot_id
                                 );
-                                    return ResponseLoadSnapshotChunk::default();
+
+                                    let response = ResponseLoadSnapshotChunk::default();
+
+                                    trace!("return={:?}", response);
+
+                                    return response;
                                 }
                             };
 


### PR DESCRIPTION
Missing `ResponseLoadSnapshotChunk` trace log in `load_snapshot_chunk` method