### PR TITLE
fix(priority fee): enforce minimum

### DIFF
--- a/bin/reth/src/commands/poa/mod.rs
+++ b/bin/reth/src/commands/poa/mod.rs
@@ -620,6 +620,7 @@ impl<Ext: clap::Args + fmt::Debug> PoaNodeCommand<Ext> {
         let validator =
             TransactionValidationTaskExecutor::eth_builder(Arc::clone(&chain_arc.clone()))
                 .with_head_timestamp(head.timestamp)
+                .with_minimum_priority_fee(self.txpool.minimum_priority_fee)
                 .with_additional_tasks(1)
                 .build_with_tasks(blockchain_db.clone(), executor.clone(), blob_store.clone());
 

--- a/crates/node/core/src/args/txpool.rs
+++ b/crates/node/core/src/args/txpool.rs
@@ -2,7 +2,7 @@
 
 use crate::cli::config::RethTransactionPoolConfig;
 use clap::Args;
-use reth_primitives::Address;
+use reth_primitives::{constants::DEFAULT_SUGGESTED_TIP, Address};
 use reth_transaction_pool::{
     blobstore::disk::DEFAULT_MAX_CACHED_BLOBS,
     pool::{NEW_TX_LISTENER_BUFFER_SIZE, PENDING_TX_LISTENER_BUFFER_SIZE},
@@ -80,8 +80,12 @@ pub struct TxPoolArgs {
 
     /// Minimum priority fee required for transaction acceptance into the pool.
     /// Transactions with priority fee below this value will be rejected.
-    #[arg(long = "txpool.minimum-priority-fee")]
-    pub minimum_priority_fee: Option<u128>,
+    #[arg(
+        long = "txpool.minimum-priority-fee",
+        alias = "txpool.minimum_priority_fee",
+        default_value_t = DEFAULT_SUGGESTED_TIP
+    )]
+    pub minimum_priority_fee: u128,
 }
 
 impl Default for TxPoolArgs {
@@ -104,7 +108,7 @@ impl Default for TxPoolArgs {
             additional_validation_tasks: DEFAULT_TXPOOL_ADDITIONAL_VALIDATION_TASKS,
             pending_tx_listener_buffer_size: PENDING_TX_LISTENER_BUFFER_SIZE,
             new_tx_listener_buffer_size: NEW_TX_LISTENER_BUFFER_SIZE,
-            minimum_priority_fee: None,
+            minimum_priority_fee: DEFAULT_SUGGESTED_TIP,
         }
     }
 }

--- a/crates/node/core/src/args/txpool.rs
+++ b/crates/node/core/src/args/txpool.rs
@@ -77,6 +77,11 @@ pub struct TxPoolArgs {
     /// Maximum number of new transactions to buffer
     #[arg(long = "txpool.max-new-txns", alias = "txpool.max_new_txns", default_value_t = NEW_TX_LISTENER_BUFFER_SIZE)]
     pub new_tx_listener_buffer_size: usize,
+
+    /// Minimum priority fee required for transaction acceptance into the pool.
+    /// Transactions with priority fee below this value will be rejected.
+    #[arg(long = "txpool.minimum-priority-fee")]
+    pub minimum_priority_fee: Option<u128>,
 }
 
 impl Default for TxPoolArgs {
@@ -99,6 +104,7 @@ impl Default for TxPoolArgs {
             additional_validation_tasks: DEFAULT_TXPOOL_ADDITIONAL_VALIDATION_TASKS,
             pending_tx_listener_buffer_size: PENDING_TX_LISTENER_BUFFER_SIZE,
             new_tx_listener_buffer_size: NEW_TX_LISTENER_BUFFER_SIZE,
+            minimum_priority_fee: None,
         }
     }
 }
@@ -135,6 +141,7 @@ impl RethTransactionPoolConfig for TxPoolArgs {
             },
             pending_tx_listener_buffer_size: self.pending_tx_listener_buffer_size,
             new_tx_listener_buffer_size: self.new_tx_listener_buffer_size,
+            minimum_priority_fee: self.minimum_priority_fee,
         }
     }
 }

