### PR TITLE
feat(consensus/hard-fork): Initiate `ActivationManager` with conditions & compliance logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10712,7 +10712,6 @@ dependencies = [
  "reth-trie",
  "reth-trie-db",
  "revm",
- "secp256k1 0.29.1",
  "strum 0.26.3",
  "tempfile",
  "tokio",

--- a/bin/reth/src/commands/poa/mod.rs
+++ b/bin/reth/src/commands/poa/mod.rs
@@ -14,7 +14,11 @@ use eyre::Context;
 use fdlimit::raise_fd_limit;
 use futures::TryFutureExt;
 use reth_authority_consensus::{
-    comet_bft::abci::ABCIDriver,
+    activation_manager::ActivationManagerBuilder,
+    comet_bft::{
+        abci::{ABCIDriver, RUNTIME_VERSION_ACTIVE, RUNTIME_VERSION_UPGRADE},
+        vote_tracker::VoteWatcher,
+    },
     snapshot_manager::SnapshotRunnable,
     utils::{is_known_minting_contract, retry_exec},
     wallet_state_sync::WalletStateSync,
@@ -66,7 +70,7 @@ use reth_chainspec::{BOTANIX_MAINNET_CHAIN_ID, BOTANIX_TESTNET_CHAIN_ID};
 use reth_cli_runner::CliContext;
 use reth_config::{config::StageConfig, Config};
 use reth_consensus_common::utils;
-use reth_db::{database::Database, init_db, DatabaseEnv};
+use reth_db::{database::Database, init_db, models::Vote, DatabaseEnv};
 use reth_exex::ExExManagerHandle;
 use reth_network::{
     frost::{manager::FrostConfig, protocol::FrostProtoHandler},
@@ -831,6 +835,35 @@ impl<Ext: clap::Args + fmt::Debug> PoaNodeCommand<Ext> {
             .with_port(*cometbft_rpc_port)
             .with_host(cometbft_rpc_host);
 
+        let quorum;
+        let min_validator_count;
+        let target_height;
+        let our_vote;
+
+        // ActivationManager: setup parameters and conditions.
+        if *is_testnet {
+            quorum = 100; // 100% ~= 3/3 members must approve
+            min_validator_count = 3;
+            target_height = 1; // Activate as soon as possible
+            our_vote = Vote::Aye;
+        } else {
+            quorum = 100; // 100% ~= 15/15 members must approve
+            min_validator_count = 15;
+            target_height = 1; // Activate as soon as possible
+            our_vote = Vote::Aye;
+        }
+
+        // ActivationManager: setup compliance and vote inclusion.
+        let activation_manager =
+            ActivationManagerBuilder::new(VoteWatcher::default(), RUNTIME_VERSION_ACTIVE)
+                .build_COMPLIANT_network_upgrade(
+                    RUNTIME_VERSION_UPGRADE,
+                    quorum,
+                    min_validator_count,
+                    target_height,
+                    Some(our_vote),
+                );
+
         // Build authority Consensus
         let (abci_started_tx, abci_started_rx) = tokio::sync::oneshot::channel::<()>();
         let bitcoind_client = bitcoind_factory.build_and_connect().expect("bitcoind client");
@@ -839,6 +872,7 @@ impl<Ext: clap::Args + fmt::Debug> PoaNodeCommand<Ext> {
                 Arc::clone(&chain_arc.clone()),
                 blockchain_db.clone(),
                 btc_server_factory.clone(),
+                activation_manager.clone(),
                 bitcoin_checkpoints.clone(),
                 secret_key,
                 network_handle.clone(),

--- a/crates/botanix-comet-bft-rpc/src/non_deterministic_data.rs
+++ b/crates/botanix-comet-bft-rpc/src/non_deterministic_data.rs
@@ -5,6 +5,7 @@ use thiserror::Error;
 
 /// Errors that can occur when deserializing NonDeterministicData
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum NonDeterministicDataDeserializeError {
     #[error("I/O error")]
     /// I/O error
@@ -12,10 +13,75 @@ pub enum NonDeterministicDataDeserializeError {
     #[error("invalid data format")]
     /// Invalid data format
     Decoding(#[from] encode::Error),
+    /// Invalid inclusion indicator, equivalent to Some/None
+    #[error("invalid inclusion indicator")]
+    InclusionIndicator,
+    /// // Invalid network upgrade vote
+    #[error("invalid network upgrade vote")]
+    NetworkUpgradePayloadVote,
 }
 
-// The default NDD version.
+/// The implied Botanix runtime version at mainnet launch, created
+/// retroactively.
+pub const GENESIS_RUNTIME_VERSION: (u16, u16) = (0, 1);
+
+/// Represents a validator's vote on a network upgrade proposal.
+///
+/// Validators can explicitly vote in favor of an upgrade (`Aye`),
+/// against an upgrade (`Nay`), or can abstain from voting (`Absent`).
+///
+/// Votes are included in block proposals via the `NetworkUpgradePayload`
+/// in the Non-Deterministic Data (NDD) transaction. These votes are then
+/// tracked by the activation manager to calculate support thresholds.
+///
+/// The default vote is `Nay`, indicating that validators must explicitly
+/// opt-in to upgrades rather than being opted-in by default.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Vote {
+    /// Vote in favor of the upgrade. An `Aye` vote contributes to the signaling
+    /// threshold calculations.
+    Aye = 2,
+
+    /// Vote against the upgrade. A `Nay` vote allows validators to signal
+    /// opposition while still being counted in voting statistics.
+    Nay = 1,
+
+    /// Explicit abstention from voting. An `Absent` vote functions the same as
+    /// `Nay` in quorum calculations, but communicates the validator's intent to
+    /// abstain rather than actively oppose the upgrade. It still counts as
+    /// participation in the voting process.
+    Absent = 0,
+}
+
+/// Represents a validator's stance on a network upgrade proposal.
+///
+/// This payload is included in each block's non-deterministic data when a node is
+/// configured to participate in the network upgrade voting process. It communicates
+/// the validator's current position on a specific upgrade version.
+///
+/// # Fields
+///
+/// * `version` - The specific runtime version that this vote applies to.
+///
+/// * `vote` - The validator's explicit opinion on the upgrade (Aye/Nay/Absent).
+///
+/// * `is_compliant` - Indicates whether the validator is technically ready to process blocks with
+///   the upgrade version. When `true`, the validator has the necessary software version and
+///   configuration to handle the upgrade. This can be independent of the vote - a validator may
+///   vote `Nay` but still be prepared to follow the network if the upgrade is adopted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NetworkUpgradePayload {
+    /// The runtime version that this vote applies to.
+    pub version: (u16, u16),
+    /// The validator's explicit opinion on the upgrade (Aye/Nay/Absent).
+    pub vote: Vote,
+    /// Indicates whether the validator is technically ready to process blocks with the upgrade
+    /// version.
+    pub is_compliant: bool,
+}
+
 pub const VERSION_1: u16 = 1;
+pub const VERSION_2: u16 = 2;
 
 /// Type that encapsulates non-deterministic data needed for consensus.
 #[derive(Debug, Clone, PartialEq)]
@@ -24,25 +90,36 @@ pub struct NonDeterministicData {
     pub bitcoin_block_hash: bitcoin::hash_types::BlockHash,
     pub aggregated_public_key: secp256k1::PublicKey,
     pub block_fee_recipient_address: Address,
+    pub runtime_version: (u16, u16),
+    pub network_upgrade_payload: Option<NetworkUpgradePayload>,
 }
 
 impl NonDeterministicData {
-    /// Returns the version based on whether a fee recipient address is present.
+    /// Returns the version of the non-deterministic data structure.
     pub fn version(&self) -> u16 {
         self.version
     }
 
-    /// Constructor for the NDD.
+    /// Returns the version of the Botanix runtime logic.
+    pub fn runtime_version(&self) -> (u16, u16) {
+        self.runtime_version
+    }
+
+    /// Constructor for the non-deterministic data (version 2).
     pub fn new(
         bitcoin_block_hash: bitcoin::hash_types::BlockHash,
         aggregated_public_key: secp256k1::PublicKey,
         block_fee_recipient_address: Address,
+        runtime_version: (u16, u16),
+        network_upgrade_payload: Option<NetworkUpgradePayload>,
     ) -> Self {
         Self {
-            version: VERSION_1,
+            version: VERSION_2,
             bitcoin_block_hash,
             aggregated_public_key,
             block_fee_recipient_address,
+            runtime_version,
+            network_upgrade_payload,
         }
     }
 
@@ -53,6 +130,19 @@ impl NonDeterministicData {
         self.aggregated_public_key.serialize().consensus_encode(&mut writer)?;
         self.version().consensus_encode(&mut writer)?;
         writer.write_all(self.block_fee_recipient_address.as_slice())?;
+
+        // Serialize runtime version.
+        self.runtime_version.consensus_encode(&mut writer)?;
+
+        // Serialize network upgrade payload, if available.
+        if let Some(p) = &self.network_upgrade_payload {
+            1u8.consensus_encode(&mut writer)?; // ~= Some(_)
+            p.version.consensus_encode(&mut writer)?;
+            (p.vote as u8).consensus_encode(&mut writer)?;
+            p.is_compliant.consensus_encode(&mut writer)?;
+        } else {
+            0u8.consensus_encode(&mut writer)?; // ~= None
+        }
 
         Ok(writer)
     }
@@ -79,16 +169,47 @@ impl NonDeterministicData {
             .map_err(|_e| encode::Error::ParseFailed("malformed block fee recipient address"))?;
         let block_fee_recipient_address = Address::from(address_bytes);
 
-        let this = Self {
+        let mut this = Self {
             version,
             bitcoin_block_hash,
             aggregated_public_key,
             block_fee_recipient_address,
+            runtime_version: GENESIS_RUNTIME_VERSION,
+            network_upgrade_payload: None,
         };
 
         match version {
-            VERSION_1 => {
-                // The expected version 1 NDD.
+            VERSION_2 => {
+                // Decode runtime version.
+                this.runtime_version = <(u16, u16)>::consensus_decode(reader)?;
+
+                // Check whether the network upgrade payload is included.
+                match u8::consensus_decode(reader)? {
+                    0 => {
+                        // Is NOT included, return.
+                        return Ok(this)
+                    }
+                    1 => {
+                        // Is included, proceed...
+                    }
+                    _ => return Err(NonDeterministicDataDeserializeError::InclusionIndicator),
+                }
+
+                // Decode payload information
+                let version = <(u16, u16)>::consensus_decode(reader)?;
+                let vote = match u8::consensus_decode(reader)? {
+                    0 => Vote::Absent,
+                    1 => Vote::Nay,
+                    2 => Vote::Aye,
+                    _ => {
+                        return Err(NonDeterministicDataDeserializeError::NetworkUpgradePayloadVote)
+                    }
+                };
+                let is_compliant = bool::consensus_decode(reader)?;
+
+                this.network_upgrade_payload =
+                    Some(NetworkUpgradePayload { version, vote, is_compliant });
+
                 Ok(this)
             }
             _ => {

--- a/crates/botanix-comet-bft-rpc/src/non_deterministic_data.rs
+++ b/crates/botanix-comet-bft-rpc/src/non_deterministic_data.rs
@@ -235,9 +235,8 @@ impl NonDeterministicData {
 
 #[cfg(test)]
 mod tests {
-    use bitcoin::{hashes::Hash, BlockHash};
-
     use super::*;
+    use bitcoin::{hashes::Hash, BlockHash};
 
     #[test]
     fn test_non_deterministic_data_new() {
@@ -248,15 +247,27 @@ mod tests {
                 .as_slice(),
         )
         .unwrap();
+
         let block_fee_recipient_address =
             Address::parse_checksummed("0x43C8bDCb9AFeBB1D834A7de18CC214a6FD1632d9", None)
                 .expect("valid address");
 
-        let ndd = NonDeterministicData::new(bitcoin_block_hash, pk, block_fee_recipient_address);
-        assert_eq!(ndd.version, VERSION_1);
+        let runtime_version = (1, 2);
+
+        let ndd = NonDeterministicData::new(
+            bitcoin_block_hash,
+            pk,
+            block_fee_recipient_address,
+            runtime_version,
+            None,
+        );
+
+        assert_eq!(ndd.version, VERSION_2);
         assert_eq!(ndd.bitcoin_block_hash, bitcoin_block_hash);
         assert_eq!(ndd.aggregated_public_key, pk);
         assert_eq!(ndd.block_fee_recipient_address, block_fee_recipient_address);
+        assert_eq!(ndd.runtime_version, runtime_version);
+        assert_eq!(ndd.network_upgrade_payload, None);
     }
 
     #[test]
@@ -268,19 +279,91 @@ mod tests {
                 .as_slice(),
         )
         .unwrap();
+
         let block_fee_recipient_address =
             Address::parse_checksummed("0x43C8bDCb9AFeBB1D834A7de18CC214a6FD1632d9", None)
                 .expect("valid address");
 
-        let ndd = NonDeterministicData::new(bitcoin_block_hash, pk, block_fee_recipient_address);
-        let res = ndd.serialize().unwrap();
-        let mut reader = io::Cursor::new(res);
+        let runtime_version = (1, 2);
+
+        let ndd = NonDeterministicData::new(
+            bitcoin_block_hash,
+            pk,
+            block_fee_recipient_address,
+            runtime_version,
+            None,
+        );
+        let mut reader = io::Cursor::new(ndd.serialize().unwrap());
 
         let deserialized = NonDeterministicData::deserialize(&mut reader).unwrap();
         assert_eq!(deserialized.version, ndd.version);
         assert_eq!(deserialized.bitcoin_block_hash, ndd.bitcoin_block_hash);
         assert_eq!(deserialized.aggregated_public_key, ndd.aggregated_public_key);
         assert_eq!(deserialized.block_fee_recipient_address, ndd.block_fee_recipient_address);
+        assert_eq!(deserialized.runtime_version, ndd.runtime_version);
+        assert_eq!(deserialized.network_upgrade_payload, ndd.network_upgrade_payload);
+    }
+
+    #[test]
+    fn test_non_deterministic_data_serde_with_network_upgrade_payload() {
+        let bitcoin_block_hash = BlockHash::all_zeros();
+        let pk = secp256k1::PublicKey::from_slice(
+            hex::decode("039bef292b80427d355cecb89eda8a50a7d2196a93d73dade5a0c4a07cd334815d")
+                .unwrap()
+                .as_slice(),
+        )
+        .unwrap();
+
+        let block_fee_recipient_address =
+            Address::parse_checksummed("0x43C8bDCb9AFeBB1D834A7de18CC214a6FD1632d9", None)
+                .expect("valid address");
+
+        let runtime_version = (1, 2);
+
+        let check_ndd = |network_upgrade_payload: NetworkUpgradePayload| {
+            // Create NDD with network upgrade payload
+            let ndd = NonDeterministicData::new(
+                bitcoin_block_hash,
+                pk,
+                block_fee_recipient_address,
+                runtime_version,
+                Some(network_upgrade_payload.clone()),
+            );
+
+            let res = ndd.serialize().unwrap();
+            let mut reader = io::Cursor::new(res);
+
+            let deserialized = NonDeterministicData::deserialize(&mut reader).unwrap();
+            assert_eq!(deserialized.version, ndd.version);
+            assert_eq!(deserialized.bitcoin_block_hash, ndd.bitcoin_block_hash);
+            assert_eq!(deserialized.aggregated_public_key, ndd.aggregated_public_key);
+            assert_eq!(deserialized.block_fee_recipient_address, ndd.block_fee_recipient_address);
+            assert_eq!(deserialized.runtime_version, runtime_version);
+            // Network upgrade payload must be deserialized correctly!
+            assert_eq!(deserialized.network_upgrade_payload, ndd.network_upgrade_payload);
+            assert_eq!(deserialized.network_upgrade_payload, Some(network_upgrade_payload));
+        };
+
+        #[rustfmt::skip]
+        check_ndd(NetworkUpgradePayload {
+            version: (0, 0),
+            vote: Vote::Absent,
+            is_compliant: true,
+        });
+
+        #[rustfmt::skip]
+        check_ndd(NetworkUpgradePayload {
+            version: (5, 4),
+            vote: Vote::Nay,
+            is_compliant: false
+        });
+
+        #[rustfmt::skip]
+        check_ndd(NetworkUpgradePayload {
+            version: (50, 40),
+            vote: Vote::Aye,
+            is_compliant: true
+        });
     }
 
     #[test]
@@ -294,6 +377,7 @@ mod tests {
                 .as_slice(),
         )
         .unwrap();
+
         let block_fee_recipient_address =
             Address::parse_checksummed("0x43C8bDCb9AFeBB1D834A7de18CC214a6FD1632d9", None)
                 .expect("valid address");
@@ -307,6 +391,7 @@ mod tests {
              1111111111111111111111111111111111111111111111111111111111111111",
         )
         .unwrap();
+
         let mut reader = io::Cursor::new(bytes);
         let ndd = NonDeterministicData::deserialize(&mut reader).unwrap();
 
@@ -314,12 +399,16 @@ mod tests {
         assert_eq!(ndd.bitcoin_block_hash, bitcoin_block_hash);
         assert_eq!(ndd.aggregated_public_key, pk);
         assert_eq!(ndd.block_fee_recipient_address, block_fee_recipient_address);
+        assert_eq!(ndd.runtime_version, GENESIS_RUNTIME_VERSION);
+        assert_eq!(ndd.network_upgrade_payload, None);
     }
 
     #[test]
-    /// Attempts to deserialize a NDD from a deprecated implementation that
-    /// still used version 0.
-    fn test_non_deterministic_data_serde_from_deprecated_impl() {
+    /// Attempts to deserialize a raw NDD using version 1.
+    ///
+    /// This is primarily intended for future NDD versions to ensure backwards
+    /// compatibility.
+    fn test_non_deterministic_data_serde_version_1() {
         let bitcoin_block_hash = BlockHash::all_zeros();
         let pk: secp256k1::PublicKey = secp256k1::PublicKey::from_slice(
             hex::decode("039bef292b80427d355cecb89eda8a50a7d2196a93d73dade5a0c4a07cd334815d")
@@ -327,6 +416,7 @@ mod tests {
                 .as_slice(),
         )
         .unwrap();
+
         let block_fee_recipient_address =
             Address::parse_checksummed("0x43C8bDCb9AFeBB1D834A7de18CC214a6FD1632d9", None)
                 .expect("valid address");
@@ -338,6 +428,7 @@ mod tests {
              43c8bdcb9afebb1d834a7de18cc214a6fd1632d9",
         )
         .unwrap();
+
         let mut reader = io::Cursor::new(bytes);
         let ndd = NonDeterministicData::deserialize(&mut reader).unwrap();
 
@@ -345,5 +436,97 @@ mod tests {
         assert_eq!(ndd.bitcoin_block_hash, bitcoin_block_hash);
         assert_eq!(ndd.aggregated_public_key, pk);
         assert_eq!(ndd.block_fee_recipient_address, block_fee_recipient_address);
+        assert_eq!(ndd.runtime_version, GENESIS_RUNTIME_VERSION);
+        assert_eq!(ndd.network_upgrade_payload, None);
+    }
+
+    #[test]
+    /// Attempts to deserialize a raw NDD using version 2, without network
+    /// upgrade payload.
+    ///
+    /// This is primarily intended for future NDD versions to ensure backwards
+    /// compatibility.
+    fn test_non_deterministic_data_serde_version_2() {
+        let bitcoin_block_hash = BlockHash::all_zeros();
+        let pk = secp256k1::PublicKey::from_slice(
+            hex::decode("039bef292b80427d355cecb89eda8a50a7d2196a93d73dade5a0c4a07cd334815d")
+                .unwrap()
+                .as_slice(),
+        )
+        .unwrap();
+
+        let block_fee_recipient_address =
+            Address::parse_checksummed("0x43C8bDCb9AFeBB1D834A7de18CC214a6FD1632d9", None)
+                .expect("valid address");
+
+        let runtime_version = (1, 2);
+
+        let bytes = hex::decode(
+            "0000000000000000000000000000000000000000000000000000000000000000\
+            039bef292b80427d355cecb89eda8a50a7d2196a93d73dade5a0c4a07cd334815d\
+            0200\
+            43c8bdcb9afebb1d834a7de18cc214a6fd1632d9\
+            01000200\
+            00",
+        )
+        .unwrap();
+
+        let mut reader = io::Cursor::new(bytes);
+        let ndd = NonDeterministicData::deserialize(&mut reader).unwrap();
+
+        assert_eq!(ndd.version, VERSION_2);
+        assert_eq!(ndd.bitcoin_block_hash, bitcoin_block_hash);
+        assert_eq!(ndd.aggregated_public_key, pk);
+        assert_eq!(ndd.block_fee_recipient_address, block_fee_recipient_address);
+        assert_eq!(ndd.runtime_version, runtime_version);
+        assert_eq!(ndd.network_upgrade_payload, None);
+    }
+
+    #[test]
+    /// Attempts to deserialize a raw NDD using version 2, WITH a network
+    /// upgrade payload.
+    ///
+    /// This is primarily intended for future NDD versions to ensure backwards
+    /// compatibility.
+    fn test_non_deterministic_data_serde_version_2_with_network_upgrade_payload() {
+        let bitcoin_block_hash = BlockHash::all_zeros();
+        let pk = secp256k1::PublicKey::from_slice(
+            hex::decode("039bef292b80427d355cecb89eda8a50a7d2196a93d73dade5a0c4a07cd334815d")
+                .unwrap()
+                .as_slice(),
+        )
+        .unwrap();
+
+        let block_fee_recipient_address =
+            Address::parse_checksummed("0x43C8bDCb9AFeBB1D834A7de18CC214a6FD1632d9", None)
+                .expect("valid address");
+
+        let runtime_version = (1, 2);
+
+        let bytes = hex::decode(
+            "0000000000000000000000000000000000000000000000000000000000000000\
+            039bef292b80427d355cecb89eda8a50a7d2196a93d73dade5a0c4a07cd334815d\
+            0200\
+            43c8bdcb9afebb1d834a7de18cc214a6fd1632d9\
+            01000200\
+            01\
+            01000500\
+            01\
+            00",
+        )
+        .unwrap();
+
+        let mut reader = io::Cursor::new(bytes);
+        let ndd = NonDeterministicData::deserialize(&mut reader).unwrap();
+
+        let network_upgrade_payload =
+            NetworkUpgradePayload { version: (1, 5), vote: Vote::Nay, is_compliant: false };
+
+        assert_eq!(ndd.version, VERSION_2);
+        assert_eq!(ndd.bitcoin_block_hash, bitcoin_block_hash);
+        assert_eq!(ndd.aggregated_public_key, pk);
+        assert_eq!(ndd.block_fee_recipient_address, block_fee_recipient_address);
+        assert_eq!(ndd.runtime_version, runtime_version);
+        assert_eq!(ndd.network_upgrade_payload, Some(network_upgrade_payload));
     }
 }

--- a/crates/consensus/authority/src/activation_manager/mod.rs
+++ b/crates/consensus/authority/src/activation_manager/mod.rs
@@ -259,7 +259,7 @@ impl ConditionList {
 /// This builder provides methods to configure how a validator will handle
 /// network upgrades - whether it will ignore them, signal votes without
 /// being compliant, or fully accept upgrades when conditions are met.
-pub struct ActivationManagerBuilder<DB> {
+pub struct ActivationManagerBuilder<DB, Auth> {
     /// The database client implementing ActivationManagerReaderWriter
     client: DB,
 
@@ -271,11 +271,13 @@ pub struct ActivationManagerBuilder<DB> {
 
     /// Configuration for a pending network upgrade, if any
     upgrade: Option<NetworkUpgrade>,
+
+    _p: std::marker::PhantomData<Auth>,
 }
 
-impl<DB> ActivationManagerBuilder<DB>
+impl<DB, Auth> ActivationManagerBuilder<DB, Auth>
 where
-    DB: ActivationManagerReaderWriter,
+    DB: ActivationManagerReaderWriter<Auth>,
 {
     /// Creates a new ActivationManagerBuilder with specified database client and active version.
     ///
@@ -294,6 +296,7 @@ where
             active_version,
             vote_retention_period: VOTE_RETENTION_PERIOD,
             upgrade: None,
+            _p: std::marker::PhantomData,
         }
     }
 
@@ -326,7 +329,7 @@ where
     ///
     /// # Returns
     /// * An ActivationManager configured to ignore network upgrades
-    pub fn build_ignore_nework_upgrade(self) -> ActivationManager<DB> {
+    pub fn build_ignore_nework_upgrade(self) -> ActivationManager<DB, Auth> {
         debug_assert!(self.upgrade.is_none());
         self._finalize()
     }
@@ -355,7 +358,7 @@ where
         mut self,
         upgrade_version: RuntimeVersion,
         our_vote: Vote,
-    ) -> ActivationManager<DB> {
+    ) -> ActivationManager<DB, Auth> {
         assert!(self.active_version < upgrade_version);
 
         #[rustfmt::skip]
@@ -407,7 +410,7 @@ where
         min_validator_count: usize,
         target_height: u64,
         our_vote: Option<Vote>,
-    ) -> ActivationManager<DB> {
+    ) -> ActivationManager<DB, Auth> {
         assert!(
             self.active_version < upgrade_version,
             "upgrade version is older than the active version"
@@ -436,12 +439,13 @@ where
         self._finalize()
     }
 
-    fn _finalize(self) -> ActivationManager<DB> {
+    fn _finalize(self) -> ActivationManager<DB, Auth> {
         ActivationManager {
             client: self.client,
             vote_retention_period: self.vote_retention_period,
             active_version: Arc::new(RwLock::new(self.active_version)),
             upgrade: Arc::new(RwLock::new(self.upgrade)),
+            _p: std::marker::PhantomData,
         }
     }
 }
@@ -466,7 +470,7 @@ where
 /// state through atomic reference counting and read-write locks, allowing it to
 /// be shared between concurrent contexts.
 #[derive(Clone)]
-pub struct ActivationManager<DB> {
+pub struct ActivationManager<DB, Auth> {
     /// Database client for persisting and retrieving votes
     client: DB,
 
@@ -480,11 +484,13 @@ pub struct ActivationManager<DB> {
     /// Configuration for a pending network upgrade, if any
     /// Protected by a read-write lock for thread-safe updates
     upgrade: Arc<RwLock<Option<NetworkUpgrade>>>,
+
+    _p: std::marker::PhantomData<Auth>,
 }
 
-impl<DB> ActivationManager<DB>
+impl<DB, Auth> ActivationManager<DB, Auth>
 where
-    DB: ActivationManagerReaderWriter,
+    DB: ActivationManagerReaderWriter<Auth>,
 {
     /// Prepares a proposal decision based on the current upgrade state.
     ///
@@ -632,7 +638,7 @@ where
         &self,
         block_version: RuntimeVersion,
         block_height: u64,
-        proposer_address: secp256k1::PublicKey,
+        proposer_address: Auth,
         proposer_vote: Option<NetworkUpgradePayload>,
     ) -> ProviderResult<OnFinalizeBlockDecision> {
         // Track the proposer's vote for upgrade intention, if provided
@@ -756,7 +762,7 @@ where
     fn _track_vote(
         &self,
         block_height: u64,
-        addr: secp256k1::PublicKey,
+        addr: Auth,
         vote: Option<NetworkUpgradePayload>,
     ) -> ProviderResult<()> {
         // If the proposer made a vote...

--- a/crates/consensus/authority/src/activation_manager/tests/mod.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/mod.rs
@@ -1,8 +1,7 @@
 use super::*;
-use rand::thread_rng;
 use reth_provider::ProviderResult;
-use secp256k1::generate_keypair;
 use std::{collections::HashMap, sync::Arc};
+use utils::Address;
 
 mod accept_lagging_validator;
 mod reject_ignored_upgrade;
@@ -18,7 +17,7 @@ mod wait_for_compliance;
 /// In-Memory database that integrates the `ActivationManagerReaderWriter` trait.
 #[derive(Clone)]
 struct Db {
-    votes: Arc<RwLock<HashMap<secp256k1::PublicKey, VoteEntry>>>,
+    votes: Arc<RwLock<HashMap<Address, VoteEntry>>>,
 }
 
 impl Db {
@@ -33,10 +32,10 @@ struct VoteEntry {
     botanix_height: u64,
 }
 
-impl ActivationManagerReaderWriter for Db {
+impl ActivationManagerReaderWriter<utils::Address> for Db {
     fn update_upgrading_vote(
         &self,
-        auth: secp256k1::PublicKey,
+        auth: Address,
         vote: Vote,
         is_compliant: bool,
         botanix_height: u64,
@@ -104,10 +103,10 @@ impl ActivationManagerReaderWriter for Db {
 fn activation_manager_basic_db_interface() {
     let db = Db::new();
 
-    // Generate keypairs
-    let (_, alice) = generate_keypair(&mut thread_rng());
-    let (_, bob) = generate_keypair(&mut thread_rng());
-    let (_, eve) = generate_keypair(&mut thread_rng());
+    // Generate addresses
+    let alice = b"alice".to_vec();
+    let bob = b"bob".to_vec();
+    let eve = b"eve".to_vec();
 
     let min_validator_count = 3;
 

--- a/crates/consensus/authority/src/activation_manager/tests/utils.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/utils.rs
@@ -5,7 +5,6 @@ use crate::activation_manager::{
 };
 use reth_db::models::activation_manager::{RuntimeVersion, Vote};
 use reth_provider::ActivationManagerReaderWriter;
-use secp256k1::{generate_keypair, rand::thread_rng};
 
 /// Index for the ALICE validator in the test fixture
 pub(super) const ALICE: usize = 0;
@@ -36,6 +35,9 @@ struct VoteDetails {
     is_compliant: bool,
 }
 
+/// Internal address to distinguish between members.
+pub(super) type Address = Vec<u8>;
+
 /// Main test fixture for network upgrade scenarios.
 ///
 /// This fixture manages the state for multiple validators in upgrade testing
@@ -56,11 +58,11 @@ pub(super) struct UpgradeTestFixture {
     vote_retention_period: u64,
 
     /// The public keys representing each validator's identity
-    addrs: [secp256k1::PublicKey; 3],
+    addrs: [Address; 3],
     /// In-memory databases for each validator
     dbs: [Db; 3],
     /// The activation manager instances for each validator
-    managers: [Option<ActivationManager<Db>>; 3],
+    managers: [Option<ActivationManager<Db, Address>>; 3],
     /// Expected votes to be included in block proposals for each validator
     expected_votes: [Option<VoteDetails>; 3],
 }
@@ -79,10 +81,9 @@ impl UpgradeTestFixture {
     /// # Returns
     /// * A new `UpgradeTestFixture` with default values and generated validator keys
     pub(super) fn new(upgrade_height: u64, approval_rate: usize) -> Self {
-        // Generate keypairs
-        let (_, alice_addr) = generate_keypair(&mut thread_rng());
-        let (_, bob_addr) = generate_keypair(&mut thread_rng());
-        let (_, eve_addr) = generate_keypair(&mut thread_rng());
+        let alice_addr = b"alice".to_vec();
+        let bob_addr = b"bob".to_vec();
+        let eve_addr = b"eve".to_vec();
 
         Self {
             upgrade_height,
@@ -404,7 +405,7 @@ impl ProposingTestFixture<'_> {
         dbg!(self.i.block_height);
 
         let proposer = self.i.managers[self.proposer_index].as_mut().unwrap();
-        let proposer_addr = &self.i.addrs[self.proposer_index];
+        let proposer_addr = self.i.addrs[self.proposer_index].clone();
 
         // Proposer builds the block
         let OnPrepareProposalDecision {
@@ -483,7 +484,7 @@ impl ProposingTestFixture<'_> {
                 .on_finalize_block(
                     proposer_version,
                     self.i.block_height,
-                    *proposer_addr,
+                    proposer_addr.clone(),
                     proposer_vote.clone(),
                 )
                 .unwrap();

--- a/crates/consensus/authority/src/builder.rs
+++ b/crates/consensus/authority/src/builder.rs
@@ -1,5 +1,9 @@
 use crate::{
-    comet_bft::abci::{ABCIClientBuilder, ABCIDriverMessage},
+    activation_manager::ActivationManager,
+    comet_bft::{
+        abci::{ABCIClientBuilder, ABCIDriverMessage},
+        vote_tracker::VoteWatcher,
+    },
     frost_task::FrostTask,
     snapshot_manager::{SnapshotManager, SnapshotManagerStateLock},
     wallet_state_sync::WalletStateSyncEngine,
@@ -25,6 +29,7 @@ use reth_network::{
 };
 use reth_node_core::args::StateSyncArgs;
 use reth_node_ethereum::EthEvmConfig;
+use reth_primitives::Address;
 use reth_provider::{
     BlockReaderIdExt, CanonChainTracker, CanonStateSubscriptions, ProviderFactory, SnapshotReader,
     SnapshotWriter, StagedHeader, StateProviderFactory, WalletStateSyncReader,
@@ -44,6 +49,7 @@ pub struct AuthorityConsensusBuilder<EF, BF, DB, BD, ToFrostMan, Source> {
     consensus: AuthorityConsensus,
     storage: Storage<EF, BF, DB>,
     btc_server_factory: Option<GrpcClientFactory>,
+    activation_manager: ActivationManager<VoteWatcher, Address>,
     bitcoin_checkpoints: Arc<BitcoinCheckpointsChain>,
     network_handle: NetworkHandle,
     frost_handle: Option<ToFrostMan>,
@@ -95,6 +101,7 @@ where
         chain_spec: Arc<ChainSpec>,
         client: DB,
         btc_server_factory: Option<GrpcClientFactory>,
+        activation_manager: ActivationManager<VoteWatcher, Address>,
         bitcoin_checkpoints: Arc<BitcoinCheckpointsChain>,
         sk: secp256k1::SecretKey,
         network_handle: NetworkHandle,
@@ -186,6 +193,7 @@ where
             storage,
             consensus: AuthorityConsensus::new(chain_spec),
             btc_server_factory,
+            activation_manager,
             bitcoin_checkpoints,
             network_handle,
             frost_handle,
@@ -221,6 +229,7 @@ where
             btc_server_factory,
             consensus,
             storage,
+            activation_manager,
             bitcoin_checkpoints,
             network_handle,
             frost_handle,
@@ -298,6 +307,7 @@ where
         // all nodes will have an abci client builder
         let abci_client_builder = Some(ABCIClientBuilder::new(
             storage.clone(),
+            activation_manager,
             bitcoin_checkpoints,
             consensus.clone(),
             cometbft_rpc_factory.clone(),

--- a/crates/consensus/authority/src/comet_bft/abci.rs
+++ b/crates/consensus/authority/src/comet_bft/abci.rs
@@ -2472,7 +2472,7 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
-    use crate::Storage;
+    use crate::{activation_manager::ActivationManagerBuilder, Storage};
     use bitcoin::{
         block::{BlockHash, Header, Version},
         hashes::Hash,
@@ -2483,7 +2483,9 @@ mod tests {
         bitcoind::{BitcoindConfig, BitcoindFactory},
         test_utils::MockBitcoindFactory,
     };
-    use botanix_comet_bft_rpc::HttpCometBFTRpcClientFactory;
+    use botanix_comet_bft_rpc::{
+        non_deterministic_data::GENESIS_RUNTIME_VERSION, HttpCometBFTRpcClientFactory,
+    };
     use rand::thread_rng;
     use reth_chainspec::{BOTANIX_MAINNET, BOTANIX_TESTNET};
     use reth_cli_runner::tokio_runtime;
@@ -2523,6 +2525,18 @@ mod tests {
 
     /// Build the db and the ABCI client
     fn abci_client_builder() -> ABCIClientType {
+        // By default, ignore/reject any unexpected upgrades.
+        let activation_manager =
+            ActivationManagerBuilder::new(VoteWatcher::default(), RUNTIME_VERSION_ACTIVE)
+                .build_ignore_nework_upgrade();
+
+        abci_client_builder_with_activation_manager(activation_manager)
+    }
+
+    /// Build the db and the ABCI client with a custom activation manager
+    fn abci_client_builder_with_activation_manager(
+        activation_manager: ActivationManager<VoteWatcher, Address>,
+    ) -> ABCIClientType {
         let secp = secp256k1::Secp256k1::new();
         let sk = secp256k1::SecretKey::new(&mut rand::thread_rng());
         let pk = secp256k1::PublicKey::from_secret_key(&secp, &sk);
@@ -2594,6 +2608,7 @@ mod tests {
         ABCIClient::new(
             storage,
             transaction_pool,
+            activation_manager,
             Arc::new(bitcoin_checkpoints_chain),
             driver_tx,
             cometbft_rpc_factory,
@@ -2615,7 +2630,7 @@ mod tests {
         client: &ABCIClientType,
     ) -> Result<prost::bytes::Bytes, ConsensusError> {
         client
-            .non_deterministic_data()
+            .non_deterministic_data(RuntimeVersion::new(0, 1), None)
             .and_then(|ndd| client.serialize_non_deterministic_data_to_bytes(ndd))
     }
 
@@ -2672,6 +2687,57 @@ mod tests {
     }
 
     #[test]
+    fn test_prepare_proposal_empty_mempool_with_network_upgrade_vote() {
+        let quorum = 100;
+        let min_validator_count = 10;
+        let target_height = 1_000;
+        let our_vote = Vote::Aye;
+
+        // Set the activation manager to include a vote in each NDD.
+        let activation_manager =
+            ActivationManagerBuilder::new(VoteWatcher::default(), RUNTIME_VERSION_ACTIVE)
+                .build_COMPLIANT_network_upgrade(
+                    RuntimeVersion::new(2, 0),
+                    quorum,
+                    min_validator_count,
+                    target_height,
+                    Some(our_vote),
+                );
+
+        let abci_client = abci_client_builder_with_activation_manager(activation_manager);
+
+        let request = RequestPrepareProposal {
+            max_tx_bytes: 100,
+            time: Some(Default::default()),
+            ..Default::default()
+        };
+
+        let response = abci_client.prepare_proposal(request);
+
+        // The expected payload to be included in the NDD.
+        let expected_payload = non_deterministic_data::NetworkUpgradePayload {
+            version: (2, 0),
+            vote: non_deterministic_data::Vote::Aye,
+            is_compliant: true,
+        };
+
+        let expected_ndd = NonDeterministicData::new(
+            abci_client.bitcoin_blockhash().expect("to have bitcoin blockhash"),
+            abci_client.aggregate_public_key().expect("to have agg pk"),
+            Address::ZERO,
+            GENESIS_RUNTIME_VERSION,
+            Some(expected_payload),
+        );
+        let response_ndd_bytes = response.txs.first().expect("to have tx").clone();
+        let reader_inner: Vec<u8> = vec![response_ndd_bytes].into_iter().flatten().collect();
+        let reader = &mut io::Cursor::new(reader_inner);
+        let response_ndd = NonDeterministicData::deserialize(reader).expect("to deserialize");
+
+        assert_eq!(response.txs.len(), 1);
+        assert_eq!(response_ndd, expected_ndd);
+    }
+
+    #[test]
     fn test_prepare_proposal_empty_mempool() {
         let abci_client = abci_client_builder();
 
@@ -2687,6 +2753,8 @@ mod tests {
             abci_client.bitcoin_blockhash().expect("to have bitcoin blockhash"),
             abci_client.aggregate_public_key().expect("to have agg pk"),
             Address::ZERO,
+            GENESIS_RUNTIME_VERSION,
+            None,
         );
         let response_ndd_bytes = response.txs.first().expect("to have tx").clone();
         let reader_inner: Vec<u8> = vec![response_ndd_bytes].into_iter().flatten().collect();
@@ -2724,6 +2792,8 @@ mod tests {
             abci_client.bitcoin_blockhash().expect("to have agg bitcoin blockhash"),
             abci_client.aggregate_public_key().expect("to have agg pk"),
             Address::ZERO,
+            GENESIS_RUNTIME_VERSION,
+            None,
         );
         let response_ndd_bytes = response.txs.first().expect("to have tx").clone();
         let reader_inner: Vec<u8> = vec![response_ndd_bytes].into_iter().flatten().collect();
@@ -2831,7 +2901,9 @@ mod tests {
         let mut request = RequestFinalizeBlock::default();
 
         // first tx should be non-deterministic data
-        let ndd = abci_client.non_deterministic_data().expect("to have ndd");
+        let ndd = abci_client
+            .non_deterministic_data(RuntimeVersion::new(0, 1), None)
+            .expect("to have ndd");
         let ndd_bytes =
             abci_client.serialize_non_deterministic_data_to_bytes(ndd).expect("to serialize ndd");
 

--- a/crates/consensus/authority/src/comet_bft/abci.rs
+++ b/crates/consensus/authority/src/comet_bft/abci.rs
@@ -2076,9 +2076,49 @@ where
                     }
                 };
 
+                // Activation Manager: decide whether we're willing to accept
+                // the runtime version.
+                //
+                // Note that lagging validators will automatically accept an
+                // upgrade as long as they're specifically configured to do so
+                // (non-default behavior) - whether the upgrade conditions are
+                // met or not.
+                let comet_height = request.height as u64;
+                let runtime_version = non_deterministic_data.runtime_version().into();
+                let proposer_address = Address::from_slice(&request.proposer_address);
+                //
+                match self
+                    .activation_manager
+                    .on_finalize_block(runtime_version, comet_height, proposer_address, None)
+                    .expect("db cannot fail")
+                {
+                    OnFinalizeBlockDecision::Finalize { version: _ } => {
+                        // Continue...
+                    }
+                    OnFinalizeBlockDecision::RejectBlockDeadEnd { version } => {
+                        error!("finalize_block: Rejecting finalized block with Botanix runtime version: {version}");
+                        panic!("finalize_block: Rejecting Botanix upgrade '{version}' - can no longer proceed...");
+                    }
+                }
+
+                let mut floor_base_fee_per_gas = None;
+                match runtime_version {
+                    RUNTIME_VERSION_ACTIVE => {
+                        // Continue; do not set a floor base fee per gas.
+                        debug!("finalize_block: Finalizing block with active runtime version: {runtime_version}");
+                    }
+                    RUNTIME_VERSION_UPGRADE => {
+                        // Set floor base fee per gas.
+                        debug!("finalize_block: Finalizing block with UPGRADED version: {runtime_version}");
+                        floor_base_fee_per_gas = Some(FLOOR_BASE_FEE_PER_GAS);
+                    }
+                    _ => unreachable!(),
+                };
+
                 match build_and_execute(
                     txs,
                     self.storage.chain_spec.clone(),
+                    floor_base_fee_per_gas,
                     &non_deterministic_data.block_fee_recipient_address,
                     self.storage.evm_config,
                     &self.provider_factory,

--- a/crates/consensus/authority/src/comet_bft/abci.rs
+++ b/crates/consensus/authority/src/comet_bft/abci.rs
@@ -1725,7 +1725,7 @@ where
             }
         };
 
-        if non_deterministic_data.version() != LATEST_NDD_VERSION {
+        if non_deterministic_data.version() > LATEST_NDD_VERSION {
             warn!(
                 ?non_deterministic_data,
                 "processing block with unknown non-deterministic data version"
@@ -1824,6 +1824,35 @@ where
             }
         };
 
+        // Activation Manager: decide whether we should process for the current
+        // or upgraded runtime version.
+        let mut floor_base_fee_per_gas = None;
+        let comet_height = request.height as u64;
+        let runtime_version = non_deterministic_data.runtime_version().into();
+        //
+        match self
+            .activation_manager
+            .on_process_proposal(comet_height, runtime_version)
+            .expect("db cannot fail")
+        {
+            OnProcessProposalDecision::Process { version, conditions: _ } => match version {
+                RUNTIME_VERSION_ACTIVE => {
+                    // Continue; do not set a floor base fee per gas.
+                    debug!("process_proposal: Processing with active version: {version}");
+                }
+                RUNTIME_VERSION_UPGRADE => {
+                    // Set floor base fee per gas.
+                    debug!("process_proposal: Processing with UPGRADED version: {version}");
+                    floor_base_fee_per_gas = Some(FLOOR_BASE_FEE_PER_GAS);
+                }
+                _ => unreachable!(),
+            },
+            OnProcessProposalDecision::RejectBlock { version, conditions: _ } => {
+                warn!("process_proposal: Rejecting block using Botanix runtime version: {version}");
+                return ResponseProcessProposal { status: VERIFY_REJECT };
+            }
+        }
+
         // Validation done as a result of this call:
         // - botanix consensus package created on the fly and compared to the incoming block EDH
         // - mint validation checks
@@ -1833,6 +1862,7 @@ where
         match build_and_execute(
             txs,
             self.storage.chain_spec.clone(),
+            floor_base_fee_per_gas,
             &non_deterministic_data.block_fee_recipient_address,
             self.storage.evm_config,
             &self.provider_factory,

--- a/crates/consensus/authority/src/comet_bft/abci.rs
+++ b/crates/consensus/authority/src/comet_bft/abci.rs
@@ -62,6 +62,13 @@ use tendermint_proto::{
     },
 };
 
+/// The currently active Botanix runtime version.
+pub const RUNTIME_VERSION_ACTIVE: RuntimeVersion = RuntimeVersion::new(0, 1);
+/// The Botanix runtime version to eventually upgrade to.
+pub const RUNTIME_VERSION_UPGRADE: RuntimeVersion = RuntimeVersion::new(0, 2);
+/// The floor base fee per gas to be used for the upgraded Botanix runtime version.
+const FLOOR_BASE_FEE_PER_GAS: u64 = 5_000_000; // 5_000_000 Wei = 0.005 Gwei
+
 impl From<&Snapshot> for SnapshotSyncStateLock {
     fn from(snapshot: &Snapshot) -> Self {
         let mut s = SnapshotSyncStateLock::default();
@@ -116,7 +123,7 @@ use crate::{
 use botanix_authority_metrics::AuthorityMetrics;
 use botanix_bitcoin_checkpoint::BitcoinCheckpointsChain;
 use botanix_comet_bft_rpc::{
-    non_deterministic_data::{NonDeterministicData, VERSION_1 as LATEST_NDD_VERSION},
+    non_deterministic_data::{NonDeterministicData, VERSION_2 as LATEST_NDD_VERSION},
     proto_debug::{
         RequestApplySnapshotChunkTruncatedDebug, RequestFinalizeBlockTruncatedDebug,
         RequestProcessProposalTruncatedDebug, ResponseLoadSnapshotChunkTruncatedDebug,

--- a/crates/consensus/authority/src/comet_bft/abci.rs
+++ b/crates/consensus/authority/src/comet_bft/abci.rs
@@ -4,7 +4,11 @@ use alloy_rpc_types_engine::ForkchoiceState;
 use reth_chain_state::ExecutedBlock;
 use reth_chainspec::ChainSpec;
 use reth_db::{
-    models::{self, SnapshotSync, SnapshotSyncId},
+    models::{
+        self,
+        activation_manager::{MajorVersion, MinorVersion},
+        RuntimeVersion, SnapshotSync, SnapshotSyncId, Vote,
+    },
     Database, DatabaseEnv,
 };
 use reth_provider::{
@@ -30,9 +34,9 @@ use reth_evm::execute::BlockExecutorProvider;
 
 use botanix_authority_edh::header_ext::HeaderExt;
 use botanix_authority_peg::block_with_peg::SealedBlockWithPeg;
-use botanix_comet_bft_rpc::HttpCometBFTRpcClientFactory;
+use botanix_comet_bft_rpc::{non_deterministic_data, HttpCometBFTRpcClientFactory};
 use reth_payload_builder::EthPayloadBuilderAttributes;
-use reth_primitives::{Address, BlockHash, BlockNumber, BlockWithSenders, SealedBlock, B256};
+use reth_primitives::{Address, BlockHash, BlockNumber, BlockWithSenders, SealedBlock, B256, U256};
 use reth_provider::{
     BlockReaderIdExt, CanonStateNotification, Chain, ProviderError, ProviderFactory,
     SnapshotReader, SnapshotWriter, StateProviderFactory,
@@ -488,16 +492,49 @@ where
         ))
     }
 
-    pub(crate) fn non_deterministic_data(&self) -> Result<NonDeterministicData, ConsensusError> {
+    pub(crate) fn non_deterministic_data(
+        &self,
+        runtime_version: RuntimeVersion,
+        network_upgrade_payload: Option<NetworkUpgradePayload>,
+    ) -> Result<NonDeterministicData, ConsensusError> {
         let aggregate_public_key = self.aggregate_public_key()?;
         let block_fee_recipient_address = self
             .block_fee_recipient_address
             .ok_or(ConsensusError::MissingBlockFeeRecipientAddress)?;
 
+        // Convert ActivationManager types to the corresponding NDD types.
+        // TODO (lamafab): Those types should ideally be unified asap, depending
+        // on the larger modularization overhaul.
+        let network_upgrade_payload = if let Some(p) = network_upgrade_payload {
+            let vote = match p.vote {
+                Vote::Absent => non_deterministic_data::Vote::Absent,
+                Vote::Nay => non_deterministic_data::Vote::Nay,
+                Vote::Aye => non_deterministic_data::Vote::Aye,
+            };
+
+            // Botanix runtime upgrade version to be voted on.
+            let RuntimeVersion(MajorVersion(major), MinorVersion(minor)) = p.version;
+
+            let network_upgrade_payload = non_deterministic_data::NetworkUpgradePayload {
+                version: (major, minor),
+                vote,
+                is_compliant: p.is_compliant,
+            };
+
+            Some(network_upgrade_payload)
+        } else {
+            None
+        };
+
+        // The actively used Botanix runtime version.
+        let RuntimeVersion(MajorVersion(major), MinorVersion(minor)) = runtime_version;
+
         let ndd = NonDeterministicData::new(
             self.bitcoin_blockhash()?,
             aggregate_public_key,
             block_fee_recipient_address,
+            (major, minor),
+            network_upgrade_payload,
         );
 
         Ok(ndd)

--- a/crates/consensus/authority/src/comet_bft/abci.rs
+++ b/crates/consensus/authority/src/comet_bft/abci.rs
@@ -99,6 +99,11 @@ pub enum ApplySnapshotResult {
     RejectSnapshot = 5,
 }
 use crate::{
+    activation_manager::{
+        ActivationManager, NetworkUpgradePayload, OnFinalizeBlockDecision,
+        OnProcessProposalDecision,
+    },
+    comet_bft::vote_tracker::VoteWatcher,
     excecution_utils::authority_execution_utils::{batch_execute, build_and_execute},
     snapshot_manager::{SnapshotManagerError, SnapshotManagerStateLock},
     utils::{get_staged_pegins_from_pegin_meta, get_staged_pegouts_from_pegout_data},
@@ -199,6 +204,7 @@ pub struct BlockWithContext {
 #[derive(Clone)]
 pub struct ABCIClientBuilder<EF, BF, DB> {
     storage: Storage<EF, BF, DB>,
+    activation_manager: ActivationManager<VoteWatcher, Address>,
     bitcoin_checkpoints: Arc<BitcoinCheckpointsChain>,
     authority_consensus: AuthorityConsensus,
     cbft_rpc_client_factory: HttpCometBFTRpcClientFactory,
@@ -230,6 +236,7 @@ where
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         storage: Storage<EF, BF, DB>,
+        activation_manager: ActivationManager<VoteWatcher, Address>,
         bitcoin_checkpoints: Arc<BitcoinCheckpointsChain>,
         authority_consensus: AuthorityConsensus,
         cbft_rpc_client_factory: HttpCometBFTRpcClientFactory,
@@ -255,6 +262,7 @@ where
 
         Self {
             storage,
+            activation_manager,
             bitcoin_checkpoints,
             authority_consensus,
             cbft_rpc_client_factory,
@@ -283,6 +291,7 @@ where
         let app = ABCIClient::new(
             self.storage.clone(),
             tx_pool,
+            self.activation_manager.clone(),
             self.bitcoin_checkpoints.clone(),
             self.abci_driver_tx.clone(),
             self.cbft_rpc_client_factory.clone(),
@@ -357,6 +366,7 @@ struct BlockCache {
 pub(crate) struct ABCIClient<EF, BF, DB, Pool> {
     storage: Storage<EF, BF, DB>,
     pool: Pool,
+    activation_manager: ActivationManager<VoteWatcher, Address>,
     bitcoin_checkpoints: Arc<BitcoinCheckpointsChain>,
     block_cache: Arc<RwLock<BlockCache>>,
     driver_tx: tokio::sync::mpsc::Sender<ABCIDriverMessage>,
@@ -392,6 +402,7 @@ where
     fn new(
         storage: Storage<EF, BF, DB>,
         pool: Pool,
+        activation_manager: ActivationManager<VoteWatcher, Address>,
         bitcoin_checkpoints: Arc<BitcoinCheckpointsChain>,
         driver_tx: tokio::sync::mpsc::Sender<ABCIDriverMessage>,
         cbft_rpc_provider: HttpCometBFTRpcClientFactory,
@@ -416,6 +427,7 @@ where
         Self {
             storage: storage.clone(),
             pool,
+            activation_manager,
             bitcoin_checkpoints,
             // Saving the last 5 blocks that were proposed
             block_cache,

--- a/crates/consensus/authority/src/comet_bft/abci.rs
+++ b/crates/consensus/authority/src/comet_bft/abci.rs
@@ -1406,8 +1406,32 @@ where
         let max_tx_bytes: usize =
             request.max_tx_bytes.try_into().expect("Invalid request proposal max_tx_bytes value");
 
+        // Activation Manager: decide whether we should build for the current or
+        // upgraded runtime version.
+        let decision = self
+            .activation_manager
+            .on_prepare_proposal(request.height as u64)
+            .expect("db cannot fail");
+
+        let use_version = decision.version;
+        let upgrade_vote = decision.vote;
+
+        let mut floor_base_fee_per_gas = None;
+        match use_version {
+            RUNTIME_VERSION_ACTIVE => {
+                // Continue; do not set a floor base fee per gas.
+                debug!("prepare_proposal: Building with active version: {use_version}");
+            }
+            RUNTIME_VERSION_UPGRADE => {
+                // Set floor base fee per gas.
+                debug!("prepare_proposal: Building with UPGRADED version: {use_version}");
+                floor_base_fee_per_gas = Some(FLOOR_BASE_FEE_PER_GAS);
+            }
+            _ => unreachable!(),
+        };
+
         // create non-deterministic data tx at index 0 so historical sync will pass verification
-        let non_deterministic_data = match self.non_deterministic_data() {
+        let non_deterministic_data = match self.non_deterministic_data(use_version, upgrade_vote) {
             Ok(ndd) => ndd,
             Err(e) => {
                 panic!(
@@ -1468,7 +1492,7 @@ where
             return response;
         }
 
-        let payload_config = match self.payload_builder_arguments() {
+        let mut payload_config = match self.payload_builder_arguments() {
             Ok(payload_config) => payload_config,
             Err(e) => {
                 panic!(
@@ -1477,7 +1501,15 @@ where
                 );
             }
         };
+
         let client = self.storage.client.clone();
+
+        // Set the floor base fee per gas if provided.
+        if let Some(floor) = floor_base_fee_per_gas {
+            let basefee = payload_config.initialized_block_env.basefee.to::<u64>();
+
+            payload_config.initialized_block_env.basefee = U256::from(basefee.max(floor));
+        }
 
         let build_args = BuildArguments {
             client,

--- a/crates/consensus/authority/src/comet_bft/mod.rs
+++ b/crates/consensus/authority/src/comet_bft/mod.rs
@@ -1,2 +1,3 @@
 /// ABCI client implementation and consensus engine
 pub mod abci;
+pub mod vote_tracker;

--- a/crates/consensus/authority/src/comet_bft/vote_tracker.rs
+++ b/crates/consensus/authority/src/comet_bft/vote_tracker.rs
@@ -1,0 +1,162 @@
+//! A simple in-memory vote tracker used by the ActivationManager which only
+//! tracks the last vote.
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
+
+use reth_db::models::Vote;
+use reth_primitives::Address;
+use reth_provider::{ActivationManagerReaderWriter, ProviderResult};
+
+/// A simple in-memory vote tracker used by the ActivationManager which only
+/// tracks the last vote.
+#[derive(Debug, Clone, Default)]
+pub struct VoteWatcher {
+    votes: Arc<RwLock<HashMap<Address, VoteEntry>>>,
+}
+
+#[derive(Debug)]
+struct VoteEntry {
+    vote: Vote,
+    is_compliant: bool,
+    botanix_height: u64,
+}
+
+// NOTE: This implementation was essentially copied 1-to-1 from the
+// ActivationManager unit tests.
+impl ActivationManagerReaderWriter<Address> for VoteWatcher {
+    fn update_upgrading_vote(
+        &self,
+        auth: Address,
+        vote: Vote,
+        is_compliant: bool,
+        botanix_height: u64,
+    ) -> ProviderResult<()> {
+        let mut votes = self.votes.write().unwrap();
+
+        #[rustfmt::skip]
+        votes
+            .entry(auth)
+            .and_modify(|e| {
+                e.vote = vote;
+                e.is_compliant = is_compliant;
+                e.botanix_height = botanix_height;
+            })
+            .or_insert(VoteEntry {
+                vote,
+                is_compliant,
+                botanix_height,
+            });
+
+        Ok(())
+    }
+
+    fn get_upgrading_approval_rate_ayes(
+        &self,
+        min_validator_count: usize,
+    ) -> ProviderResult<(usize, usize)> {
+        let votes = self.votes.read().unwrap();
+
+        let total = votes.len().max(min_validator_count);
+        let votes_received = votes.iter().filter(|(_, e)| e.vote == Vote::Aye).count();
+
+        // Calculate percentage (0-100) of votes received
+        let quorum = (votes_received * 100).div_ceil(total);
+
+        Ok((quorum, total))
+    }
+
+    fn get_upgrading_approval_rate_compliance(
+        &self,
+        min_validator_count: usize,
+    ) -> ProviderResult<(usize, usize)> {
+        let votes = self.votes.read().unwrap();
+
+        let total = votes.len().max(min_validator_count);
+        let votes_received = votes.iter().filter(|(_, e)| e.is_compliant).count();
+
+        // Calculate percentage (0-100) of votes received
+        let quorum = (votes_received * 100).div_ceil(total);
+
+        Ok((quorum, total))
+    }
+
+    fn remove_upgrading_votes(&self, botanix_height: u64) -> ProviderResult<usize> {
+        let mut votes = self.votes.write().unwrap();
+
+        let gross_total = votes.len();
+        votes.retain(|_, e| e.botanix_height >= botanix_height);
+
+        Ok(gross_total - votes.len())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_vote_watcher_basic_properties() {
+        let watcher = VoteWatcher::default();
+
+        let alice = Address::from_slice(&[0; 20]);
+        let bob = Address::from_slice(&[1; 20]);
+        let eve = Address::from_slice(&[2; 20]);
+
+        let min_val_count = 10;
+        let botanix_height = 500;
+
+        // Check basic init properties.
+        //
+        let ayes = watcher.get_upgrading_approval_rate_ayes(min_val_count).unwrap();
+        assert_eq!(ayes, (0, min_val_count));
+
+        let compliant = watcher.get_upgrading_approval_rate_compliance(min_val_count).unwrap();
+        assert_eq!(compliant, (0, min_val_count));
+
+        let removed = watcher.remove_upgrading_votes(botanix_height).unwrap();
+        assert_eq!(removed, 0);
+
+        // Track votes.
+        //
+        watcher.update_upgrading_vote(alice, Vote::Aye, true, botanix_height).unwrap();
+        watcher.update_upgrading_vote(bob, Vote::Aye, false, botanix_height).unwrap();
+        watcher.update_upgrading_vote(eve, Vote::Nay, false, botanix_height).unwrap();
+
+        let ayes = watcher.get_upgrading_approval_rate_ayes(min_val_count).unwrap();
+        assert_eq!(ayes, (20, min_val_count)); // 20%
+
+        let compliant = watcher.get_upgrading_approval_rate_compliance(min_val_count).unwrap();
+        assert_eq!(compliant, (10, min_val_count)); // 10%
+
+        // Eve votes again
+        //
+        watcher.update_upgrading_vote(eve, Vote::Aye, true, botanix_height).unwrap();
+
+        let ayes = watcher.get_upgrading_approval_rate_ayes(min_val_count).unwrap();
+        assert_eq!(ayes, (30, min_val_count)); // 30%
+
+        let compliant = watcher.get_upgrading_approval_rate_compliance(min_val_count).unwrap();
+        assert_eq!(compliant, (20, min_val_count)); // 20%
+
+        // Remove votes
+        //
+        let removed = watcher.remove_upgrading_votes(botanix_height).unwrap();
+        assert_eq!(removed, 0);
+
+        let removed = watcher.remove_upgrading_votes(botanix_height + 1).unwrap();
+        assert_eq!(removed, 3); // alice, bob and eve
+
+        // Removed; all is gone
+        //
+        let ayes = watcher.get_upgrading_approval_rate_ayes(min_val_count).unwrap();
+        assert_eq!(ayes, (0, min_val_count));
+
+        let compliant = watcher.get_upgrading_approval_rate_compliance(min_val_count).unwrap();
+        assert_eq!(compliant, (0, min_val_count));
+
+        let removed = watcher.remove_upgrading_votes(botanix_height).unwrap();
+        assert_eq!(removed, 0);
+    }
+}

--- a/crates/consensus/authority/src/excecution_utils.rs
+++ b/crates/consensus/authority/src/excecution_utils.rs
@@ -41,6 +41,7 @@ pub(crate) mod authority_execution_utils {
     pub(crate) fn build_and_execute<BF, DB>(
         transactions: Vec<TransactionSigned>,
         chain_spec: Arc<ChainSpec>,
+        floor_base_fee: Option<u64>,
         block_fee_recipient_address: &Address,
         evm_config: EthEvmConfig,
         database_provider: &ProviderFactory<DB>,
@@ -67,7 +68,7 @@ pub(crate) mod authority_execution_utils {
         );
 
         // Construct block and header
-        let header = build_header_template(
+        let mut header = build_header_template(
             &transactions,
             database_provider,
             bitcoin_checkpoint_block_hash,
@@ -76,6 +77,15 @@ pub(crate) mod authority_execution_utils {
             timestamp,
             block_fee_recipient_address,
         )?;
+
+        debug_assert!(header.base_fee_per_gas.is_some());
+
+        // Set the floor base fee per gas if provided.
+        header.base_fee_per_gas.as_mut().map(|base_fee| {
+            if let Some(floor) = floor_base_fee {
+                *base_fee = (*base_fee).max(floor);
+            }
+        });
 
         let mut block =
             Block { header, body: transactions, ommers: vec![], withdrawals: None, requests: None };

--- a/crates/storage/db-api/src/models/activation_manager.rs
+++ b/crates/storage/db-api/src/models/activation_manager.rs
@@ -85,6 +85,12 @@ impl From<(u16, u16)> for RuntimeVersion {
     }
 }
 
+impl std::fmt::Display for RuntimeVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}", self.0 .0, self.1 .0)
+    }
+}
+
 /// Represents a major version component of a runtime version.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct MajorVersion(pub u16);

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -54,7 +54,6 @@ reth-trie-db = { workspace = true, features = ["metrics"] }
 revm = { workspace = true }
 
 ## crypto
-secp256k1 = { workspace = true, features = ["global-context", "rand-std", "recovery"] }
 strum = { workspace = true }
 
 # async

--- a/crates/storage/provider/src/traits/activation_manager.rs
+++ b/crates/storage/provider/src/traits/activation_manager.rs
@@ -9,7 +9,7 @@ use reth_errors::ProviderResult;
 /// Implementations should maintain persistence of votes between blocks and handle
 /// the removal of expired votes.
 #[auto_impl::auto_impl(&, Arc, Box)]
-pub trait ActivationManagerReaderWriter: Send + Sync {
+pub trait ActivationManagerReaderWriter<Auth>: Send + Sync {
     /// Records or updates a validator's vote for a network upgrade.
     ///
     /// This method stores a validator's vote and acceptance status for a network upgrade
@@ -27,7 +27,7 @@ pub trait ActivationManagerReaderWriter: Send + Sync {
     /// * `Err` if there was an error recording the vote
     fn update_upgrading_vote(
         &self,
-        auth: secp256k1::PublicKey,
+        auth: Auth,
         vote: Vote,
         is_compliant: bool,
         botanix_height: u64,


### PR DESCRIPTION
_TBD_

**Important Commits**
* Poa upgrade parameters and conditions (mainnet & testnet): https://github.com/botanix-labs/Macbeth/pull/840/commits/9775c6138f76991a66ba11f70f71059dcbe22c47
```rust
if *is_testnet {
    quorum = 100; // 100% ~= 3/3 members must approve
    min_validator_count = 3;
    target_height = 1; // Activate as soon as possible
    our_vote = Vote::Aye;
} else {
    quorum = 100; // 100% ~= 15/15 members must approve
    min_validator_count = 15;
    target_height = 1; // Activate as soon as possible
    our_vote = Vote::Aye;
}
```
* NDD upgrade (backwards-compatible): https://github.com/botanix-labs/Macbeth/pull/840/commits/24f99f304c3165bfc8b13885f89fffc32eb7a9b0
  * Note that this should be unified with the types in the `activation_manager` module at some point, added a comment about that here: https://github.com/botanix-labs/Macbeth/pull/840/commits/888399157da908ba8b9f028020c63cc9988ea28d
* `build_and_execute` option to set floor base fee per gas: https://github.com/botanix-labs/Macbeth/pull/840/commits/8f342da8f4a66102825e15ab5e4480a1a64f97d0
* Consensus compliance and migration logic:
  * `prepare_proposal`: https://github.com/botanix-labs/Macbeth/pull/840/commits/a04b598c4381190eb01b9fa1d161629d1c35e9ed
    * Note the manual interference into `payload_config`
  * `process_proposal`: https://github.com/botanix-labs/Macbeth/pull/840/commits/17e84264e861b45c0383f51013a38f1b28355866
  * `finalize_block`: https://github.com/botanix-labs/Macbeth/pull/840/commits/082a867d3716f425e611a60767f38794abccdab1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced support for network upgrade voting, allowing validators to vote on runtime upgrades with explicit compliance tracking.
  * Added runtime version awareness throughout block proposal, processing, and finalization, including adjustable base fee handling for upgraded versions.
  * Integrated an in-memory vote tracker for real-time validator vote management and approval rate calculation.
  * Enabled activation management with configurable quorum and validator counts for testnet and mainnet modes.

* **Improvements**
  * Enhanced compatibility and flexibility in validator identity handling by generalizing authorization key types.
  * Improved serialization and deserialization logic for non-deterministic data, supporting versioned fields and backward compatibility.
  * Added user-friendly display formatting for runtime versions.
  * Simplified test utilities by replacing cryptographic keys with basic address types for validator identities.

* **Bug Fixes**
  * Ensured backward compatibility with previous data formats during upgrades.

* **Tests**
  * Expanded and updated test coverage for voting, network upgrade handling, and approval rate calculations.
  * Added tests verifying network upgrade votes in block proposals with empty mempools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->