### PR TITLE
build: autoload bitcoin wallet for local setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -883,11 +883,19 @@ init-docker-local:
       --gateway=172.22.0.1 \
       botanix-local
 
+	make init-bitcoin-core
+
+.PHONY: init-bitcoin-core
+init-bitcoin-core:
 	# Start single bitcoin-core node
 	docker compose --file docker-local/docker-compose.bitcoin.yml up -d
 
 	# Create a wallet
+	# https://developer.bitcoin.org/reference/rpc/createwallet.html
+	# createwallet "wallet_name" ( disable_private_keys blank "passphrase" avoid_reuse descriptors load_on_startup )
 	make bitcoin-cli CMD='--rpcwait createwallet local false false "" false false true';
+
+	# Generate 10 blocks
 	make bitcoin-cli CMD="-generate 10";
 
 	# Stop the bitcoin-core node
@@ -963,15 +971,7 @@ reset-docker-local:
 		rm -rf $${DIR}cometbft/data/*.db; \
 	done
 
-	# Start single bitcoin-core node
-	docker compose --file docker-local/docker-compose.bitcoin.yml up -d
-
-	# Create wallet
-	make bitcoin-cli CMD='--rpcwait createwallet local false false "" false false true';
-	make bitcoin-cli CMD="-generate 10";
-
-	# Stop bitcoin-core node
-	docker compose --file docker-local/docker-compose.bitcoin.yml stop
+	make init-bitcoin-core
 
 .PHONY: clean-docker-local
 clean-docker-local:

--- a/Makefile
+++ b/Makefile
@@ -887,7 +887,7 @@ init-docker-local:
 	docker compose --file docker-local/docker-compose.bitcoin.yml up -d
 
 	# Create a wallet
-	make bitcoin-cli CMD="--rpcwait createwallet local";
+	make bitcoin-cli CMD='--rpcwait createwallet local false false "" false false true';
 	make bitcoin-cli CMD="-generate 10";
 
 	# Stop the bitcoin-core node
@@ -967,7 +967,7 @@ reset-docker-local:
 	docker compose --file docker-local/docker-compose.bitcoin.yml up -d
 
 	# Create wallet
-	make bitcoin-cli CMD="--rpcwait createwallet local";
+	make bitcoin-cli CMD='--rpcwait createwallet local false false "" false false true';
 	make bitcoin-cli CMD="-generate 10";
 
 	# Stop bitcoin-core node


### PR DESCRIPTION
## Issue being fixed or feature implemented
Everytime you starting docker local setup you need to load wallet before you can generate blocks

## What was done?
- Create the local wallet with enabled autoloading  

## How Has This Been Tested?
- Started a local network and generated blocks without calling `loadwallet`

## Breaking Changes
None

## Checklist:
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have tested my changes running a local network, and they work as expected
- [x] I have performed a self-review
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved the local Docker setup and reset process for the Bitcoin Core node with a streamlined initialization sequence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->