### PR TITLE
Test/re enable rpc node int test

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -146,7 +146,8 @@ jobs:
           "block_builder",
           "test_conflicting_input",
           "test_round1_then_new_signing_session",
-          "test_track_mempool"]
+          "test_track_mempool",
+          "rpc_node"]
     env:
       RUST_BACKTRACE: 1
       TEST_TO_RUN: ${{ matrix.test }}

--- a/bin/botanix-up/src/main.rs
+++ b/bin/botanix-up/src/main.rs
@@ -85,6 +85,7 @@ async fn create_cometbft_nodes(num_nodes: u16, output_path: PathBuf) -> AnyResul
             test_signal_tx,
             node_path,
             false,
+            false,
         )
         .await?;
         cometbft_nodes.push(cometbft_node);

--- a/bin/test-suite/src/suite/consensus/common/comet_node.rs
+++ b/bin/test-suite/src/suite/consensus/common/comet_node.rs
@@ -109,6 +109,7 @@ pub struct CometBftNodeConfig {
     pub peer_id: String,
     pub test_signal_tx: Sender<TestSignal>,
     pub is_state_syncing: bool,
+    pub is_rpc_node: bool,
 }
 
 impl CometBftNodeConfig {
@@ -122,6 +123,7 @@ impl CometBftNodeConfig {
         test_signal_tx: Sender<TestSignal>,
         working_directory: PathBuf,
         is_state_syncing: bool,
+        is_rpc_node: bool,
     ) -> anyhow::Result<Self> {
         Ok(Self {
             index,
@@ -134,6 +136,7 @@ impl CometBftNodeConfig {
             cometbft_p2p_app_port,
             test_signal_tx,
             is_state_syncing,
+            is_rpc_node,
         })
     }
 
@@ -395,6 +398,7 @@ pub fn update_config_toml_with_trusted_height_and_hash(
     Ok(())
 }
 
+#[allow(clippy::too_many_lines)]
 pub async fn create_cometbft_nodes(
     global_context: Arc<GlobalContext>,
 ) -> anyhow::Result<(
@@ -405,8 +409,10 @@ pub async fn create_cometbft_nodes(
     let mut cometbft_nodes: BTreeMap<u16, CometBftNodeConfig> = BTreeMap::new();
 
     // loop and create all cometbft nodes
-    let poa_instances = global_context.fed_instances - global_context.syncing_instances;
-    for member_index in 0..global_context.fed_instances {
+    let fed_instances_non_syncing = global_context.fed_instances - global_context.syncing_instances;
+    let syncing_instances_range =
+        fed_instances_non_syncing..(fed_instances_non_syncing + global_context.syncing_instances);
+    for member_index in 0..global_context.fed_instances + global_context.rpc_instances {
         // allocate ports
         let cometbft_proxy_app_port = ABCI_PORT_BASE + 1000 * member_index;
         let cometbft_rpc_app_port = cometbft_proxy_app_port - 1;
@@ -480,7 +486,8 @@ pub async fn create_cometbft_nodes(
             cometbft_p2p_app_port,
             test_signal_tx,
             working_directory,
-            member_index > poa_instances - 1,
+            syncing_instances_range.contains(&member_index),
+            member_index >= global_context.fed_instances,
         )
         .await?;
 
@@ -488,14 +495,15 @@ pub async fn create_cometbft_nodes(
         cometbft_nodes.insert(member_index, cometbft_node);
     }
 
-    // extract validators set
+    // extract validators set and filter out rpc nodes
     let all_genesis_validators = cometbft_nodes
         .iter()
+        .filter(|(_, config)| !config.is_rpc_node)
         .map(|(_, config)| GenesisValidator::from(&config.validator))
         .collect::<Vec<GenesisValidator>>();
 
     // now insert peers into each cometbft member
-    for member_index in 0..global_context.fed_instances {
+    for member_index in 0..global_context.fed_instances + global_context.rpc_instances {
         // get the cometbft node
         let cometbft_node = cometbft_nodes
             .get(&member_index)

--- a/bin/test-suite/src/suite/consensus/common/rpc_node.rs
+++ b/bin/test-suite/src/suite/consensus/common/rpc_node.rs
@@ -19,11 +19,10 @@ use reth::args::FedMemberPubKey;
 use reth_primitives::{
     constants::nums_secp256k1_pk,
     extra_data_header::{ExtraDataHeader, CHAIN_VERSION, EXTRA_HEADER_VERSION},
-    hex::encode as hex_encode,
     Address,
 };
 use reth_rpc_types::PeerId;
-use secp256k1::{PublicKey, SECP256K1};
+use secp256k1::{PublicKey, SecretKey, SECP256K1};
 use std::{
     collections::BTreeMap,
     io::Write,
@@ -37,7 +36,7 @@ use url::Url;
 use super::{
     botanix_client::BotanixEthClient,
     create_temp_working_directory, kill_process_at_port,
-    poa_node::{DISCOVERY_PORT_BASE, RPC_PORT_BASE, WS_PORT_BASE},
+    poa_node::{ABCI_PORT_BASE, DISCOVERY_PORT_BASE, RPC_PORT_BASE, WS_PORT_BASE},
 };
 
 #[derive(Clone, Debug)]
@@ -78,10 +77,11 @@ impl SpawnedRpcServerProcess {
 pub struct NonFederationMemberTestConfig {
     pub index: u16,
     pub temp_path: PathBuf,
-    pub secret_key: String,
+    pub secret_key: SecretKey,
     pub rpc_port: u16,
     pub ws_port: u16,
     pub discovery_port: u16,
+    pub abci_port: u16,
     pub bitcoind_url: Url,
     pub bitcoind_username: String,
     pub bitcoind_password: String,
@@ -97,7 +97,7 @@ impl NonFederationMemberTestConfig {
     #[allow(clippy::too_many_arguments)]
     pub async fn new(
         index: u16,
-        secret_key: String,
+        secret_key: SecretKey,
         sender: tokio::sync::broadcast::Sender<Notifications>,
         bitcoind_url: Url,
         bitcoind_username: String,
@@ -107,6 +107,7 @@ impl NonFederationMemberTestConfig {
         rpc_port: u16,
         ws_port: u16,
         discovery_port: u16,
+        abci_port: u16,
         lst_fee_receiver: String,
     ) -> anyhow::Result<Self> {
         Ok(Self {
@@ -116,6 +117,7 @@ impl NonFederationMemberTestConfig {
             rpc_port,
             ws_port,
             discovery_port,
+            abci_port,
             bitcoind_url,
             bitcoind_username,
             bitcoind_password,
@@ -137,7 +139,7 @@ impl NonFederationMemberTestConfig {
         edh_authorities_list: Arc<Vec<PublicKey>>,
         poa_nodes: Vec<FederationMemberTestConfig>,
     ) -> anyhow::Result<SpawnedRpcServerProcess> {
-        it_info_print!(format!("RPC Engine {} secret key = {}", self.index, &self.secret_key));
+        it_info_print!(format!("RPC Engine {} secret key = {:?}", self.index, &self.secret_key));
         self.insert_peers_list(poa_nodes.clone());
 
         let datadir = self.temp_path.to_str().context("created temp path is unparsable")?;
@@ -148,7 +150,7 @@ impl NonFederationMemberTestConfig {
             .open(discovery_secret_path.clone())
             .context("discovery secret file cannot be created/opened")?;
         let _ = file
-            .write_all(&self.secret_key.as_bytes())
+            .write_all(&self.secret_key.display_secret().to_string().as_bytes())
             .context("error writing secret key to file")?;
 
         // now create the edh
@@ -180,6 +182,12 @@ impl NonFederationMemberTestConfig {
             };
             fed_member_pks.push(pk);
         }
+        // add ourselves
+        let my_pk = FedMemberPubKey {
+            key: self.secret_key.public_key(SECP256K1).to_string(),
+            socket_addr: format!("127.0.0.1:{}", self.discovery_port),
+        };
+        fed_member_pks.push(my_pk);
 
         // NOTE: fed members have already created their EDH with the correct authorities
         // but the order may not be the same as fed_member_pks since we added ourselves last
@@ -194,6 +202,7 @@ impl NonFederationMemberTestConfig {
             }
         }
 
+        // Need to create a federation.toml in the data dir
         let federation_config = FederationTomlConfig::new(
             edh_authorities,
             self.botanix_fee_recipient.clone(),
@@ -212,8 +221,6 @@ impl NonFederationMemberTestConfig {
         for _ in 0..2 {
             working_directory.pop();
         }
-        working_directory.push("bin");
-        working_directory.push("reth");
 
         let federation_config_path = federation_config_path.display().to_string();
         let rpc_port = self.rpc_port.to_string();
@@ -222,6 +229,7 @@ impl NonFederationMemberTestConfig {
         let bitcoind_username = self.bitcoind_username.clone();
         let bitcoind_password = self.bitcoind_password.clone();
         let discovery_port = self.discovery_port.to_string();
+        let abci_port = self.abci_port.to_string();
 
         // prepare run arguments
         let command = "./target/debug/reth";
@@ -275,6 +283,8 @@ impl NonFederationMemberTestConfig {
             discovery_port.as_str(),
             "--p2p-secret-key",
             discovery_secret_path.to_str().context("discovery secret path to exist")?,
+            "--abci-port",
+            abci_port.as_str(),
             "--sync.enable_state_sync",
             "--sync.enable_historical_sync",
         ];
@@ -349,13 +359,11 @@ pub async fn create_rpc_nodes(
     for member_index in 0..global_context.rpc_instances {
         let secret_key = secp256k1::SecretKey::new(&mut rand::thread_rng());
         let pk = secp256k1::PublicKey::from_secret_key(&secp, &secret_key);
-        let rpc_secret_key = hex_encode(secret_key.as_ref());
         let rpc_peer_id = pk2id(&pk);
 
         let rpc_node = NonFederationMemberTestConfig::new(
-            global_context.fed_instances + member_index, /* indexing follows up from poa nodes
-                                                          * onwards */
-            rpc_secret_key,
+            global_context.fed_instances + member_index, // indexing follows up from poa nodes onwards
+            secret_key,
             tx.clone(),
             global_context.bitcoind_url.clone(),
             global_context.bitcoind_user.clone(),
@@ -369,6 +377,7 @@ pub async fn create_rpc_nodes(
                                                                           * start port assigning
                                                                           * after poa servers */
             DISCOVERY_PORT_BASE + global_context.fed_instances + member_index, /* Note: make sure we start port assigning after poa servers */
+            ABCI_PORT_BASE + 1000 * (global_context.fed_instances + member_index),
             global_context.lst_fee_receiver.clone(),
         ).await?;
         rpc_members.insert(global_context.fed_instances + member_index, rpc_node);

--- a/bin/test-suite/src/suite/consensus/common/rpc_node.rs
+++ b/bin/test-suite/src/suite/consensus/common/rpc_node.rs
@@ -154,25 +154,6 @@ impl NonFederationMemberTestConfig {
             .write_all(&self.secret_key.display_secret().to_string().as_bytes())
             .context("error writing secret key to file")?;
 
-        // now create the edh
-        let edh = ExtraDataHeader::new(
-            EXTRA_HEADER_VERSION,
-            CHAIN_VERSION,
-            BlockHash::hash(&[1]),
-            nums_secp256k1_pk(),
-            Address::ZERO,
-        );
-
-        // update genesis config with edh and render file
-        let _botanix_testnet_config_genesis = {
-            let edh = hex::encode(edh.serialize());
-            let botanix_testnet_config_genesis = BotanixTestnetGenesisConfig { edh: &edh };
-            let rendered_json = botanix_testnet_config_genesis
-                .render()
-                .context("error rendering botanix testnet genesis config")?;
-            rendered_json
-        };
-
         // Need to create a chain.toml in the data dir
         // Need to zip together the soc address and pk
         let mut fed_member_pks = vec![];
@@ -372,7 +353,7 @@ pub async fn create_rpc_nodes(
             ABCI_PORT_BASE + 1000 * (global_context.fed_instances + member_index),
             global_context.lst_fee_receiver.clone(),
         ).await?;
-        rpc_members.insert(global_context.fed_instances + member_index, rpc_node);
+        rpc_members.insert(member_index, rpc_node);
     }
 
     // Note: before we create the chain.toml edh and authorities list need to be set

--- a/bin/test-suite/src/suite/consensus/common/rpc_node.rs
+++ b/bin/test-suite/src/suite/consensus/common/rpc_node.rs
@@ -134,6 +134,7 @@ impl NonFederationMemberTestConfig {
         self.peers_list = peers;
     }
 
+    #[allow(clippy::too_many_lines)]
     pub fn spawn_service(
         &mut self,
         edh_authorities_list: Arc<Vec<PublicKey>>,
@@ -182,16 +183,7 @@ impl NonFederationMemberTestConfig {
             };
             fed_member_pks.push(pk);
         }
-        // add ourselves
-        let my_pk = FedMemberPubKey {
-            key: self.secret_key.public_key(SECP256K1).to_string(),
-            socket_addr: format!("127.0.0.1:{}", self.discovery_port),
-        };
-        fed_member_pks.push(my_pk);
 
-        // NOTE: fed members have already created their EDH with the correct authorities
-        // but the order may not be the same as fed_member_pks since we added ourselves last
-        // so compare the EDH authorities list and build a new list in the correct order
         let mut edh_authorities = vec![];
         for authority in edh_authorities_list.to_vec().iter() {
             for pk in fed_member_pks.iter() {

--- a/bin/test-suite/src/suite/consensus/mod.rs
+++ b/bin/test-suite/src/suite/consensus/mod.rs
@@ -370,6 +370,7 @@ impl Suite for ConsensusIntegrationTestSuite {
         "ConsensusIntegrationTestSuite"
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn run(&mut self, test_to_run: String) -> Vec<Outcome> {
         self.set_panic_hook();
         match test_to_run.as_str() {
@@ -779,6 +780,7 @@ impl Suite for ConsensusIntegrationTestSuite {
         }
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn create_new_local_context(
         &mut self,
         create_test_config: CreateTestConfig,

--- a/bin/test-suite/src/suite/consensus/mod.rs
+++ b/bin/test-suite/src/suite/consensus/mod.rs
@@ -888,7 +888,7 @@ impl Suite for ConsensusIntegrationTestSuite {
             tokio::time::sleep(Duration::from_secs(5)).await;
         }
 
-        // =================== COMMETBFT NODES ================== //
+        // =================== COMETBFT NODES ================== //
         let mut cometbft_rpc_clients = vec![];
         let mut spawned_cometbft_processes = vec![];
         if create_test_config.create_cometbft_nodes {
@@ -896,8 +896,23 @@ impl Suite for ConsensusIntegrationTestSuite {
             let (cometbft_nodes, tx) = create_cometbft_nodes(self.global_context.clone()).await?;
             let poa_instances =
                 self.global_context.fed_instances - self.global_context.syncing_instances;
-            let (cometbft_nodes, cometbft_nodes_syncing) =
+            // split cometbft nodes into syncing and non-syncing or rpc nodes
+            // then create 2 separate BTreeMaps:
+            // 1. cometbft_nodes - nodes that are fed members (non-syncing) or rpc nodes
+            // 2. cometbft_nodes_syncing - nodes that are fed members (syncing)
+            // These maps are added to the local context and used later in tests
+            let (mut cometbft_nodes, mut cometbft_nodes_syncing_and_rpcs) =
                 split_members_at(cometbft_nodes, poa_instances as usize);
+            // get cometbft rpc nodes
+            let cometbft_rpc_nodes = cometbft_nodes_syncing_and_rpcs
+                .iter()
+                .filter(|(_, node)| node.is_rpc_node)
+                .collect::<Vec<_>>();
+            // add to cometbft nodes so they will be spawned
+            cometbft_nodes.extend(cometbft_rpc_nodes.iter().map(|(&k, &ref v)| (k, v.clone())));
+            // remove rpc cometbft nodes
+            cometbft_nodes_syncing_and_rpcs.retain(|_, node| !node.is_rpc_node);
+            let cometbft_nodes_syncing = cometbft_nodes_syncing_and_rpcs;
 
             for (_, cometbft_node) in cometbft_nodes.iter() {
                 // spawn cometbft node as a process
@@ -908,7 +923,6 @@ impl Suite for ConsensusIntegrationTestSuite {
                     "0.0.0.0".to_string(),
                     cometbft_node.cometbft_rpc_app_port,
                 );
-                let _cometbft_http_client = cometbft_client.build_and_connect()?;
                 cometbft_rpc_clients.push(cometbft_client);
 
                 // await initialization
@@ -1039,7 +1053,7 @@ impl Suite for ConsensusIntegrationTestSuite {
                 tokio::time::sleep(Duration::from_secs(2)).await;
             }
 
-            // loop over the poa nodes and wait until they become initialized so the eth clients can
+            // loop over the rpc nodes and wait until they become initialized so the eth clients can
             // connect with them
             for (index, rpc_node) in rpc_nodes.iter_mut() {
                 // create botanix client and await initialization
@@ -1064,7 +1078,7 @@ impl Suite for ConsensusIntegrationTestSuite {
                 };
                 rpc_node.botanix_eth_client = Some(botanix_eth_client.clone());
                 rpc_botanix_clients.push(botanix_eth_client);
-                it_info_print!("Botanix client created for poa member {}", index);
+                it_info_print!("Botanix client created for rpc member {}", index);
 
                 // await initialization
                 rpc_node.await_initialization()?;
@@ -1072,7 +1086,7 @@ impl Suite for ConsensusIntegrationTestSuite {
 
             // update local context
             self.local_context.rpc_processes = Some(spawned_rpc_processes);
-            self.local_context.rpc_nodes = Some(rpc_nodes);
+            self.local_context.rpc_nodes = Some(rpc_nodes.clone());
             self.local_context.rpc_notification = Some(tx);
             self.local_context.rpc_eth_providers = Some(rpc_botanix_clients);
         }

--- a/bin/test-suite/src/suite/consensus/rpc_node/test_rpc_node.rs
+++ b/bin/test-suite/src/suite/consensus/rpc_node/test_rpc_node.rs
@@ -16,12 +16,12 @@ use crate::{
 pub async fn test_rpc_node(suite: &ConsensusIntegrationTestSuite) -> anyhow::Result<()> {
     it_info_print!("Running rpc node test");
     // subscribe to rpc node events
-    let _rx = suite
-        .local_context
-        .rpc_notification
-        .as_ref()
-        .expect("broadcast sender to be set")
-        .subscribe();
+    // let _rx = suite
+    //     .local_context
+    //     .rpc_notification
+    //     .as_ref()
+    //     .expect("broadcast sender to be set")
+    //     .subscribe();
     let test_fed_members = suite.local_context.poa_nodes.as_ref().unwrap();
 
     // create botanix clients

--- a/bin/test-suite/src/suite/consensus/rpc_node/test_rpc_node.rs
+++ b/bin/test-suite/src/suite/consensus/rpc_node/test_rpc_node.rs
@@ -1,6 +1,5 @@
 use anyhow::Context;
 use ethers::types::U64;
-use tokio::time::Duration;
 
 use crate::{
     it_info_print,
@@ -15,14 +14,12 @@ use crate::{
 #[allow(clippy::unwrap_used, clippy::cast_possible_truncation)]
 pub async fn test_rpc_node(suite: &ConsensusIntegrationTestSuite) -> anyhow::Result<()> {
     it_info_print!("Running rpc node test");
-    // subscribe to rpc node events
-    // let _rx = suite
-    //     .local_context
-    //     .rpc_notification
-    //     .as_ref()
-    //     .expect("broadcast sender to be set")
-    //     .subscribe();
-    let test_fed_members = suite.local_context.poa_nodes.as_ref().unwrap();
+    let mut test_fed_members = suite.local_context.poa_nodes.as_ref().unwrap().clone();
+    // Remove syncing nodes: syncing nodes are the last entries in the map
+    let num_to_keep = test_fed_members.len()
+        - suite.local_context.cometbft_nodes_syncing.clone().unwrap_or_default().len();
+    test_fed_members = test_fed_members.into_iter().take(num_to_keep).collect();
+    it_info_print!("Test federation members", test_fed_members.len());
 
     // create botanix clients
     let mut botanix_clients: Vec<BotanixEthClient> = vec![];
@@ -37,7 +34,6 @@ pub async fn test_rpc_node(suite: &ConsensusIntegrationTestSuite) -> anyhow::Res
     }
 
     // send eoa messages from all botanix clients
-    let total_authorities = test_fed_members.len();
     let eoa_receiver = ethers::core::types::Address::random();
 
     let last_tx_hash = botanix_clients
@@ -49,15 +45,6 @@ pub async fn test_rpc_node(suite: &ConsensusIntegrationTestSuite) -> anyhow::Res
         .unwrap();
     it_info_print!("Eoa tx to Poa node: {:?}", last_tx_hash);
 
-    // get the latest header hash from the federation
-    let fed_latest_header_hash = botanix_clients
-        .first()
-        .expect("botanix client to exist")
-        .get_latest_block_hash()
-        .await
-        .unwrap();
-
-    tokio::time::sleep(Duration::from_secs(10)).await;
     // create rpc node and sync with federation peers
     let rpc_node = suite
         .local_context
@@ -79,7 +66,16 @@ pub async fn test_rpc_node(suite: &ConsensusIntegrationTestSuite) -> anyhow::Res
     .await
     .context("Failed to create rpc botanix client")?;
 
+    // get the latest header hash from the federation
+    let fed_latest_header_hash = botanix_clients
+        .first()
+        .expect("botanix client to exist")
+        .get_latest_block_hash()
+        .await
+        .unwrap();
     let rpc_latest_block_header = rpc_botanix_client.get_latest_block_hash().await.unwrap();
+
+    it_info_print!("Federation latest header hash", fed_latest_header_hash);
     it_info_print!("RPC node latest header hash", rpc_latest_block_header);
 
     assert_eq!(rpc_latest_block_header, fed_latest_header_hash);
@@ -87,35 +83,23 @@ pub async fn test_rpc_node(suite: &ConsensusIntegrationTestSuite) -> anyhow::Res
     // submit a tx to the rpc node
     let rpc_tx_receipt =
         rpc_botanix_client.send_eoa(eoa_receiver, SEND_AMOUNT).await.unwrap().unwrap();
-    it_info_print!("RPC node tx hash", rpc_tx_receipt);
+    it_info_print!("RPC node tx receipt", rpc_tx_receipt);
 
     // assert tx is confirmed (status = 1)
     let status = rpc_tx_receipt.status.expect("tx status to exist");
     assert_eq!(status, U64::from(1));
 
-    // wait for fed members to sync on the block
-    tokio::time::sleep(Duration::from_secs(5)).await;
+    let rpc_tx_block_hash = rpc_tx_receipt.block_hash.expect("block hash to exist");
+    it_info_print!("RPC tx block hash", rpc_tx_block_hash);
 
-    let latest_block_hash = rpc_tx_receipt.block_hash.expect("block hash to exist");
+    // call all fed members and check they have the block with the rpc tx
+    for client in botanix_clients.iter() {
+        let block = client.get_latest_block_by_hash(rpc_tx_block_hash).await.unwrap();
+        let tx_hash = block.transactions.first().expect("tx to exist");
+        it_info_print!("Fed node tx hash", tx_hash);
+        it_info_print!("RPC node tx hash", rpc_tx_receipt.transaction_hash);
 
-    // call all fed members and check they have same block hash
-    // then check block contains rpc tx
-    for (index, client) in botanix_clients.iter().enumerate() {
-        let block_hash = client.get_latest_block_hash().await.unwrap();
-        it_info_print!("Botanix client", format!("index={index}: block hash - {block_hash}"));
-
-        assert_eq!(block_hash, latest_block_hash);
-        // if last fed member, check tx is in block
-        if index == total_authorities - 1 {
-            let block = client.get_latest_block_by_hash(block_hash).await.unwrap();
-            it_info_print!("Final Botanix client block", block);
-
-            let tx_hash = block.transactions.first().expect("tx to exist");
-            it_info_print!("Latest block containing tx hash", tx_hash);
-            it_info_print!("RPC node tx hash", rpc_tx_receipt.transaction_hash);
-
-            assert_eq!(*tx_hash, rpc_tx_receipt.transaction_hash);
-        }
+        assert_eq!(*tx_hash, rpc_tx_receipt.transaction_hash);
     }
 
     Ok(())

--- a/test_runner.sh
+++ b/test_runner.sh
@@ -4,10 +4,7 @@ set -e
 set -o pipefail
 
 # Define the list of strings
-# "e2e_peer_disconnect" is temporarily disabled as we are waiting for Reth's fix here: https://github.com/paradigmxyz/reth/issues/10016
-# "rpc_node" "batch_pegins" "frost_e2e_failed_signing_disconnect" "frost_e2e_failed_signing"
-# Add these back in as we fix the test suite
-tests_to_run=("dkg_flow" "utxo_commitment" "signing_flow" "test_mempool_gossip" "utxo_sync" "state_sync" "wallet_sync" "frost_e2e_stable" "test_pegin_v1" "invalid_pegin" "invalid_pegout" "block_builder" "test_conflicting_input" "test_round1_then_new_signing_session" "test_track_mempool")
+tests_to_run=("dkg_flow" "utxo_commitment" "signing_flow" "test_mempool_gossip" "utxo_sync" "state_sync" "wallet_sync" "frost_e2e_stable" "test_pegin_v1" "invalid_pegin" "invalid_pegout" "block_builder" "test_conflicting_input" "test_round1_then_new_signing_session" "test_track_mempool" "rpc_node")
 
 exit_codes=()
 


### PR DESCRIPTION
This pr re-enables RPC tests.

Changes:
- spawn a cometbft node for rpc nodes
- refactor the int test to reflect we use cometbft: the original test is from when we did our own pbft.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for RPC nodes in consensus and integration tests, including configuration and node management.
  - Introduced ABCI port assignment for RPC nodes.

- **Bug Fixes**
  - Improved handling and categorization of syncing and non-syncing nodes in test setups.
  - Streamlined federation member selection in RPC node tests for more accurate validation.

- **Chores**
  - Re-enabled the "rpc_node" test in the automated test suite.
  - Expanded end-to-end test coverage to include RPC nodes.

- **Documentation**
  - Enhanced comments and logging for clarity regarding node roles and test operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->