### PR TITLE
fix(btc-server): added checks for removing already spent or invalid i…

### DIFF
--- a/bin/btc-server/src/bin/main.rs
+++ b/bin/btc-server/src/bin/main.rs
@@ -1285,11 +1285,20 @@ where
             Ok(tx_id) => Ok(Some(tx_id)),
             Err(err) => {
                 let err_msg = err.to_string();
-                if err_msg.contains("already in chain") {
-                    Ok(None)
-                } else {
-                    error!("Failed to broadcast tx: {}", err);
-                    Err(CoordinatorError::FailedToBroadcastTx(err))
+                match err_msg.as_str() {
+                    msg if msg.contains("already in chain") => {
+                        info!("Transaction already in chain, skipping");
+                        Ok(None)
+                    }
+                    msg if msg.contains("tx-invalid-input-missingorspent") => {
+                        error!("Invalid input detected: {}", msg);
+                        self.handle_invalid_inputs(&tx).to_status()?;
+                        Err(CoordinatorError::FailedToBroadcastTx(err))
+                    }
+                    _ => {
+                        error!("Failed to broadcast transaction: {}", err_msg);
+                        Err(CoordinatorError::FailedToBroadcastTx(err))
+                    }
                 }
             }
         }
@@ -2072,6 +2081,27 @@ where
         _req: tonic::Request<rpc::FinalizeSignerRequest>,
     ) -> Result<tonic::Response<rpc::FinalizeSigningResponse>, tonic::Status> {
         panic!("Not used");
+    }
+}
+
+impl<BitcoindClient> App<BitcoindClient> {
+    fn handle_invalid_inputs(&self, tx: &Transaction) -> Result<(), btcserverlib::database::Error> {
+        for input in &tx.input {
+            if let Some(_utxo) = self.db.get_utxo(input.previous_output)? {
+                match self.db.remove_utxo(&input.previous_output) {
+                    Ok(_) => {
+                        info!("Removed spent input: {} from DB", input.previous_output);
+                    }
+                    Err(e) => {
+                        error!(
+                            "Failed to remove spent input: {} from DB: {}",
+                            input.previous_output, e
+                        );
+                    }
+                }
+            }
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
…nputs

<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->
This PR adds a mechanism for removing the spent utxos when a tx fails with an error `tx-invalid-input-missingorspent` by checking every input in the failed tx to see if it's spent and is so, it is being removed.

## Issue being fixed or feature implemented

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please provide a link to the issue -->
This PR fixes the recently seen problems on mainnet of having txs trying to re-use already spent utxos.

## What was done?

<!--- Describe your changes in detail -->
In the btc-server I have added  a mechanism for removing the spent utxos when a tx fails with an error `tx-invalid-input-missingorspent` by checking every input in the failed tx to see if it's spent and is so, it is being removed.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
via CI/CD checks and manually

## Breaking Changes

<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] I have added or updated relevant unit/integration/functional/e2e tests
-   [x] I have tested my changes running a local network, and they work as expected
-   [x] I have performed a self-review
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
-   [x] I have made corresponding changes to the documentation if needed
-   [x] I have added assignees and reviewers to this pull request
-   [x] I have added the PR to the project board or linked it to an issue from the board


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when broadcasting transactions, with more detailed responses for specific error cases.
  * Enhanced cleanup of invalid or missing transaction inputs to ensure better database consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->