### PR TITLE
feat (frost signing): enforce signing for pegouts within last 3 months

### DIFF
--- a/crates/consensus/authority/Cargo.toml
+++ b/crates/consensus/authority/Cargo.toml
@@ -23,6 +23,8 @@ client = { path = "../../../bin/btc-server/client" }
 comet-bft-rpc = { workspace = true }
 displaydoc = "0.2"
 
+ethabi = "18.0.0"
+
 # frost
 frost-secp256k1-tr = { workspace = true }
 futures = { workspace = true }
@@ -95,7 +97,6 @@ tracing = { workspace = true }
 uuid = { version = "1.8.0", features = ["v4"] }
 
 [dev-dependencies]
-ethabi = "18.0.0"
 rand = "0.8.5"
 reth-cli-runner = { workspace = true }
 reth-db-common = { workspace = true }

--- a/crates/consensus/authority/src/frost_task.rs
+++ b/crates/consensus/authority/src/frost_task.rs
@@ -384,7 +384,8 @@ where
         };
 
         if let Err(e) =
-            validate_psbt_by_ids(self.storage.client.clone(), self.storage.btc_network, &psbt).await
+            validate_psbt_by_ids(&self.storage.client.clone(), self.storage.btc_network, &psbt)
+                .await
         {
             error!(
                 target: "consensus::authority::frost_task::handle_canon_state_commit",
@@ -668,7 +669,7 @@ where
                                 };
 
                                 if let Err(e) = validate_psbt_by_ids(
-                                    self.storage.client.clone(),
+                                    &self.storage.client.clone(),
                                     self.storage.btc_network,
                                     &psbt_res,
                                 )
@@ -700,7 +701,7 @@ where
                                 };
 
                                 if let Err(e) = validate_psbt_by_ids(
-                                    self.storage.client.clone(),
+                                    &self.storage.client.clone(),
                                     self.storage.btc_network,
                                     &psbt_res,
                                 )
@@ -732,7 +733,7 @@ where
                                 };
 
                                 if let Err(e) = validate_psbt_by_ids(
-                                    self.storage.client.clone(),
+                                    &self.storage.client.clone(),
                                     self.storage.btc_network,
                                     &psbt_res,
                                 )
@@ -764,7 +765,7 @@ where
                                 };
 
                                 if let Err(e) = validate_psbt_by_ids(
-                                    self.storage.client.clone(),
+                                    &self.storage.client.clone(),
                                     self.storage.btc_network,
                                     &psbt_res,
                                 )

--- a/crates/consensus/authority/src/frost_task.rs
+++ b/crates/consensus/authority/src/frost_task.rs
@@ -384,8 +384,7 @@ where
         };
 
         if let Err(e) =
-            validate_psbt_by_ids(&self.storage.client.clone(), self.storage.btc_network, &psbt)
-                .await
+            validate_psbt_by_ids(&self.storage.client, self.storage.btc_network, &psbt).await
         {
             error!(
                 target: "consensus::authority::frost_task::handle_canon_state_commit",
@@ -669,7 +668,7 @@ where
                                 };
 
                                 if let Err(e) = validate_psbt_by_ids(
-                                    &self.storage.client.clone(),
+                                    &self.storage.client,
                                     self.storage.btc_network,
                                     &psbt_res,
                                 )
@@ -701,7 +700,7 @@ where
                                 };
 
                                 if let Err(e) = validate_psbt_by_ids(
-                                    &self.storage.client.clone(),
+                                    &self.storage.client,
                                     self.storage.btc_network,
                                     &psbt_res,
                                 )
@@ -733,7 +732,7 @@ where
                                 };
 
                                 if let Err(e) = validate_psbt_by_ids(
-                                    &self.storage.client.clone(),
+                                    &self.storage.client,
                                     self.storage.btc_network,
                                     &psbt_res,
                                 )
@@ -765,7 +764,7 @@ where
                                 };
 
                                 if let Err(e) = validate_psbt_by_ids(
-                                    &self.storage.client.clone(),
+                                    &self.storage.client,
                                     self.storage.btc_network,
                                     &psbt_res,
                                 )

--- a/crates/consensus/authority/src/lib.rs
+++ b/crates/consensus/authority/src/lib.rs
@@ -57,6 +57,7 @@ pub mod utils;
 pub use builder::AuthorityConsensusBuilder;
 pub mod metrics;
 pub mod random_source_provider;
+pub mod test_utils;
 pub mod wallet_state_sync;
 
 /// Max EDH size; for specific details see [ExtraDataHeader]

