### PR TITLE
feat(pegouts): check pending pegout not finalized before storing

### DIFF
--- a/bin/btc-server/src/bin/main.rs
+++ b/bin/btc-server/src/bin/main.rs
@@ -2569,6 +2569,83 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_new_consensus_checkpoint_no_finalized_pegouts_stored() {
+        let app = setup().await;
+        let (shares, pk_package) = trusted_dealer_setup(app.min_signers, app.max_signers);
+        let key_package = frost::keys::KeyPackage::try_from(shares[&app.identifier].clone())
+            .expect("valid key package");
+
+        // Add the key packages
+        app.db.set_pubkey_package(pk_package.clone()).expect("set public key package");
+        app.db.set_key_package(key_package.clone()).expect("set key package");
+
+        // Add some pegin utxos
+        let mut pegins = vec![];
+        for _ in 0..10 {
+            let dummy_tx = create_tx(1, 1, None);
+            let utxo = crate::database::Utxo::new(
+                dummy_tx.input[0].previous_output,
+                dummy_tx.output[0].clone(),
+                None,
+                None,
+            );
+
+            // create pegins btc client can send
+            let tx_out = dummy_tx.output.get(utxo.outpoint.vout as usize).expect("valid vout");
+            let serialized_script_pub_key = bitcoin::consensus::serialize(&tx_out.script_pubkey);
+            let utxo = Utxo {
+                outpoint: Some(rpc::OutPoint {
+                    txid: bitcoin::consensus::serialize(&utxo.outpoint.txid),
+                    vout: utxo.outpoint.vout,
+                }),
+                output: Some(rpc::TxOut {
+                    script_pubkey: Some(rpc::ScriptBuf { script: serialized_script_pub_key }),
+                    value: tx_out.value.to_sat(),
+                }),
+                eth_address: hex::encode(&[0; 20]),
+            };
+            pegins.push(utxo);
+        }
+        let req = tonic::Request::new(rpc::ConsensusCheckpointRequest {
+            checkpoint_block_hash: BlockHash::all_zeros().to_byte_array().to_vec(),
+            pegins: pegins.clone(),
+            pending_pegouts: vec![],
+        });
+        let _res = app.new_consensus_checkpoint(req).await.unwrap();
+
+        // Store finalized pegout
+        let mut rng = thread_rng();
+        let pegout_id = PegoutId::new(rng.gen::<[u8; 32]>(), 0);
+        let finalized_pegout = btcserverlib::database::FinalizedPegout {
+            id: pegout_id,
+            block_number: 100,
+            timestamp: None,
+        };
+        app.db.store_finalized_pegout_ids(&[&finalized_pegout]).expect("valid finalized pegout");
+
+        // Try and store a pending pegout with the the finalized pegout id
+        let pending_pegout = rpc::PendingPegout {
+            pegout_id: finalized_pegout.id.as_bytes().to_vec(),
+            spk: random_p2wpkh_script().as_bytes().to_vec(),
+            amount: 100_000, // sats
+            height: 1,
+            timestamp: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("valid duration")
+                .as_secs(),
+        };
+        let req = tonic::Request::new(rpc::ConsensusCheckpointRequest {
+            checkpoint_block_hash: BlockHash::all_zeros().to_byte_array().to_vec(),
+            pegins: vec![],
+            pending_pegouts: vec![pending_pegout],
+        });
+        let _res = app.new_consensus_checkpoint(req).await.unwrap();
+
+        let pending_pegouts = app.db.get_pending_pegouts().expect("valid pending pegouts");
+        assert!(pending_pegouts.is_empty(), "No pending pegouts should be stored");
+    }
+
+    #[tokio::test]
     async fn test_finalized_pegout_ids_streaming_chunksize_gt_chunks() {
         let app = setup().await;
         let num_txs = 52;

--- a/bin/btc-server/src/bin/main.rs
+++ b/bin/btc-server/src/bin/main.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 extern crate log;
 
+use alloy_primitives::map::HashSet;
 use base64::{engine::general_purpose, Engine};
 use bitcoin::{
     consensus::Decodable, secp256k1, Amount, BlockHash, Psbt, ScriptBuf, Transaction, TxOut,
@@ -759,7 +760,20 @@ where
             .collect::<Result<Vec<PegoutRequest>, tonic::Status>>();
 
         let pegouts = pegouts?;
-        let pegouts_refs: Vec<&PegoutRequest> = pegouts.iter().collect();
+        // Check pegouts are not in the finalized pegout ids list
+        let finalized_pegout_ids: HashSet<_> =
+            self.db.get_finalized_pegout_ids().to_status()?.iter().map(|p| p.id).collect();
+        let pegouts_refs: Vec<&PegoutRequest> = pegouts
+            .iter()
+            .filter(|pegout| {
+                if finalized_pegout_ids.contains(&pegout.id) {
+                    error!("Received a pegout request for finalized id: {:?}", pegout.id);
+                    return false;
+                }
+                true
+            })
+            .collect();
+
         self.db.store_pending_pegouts(&pegouts_refs).to_status()?;
         self.db.flush().to_status()?;
         info!("stored pegouts.len(): {:?}", pegouts.len());

--- a/bin/btc-server/src/bin/main.rs
+++ b/bin/btc-server/src/bin/main.rs
@@ -1,7 +1,6 @@
 #[macro_use]
 extern crate log;
 
-use alloy_primitives::map::HashSet;
 use base64::{engine::general_purpose, Engine};
 use bitcoin::{
     consensus::Decodable, secp256k1, Amount, BlockHash, Psbt, ScriptBuf, Transaction, TxOut,
@@ -46,7 +45,7 @@ use frost_secp256k1_tr as frost;
 use futures::{pin_mut, StreamExt};
 use futures_util::future::FutureExt;
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashSet},
     fmt::Debug,
     net::{IpAddr, Ipv4Addr, SocketAddr},
     path::Path,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Related issue: https://github.com/botanix-labs/botanix/issues/1052

Check that a pending pegout has not already been finalized before storing

## What was done?
- Check pending pegout is not in the finalize pegout ids list before storing

## How Has This Been Tested?
- Added a unit test
- Existing unit tests pass

## Breaking Changes
- None 
- 
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] I have added or updated relevant unit/integration/functional/e2e tests
-   [x] I have tested my changes running a local network, and they work as expected
-   [x] I have performed a self-review
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
-   [x] I have made corresponding changes to the documentation if needed
-   [x] I have added assignees and reviewers to this pull request
-   [x] I have added the PR to the project board or linked it to an issue from the board


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of pegout requests to prevent storing duplicates that have already been finalized.

* **Tests**
  * Added a new test to verify that finalized pegout IDs are not stored again as pending pegouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->