### PR TITLE
build: adjust reth log filter in `.env`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,9 @@ NODE_1_DIR=/path_to_/node_1
 NODE_2_DIR=/path_to_/node_2
 NON_FED_1_DIR=/path_to_/non_fed_1
 
+Filter for POA stdout logs
+#POA_LOG_STDOUT_FILTER=reth_authority_consensus=trace,reth=trace,block_with_context=off
+
 # bitcoind
 BITCOIND_NETWORK=regtest
 BITCOIND_URL=http://localhost:18443

--- a/Makefile
+++ b/Makefile
@@ -916,7 +916,11 @@ restart-docker-local:
 			echo "Error: Environment file does not exist: $$DIR.env"; \
 			exit 1; \
 		fi; \
-		docker compose --env-file "$$DIR.env" -f docker-local/docker-compose.yml restart; \
+		docker compose \
+		--env-file=.env
+		--env-file "$$DIR.env" \
+		-f docker-local/docker-compose.yml \
+		restart; \
 	done
 
 .PHONY: stop-docker-local
@@ -933,7 +937,11 @@ stop-docker-local:
 			echo "Error: Environment file does not exist: $$DIR.env"; \
 			exit 1; \
 		fi; \
-		docker compose --env-file "$$DIR.env" -f docker-local/docker-compose.yml stop; \
+		docker compose \
+		--env-file=.env \
+		--env-file "$$DIR.env" \
+		-f docker-local/docker-compose.yml \
+		stop; \
 	done
 
 .PHONY: build-docker-local
@@ -948,7 +956,11 @@ build-docker-local:
 			echo "Error: Environment file does not exist: $$DIR.env"; \
 			exit 1; \
 		fi; \
-		docker compose --env-file "$$DIR.env" -f docker-local/docker-compose.yml up -d; \
+		docker compose \
+		--env-file=.env \
+		--env-file "$$DIR.env" \
+		-f docker-local/docker-compose.yml \
+		up -d; \
 	done
 
 .PHONY: reset-docker-local
@@ -958,7 +970,11 @@ reset-docker-local:
 	# Down nodes defined in the NODES_DIR
 	for DIR in $(NODES_DIR_ABS)/*/; do \
 		if [ -f "$$DIR.env" ]; then \
-			docker compose --env-file $$DIR.env -f docker-local/docker-compose.yml down -v; \
+			docker compose \
+			--env-file=.env \
+			--env-file $$DIR.env \
+			-f docker-local/docker-compose.yml \
+			down -v; \
 		fi; \
 		rm -rf $${DIR}cometbft/data/*.db; \
 	done
@@ -981,7 +997,11 @@ clean-docker-local:
 	# Down nodes defined in the NODES_DIR
 	for DIR in $(NODES_DIR_ABS)/*/; do \
 		if [ -f "$$DIR.env" ]; then \
-			docker compose --env-file $$DIR.env -f docker-local/docker-compose.yml down -v; \
+			docker compose \
+			--env-file=.env \
+			--env-file $$DIR.env \
+			-f docker-local/docker-compose.yml \
+			down -v; \
 		fi; \
 		rm -rf $${DIR}cometbft/data/*.db; \
 	done

--- a/Makefile
+++ b/Makefile
@@ -916,11 +916,11 @@ restart-docker-local:
 			echo "Error: Environment file does not exist: $$DIR.env"; \
 			exit 1; \
 		fi; \
-		docker compose \
-		--env-file=.env
-		--env-file "$$DIR.env" \
-		-f docker-local/docker-compose.yml \
-		restart; \
+        docker compose \
+        --env-file=.env \
+        --env-file "$$DIR.env" \
+        -f docker-local/docker-compose.yml \
+        restart; \
 	done
 
 .PHONY: stop-docker-local

--- a/docker-local/docker-compose.yml
+++ b/docker-local/docker-compose.yml
@@ -65,6 +65,7 @@ services:
       - --ws.addr=0.0.0.0
       - --ws.api=eth,net,trace,txpool,web3,rpc,admin
       - -vvv
+      - --log.stdout.filter=${POA_LOG_STDOUT_FILTER:-block_with_context=off}
       - --btc-server=${COMPOSE_PROJECT_NAME?:err}-btc_server-1:8080
       - --btc-network=${BITCOIND_NETWORK:?err}
       - --btc-signing-server-jwt-secret=/app/config/bjwt.hex


### PR DESCRIPTION
## Issue being fixed or feature implemented
There is no way to change reth log level without editing docker compose file

## What was done?
- Added the `POA_LOG_STDOUT_FILTER` env to the `.env` file to configure the `--log.stdout.filter` option.

For example: 
```bash
POA_LOG_STDOUT_FILTER=reth_authority_consensus=trace,reth=trace,block_with_context=off
```

## How Has This Been Tested?
- Running a local network and seeing trace logs from the poa.

## Breaking Changes
None

## Checklist:
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have tested my changes running a local network, and they work as expected
- [x] I have performed a self-review
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the example environment file to include a new log filter configuration option for POA stdout logs.

- **Chores**
  - Modified Docker Compose and Makefile configurations to support loading environment variables from both a global `.env` file and node-specific files.
  - Enhanced the POA Docker service to allow log filtering via an environment variable, with a default value provided if not set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->