--- a/crates/primitives-traits/src/constants/mod.rs
+++ b/crates/primitives-traits/src/constants/mod.rs
@@ -99,8 +99,8 @@ pub const BASE_SEPOLIA_EIP1559_DEFAULT_ELASTICITY_MULTIPLIER: u128 = 10;
 /// Multiplier for converting gwei to wei.
 pub const GWEI_TO_WEI: u64 = 1_000_000_000;
 
-/// Default suggested tip of 0.001 GWEI for the Gas Oracle.
-pub const DEFAULT_SUGGESTED_TIP: u64 = 1_000_000;
+/// Default suggested tip of 0.025 GWEI for the Gas Oracle.
+pub const DEFAULT_SUGGESTED_TIP: u128 = 25_000_000;
 
 /// Multiplier for converting finney (milliether) to wei.
 pub const FINNEY_TO_WEI: u128 = (GWEI_TO_WEI as u128) * 1_000_000;

--- a/crates/rpc/rpc-eth-types/src/error.rs
+++ b/crates/rpc/rpc-eth-types/src/error.rs
@@ -394,6 +394,12 @@ pub enum RpcInvalidTransactionError {
     /// EIP-7702 transaction has invalid fields set.
     #[error("EIP-7702 authorization list has invalid fields")]
     AuthorizationListInvalidFields,
+    /// Transaction priority fee is below the minimum required priority fee.
+    #[error("transaction priority fee below minimum required priority fee {minimum_priority_fee}")]
+    PriorityFeeBelowMinimum {
+        /// Minimum required priority fee.
+        minimum_priority_fee: u128,
+    },
     /// Any other error
     #[error("{0}")]
     Other(Box<dyn ToRpcError>),
@@ -665,6 +671,11 @@ impl From<InvalidPoolTransactionError> for RpcPoolError {
             InvalidPoolTransactionError::Eip4844(err) => Self::Eip4844(err),
             InvalidPoolTransactionError::Overdraft => {
                 Self::Invalid(RpcInvalidTransactionError::InsufficientFunds)
+            }
+            InvalidPoolTransactionError::PriorityFeeBelowMinimum { minimum_priority_fee } => {
+                Self::Invalid(RpcInvalidTransactionError::PriorityFeeBelowMinimum {
+                    minimum_priority_fee,
+                })
             }
         }
     }