--- a/crates/consensus/authority/src/test_utils.rs
+++ b/crates/consensus/authority/src/test_utils.rs
@@ -1,0 +1,252 @@
+//! Test utilities for the authority consensus crate.
+use ethabi;
+use reth_chainspec::ChainInfo;
+use reth_primitives::{
+    address, b256,
+    botanix::mint_validation::{BURN_TOPIC, MINT_CONTRACT_ADDRESS},
+    bytes,
+    hex_literal::hex,
+    BlockNumber, Bytes, Header, Log, LogData, Receipt, SealedHeader, TransactionMeta,
+    TransactionSigned, TransactionSignedNoHash, TxHash, TxNumber, TxType, B256, U256,
+};
+use reth_provider::{
+    BlockHashReader, BlockNumReader, HeaderProvider, ProviderResult, ReceiptProvider,
+    TransactionsProvider,
+};
+use reth_rpc_types::BlockHashOrNumber;
+use std::{
+    ops::RangeBounds,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+/// A mock provider for testing purposes.
+#[derive(Default, Clone)]
+pub struct MockProvider {}
+
+impl MockProvider {
+    fn receipt() -> Receipt {
+        Receipt {
+            tx_type: TxType::Legacy,
+            cumulative_gas_used: 0x1u64,
+            logs: vec![Log::new_unchecked(
+                address!("0000000000000000000000000000000000000011"),
+                vec![
+                    b256!("000000000000000000000000000000000000000000000000000000000000dead"),
+                    b256!("000000000000000000000000000000000000000000000000000000000000beef"),
+                ],
+                bytes!("0100ff"),
+            )],
+            success: false,
+        }
+    }
+}
+
+impl ReceiptProvider for MockProvider {
+    fn receipt(&self, _id: TxNumber) -> ProviderResult<Option<Receipt>> {
+        Ok(Some(MockProvider::receipt()))
+    }
+
+    // return receipt with burn log
+    fn receipt_by_hash(&self, _hash: TxHash) -> ProviderResult<Option<Receipt>> {
+        // encoded values (amount, destination, version)
+        let amount =
+            ethabi::Token::Uint(ethabi::ethereum_types::U256::from(10_000_000_000_000_u64));
+        let destination = ethabi::Token::String("mrpkDJFJdNGA22FaxCWw6T9oXogXfHU1rh".to_string());
+        let version = ethabi::Token::Bytes(vec![0]);
+        let payload = ethabi::encode(&[amount, destination, version]);
+
+        let log = Log {
+            address: *MINT_CONTRACT_ADDRESS,
+            data: LogData::new(
+                vec![
+                    *BURN_TOPIC,
+                    // msg.sender
+                    B256::from(hex!(
+                        "000000000000000000000000a65812bac44dadb79c3e4930dbd98d5a75376b2a"
+                    )),
+                ],
+                Bytes::copy_from_slice(payload.as_slice()),
+            )
+            .unwrap(),
+        };
+
+        let mut receipt = MockProvider::receipt();
+        receipt.logs = vec![log];
+
+        Ok(Some(receipt))
+    }
+
+    fn receipts_by_block(&self, _block: BlockHashOrNumber) -> ProviderResult<Option<Vec<Receipt>>> {
+        Ok(Some(vec![MockProvider::receipt()]))
+    }
+
+    fn receipts_by_tx_range(
+        &self,
+        _range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Receipt>> {
+        Ok(vec![MockProvider::receipt()])
+    }
+}
+
+impl TransactionsProvider for MockProvider {
+    fn transaction_by_hash_with_meta(
+        &self,
+        _hash: TxHash,
+    ) -> ProviderResult<Option<(TransactionSigned, TransactionMeta)>> {
+        let tx_signed = TransactionSigned::default();
+        let tx_meta = TransactionMeta::default();
+
+        Ok(Some((tx_signed, tx_meta)))
+    }
+
+    fn transaction_id(&self, _tx_hash: TxHash) -> ProviderResult<Option<TxNumber>> {
+        unimplemented!();
+    }
+
+    fn transaction_by_id(&self, _id: TxNumber) -> ProviderResult<Option<TransactionSigned>> {
+        unimplemented!();
+    }
+
+    fn transaction_by_id_no_hash(
+        &self,
+        _id: TxNumber,
+    ) -> ProviderResult<Option<TransactionSignedNoHash>> {
+        unimplemented!();
+    }
+
+    fn transaction_by_hash(&self, _hash: TxHash) -> ProviderResult<Option<TransactionSigned>> {
+        unimplemented!();
+    }
+
+    fn transaction_block(&self, _id: TxNumber) -> ProviderResult<Option<BlockNumber>> {
+        unimplemented!();
+    }
+
+    fn transactions_by_block(
+        &self,
+        _block: BlockHashOrNumber,
+    ) -> ProviderResult<Option<Vec<TransactionSigned>>> {
+        unimplemented!();
+    }
+
+    fn transactions_by_block_range(
+        &self,
+        _range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<Vec<Vec<TransactionSigned>>> {
+        unimplemented!();
+    }
+
+    fn transactions_by_tx_range(
+        &self,
+        _range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<TransactionSignedNoHash>> {
+        unimplemented!();
+    }
+
+    fn senders_by_tx_range(
+        &self,
+        _range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<reth_primitives::Address>> {
+        unimplemented!();
+    }
+
+    fn transaction_sender(
+        &self,
+        _id: TxNumber,
+    ) -> std::result::Result<
+        std::option::Option<reth_primitives::Address>,
+        reth_provider::ProviderError,
+    > {
+        unimplemented!();
+    }
+}
+
+impl BlockHashReader for MockProvider {
+    fn block_hash(&self, _number: BlockNumber) -> ProviderResult<Option<B256>> {
+        unimplemented!()
+    }
+
+    fn convert_block_hash(
+        &self,
+        _hash_or_number: BlockHashOrNumber,
+    ) -> ProviderResult<Option<B256>> {
+        unimplemented!()
+    }
+
+    fn canonical_hashes_range(
+        &self,
+        _start: BlockNumber,
+        _end: BlockNumber,
+    ) -> ProviderResult<Vec<B256>> {
+        unimplemented!()
+    }
+}
+
+impl BlockNumReader for MockProvider {
+    fn chain_info(&self) -> ProviderResult<ChainInfo> {
+        unimplemented!()
+    }
+
+    fn block_number(&self, _hash: B256) -> ProviderResult<Option<BlockNumber>> {
+        unimplemented!()
+    }
+
+    fn best_block_number(&self) -> ProviderResult<BlockNumber> {
+        unimplemented!()
+    }
+
+    fn last_block_number(&self) -> ProviderResult<BlockNumber> {
+        unimplemented!()
+    }
+
+    fn convert_hash_or_number(
+        &self,
+        _id: BlockHashOrNumber,
+    ) -> ProviderResult<Option<BlockNumber>> {
+        unimplemented!()
+    }
+
+    fn convert_number(&self, _id: BlockHashOrNumber) -> ProviderResult<Option<B256>> {
+        unimplemented!()
+    }
+}
+
+impl HeaderProvider for MockProvider {
+    fn header_by_number(&self, _num: u64) -> ProviderResult<Option<Header>> {
+        Ok(Some(Header {
+            timestamp: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_else(|_| Duration::from_secs(0))
+                .as_secs(),
+            ..Default::default()
+        }))
+    }
+
+    fn header(&self, _block_hash: &reth_primitives::BlockHash) -> ProviderResult<Option<Header>> {
+        unimplemented!()
+    }
+
+    fn header_td(&self, _hash: &reth_primitives::BlockHash) -> ProviderResult<Option<U256>> {
+        unimplemented!()
+    }
+
+    fn header_td_by_number(&self, _number: BlockNumber) -> ProviderResult<Option<U256>> {
+        unimplemented!()
+    }
+
+    fn headers_range(&self, _range: impl RangeBounds<BlockNumber>) -> ProviderResult<Vec<Header>> {
+        unimplemented!()
+    }
+
+    fn sealed_header(&self, _number: BlockNumber) -> ProviderResult<Option<SealedHeader>> {
+        unimplemented!()
+    }
+
+    fn sealed_headers_while(
+        &self,
+        _range: impl RangeBounds<BlockNumber>,
+        _predicate: impl FnMut(&SealedHeader) -> bool,
+    ) -> ProviderResult<Vec<SealedHeader>> {
+        unimplemented!()
+    }
+}

--- a/crates/consensus/authority/src/test_utils.rs
+++ b/crates/consensus/authority/src/test_utils.rs
@@ -14,14 +14,22 @@ use reth_provider::{
     TransactionsProvider,
 };
 use reth_rpc_types::BlockHashOrNumber;
-use std::{
-    ops::RangeBounds,
-    time::{Duration, SystemTime, UNIX_EPOCH},
-};
+use std::ops::RangeBounds;
 
 /// A mock provider for testing purposes.
 #[derive(Default, Clone)]
-pub struct MockProvider {}
+pub struct MockProvider {
+    /// The timestamp used for mock headers
+    pub timestamp: u64,
+}
+
+impl MockProvider {
+    /// Sets the timestamp used for mock headers.
+    pub fn set_timestamp(mut self, timestamp: u64) -> Self {
+        self.timestamp = timestamp;
+        self
+    }
+}
 
 impl MockProvider {
     fn receipt() -> Receipt {
@@ -213,13 +221,7 @@ impl BlockNumReader for MockProvider {
 
 impl HeaderProvider for MockProvider {
     fn header_by_number(&self, _num: u64) -> ProviderResult<Option<Header>> {
-        Ok(Some(Header {
-            timestamp: SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap_or_else(|_| Duration::from_secs(0))
-                .as_secs(),
-            ..Default::default()
-        }))
+        Ok(Some(Header { timestamp: self.timestamp, ..Default::default() }))
     }
 
     fn header(&self, _block_hash: &reth_primitives::BlockHash) -> ProviderResult<Option<Header>> {

--- a/crates/consensus/authority/src/utils.rs
+++ b/crates/consensus/authority/src/utils.rs
@@ -23,7 +23,7 @@ use reth_primitives::{
     constants::EPOCH_LENGTH,
     Bloom, BloomInput,
 };
-use reth_provider::{BlockReaderIdExt, ReceiptProvider, TransactionsProvider};
+use reth_provider::{BlockReaderIdExt, HeaderProvider, ReceiptProvider, TransactionsProvider};
 use reth_revm::primitives::FixedBytes;
 use reth_rpc_types::BlockHashOrNumber;
 use std::{
@@ -611,7 +611,7 @@ pub fn validate_psbt_by_output(
 // TODO(lamafab): All those responsibilities SHOULD be handled in one place,
 // ideally by a single function.
 pub async fn validate_psbt_by_ids(
-    client: &(impl ReceiptProvider + TransactionsProvider + BlockReaderIdExt + Clone),
+    client: &(impl ReceiptProvider + TransactionsProvider + HeaderProvider + Clone),
     btc_network: bitcoin::Network,
     psbt: &Psbt,
 ) -> Result<(), PsbtValidationError> {
@@ -734,7 +734,7 @@ pub async fn validate_psbt_by_ids(
 /// Returns `Ok(())` if the pegout ID is valid, otherwise returns a `PsbtValidationError`.
 pub fn validate_psbt_id_by_maximum_cutoff_age(
     pegout_id: &PegoutId,
-    client: &(impl ReceiptProvider + TransactionsProvider + BlockReaderIdExt + Clone),
+    client: &(impl ReceiptProvider + TransactionsProvider + HeaderProvider + Clone),
 ) -> Result<(), PsbtValidationError> {
     // Get the transaction by pegout id
     let (_, tx) = client
@@ -756,7 +756,7 @@ pub fn validate_psbt_id_by_maximum_cutoff_age(
 
     // Get the timestamp of the block that contains the transaction
     let block_timestamp = client
-        .block_by_number(tx.block_number)
+        .header_by_number(tx.block_number)
         .map_err(|e| {
             error!(target: "consensus::authority::frost_task::validate_psbt_ids_by_maximum_cutoff_age", "Failed to get block by number {:?}: {:?}", tx.block_number, e);
             PsbtValidationError::FailedToGetBlockForPegoutId(format!(
@@ -793,13 +793,8 @@ mod tests {
     };
     use btcserverlib::{test_utils::random_p2wpkh_script, wallet::psbt::PsbtOutputExt};
     use rand::{thread_rng, Rng, RngCore};
-    use reth_primitives::{
-        address, b256, bytes, hex_literal::hex, Bytes, Header, Log, LogData, Receipt, TxHash,
-        TxNumber, TxType, B256, U256,
-    };
-    use reth_provider::ProviderResult;
+    use reth_primitives::{address, b256, bytes, Header, B256, U256};
     use std::{
-        ops::RangeBounds,
         str::FromStr,
         sync::{
             atomic::{AtomicUsize, Ordering},
@@ -807,85 +802,11 @@ mod tests {
         },
     };
 
+    use crate::test_utils::MockProvider;
+
     use super::*;
 
     const FEERATE: FeeRate = FeeRate::from_sat_per_kwu(5 * 250);
-
-    #[derive(Clone)]
-    struct MockProvider {}
-
-    impl MockProvider {
-        fn new() -> Self {
-            Self {}
-        }
-
-        fn receipt() -> Receipt {
-            Receipt {
-                tx_type: TxType::Legacy,
-                cumulative_gas_used: 0x1u64,
-                logs: vec![Log::new_unchecked(
-                    address!("0000000000000000000000000000000000000011"),
-                    vec![
-                        b256!("000000000000000000000000000000000000000000000000000000000000dead"),
-                        b256!("000000000000000000000000000000000000000000000000000000000000beef"),
-                    ],
-                    bytes!("0100ff"),
-                )],
-                success: false,
-            }
-        }
-    }
-
-    impl ReceiptProvider for MockProvider {
-        fn receipt(&self, _id: TxNumber) -> ProviderResult<Option<Receipt>> {
-            Ok(Some(MockProvider::receipt()))
-        }
-
-        // return receipt with burn log
-        fn receipt_by_hash(&self, _hash: TxHash) -> ProviderResult<Option<Receipt>> {
-            // encoded values (amount, destination, version)
-            let amount =
-                ethabi::Token::Uint(ethabi::ethereum_types::U256::from(10_000_000_000_000_u64));
-            let destination =
-                ethabi::Token::String("mrpkDJFJdNGA22FaxCWw6T9oXogXfHU1rh".to_string());
-            let version = ethabi::Token::Bytes(vec![0]);
-            let payload = ethabi::encode(&[amount, destination, version]);
-
-            let log = Log {
-                address: *MINT_CONTRACT_ADDRESS,
-                data: LogData::new(
-                    vec![
-                        *BURN_TOPIC,
-                        // msg.sender
-                        B256::from(hex!(
-                            "000000000000000000000000a65812bac44dadb79c3e4930dbd98d5a75376b2a"
-                        )),
-                    ],
-                    Bytes::copy_from_slice(payload.as_slice()),
-                )
-                .unwrap(),
-            };
-
-            let mut receipt = MockProvider::receipt();
-            receipt.logs = vec![log];
-
-            Ok(Some(receipt))
-        }
-
-        fn receipts_by_block(
-            &self,
-            _block: BlockHashOrNumber,
-        ) -> ProviderResult<Option<Vec<Receipt>>> {
-            Ok(Some(vec![MockProvider::receipt()]))
-        }
-
-        fn receipts_by_tx_range(
-            &self,
-            _range: impl RangeBounds<TxNumber>,
-        ) -> ProviderResult<Vec<Receipt>> {
-            Ok(vec![MockProvider::receipt()])
-        }
-    }
 
     fn create_random_pegout_id() -> PegoutId {
         let mut rng = thread_rng();
@@ -1346,7 +1267,7 @@ mod tests {
         psbt.outputs[0].set_pegout_id(pegout_id);
 
         let result =
-            validate_psbt_by_ids(MockProvider::new(), bitcoin::Network::Regtest, &psbt).await;
+            validate_psbt_by_ids(&MockProvider::default(), bitcoin::Network::Regtest, &psbt).await;
         println!("Result: {:?}", result);
         assert!(result.is_ok());
     }
@@ -1379,7 +1300,7 @@ mod tests {
         psbt.outputs[1].set_pegout_id(pegout_id);
 
         let result =
-            validate_psbt_by_ids(MockProvider::new(), bitcoin::Network::Regtest, &psbt).await;
+            validate_psbt_by_ids(&MockProvider::default(), bitcoin::Network::Regtest, &psbt).await;
 
         assert!(result.is_err());
         // This error should now be due to duplicate pegout IDs, which is checked before
@@ -1395,7 +1316,7 @@ mod tests {
     #[tokio::test]
     async fn test_validate_psbt_by_ids_mismatched_lengths_and_multiple_change() {
         let btc_network = bitcoin::Network::Regtest;
-        let mock_provider = MockProvider::new();
+        let mock_provider = MockProvider::default();
         let base_destination = bitcoin::Address::from_str("mrpkDJFJdNGA22FaxCWw6T9oXogXfHU1rh")
             .expect("valid address")
             .assume_checked();
@@ -1416,7 +1337,7 @@ mod tests {
             });
             // Now psbt.outputs.len() == 1, but psbt.unsigned_tx.output.len() == 2
 
-            let result = validate_psbt_by_ids(mock_provider.clone(), btc_network, &psbt).await;
+            let result = validate_psbt_by_ids(&mock_provider, btc_network, &psbt).await;
             assert!(result.is_err(), "Scenario A: Mismatched lengths should error");
             assert_eq!(
                 result.unwrap_err(),
@@ -1479,7 +1400,7 @@ mod tests {
             // psbt.outputs[1] and psbt.outputs[2] have no pegout_id, so they count as change
             // outputs.
 
-            let result = validate_psbt_by_ids(mock_provider.clone(), btc_network, &psbt).await;
+            let result = validate_psbt_by_ids(&mock_provider, btc_network, &psbt).await;
             assert!(result.is_err(), "Scenario B: Multiple change outputs should error");
             assert_eq!(
                 result.unwrap_err(),

--- a/crates/consensus/authority/src/utils.rs
+++ b/crates/consensus/authority/src/utils.rs
@@ -1783,7 +1783,7 @@ mod tests {
     fn test_validate_psbt_id_by_maximum_cutoff_age_outside_cutoff() {
         let pegout_id = PegoutId::new([0; 32], 0);
 
-        // Inalid case: MockProvider::default() returns a timestamp of 0
+        // Invalid case: MockProvider::default() returns a timestamp of 0
         assert!(
             validate_psbt_id_by_maximum_cutoff_age(&pegout_id, &MockProvider::default()).is_err()
         );

--- a/crates/consensus/authority/src/utils.rs
+++ b/crates/consensus/authority/src/utils.rs
@@ -540,7 +540,7 @@ pub enum PsbtValidationError {
     FailedToGetTransactionByPegoutId(String),
     /// Failed to get block for pegout id
     #[error("Failed to get block for pegout id: {0}")]
-    FailedToGetBlockForPegoutId(String),
+    FailedToGetHeaderForPegoutId(String),
     /// Failed to validate pegout id by maximum cutoff age
     #[error("Pegout ID outside the maximum cutoff age: {0}")]
     PegoutIdOutsideMaximumCutoffAge(String),
@@ -754,25 +754,25 @@ pub fn validate_psbt_id_by_maximum_cutoff_age(
             ))
         })?;
 
-    // Get the timestamp of the block that contains the transaction
-    let block_timestamp = client
+    // Get the timestamp of the header that contains the transaction
+    let header_timestamp = client
         .header_by_number(tx.block_number)
         .map_err(|e| {
-            error!(target: "consensus::authority::frost_task::validate_psbt_ids_by_maximum_cutoff_age", "Failed to get block by number {:?}: {:?}", tx.block_number, e);
-            PsbtValidationError::FailedToGetBlockForPegoutId(format!(
-                "Failed to get block by number from database {:?}",
+            error!(target: "consensus::authority::frost_task::validate_psbt_ids_by_maximum_cutoff_age", "Failed to get header by number {:?}: {:?}", tx.block_number, e);
+            PsbtValidationError::FailedToGetHeaderForPegoutId(format!(
+                "Failed to get header by number from database {:?}",
                 tx.block_number
             ))
         })?
         .ok_or_else(|| {
-            error!(target: "consensus::authority::frost_task::validate_psbt_ids_by_maximum_cutoff_age", "Block not found for transaction {:?}", tx);
-            PsbtValidationError::FailedToGetBlockForPegoutId(format!(
-                "Block not found for pegout id {:?}",
+            error!(target: "consensus::authority::frost_task::validate_psbt_ids_by_maximum_cutoff_age", "Header not found for transaction {:?}", tx);
+            PsbtValidationError::FailedToGetHeaderForPegoutId(format!(
+                "Header not found for pegout id {:?}",
                 tx.tx_hash
             ))
         })?.timestamp;
 
-    if !is_block_age_acceptable(block_timestamp, *MAX_BLOCK_TS_CUTOFF_DURATION) {
+    if !is_block_age_acceptable(header_timestamp, *MAX_BLOCK_TS_CUTOFF_DURATION) {
         error!(target: "consensus::authority::frost_task::validate_psbt_ids_by_maximum_cutoff_age", "Pegout id: {:?} is outside the maximum cutoff range", tx.tx_hash);
         return Err(PsbtValidationError::PegoutIdOutsideMaximumCutoffAge(format!(
             "Pegout id: {:?} is outside the maximum cutoff range",

--- a/crates/consensus/authority/src/utils.rs
+++ b/crates/consensus/authority/src/utils.rs
@@ -23,7 +23,7 @@ use reth_primitives::{
     constants::EPOCH_LENGTH,
     Bloom, BloomInput,
 };
-use reth_provider::{BlockReaderIdExt, ReceiptProvider};
+use reth_provider::{BlockReaderIdExt, ReceiptProvider, TransactionsProvider};
 use reth_revm::primitives::FixedBytes;
 use reth_rpc_types::BlockHashOrNumber;
 use std::{
@@ -32,6 +32,8 @@ use std::{
 };
 use tracing::{error, info, warn};
 use uuid::Uuid;
+
+use crate::wallet_state_sync::MAX_BLOCK_TS_CUTOFF_DURATION;
 
 /// Checks if the network is undergoing an active sync or not
 pub fn is_active_sync_in_progress(network_handle: &NetworkHandle) -> bool {
@@ -530,9 +532,18 @@ pub fn is_known_minting_contract(
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 /// Represents errors that can occur during psbt validation
 pub enum PsbtValidationError {
-    #[error("Failed to validate psbt by ids: {0}")]
     /// Failed to validate psbt by ids
+    #[error("Failed to validate psbt by ids: {0}")]
     FailedToValidatePsbtByIds(String),
+    /// Failed to get transaction by pegout id
+    #[error("Failed to get transaction by pegout id: {0}")]
+    FailedToGetTransactionByPegoutId(String),
+    /// Failed to get block for pegout id
+    #[error("Failed to get block for pegout id: {0}")]
+    FailedToGetBlockForPegoutId(String),
+    /// Failed to validate pegout id by maximum cutoff age
+    #[error("Pegout ID outside the maximum cutoff age: {0}")]
+    PegoutIdOutsideMaximumCutoffAge(String),
 }
 
 /// Extract pegouts ids from psbt
@@ -584,8 +595,8 @@ pub fn validate_psbt_by_output(
 /// receipt database.
 ///
 /// This function extracts pegout IDs from the PSBT, retrieves the corresponding
-/// pegout data from the database, and validates each output's destination and
-/// amount.
+/// pegout data from the database, validates each output's destination and
+/// amount, and enforces a maximum age for pending pegouts in the psbt.
 ///
 /// # Warning
 ///
@@ -600,7 +611,7 @@ pub fn validate_psbt_by_output(
 // TODO(lamafab): All those responsibilities SHOULD be handled in one place,
 // ideally by a single function.
 pub async fn validate_psbt_by_ids(
-    client: impl ReceiptProvider + Clone,
+    client: &(impl ReceiptProvider + TransactionsProvider + BlockReaderIdExt + Clone),
     btc_network: bitcoin::Network,
     psbt: &Psbt,
 ) -> Result<(), PsbtValidationError> {
@@ -630,6 +641,15 @@ pub async fn validate_psbt_by_ids(
             )));
         }
     }
+
+    // Verify that each pegout is within the maximum cutoff age.
+    // The coordinator and signers should not create nor sign a PSBT if any of the pending pegouts
+    // are older than the maximum cutoff age. The coordinator and signers only store the most recent
+    // maximum cutoff age of finalized pegouts against which the PSBT is validated. This
+    // prevents having to store an unbounded list of finalized pegouts.
+    pegout_ids
+        .iter()
+        .try_for_each(|(_, pegout_id)| validate_psbt_id_by_maximum_cutoff_age(pegout_id, client))?;
 
     // Verify that there is at most one change output
     // and that all outputs are either a validated pegout or the single change output.
@@ -700,6 +720,64 @@ pub async fn validate_psbt_by_ids(
         )?;
 
         validate_psbt_by_output(tx_out, &destination, amount, fee_per_output)?;
+    }
+
+    Ok(())
+}
+
+/// Validates the pegout ID against the maximum cutoff age.
+/// This function checks if the pegout ID's transaction is within the acceptable age limit.
+/// # Arguments
+/// * `pegout_id` - The pegout ID to validate.
+/// * `client` - The client to use for fetching the transaction by pegout ID.
+/// # Returns
+/// Returns `Ok(())` if the pegout ID is valid, otherwise returns a `PsbtValidationError`.
+pub fn validate_psbt_id_by_maximum_cutoff_age(
+    pegout_id: &PegoutId,
+    client: &(impl ReceiptProvider + TransactionsProvider + BlockReaderIdExt + Clone),
+) -> Result<(), PsbtValidationError> {
+    // Get the transaction by pegout id
+    let (_, tx) = client
+        .transaction_by_hash_with_meta(pegout_id.txid.into())
+        .map_err(|e| {
+            error!(target: "consensus::authority::frost_task::validate_psbt_ids_by_maximum_cutoff_age", "Failed to get transaction by pegout id {:?}: {:?}", pegout_id, e);
+            PsbtValidationError::FailedToGetTransactionByPegoutId(format!(
+                "Failed to get transaction by pegout id from database {:?}",
+                pegout_id.txid
+            ))
+        })?
+        .ok_or_else(|| {
+            error!(target: "consensus::authority::frost_task::validate_psbt_ids_by_maximum_cutoff_age", "Transaction not found for pegout id {:?}", pegout_id);
+            PsbtValidationError::FailedToGetTransactionByPegoutId(format!(
+                "Transaction not found for pegout id {:?}",
+                pegout_id.txid
+            ))
+        })?;
+
+    // Get the timestamp of the block that contains the transaction
+    let block_timestamp = client
+        .block_by_number(tx.block_number)
+        .map_err(|e| {
+            error!(target: "consensus::authority::frost_task::validate_psbt_ids_by_maximum_cutoff_age", "Failed to get block by number {:?}: {:?}", tx.block_number, e);
+            PsbtValidationError::FailedToGetBlockForPegoutId(format!(
+                "Failed to get block by number from database {:?}",
+                tx.block_number
+            ))
+        })?
+        .ok_or_else(|| {
+            error!(target: "consensus::authority::frost_task::validate_psbt_ids_by_maximum_cutoff_age", "Block not found for transaction {:?}", tx);
+            PsbtValidationError::FailedToGetBlockForPegoutId(format!(
+                "Block not found for pegout id {:?}",
+                tx.tx_hash
+            ))
+        })?.timestamp;
+
+    if !is_block_age_acceptable(block_timestamp, *MAX_BLOCK_TS_CUTOFF_DURATION) {
+        error!(target: "consensus::authority::frost_task::validate_psbt_ids_by_maximum_cutoff_age", "Pegout id: {:?} is outside the maximum cutoff range", tx.tx_hash);
+        return Err(PsbtValidationError::PegoutIdOutsideMaximumCutoffAge(format!(
+            "Pegout id: {:?} is outside the maximum cutoff range",
+            tx.tx_hash
+        )));
     }
 
     Ok(())

--- a/crates/consensus/authority/src/utils.rs
+++ b/crates/consensus/authority/src/utils.rs
@@ -1266,8 +1266,14 @@ mod tests {
         let pegout_id = PegoutId::new([0u8; 32], 0).as_bytes();
         psbt.outputs[0].set_pegout_id(pegout_id);
 
-        let result =
-            validate_psbt_by_ids(&MockProvider::default(), bitcoin::Network::Regtest, &psbt).await;
+        let mock_provider = MockProvider::default().set_timestamp(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_else(|_| Duration::from_secs(0))
+                .as_secs(),
+        );
+
+        let result = validate_psbt_by_ids(&mock_provider, bitcoin::Network::Regtest, &psbt).await;
         println!("Result: {:?}", result);
         assert!(result.is_ok());
     }
@@ -1316,7 +1322,12 @@ mod tests {
     #[tokio::test]
     async fn test_validate_psbt_by_ids_mismatched_lengths_and_multiple_change() {
         let btc_network = bitcoin::Network::Regtest;
-        let mock_provider = MockProvider::default();
+        let mock_provider = MockProvider::default().set_timestamp(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_else(|_| Duration::from_secs(0))
+                .as_secs(),
+        );
         let base_destination = bitcoin::Address::from_str("mrpkDJFJdNGA22FaxCWw6T9oXogXfHU1rh")
             .expect("valid address")
             .assume_checked();
@@ -1753,5 +1764,28 @@ mod tests {
         let pending2 = get_pending_pegouts_from_pegout_data(&pegouts, height, now);
 
         assert_eq!(pending1, pending2);
+    }
+
+    #[test]
+    fn test_validate_psbt_id_by_maximum_cutoff_age_within_cutoff() {
+        let pegout_id = PegoutId::new([0; 32], 0);
+        let mock_provider = MockProvider::default().set_timestamp(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_else(|_| Duration::from_secs(0))
+                .as_secs(),
+        );
+
+        assert!(validate_psbt_id_by_maximum_cutoff_age(&pegout_id, &mock_provider).is_ok());
+    }
+
+    #[test]
+    fn test_validate_psbt_id_by_maximum_cutoff_age_outside_cutoff() {
+        let pegout_id = PegoutId::new([0; 32], 0);
+
+        // Inalid case: MockProvider::default() returns a timestamp of 0
+        assert!(
+            validate_psbt_id_by_maximum_cutoff_age(&pegout_id, &MockProvider::default()).is_err()
+        );
     }
 }

--- a/crates/consensus/authority/src/wallet_state_sync.rs
+++ b/crates/consensus/authority/src/wallet_state_sync.rs
@@ -40,7 +40,9 @@ use uuid::Uuid;
 
 const MAX_BLOCK_TS_CUTOFF_DURATION_SECS: u64 = 30 * 24 * 60 * 60 * 3; // 3 months
 
-static MAX_BLOCK_TS_CUTOFF_DURATION: Lazy<Duration> =
+/// Maximum duration for block timestamp cutoff
+/// This is used to determine how far back we should consider finalized pegouts when syncing.
+pub static MAX_BLOCK_TS_CUTOFF_DURATION: Lazy<Duration> =
     Lazy::new(|| Duration::from_secs(MAX_BLOCK_TS_CUTOFF_DURATION_SECS));
 
 #[derive(Debug, thiserror::Error)]


### PR DESCRIPTION
## Issue being fixed or feature implemented
Signers should only sign a psbt that contains pegouts within the last 3 months. The btc-server db is only storing the last 3 months of finalized pegouts so it doesn't store an unbounded list. Signers cross-check the finalized pegouts list when signing to prevent replaying pegouts that have already been honored on the L1. Signers must not sign for any pending pegouts outside of the 3 months window or an older pegout could be replayed.

The btc-server does not have access to the L2 db so cannot do this check.  

## What was done?
- Added `validate_psbt_id_by_maximum_cutoff_age` which is called in `validate_psbt_by_ids` which is called during psbt creation and every round of signing.

## How Has This Been Tested?
- Added unit tests

## Breaking Changes
None

## Checklist:
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have tested my changes running a local network, and they work as expected
- [x] I have performed a self-review
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed