### PR TITLE
fix(rpc): periodically wake up and poll TransactionManager

### DIFF
--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -249,6 +249,8 @@ pub struct TransactionsManager<Pool> {
     max_transactions_seen_by_peer_history: u32,
     /// `TransactionsManager` metrics
     metrics: TransactionsManagerMetrics,
+    // Optional periodic waker task to prevent starvation
+    periodic_waker: Option<tokio::task::JoinHandle<()>>,
 }
 
 impl<Pool: TransactionPool> TransactionsManager<Pool> {
@@ -300,6 +302,7 @@ impl<Pool: TransactionPool> TransactionsManager<Pool> {
             max_transactions_seen_by_peer_history: transactions_manager_config
                 .max_transactions_seen_by_peer_history,
             metrics,
+            periodic_waker: None,
         }
     }
 }
@@ -1240,11 +1243,16 @@ where
         // Temporary fix: this future is sometimes starved and
         // never polled again. This means pending txs are never gossiped to peers.
         // TODO: test after upstream merge and remove if unneeded.
-        let waker = cx.waker().clone();
-        tokio::task::spawn(async move {
-            tokio::time::sleep(Duration::from_secs(3)).await;
-            waker.wake_by_ref();
-        });
+        if this.periodic_waker.is_none() {
+            let waker = cx.waker().clone();
+            this.periodic_waker = Some(tokio::spawn(async move {
+                let mut interval = tokio::time::interval(Duration::from_secs(3));
+                loop {
+                    interval.tick().await;
+                    waker.wake_by_ref();
+                }
+            }));
+        }
 
         // All streams are polled until their corresponding budget is exhausted, then we manually
         // yield back control to tokio. See `NetworkManager` for more context on the design

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -1236,6 +1236,16 @@ where
 
         let this = self.get_mut();
 
+        // Ensure periodic wake-up in case of starvation
+        // Temporary fix: this future is sometimes starved and
+        // never polled again. This means pending txs are never gossiped to peers.
+        // TODO: test after upstream merge and remove if unneeded.
+        let waker = cx.waker().clone();
+        tokio::task::spawn(async move {
+            tokio::time::sleep(Duration::from_secs(3)).await;
+            waker.wake_by_ref();
+        });
+
         // All streams are polled until their corresponding budget is exhausted, then we manually
         // yield back control to tokio. See `NetworkManager` for more context on the design
         // pattern.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
RPC nodes sometimes don't gossip their pending txs. This could be bc the future that handles this functionality is starved.
I was not able to reproduce this locally.

Another cause could be the node doesn't gossip the pending txs successfully but thinks it has.

## What was done?
<!--- Describe your changes in detail -->
- Every 3 seconds wake the future so it's queues (including pending txs) are drained and pending txs are gossiped.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- I've tested this locally.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
- None

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have tested my changes running a local network, and they work as expected
- [x] I have performed a self-review
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed
- [x] I have added assignees and reviewers to this pull request
- [x] I have added the PR to the project board or linked it to an issue from the board
