### PR TITLE
feature(priority-fee): set default to 0.01 gwei

### DIFF
--- a/crates/primitives-traits/src/constants/mod.rs
+++ b/crates/primitives-traits/src/constants/mod.rs
@@ -99,6 +99,9 @@ pub const BASE_SEPOLIA_EIP1559_DEFAULT_ELASTICITY_MULTIPLIER: u128 = 10;
 /// Multiplier for converting gwei to wei.
 pub const GWEI_TO_WEI: u64 = 1_000_000_000;
 
+/// Default suggested tip of 0.001 GWEI for the Gas Oracle.
+pub const DEFAULT_SUGGESTED_TIP: u64 = 1_000_000;
+
 /// Multiplier for converting finney (milliether) to wei.
 pub const FINNEY_TO_WEI: u128 = (GWEI_TO_WEI as u128) * 1_000_000;
 

--- a/crates/rpc/rpc-eth-types/src/gas_oracle.rs
+++ b/crates/rpc/rpc-eth-types/src/gas_oracle.rs
@@ -4,7 +4,7 @@
 use std::fmt::{self, Debug, Formatter};
 
 use derive_more::{Deref, DerefMut, From, Into};
-use reth_primitives::{constants::GWEI_TO_WEI, BlockNumberOrTag, B256, U256};
+use reth_primitives::{constants::DEFAULT_SUGGESTED_TIP, BlockNumberOrTag, B256, U256};
 use reth_rpc_server_types::constants;
 use reth_storage_api::BlockReaderIdExt;
 use schnellru::{ByLength, LruMap};
@@ -290,7 +290,9 @@ pub struct GasPriceOracleResult {
 
 impl Default for GasPriceOracleResult {
     fn default() -> Self {
-        Self { block_hash: B256::ZERO, price: U256::from(GWEI_TO_WEI) }
+        // Set default to 0.001 GWEI instead of 1 GWEI (previously used GWEI_TO_WEI constant).
+        // The initial base fee is 7 WEI so a default of 1 GWEI is not practical.
+        Self { block_hash: B256::ZERO, price: U256::from(DEFAULT_SUGGESTED_TIP) }
     }
 }
 
@@ -307,6 +309,7 @@ impl Default for GasCap {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use reth_primitives::constants::GWEI_TO_WEI;
 
     #[test]
     fn max_price_sanity() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please provide a link to the issue -->
This PR sets the default `eth_maxPriorityFeePerGas` to 0.01 gwei.
This currently defaults to 1 gwei.
Our initial basefee is 7 wei.  So `eth_gasPrice` would return a suggested gas price of `1_000_000_007` which `1.000000007` gwei.  This is way overpriced so setting the default to 0 would result in a gas price of 7 wei.  The gas price is dynamic but only considers the last 20 blocks (this is a constant that can be changed). Some libraries like ethers may hardcode the priority fee to 1 gwei which we can't control.  But if they hit our node directly they will get the accurate estimate.

For a deeper explanation on how the gas oracle that determines gas price estimates work, you can see the original GH issue from the ethereum repo at https://github.com/ethereum/pm/issues/328#issuecomment-853234014

TL;DR
```
Edit: Geth's gas price oracle retrieves the cheapest 3 transactions from the past X blocks, and uses the 60th percentile as the suggestion for the price. The 60th percentile ensures we're aiming for inclusion in 2-3 blocks, whereas looking at the minimums ensures we're trying to push prices downward instead of up.
```

## What was done?
<!--- Describe your changes in detail -->
- Set the initial `eth_maxPriorityFeePerGas` to 0.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested locally

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
- None

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have tested my changes running a local network, and they work as expected
- [x] I have performed a self-review
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed
- [x] I have added assignees and reviewers to this pull request
- [x] I have added the PR to the project board or linked it to an issue from the board
