### PR TITLE
fix(tx receipt): use correct block number

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -533,7 +533,8 @@ impl CanonicalInMemoryState {
         &self,
         tx_hash: TxHash,
     ) -> Option<(TransactionSigned, TransactionMeta)> {
-        for (block_number, block_state) in self.canonical_chain().enumerate() {
+        for block_state in self.canonical_chain() {
+            let block_number = block_state.number();
             if let Some((index, tx)) = block_state
                 .block()
                 .block()
@@ -546,12 +547,12 @@ impl CanonicalInMemoryState {
                     tx_hash,
                     index: index as u64,
                     block_hash: block_state.hash(),
-                    block_number: block_number as u64,
+                    block_number,
                     base_fee: block_state.block().block().header.base_fee_per_gas,
                     timestamp: block_state.block().block.timestamp,
                     excess_blob_gas: block_state.block().block.excess_blob_gas,
                 };
-                return Some((tx.clone(), meta))
+                return Some((tx.clone(), meta));
             }
         }
         None

--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -534,7 +534,6 @@ impl CanonicalInMemoryState {
         tx_hash: TxHash,
     ) -> Option<(TransactionSigned, TransactionMeta)> {
         for block_state in self.canonical_chain() {
-            let block_number = block_state.number();
             if let Some((index, tx)) = block_state
                 .block()
                 .block()
@@ -547,7 +546,7 @@ impl CanonicalInMemoryState {
                     tx_hash,
                     index: index as u64,
                     block_hash: block_state.hash(),
-                    block_number,
+                    block_number: block_state.number(),
                     base_fee: block_state.block().block().header.base_fee_per_gas,
                     timestamp: block_state.block().block.timestamp,
                     excess_blob_gas: block_state.block().block.excess_blob_gas,


### PR DESCRIPTION
## Issue being fixed or feature implemented
- `TransactionReceipt` sometimes populates `block_number` as 0 which causes issues for the explorer.
- GH issue: https://github.com/botanix-labs/botanix/issues/1057

## What was done?
- Fixed a bug where the index of the block in the vector was being used as the block number instead of the actual block number

## How Has This Been Tested?
- This is tested in the `dev` pr https://github.com/botanix-labs/Macbeth/pull/769
- The `dev` branch has a working `test_rpc_node` int test but main does not

## Breaking Changes
None