--- a/crates/rpc/rpc-eth-types/src/gas_oracle.rs
+++ b/crates/rpc/rpc-eth-types/src/gas_oracle.rs
@@ -290,7 +290,7 @@ pub struct GasPriceOracleResult {
 
 impl Default for GasPriceOracleResult {
     fn default() -> Self {
-        // Set default to 0.001 GWEI instead of 1 GWEI (previously used GWEI_TO_WEI constant).
+        // Set default to 0.025 GWEI instead of 1 GWEI (previously used GWEI_TO_WEI constant).
         // The initial base fee is 7 WEI so a default of 1 GWEI is not practical.
         Self { block_hash: B256::ZERO, price: U256::from(DEFAULT_SUGGESTED_TIP) }
     }

--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -40,7 +40,7 @@ pub struct PoolConfig {
     /// Price bump (in %) for the transaction pool underpriced check.
     pub price_bumps: PriceBumpConfig,
     /// Minimum priority fee required for transaction acceptance into the pool.
-    pub minimum_priority_fee: Option<u128>,
+    pub minimum_priority_fee: u128,
     /// How to handle locally received transactions:
     /// [`TransactionOrigin::Local`](crate::TransactionOrigin).
     pub local_transactions_config: LocalTransactionConfig,
@@ -70,7 +70,7 @@ impl Default for PoolConfig {
             blob_limit: Default::default(),
             max_account_slots: TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
             price_bumps: Default::default(),
-            minimum_priority_fee: None,
+            minimum_priority_fee: Default::default(),
             local_transactions_config: Default::default(),
             pending_tx_listener_buffer_size: PENDING_TX_LISTENER_BUFFER_SIZE,
             new_tx_listener_buffer_size: NEW_TX_LISTENER_BUFFER_SIZE,

--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -39,6 +39,8 @@ pub struct PoolConfig {
     pub max_account_slots: usize,
     /// Price bump (in %) for the transaction pool underpriced check.
     pub price_bumps: PriceBumpConfig,
+    /// Minimum priority fee required for transaction acceptance into the pool.
+    pub minimum_priority_fee: Option<u128>,
     /// How to handle locally received transactions:
     /// [`TransactionOrigin::Local`](crate::TransactionOrigin).
     pub local_transactions_config: LocalTransactionConfig,
@@ -68,6 +70,7 @@ impl Default for PoolConfig {
             blob_limit: Default::default(),
             max_account_slots: TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
             price_bumps: Default::default(),
+            minimum_priority_fee: None,
             local_transactions_config: Default::default(),
             pending_tx_listener_buffer_size: PENDING_TX_LISTENER_BUFFER_SIZE,
             new_tx_listener_buffer_size: NEW_TX_LISTENER_BUFFER_SIZE,

--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -205,6 +205,12 @@ pub enum InvalidPoolTransactionError {
     /// invocation.
     #[error("intrinsic gas too low")]
     IntrinsicGasTooLow,
+    /// The transaction priority fee is below the minimum required priority fee.
+    #[error("transaction priority fee below minimum required priority fee {minimum_priority_fee}")]
+    PriorityFeeBelowMinimum {
+        /// Minimum required priority fee.
+        minimum_priority_fee: u128,
+    },
 }
 
 // === impl InvalidPoolTransactionError ===
@@ -289,6 +295,7 @@ impl InvalidPoolTransactionError {
                     }
                 }
             }
+            Self::PriorityFeeBelowMinimum { .. } => false,
         }
     }
 

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -124,7 +124,7 @@ pub(crate) struct EthTransactionValidatorInner<Client, T> {
     /// The current max gas limit
     block_gas_limit: u64,
     /// Minimum priority fee to enforce for acceptance into the pool.
-    minimum_priority_fee: Option<u128>,
+    minimum_priority_fee: u128,
     /// Stores the setup and parameters needed for validating KZG proofs.
     kzg_settings: EnvKzgSettings,
     /// How to handle [`TransactionOrigin::Local`](TransactionOrigin) transactions.
@@ -248,14 +248,12 @@ where
         // the pool.
         if !self.local_transactions_config.is_local(origin, transaction.sender()) &&
             transaction.is_eip1559() &&
-            transaction.max_priority_fee_per_gas() < self.minimum_priority_fee
+            transaction.max_priority_fee_per_gas() < Some(self.minimum_priority_fee)
         {
             return TransactionValidationOutcome::Invalid(
                 transaction,
                 InvalidPoolTransactionError::PriorityFeeBelowMinimum {
-                    minimum_priority_fee: self
-                        .minimum_priority_fee
-                        .expect("minimum priority fee is expected inside if statement"),
+                    minimum_priority_fee: self.minimum_priority_fee,
                 },
             );
         }
@@ -458,7 +456,7 @@ pub struct EthTransactionValidatorBuilder {
     /// The current max gas limit
     block_gas_limit: u64,
     /// Minimum priority fee to enforce for acceptance into the pool.
-    minimum_priority_fee: Option<u128>,
+    minimum_priority_fee: u128,
     /// Determines how many additional tasks to spawn
     ///
     /// Default is 1
@@ -485,7 +483,7 @@ impl EthTransactionValidatorBuilder {
         Self {
             block_gas_limit: chain_spec.max_gas_limit,
             chain_spec,
-            minimum_priority_fee: None,
+            minimum_priority_fee: Default::default(),
             additional_tasks: 1,
             kzg_settings: EnvKzgSettings::Default,
             local_transactions_config: Default::default(),
@@ -590,7 +588,7 @@ impl EthTransactionValidatorBuilder {
     }
 
     /// Sets a minimum priority fee that's enforced for acceptance into the pool.
-    pub const fn with_minimum_priority_fee(mut self, minimum_priority_fee: Option<u128>) -> Self {
+    pub const fn with_minimum_priority_fee(mut self, minimum_priority_fee: u128) -> Self {
         self.minimum_priority_fee = minimum_priority_fee;
         self
     }
@@ -899,7 +897,7 @@ mod tests {
     // Helper function to create a validator with minimum priority fee
     fn create_validator_with_minimum_fee(
         provider: MockEthProvider,
-        minimum_priority_fee: Option<u128>,
+        minimum_priority_fee: u128,
         local_config: Option<LocalTransactionConfig>,
     ) -> EthTransactionValidator<MockEthProvider, EthPooledTransaction> {
         let blob_store = InMemoryBlobStore::default();
@@ -924,8 +922,7 @@ mod tests {
         let minimum_priority_fee =
             transaction.max_priority_fee_per_gas().expect("priority fee is expected") * 2;
 
-        let validator =
-            create_validator_with_minimum_fee(provider, Some(minimum_priority_fee), None);
+        let validator = create_validator_with_minimum_fee(provider, minimum_priority_fee, None);
 
         // External transaction should be rejected due to low priority fee
         let outcome = validator.validate_one(TransactionOrigin::External, transaction.clone());
@@ -958,7 +955,7 @@ mod tests {
         // Local transactions should still be accepted regardless of minimum priority fee
         let (_, local_provider) = setup_priority_fee_test();
         let validator_local =
-            create_validator_with_minimum_fee(local_provider, Some(minimum_priority_fee), None);
+            create_validator_with_minimum_fee(local_provider, minimum_priority_fee, None);
 
         let local_outcome = validator_local.validate_one(TransactionOrigin::Local, transaction);
         assert!(local_outcome.is_valid());
@@ -971,7 +968,7 @@ mod tests {
         // Set minimum priority fee equal to transaction's priority fee
         let tx_priority_fee =
             transaction.max_priority_fee_per_gas().expect("priority fee is expected");
-        let validator = create_validator_with_minimum_fee(provider, Some(tx_priority_fee), None);
+        let validator = create_validator_with_minimum_fee(provider, tx_priority_fee, None);
 
         let outcome = validator.validate_one(TransactionOrigin::External, transaction);
         assert!(outcome.is_valid());
@@ -986,8 +983,7 @@ mod tests {
             transaction.max_priority_fee_per_gas().expect("priority fee is expected");
         let minimum_priority_fee = tx_priority_fee / 2; // Half of transaction's priority fee
 
-        let validator =
-            create_validator_with_minimum_fee(provider, Some(minimum_priority_fee), None);
+        let validator = create_validator_with_minimum_fee(provider, minimum_priority_fee, None);
 
         let outcome = validator.validate_one(TransactionOrigin::External, transaction);
         assert!(outcome.is_valid());
@@ -998,7 +994,7 @@ mod tests {
         let (transaction, provider) = setup_priority_fee_test();
 
         // No minimum priority fee set (default is None)
-        let validator = create_validator_with_minimum_fee(provider, None, None);
+        let validator = create_validator_with_minimum_fee(provider, 0, None);
 
         let outcome = validator.validate_one(TransactionOrigin::External, transaction);
         assert!(outcome.is_valid());
@@ -1012,8 +1008,7 @@ mod tests {
         let minimum_priority_fee =
             transaction.max_priority_fee_per_gas().expect("priority fee is expected") * 2;
 
-        let validator =
-            create_validator_with_minimum_fee(provider, Some(minimum_priority_fee), None);
+        let validator = create_validator_with_minimum_fee(provider, minimum_priority_fee, None);
 
         // Private transactions are also subject to minimum priority fee validation
         // because they are not considered "local" by default unless specifically configured
@@ -1041,11 +1036,8 @@ mod tests {
         let local_config =
             LocalTransactionConfig { propagate_local_transactions: true, ..Default::default() };
 
-        let validator = create_validator_with_minimum_fee(
-            provider,
-            Some(minimum_priority_fee),
-            Some(local_config),
-        );
+        let validator =
+            create_validator_with_minimum_fee(provider, minimum_priority_fee, Some(local_config));
 
         // With appropriate local config, the behavior depends on the local transaction logic
         // This test documents the current behavior - private transactions are still validated

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -252,8 +252,12 @@ where
         {
             return TransactionValidationOutcome::Invalid(
                 transaction,
-                InvalidPoolTransactionError::Underpriced,
-            )
+                InvalidPoolTransactionError::PriorityFeeBelowMinimum {
+                    minimum_priority_fee: self
+                        .minimum_priority_fee
+                        .expect("minimum priority fee is expected inside if statement"),
+                },
+            );
         }
 
         // Checks for chainid
@@ -586,8 +590,8 @@ impl EthTransactionValidatorBuilder {
     }
 
     /// Sets a minimum priority fee that's enforced for acceptance into the pool.
-    pub const fn with_minimum_priority_fee(mut self, minimum_priority_fee: u128) -> Self {
-        self.minimum_priority_fee = Some(minimum_priority_fee);
+    pub const fn with_minimum_priority_fee(mut self, minimum_priority_fee: Option<u128>) -> Self {
+        self.minimum_priority_fee = minimum_priority_fee;
         self
     }
 
@@ -879,5 +883,174 @@ mod tests {
         ));
         let tx = pool.get(transaction.hash());
         assert!(tx.is_none());
+    }
+
+    // Helper function to set up common test infrastructure for priority fee tests
+    fn setup_priority_fee_test() -> (EthPooledTransaction, MockEthProvider) {
+        let transaction = get_transaction();
+        let provider = MockEthProvider::default();
+        provider.add_account(
+            transaction.sender(),
+            ExtendedAccount::new(transaction.nonce(), U256::MAX),
+        );
+        (transaction, provider)
+    }
+
+    // Helper function to create a validator with minimum priority fee
+    fn create_validator_with_minimum_fee(
+        provider: MockEthProvider,
+        minimum_priority_fee: Option<u128>,
+        local_config: Option<LocalTransactionConfig>,
+    ) -> EthTransactionValidator<MockEthProvider, EthPooledTransaction> {
+        let blob_store = InMemoryBlobStore::default();
+        let mut builder = EthTransactionValidatorBuilder::new(MAINNET.clone())
+            .with_minimum_priority_fee(minimum_priority_fee);
+
+        if let Some(config) = local_config {
+            builder = builder.with_local_transactions_config(config);
+        }
+
+        builder.build(provider, blob_store)
+    }
+
+    #[tokio::test]
+    async fn invalid_on_priority_fee_lower_than_configured_minimum() {
+        let (transaction, provider) = setup_priority_fee_test();
+
+        // Verify the test transaction is a dynamic fee transaction
+        assert!(transaction.transaction.is_dynamic_fee());
+
+        // Set minimum priority fee to be double the transaction's priority fee
+        let minimum_priority_fee =
+            transaction.max_priority_fee_per_gas().expect("priority fee is expected") * 2;
+
+        let validator =
+            create_validator_with_minimum_fee(provider, Some(minimum_priority_fee), None);
+
+        // External transaction should be rejected due to low priority fee
+        let outcome = validator.validate_one(TransactionOrigin::External, transaction.clone());
+        assert!(outcome.is_invalid());
+
+        if let TransactionValidationOutcome::Invalid(_, err) = outcome {
+            assert!(matches!(
+                err,
+                InvalidPoolTransactionError::PriorityFeeBelowMinimum { minimum_priority_fee: min_fee }
+                if min_fee == minimum_priority_fee
+            ));
+        }
+
+        // Test pool integration
+        let blob_store = InMemoryBlobStore::default();
+        let pool =
+            Pool::new(validator, CoinbaseTipOrdering::default(), blob_store, Default::default());
+
+        let res = pool.add_external_transaction(transaction.clone()).await;
+        assert!(res.is_err());
+        assert!(matches!(
+            res.unwrap_err().kind,
+            PoolErrorKind::InvalidTransaction(
+                InvalidPoolTransactionError::PriorityFeeBelowMinimum { .. }
+            )
+        ));
+        let tx = pool.get(transaction.hash());
+        assert!(tx.is_none());
+
+        // Local transactions should still be accepted regardless of minimum priority fee
+        let (_, local_provider) = setup_priority_fee_test();
+        let validator_local =
+            create_validator_with_minimum_fee(local_provider, Some(minimum_priority_fee), None);
+
+        let local_outcome = validator_local.validate_one(TransactionOrigin::Local, transaction);
+        assert!(local_outcome.is_valid());
+    }
+
+    #[tokio::test]
+    async fn valid_on_priority_fee_equal_to_minimum() {
+        let (transaction, provider) = setup_priority_fee_test();
+
+        // Set minimum priority fee equal to transaction's priority fee
+        let tx_priority_fee =
+            transaction.max_priority_fee_per_gas().expect("priority fee is expected");
+        let validator = create_validator_with_minimum_fee(provider, Some(tx_priority_fee), None);
+
+        let outcome = validator.validate_one(TransactionOrigin::External, transaction);
+        assert!(outcome.is_valid());
+    }
+
+    #[tokio::test]
+    async fn valid_on_priority_fee_above_minimum() {
+        let (transaction, provider) = setup_priority_fee_test();
+
+        // Set minimum priority fee below transaction's priority fee
+        let tx_priority_fee =
+            transaction.max_priority_fee_per_gas().expect("priority fee is expected");
+        let minimum_priority_fee = tx_priority_fee / 2; // Half of transaction's priority fee
+
+        let validator =
+            create_validator_with_minimum_fee(provider, Some(minimum_priority_fee), None);
+
+        let outcome = validator.validate_one(TransactionOrigin::External, transaction);
+        assert!(outcome.is_valid());
+    }
+
+    #[tokio::test]
+    async fn valid_on_minimum_priority_fee_disabled() {
+        let (transaction, provider) = setup_priority_fee_test();
+
+        // No minimum priority fee set (default is None)
+        let validator = create_validator_with_minimum_fee(provider, None, None);
+
+        let outcome = validator.validate_one(TransactionOrigin::External, transaction);
+        assert!(outcome.is_valid());
+    }
+
+    #[tokio::test]
+    async fn priority_fee_validation_applies_to_private_transactions() {
+        let (transaction, provider) = setup_priority_fee_test();
+
+        // Set minimum priority fee to be double the transaction's priority fee
+        let minimum_priority_fee =
+            transaction.max_priority_fee_per_gas().expect("priority fee is expected") * 2;
+
+        let validator =
+            create_validator_with_minimum_fee(provider, Some(minimum_priority_fee), None);
+
+        // Private transactions are also subject to minimum priority fee validation
+        // because they are not considered "local" by default unless specifically configured
+        let outcome = validator.validate_one(TransactionOrigin::Private, transaction);
+        assert!(outcome.is_invalid());
+
+        if let TransactionValidationOutcome::Invalid(_, err) = outcome {
+            assert!(matches!(
+                err,
+                InvalidPoolTransactionError::PriorityFeeBelowMinimum { minimum_priority_fee: min_fee }
+                if min_fee == minimum_priority_fee
+            ));
+        }
+    }
+
+    #[tokio::test]
+    async fn valid_on_local_config_exempts_private_transactions() {
+        let (transaction, provider) = setup_priority_fee_test();
+
+        // Set minimum priority fee to be double the transaction's priority fee
+        let minimum_priority_fee =
+            transaction.max_priority_fee_per_gas().expect("priority fee is expected") * 2;
+
+        // Configure local transactions to include all private transactions
+        let local_config =
+            LocalTransactionConfig { propagate_local_transactions: true, ..Default::default() };
+
+        let validator = create_validator_with_minimum_fee(
+            provider,
+            Some(minimum_priority_fee),
+            Some(local_config),
+        );
+
+        // With appropriate local config, the behavior depends on the local transaction logic
+        // This test documents the current behavior - private transactions are still validated
+        // unless the sender is specifically whitelisted in local_transactions_config
+        let outcome = validator.validate_one(TransactionOrigin::Private, transaction);
+        assert!(outcome.is_invalid()); // Still invalid because sender not in whitelist
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

We want to enforce a minimum priority fee 

This has two main benefits:
- enforcing a minimum will prevent spam
- while txs will still be very cheap, block fees will increase which helps the overall ecosystem of the network
  - node operators will be better rewarded for securing the network
  - more fees will enter the yield contract which is spread across all stakers which rewards participation

tracking issue: https://github.com/botanix-labs/botanix/issues/1074

## What was done?

Added `--txpool.minimum-priority-fee` parameter and set its default to DEFAULT_SUGGESTED_TIP
That default is what the gas oracle uses so it makes sense to make the default at least that value.

## How Has This Been Tested?

Tested locally and ensured our bridge works as expected. The dapp and sidecar both use legacy txs so they aren't impacted by this ticket.  

## Breaking Changes

None. This only rejects txs that don't meet the minimum tip and returns that message so the user can adjust their price.

These change exist upstream in Reth repo:
https://github.com/paradigmxyz/reth/pull/17183

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] I have added or updated relevant unit/integration/functional/e2e tests
-   [x] I have tested my changes running a local network, and they work as expected
-   [x] I have performed a self-review
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
-   [x] I have made corresponding changes to the documentation if needed
-   [x] I have added assignees and reviewers to this pull request
-   [x] I have added the PR to the project board or linked it to an issue from the board
