### PR TITLE
Fix/tx receipt/use correct block number

### DIFF
--- a/bin/test-suite/src/suite/consensus/rpc_node/test_rpc_node.rs
+++ b/bin/test-suite/src/suite/consensus/rpc_node/test_rpc_node.rs
@@ -100,6 +100,14 @@ pub async fn test_rpc_node(suite: &ConsensusIntegrationTestSuite) -> anyhow::Res
         it_info_print!("RPC node tx hash", rpc_tx_receipt.transaction_hash);
 
         assert_eq!(*tx_hash, rpc_tx_receipt.transaction_hash);
+
+        // assert tx_receipt has correct block number
+        // this test a previous bug where the tx_receipt block number was sometimes 0
+        let rpc_tx_block_number = rpc_tx_receipt.block_number.expect("block number to exist");
+        let fed_block_number = block.number.expect("block number to exist");
+        it_info_print!("RPC tx block number", rpc_tx_block_number);
+        it_info_print!("Fed block number", fed_block_number);
+        assert_eq!(rpc_tx_block_number, fed_block_number);
     }
 
     Ok(())

--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -533,7 +533,8 @@ impl CanonicalInMemoryState {
         &self,
         tx_hash: TxHash,
     ) -> Option<(TransactionSigned, TransactionMeta)> {
-        for (block_number, block_state) in self.canonical_chain().enumerate() {
+        for block_state in self.canonical_chain() {
+            let block_number = block_state.number();
             if let Some((index, tx)) = block_state
                 .block()
                 .block()
@@ -546,12 +547,12 @@ impl CanonicalInMemoryState {
                     tx_hash,
                     index: index as u64,
                     block_hash: block_state.hash(),
-                    block_number: block_number as u64,
+                    block_number,
                     base_fee: block_state.block().block().header.base_fee_per_gas,
                     timestamp: block_state.block().block.timestamp,
                     excess_blob_gas: block_state.block().block.excess_blob_gas,
                 };
-                return Some((tx.clone(), meta))
+                return Some((tx.clone(), meta));
             }
         }
         None

--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -534,7 +534,6 @@ impl CanonicalInMemoryState {
         tx_hash: TxHash,
     ) -> Option<(TransactionSigned, TransactionMeta)> {
         for block_state in self.canonical_chain() {
-            let block_number = block_state.number();
             if let Some((index, tx)) = block_state
                 .block()
                 .block()
@@ -547,7 +546,7 @@ impl CanonicalInMemoryState {
                     tx_hash,
                     index: index as u64,
                     block_hash: block_state.hash(),
-                    block_number,
+                    block_number: block_state.number(),
                     base_fee: block_state.block().block().header.base_fee_per_gas,
                     timestamp: block_state.block().block.timestamp,
                     excess_blob_gas: block_state.block().block.excess_blob_gas,


### PR DESCRIPTION
## Issue being fixed or feature implemented
- `TransactionReceipt` sometimes populates `block_number` as 0 which causes issues for the explorer.

## What was done?
- Fixed a bug where the index of the block in the vector was being used as the block number instead of the actual block number

## How Has This Been Tested?
- Refactored `test_rpc_node` to assert the block number is correct

## Breaking Changes
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved test coverage to ensure transaction receipt block numbers from the RPC node match those from federation members, addressing an issue where block numbers could be reported as zero.
- **Refactor**
	- Enhanced internal handling of block numbers during transaction searches to improve accuracy and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->