### PR TITLE
hotfix(hard-fork): Initiate `ActivationManager` with upgrade conditions & floor base fee per gas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10412,7 +10412,6 @@ dependencies = [
  "reth-trie",
  "reth-trie-db",
  "revm",
- "secp256k1 0.29.1",
  "strum 0.26.3",
  "tempfile",
  "tokio",

--- a/bin/reth/src/commands/poa/mod.rs
+++ b/bin/reth/src/commands/poa/mod.rs
@@ -13,7 +13,11 @@ use eyre::Context;
 use fdlimit::raise_fd_limit;
 use futures::TryFutureExt;
 use reth_authority_consensus::{
-    comet_bft::abci::ABCIDriver,
+    activation_manager::ActivationManagerBuilder,
+    comet_bft::{
+        abci::{ABCIDriver, RUNTIME_VERSION_ACTIVE, RUNTIME_VERSION_UPGRADE},
+        vote_tracker::VoteWatcher,
+    },
     random_source_provider::RandomSourceProvider,
     snapshot_manager::SnapshotRunnable,
     utils::{is_known_minting_contract, retry_exec},
@@ -57,7 +61,7 @@ use reth_chainspec::{BOTANIX_MAINNET_CHAIN_ID, BOTANIX_TESTNET_CHAIN_ID};
 use reth_cli_runner::CliContext;
 use reth_config::{config::StageConfig, Config};
 use reth_consensus_common::utils;
-use reth_db::{database::Database, init_db, DatabaseEnv};
+use reth_db::{database::Database, init_db, models::Vote, DatabaseEnv};
 use reth_exex::ExExManagerHandle;
 use reth_network::{
     frost::{manager::FrostConfig, protocol::FrostProtoHandler},
@@ -771,12 +775,42 @@ impl<Ext: clap::Args + fmt::Debug> PoaNodeCommand<Ext> {
             .with_port(*cometbft_rpc_port)
             .with_host(cometbft_rpc_host);
 
+        let quorum;
+        let min_validator_count;
+        let target_height;
+        let our_vote;
+
+        // ActivationManager: setup parameters and conditions.
+        if *is_testnet {
+            quorum = 100; // 100% ~= 3/3 members must approve
+            min_validator_count = 3;
+            target_height = 1; // Activate as soon as possible
+            our_vote = Vote::Aye;
+        } else {
+            quorum = 100; // 100% ~= 15/15 members must approve
+            min_validator_count = 15;
+            target_height = 1; // Activate as soon as possible
+            our_vote = Vote::Aye;
+        }
+
+        // ActivationManager: setup compliance and vote inclusion.
+        let activation_manager =
+            ActivationManagerBuilder::new(VoteWatcher::default(), RUNTIME_VERSION_ACTIVE)
+                .build_COMPLIANT_network_upgrade(
+                    RUNTIME_VERSION_UPGRADE,
+                    quorum,
+                    min_validator_count,
+                    target_height,
+                    Some(our_vote),
+                );
+
         // Build authority Consensus
         let (abci_started_tx, abci_started_rx) = tokio::sync::oneshot::channel::<()>();
         let (frost_task, abci_client_builder, snapshot_manager, wallet_sync) =
             match AuthorityConsensusBuilder::try_new(
                 Arc::clone(&chain_arc.clone()),
                 blockchain_db.clone(),
+                activation_manager,
                 btc_server_factory.clone(),
                 bitcoin_block_header_clone.clone(),
                 secret_key,

--- a/bin/reth/src/commands/poa/mod.rs
+++ b/bin/reth/src/commands/poa/mod.rs
@@ -787,8 +787,8 @@ impl<Ext: clap::Args + fmt::Debug> PoaNodeCommand<Ext> {
             target_height = 1; // Activate as soon as possible
             our_vote = Vote::Aye;
         } else {
-            quorum = 100; // 100% ~= 15/15 members must approve
-            min_validator_count = 15;
+            quorum = 100; // 100% ~= 16/16 members must approve
+            min_validator_count = 16;
             target_height = 1; // Activate as soon as possible
             our_vote = Vote::Aye;
         }

--- a/crates/consensus/authority/src/activation_manager/mod.rs
+++ b/crates/consensus/authority/src/activation_manager/mod.rs
@@ -260,7 +260,7 @@ impl ConditionList {
 /// This builder provides methods to configure how a validator will handle
 /// network upgrades - whether it will ignore them, signal votes without
 /// being compliant, or fully accept upgrades when conditions are met.
-pub struct ActivationManagerBuilder<DB> {
+pub struct ActivationManagerBuilder<DB, Auth> {
     /// The database client implementing ActivationManagerReaderWriter
     client: DB,
 
@@ -272,11 +272,13 @@ pub struct ActivationManagerBuilder<DB> {
 
     /// Configuration for a pending network upgrade, if any
     upgrade: Option<NetworkUpgrade>,
+
+    _p: std::marker::PhantomData<Auth>,
 }
 
-impl<DB> ActivationManagerBuilder<DB>
+impl<DB, Auth> ActivationManagerBuilder<DB, Auth>
 where
-    DB: ActivationManagerReaderWriter,
+    DB: ActivationManagerReaderWriter<Auth>,
 {
     /// Creates a new ActivationManagerBuilder with specified database client and active version.
     ///
@@ -295,6 +297,7 @@ where
             active_version,
             vote_retention_period: VOTE_RETENTION_PERIOD,
             upgrade: None,
+            _p: std::marker::PhantomData,
         }
     }
 
@@ -327,7 +330,7 @@ where
     ///
     /// # Returns
     /// * An ActivationManager configured to ignore network upgrades
-    pub fn build_ignore_nework_upgrade(self) -> ActivationManager<DB> {
+    pub fn build_ignore_nework_upgrade(self) -> ActivationManager<DB, Auth> {
         debug_assert!(self.upgrade.is_none());
         self._finalize()
     }
@@ -356,7 +359,7 @@ where
         mut self,
         upgrade_version: RuntimeVersion,
         our_vote: Vote,
-    ) -> ActivationManager<DB> {
+    ) -> ActivationManager<DB, Auth> {
         assert!(self.active_version < upgrade_version);
 
         #[rustfmt::skip]
@@ -408,7 +411,7 @@ where
         min_validator_count: usize,
         target_height: u64,
         our_vote: Option<Vote>,
-    ) -> ActivationManager<DB> {
+    ) -> ActivationManager<DB, Auth> {
         assert!(
             self.active_version < upgrade_version,
             "upgrade version is older than the active version"
@@ -437,12 +440,13 @@ where
         self._finalize()
     }
 
-    fn _finalize(self) -> ActivationManager<DB> {
+    fn _finalize(self) -> ActivationManager<DB, Auth> {
         ActivationManager {
             client: self.client,
             vote_retention_period: self.vote_retention_period,
             active_version: Arc::new(RwLock::new(self.active_version)),
             upgrade: Arc::new(RwLock::new(self.upgrade)),
+            _p: std::marker::PhantomData,
         }
     }
 }
@@ -467,7 +471,7 @@ where
 /// state through atomic reference counting and read-write locks, allowing it to
 /// be shared between concurrent contexts.
 #[derive(Clone)]
-pub struct ActivationManager<DB> {
+pub struct ActivationManager<DB, Auth> {
     /// Database client for persisting and retrieving votes
     client: DB,
 
@@ -481,11 +485,13 @@ pub struct ActivationManager<DB> {
     /// Configuration for a pending network upgrade, if any
     /// Protected by a read-write lock for thread-safe updates
     upgrade: Arc<RwLock<Option<NetworkUpgrade>>>,
+
+    _p: std::marker::PhantomData<Auth>,
 }
 
-impl<DB> ActivationManager<DB>
+impl<DB, Auth> ActivationManager<DB, Auth>
 where
-    DB: ActivationManagerReaderWriter,
+    DB: ActivationManagerReaderWriter<Auth>,
 {
     /// Prepares a proposal decision based on the current upgrade state.
     ///
@@ -633,7 +639,7 @@ where
         &self,
         block_version: RuntimeVersion,
         block_height: u64,
-        proposer_address: secp256k1::PublicKey,
+        proposer_address: Auth,
         proposer_vote: Option<NetworkUpgradePayload>,
     ) -> ProviderResult<OnFinalizeBlockDecision> {
         // Track the proposer's vote for upgrade intention, if provided
@@ -757,7 +763,7 @@ where
     fn _track_vote(
         &self,
         block_height: u64,
-        addr: secp256k1::PublicKey,
+        addr: Auth,
         vote: Option<NetworkUpgradePayload>,
     ) -> ProviderResult<()> {
         // If the proposer made a vote...

--- a/crates/consensus/authority/src/activation_manager/tests/mod.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/mod.rs
@@ -1,8 +1,7 @@
 use super::*;
-use rand::thread_rng;
 use reth_provider::ProviderResult;
-use secp256k1::generate_keypair;
 use std::{collections::HashMap, sync::Arc};
+use utils::Address;
 
 mod accept_lagging_validator;
 mod reject_ignored_upgrade;
@@ -18,7 +17,7 @@ mod wait_for_compliance;
 /// In-Memory database that integrates the `ActivationManagerReaderWriter` trait.
 #[derive(Clone)]
 struct Db {
-    votes: Arc<RwLock<HashMap<secp256k1::PublicKey, VoteEntry>>>,
+    votes: Arc<RwLock<HashMap<Address, VoteEntry>>>,
 }
 
 impl Db {
@@ -33,10 +32,10 @@ struct VoteEntry {
     botanix_height: u64,
 }
 
-impl ActivationManagerReaderWriter for Db {
+impl ActivationManagerReaderWriter<utils::Address> for Db {
     fn update_upgrading_vote(
         &self,
-        auth: secp256k1::PublicKey,
+        auth: Address,
         vote: Vote,
         is_compliant: bool,
         botanix_height: u64,
@@ -104,10 +103,10 @@ impl ActivationManagerReaderWriter for Db {
 fn activation_manager_basic_db_interface() {
     let db = Db::new();
 
-    // Generate keypairs
-    let (_, alice) = generate_keypair(&mut thread_rng());
-    let (_, bob) = generate_keypair(&mut thread_rng());
-    let (_, eve) = generate_keypair(&mut thread_rng());
+    // Generate addresses
+    let alice = b"alice".to_vec();
+    let bob = b"bob".to_vec();
+    let eve = b"eve".to_vec();
 
     let min_validator_count = 3;
 

--- a/crates/consensus/authority/src/activation_manager/tests/utils.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/utils.rs
@@ -5,7 +5,6 @@ use crate::activation_manager::{
 };
 use reth_db::models::activation_manager::{RuntimeVersion, Vote};
 use reth_provider::ActivationManagerReaderWriter;
-use secp256k1::{generate_keypair, rand::thread_rng};
 
 /// Index for the ALICE validator in the test fixture
 pub(super) const ALICE: usize = 0;
@@ -36,6 +35,9 @@ struct VoteDetails {
     is_compliant: bool,
 }
 
+/// Internal address to distinguish between members.
+pub(super) type Address = Vec<u8>;
+
 /// Main test fixture for network upgrade scenarios.
 ///
 /// This fixture manages the state for multiple validators in upgrade testing
@@ -56,11 +58,11 @@ pub(super) struct UpgradeTestFixture {
     vote_retention_period: u64,
 
     /// The public keys representing each validator's identity
-    addrs: [secp256k1::PublicKey; 3],
+    addrs: [Address; 3],
     /// In-memory databases for each validator
     dbs: [Db; 3],
     /// The activation manager instances for each validator
-    managers: [Option<ActivationManager<Db>>; 3],
+    managers: [Option<ActivationManager<Db, Address>>; 3],
     /// Expected votes to be included in block proposals for each validator
     expected_votes: [Option<VoteDetails>; 3],
 }
@@ -79,10 +81,9 @@ impl UpgradeTestFixture {
     /// # Returns
     /// * A new `UpgradeTestFixture` with default values and generated validator keys
     pub(super) fn new(upgrade_height: u64, approval_rate: usize) -> Self {
-        // Generate keypairs
-        let (_, alice_addr) = generate_keypair(&mut thread_rng());
-        let (_, bob_addr) = generate_keypair(&mut thread_rng());
-        let (_, eve_addr) = generate_keypair(&mut thread_rng());
+        let alice_addr = b"alice".to_vec();
+        let bob_addr = b"bob".to_vec();
+        let eve_addr = b"eve".to_vec();
 
         Self {
             upgrade_height,
@@ -404,7 +405,7 @@ impl ProposingTestFixture<'_> {
         dbg!(self.i.block_height);
 
         let proposer = self.i.managers[self.proposer_index].as_mut().unwrap();
-        let proposer_addr = &self.i.addrs[self.proposer_index];
+        let proposer_addr = self.i.addrs[self.proposer_index].clone();
 
         // Proposer builds the block
         let OnPrepareProposalDecision {
@@ -483,8 +484,8 @@ impl ProposingTestFixture<'_> {
                 .on_finalize_block(
                     proposer_version,
                     self.i.block_height,
-                    *proposer_addr,
-                    proposer_vote.clone(),
+                    proposer_addr.clone(),
+                    proposer_vote,
                 )
                 .unwrap();
 

--- a/crates/consensus/authority/src/builder.rs
+++ b/crates/consensus/authority/src/builder.rs
@@ -1,5 +1,9 @@
 use crate::{
-    comet_bft::abci::{ABCIClientBuilder, ABCIDriverMessage},
+    activation_manager::ActivationManager,
+    comet_bft::{
+        abci::{ABCIClientBuilder, ABCIDriverMessage},
+        vote_tracker::VoteWatcher,
+    },
     frost_task::FrostTask,
     metrics::AuthorityMetrics,
     random_source_provider::RandomSource,
@@ -22,9 +26,11 @@ use reth_network::{
 };
 use reth_node_core::args::StateSyncArgs;
 use reth_node_ethereum::EthEvmConfig;
-use reth_primitives::header_ext::HeaderExt;
+use reth_primitives::{header_ext::HeaderExt, Address};
 use reth_provider::{
-    BlockReaderIdExt, CanonChainTracker, CanonStateSubscriptions, ProviderFactory, SnapshotReader, SnapshotWriter, StagedHeader, StateProviderFactory, WalletStateSyncReader, WalletStateSyncWriter
+    BlockReaderIdExt, CanonChainTracker, CanonStateSubscriptions, ProviderFactory, SnapshotReader,
+    SnapshotWriter, StagedHeader, StateProviderFactory, WalletStateSyncReader,
+    WalletStateSyncWriter,
 };
 
 use reth_tasks::TaskExecutor;
@@ -42,6 +48,7 @@ pub(crate) type BitcoinCheckpoint = Arc<TokioRwLock<Option<(bitcoin::block::Head
 pub struct AuthorityConsensusBuilder<EF, BF, DB, ToFrostMan, Source> {
     consensus: AuthorityConsensus,
     storage: Storage<EF, BF, DB>,
+    activation_manager: ActivationManager<VoteWatcher, Address>,
     btc_server_factory: Option<GrpcClientFactory>,
     bitcoin_block_header: Arc<TokioRwLock<Option<(bitcoin::block::Header, u32)>>>,
     network_handle: NetworkHandle,
@@ -90,6 +97,7 @@ where
     pub fn try_new(
         chain_spec: Arc<ChainSpec>,
         client: DB,
+        activation_manager: ActivationManager<VoteWatcher, Address>,
         btc_server_factory: Option<GrpcClientFactory>,
         bitcoin_block_header: BitcoinCheckpoint,
         sk: secp256k1::SecretKey,
@@ -179,6 +187,7 @@ where
 
         Ok(Self {
             storage,
+            activation_manager,
             consensus: AuthorityConsensus::new(chain_spec),
             btc_server_factory,
             bitcoin_block_header,
@@ -215,6 +224,7 @@ where
             btc_server_factory,
             consensus,
             storage,
+            activation_manager,
             bitcoin_block_header,
             network_handle,
             frost_handle,
@@ -291,6 +301,7 @@ where
         // all nodes will have an abci client builder
         let abci_client_builder = Some(ABCIClientBuilder::new(
             storage.clone(),
+            activation_manager,
             bitcoin_block_header,
             consensus.clone(),
             cometbft_rpc_factory.clone(),

--- a/crates/consensus/authority/src/comet_bft/abci.rs
+++ b/crates/consensus/authority/src/comet_bft/abci.rs
@@ -113,7 +113,7 @@ use super::proto_debug::{
     ResponsePrepareProposalTruncatedDebug,
 };
 use crate::{
-    activation_manager::{ActivationManager, OnProcessProposalDecision},
+    activation_manager::{ActivationManager, OnFinalizeBlockDecision, OnProcessProposalDecision},
     builder::BitcoinCheckpoint,
     comet_bft::{
         non_deterministic_data::{
@@ -2070,10 +2070,30 @@ where
                     }
                 };
 
+                let runtime_version = non_deterministic_data.runtime_version();
+                let network_upgrade_payload =
+                    non_deterministic_data.network_upgrade_payload().copied();
+
+                let floor_base_fee_per_gas = match runtime_version {
+                    RUNTIME_VERSION_ACTIVE => {
+                        // Continue; do not set a floor base fee per gas.
+                        debug!("finalize_block: Finalizing block with active runtime version: {runtime_version}");
+                        None
+                    }
+                    RUNTIME_VERSION_UPGRADE => {
+                        // Set floor base fee per gas.
+                        debug!("finalize_block: Finalizing block with UPGRADED version: {runtime_version}");
+                        Some(FLOOR_BASE_FEE_PER_GAS)
+                    }
+                    _ => unreachable!(),
+                };
+
                 match build_and_execute(
                     txs,
                     self.storage.chain_spec.clone(),
-                    None,
+                    runtime_version,
+                    network_upgrade_payload,
+                    floor_base_fee_per_gas,
                     &block_fee_recipient_address,
                     self.storage.evm_config,
                     &self.provider_factory,
@@ -2102,6 +2122,32 @@ where
                 }
             }
         };
+
+        // Activation Manager: decide whether we're willing to accept
+        // the runtime version.
+        //
+        // Note that lagging validators will automatically accept an
+        // upgrade as long as they're specifically configured to do so
+        // (non-default behavior) - whether the upgrade conditions are
+        // met or not.
+        let comet_height = request.height as u64;
+        let runtime_version = block_with_context.runtime_version;
+        let proposer_address = Address::from_slice(&request.proposer_address);
+        let proposer_vote = block_with_context.network_upgrade_payload;
+        //
+        match self
+            .activation_manager
+            .on_finalize_block(runtime_version, comet_height, proposer_address, proposer_vote)
+            .expect("db cannot fail")
+        {
+            OnFinalizeBlockDecision::Finalize { version: _ } => {
+                // Continue...
+            }
+            OnFinalizeBlockDecision::RejectBlockDeadEnd { version } => {
+                error!("finalize_block: Rejecting finalized block with Botanix runtime version: {version}");
+                panic!("finalize_block: Rejecting Botanix upgrade '{version}' - can no longer proceed...");
+            }
+        }
 
         // Rpc node needs to store aggregate public key from block height 1
         let block_height = block_with_context.sealed_block_with_peg.block().number;

--- a/crates/consensus/authority/src/comet_bft/abci.rs
+++ b/crates/consensus/authority/src/comet_bft/abci.rs
@@ -32,7 +32,7 @@ use comet_bft_rpc::HttpCometBFTRpcClientFactory;
 use reth_payload_builder::EthPayloadBuilderAttributes;
 use reth_primitives::{
     botanix::block_with_peg::SealedBlockWithPeg, header_ext::HeaderExt, Address, BlockHash,
-    BlockNumber, BlockWithSenders, SealedBlock, B256,
+    BlockNumber, BlockWithSenders, SealedBlock, B256, U256,
 };
 use reth_provider::{
     BlockReaderIdExt, CanonStateNotification, Chain, ProviderError, ProviderFactory,
@@ -58,6 +58,13 @@ use tendermint_proto::{
         Snapshot,
     },
 };
+
+/// The currently active Botanix runtime version.
+pub const RUNTIME_VERSION_ACTIVE: RuntimeVersion = GENESIS_RUNTIME_VERSION;
+/// The Botanix runtime version to eventually upgrade to.
+pub const RUNTIME_VERSION_UPGRADE: RuntimeVersion = RuntimeVersion::new(0, 2);
+/// The floor base fee per gas to be used for the upgraded Botanix runtime version.
+const FLOOR_BASE_FEE_PER_GAS: u64 = 5_000_000; // 5_000_000 Wei = 0.005 Gwei
 
 impl From<&Snapshot> for SnapshotSyncStateLock {
     fn from(snapshot: &Snapshot) -> Self {
@@ -109,7 +116,9 @@ use crate::{
     activation_manager::ActivationManager,
     builder::BitcoinCheckpoint,
     comet_bft::{
-        non_deterministic_data::{NetworkUpgradePayload, NonDeterministicData},
+        non_deterministic_data::{
+            NetworkUpgradePayload, NonDeterministicData, GENESIS_RUNTIME_VERSION,
+        },
         utils::transactions_signed_from_bytes,
         vote_tracker::VoteWatcher,
     },
@@ -1299,8 +1308,19 @@ where
         let max_tx_bytes: usize =
             request.max_tx_bytes.try_into().expect("Invalid request proposal max_tx_bytes value");
 
-        // create non-deterministic data tx at index 0 so historical sync will pass verification
-        let non_deterministic_data = match self.non_deterministic_data() {
+        // Activation Manager: decide whether we should build for the current or
+        // upgraded runtime version.
+        let decision = self
+            .activation_manager
+            .on_prepare_proposal(request.height as u64)
+            .expect("db cannot fail");
+
+        let use_version = decision.version;
+        let upgrade_vote = decision.vote;
+
+        // Construct the NDD version 2 with a runtime version indicator
+        // and an (optional) network upgrade payload.
+        let non_deterministic_data = match self.non_deterministic_data(use_version, upgrade_vote) {
             Ok(ndd) => ndd,
             Err(e) => {
                 panic!(
@@ -1310,9 +1330,27 @@ where
             }
         };
 
+        let floor_base_fee_per_gas = match use_version {
+            RUNTIME_VERSION_ACTIVE => {
+                // Continue with active version.
+                debug!("prepare_proposal: Building with active version: {use_version}");
+
+                // Do not set a floor base fee per gas.
+                None
+            }
+            RUNTIME_VERSION_UPGRADE => {
+                debug!("prepare_proposal: Building with UPGRADED version: {use_version}");
+
+                // Set floor base fee per gas.
+                Some(FLOOR_BASE_FEE_PER_GAS)
+            }
+            _ => unreachable!(),
+        };
+
         trace!("non_deterministic_data={:?}", non_deterministic_data);
 
-        // serialize non-deterministic data tx to bytes
+        // serialize non-deterministic data tx at index 0 to bytes so historical
+        // sync will pass verification
         let non_deterministic_data_bytes = match self
             .serialize_non_deterministic_data_to_bytes(non_deterministic_data)
         {
@@ -1361,7 +1399,7 @@ where
             return response;
         }
 
-        let payload_config = match self.payload_builder_arguments() {
+        let mut payload_config = match self.payload_builder_arguments() {
             Ok(payload_config) => payload_config,
             Err(e) => {
                 panic!(
@@ -1371,6 +1409,14 @@ where
             }
         };
         let client = self.storage.client.clone();
+
+        // Set the floor base fee per gas if provided.
+        if let Some(floor) = floor_base_fee_per_gas {
+            let basefee = payload_config.initialized_block_env.basefee.to::<u64>();
+            let min_basefee = basefee.max(floor);
+
+            payload_config.initialized_block_env.basefee = U256::from(min_basefee);
+        }
 
         let build_args = BuildArguments {
             client,

--- a/crates/consensus/authority/src/comet_bft/abci.rs
+++ b/crates/consensus/authority/src/comet_bft/abci.rs
@@ -106,10 +106,12 @@ use super::proto_debug::{
     ResponsePrepareProposalTruncatedDebug,
 };
 use crate::{
+    activation_manager::ActivationManager,
     builder::BitcoinCheckpoint,
     comet_bft::{
         non_deterministic_data::{NetworkUpgradePayload, NonDeterministicData},
         utils::transactions_signed_from_bytes,
+        vote_tracker::VoteWatcher,
     },
     excecution_utils::authority_execution_utils::{batch_execute, build_and_execute},
     metrics::AuthorityMetrics,
@@ -201,6 +203,7 @@ pub struct BlockWithContext {
 #[derive(Clone)]
 pub struct ABCIClientBuilder<EF, BF, DB> {
     storage: Storage<EF, BF, DB>,
+    activation_manager: ActivationManager<VoteWatcher, Address>,
     bitcoin_checkpoint: BitcoinCheckpoint,
     authority_consensus: AuthorityConsensus,
     cbft_rpc_client_factory: HttpCometBFTRpcClientFactory,
@@ -231,6 +234,7 @@ where
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         storage: Storage<EF, BF, DB>,
+        activation_manager: ActivationManager<VoteWatcher, Address>,
         bitcoin_checkpoint: BitcoinCheckpoint,
         authority_consensus: AuthorityConsensus,
         cbft_rpc_client_factory: HttpCometBFTRpcClientFactory,
@@ -246,6 +250,7 @@ where
     ) -> Self {
         Self {
             storage,
+            activation_manager,
             bitcoin_checkpoint,
             authority_consensus,
             cbft_rpc_client_factory,
@@ -273,6 +278,7 @@ where
         let app = ABCIClient::new(
             self.storage.clone(),
             tx_pool,
+            self.activation_manager.clone(),
             self.bitcoin_checkpoint.clone(),
             self.abci_driver_tx.clone(),
             self.cbft_rpc_client_factory.clone(),
@@ -337,6 +343,7 @@ enum PayloadBuilderError {
 pub(crate) struct ABCIClient<EF, BF, DB, Pool> {
     storage: Storage<EF, BF, DB>,
     pool: Pool,
+    activation_manager: ActivationManager<VoteWatcher, Address>,
     bitcoin_checkpoint: BitcoinCheckpoint,
     block_cache: Arc<RwLock<LruMap<BlockHash, BlockWithContext>>>,
     driver_tx: tokio::sync::mpsc::Sender<ABCIDriverMessage>,
@@ -372,6 +379,7 @@ where
     fn new(
         storage: Storage<EF, BF, DB>,
         pool: Pool,
+        activation_manager: ActivationManager<VoteWatcher, Address>,
         bitcoin_checkpoint: BitcoinCheckpoint,
         driver_tx: tokio::sync::mpsc::Sender<ABCIDriverMessage>,
         cbft_rpc_provider: HttpCometBFTRpcClientFactory,
@@ -389,6 +397,7 @@ where
         Self {
             storage: storage.clone(),
             pool,
+            activation_manager,
             bitcoin_checkpoint,
             // Saving the last 5 blocks that were proposed
             block_cache: Arc::new(RwLock::new(LruMap::new(ByLength::new(5)))),
@@ -2335,7 +2344,10 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
-    use crate::{builder::BitcoinCheckpoint, Storage};
+    use crate::{
+        activation_manager::ActivationManagerBuilder, builder::BitcoinCheckpoint,
+        comet_bft::non_deterministic_data::GENESIS_RUNTIME_VERSION, Storage,
+    };
     use bitcoin::{
         block::{BlockHash, Header, Version},
         hashes::Hash,
@@ -2434,6 +2446,10 @@ mod tests {
         let transaction_pool =
             RethPool::eth_pool(validator.clone(), blob_store, TxPoolArgs::default().pool_config());
 
+        let activation_manager =
+            ActivationManagerBuilder::new(VoteWatcher::default(), GENESIS_RUNTIME_VERSION)
+                .build_ignore_nework_upgrade();
+
         let bitcoin_header = Header {
             version: Version::default(),
             prev_blockhash: BlockHash::all_zeros(),
@@ -2453,6 +2469,7 @@ mod tests {
         ABCIClient::new(
             storage,
             transaction_pool,
+            activation_manager,
             bitcoin_checkpoint,
             driver_tx,
             cometbft_rpc_factory,

--- a/crates/consensus/authority/src/comet_bft/abci.rs
+++ b/crates/consensus/authority/src/comet_bft/abci.rs
@@ -113,7 +113,7 @@ use super::proto_debug::{
     ResponsePrepareProposalTruncatedDebug,
 };
 use crate::{
-    activation_manager::ActivationManager,
+    activation_manager::{ActivationManager, OnProcessProposalDecision},
     builder::BitcoinCheckpoint,
     comet_bft::{
         non_deterministic_data::{
@@ -1785,6 +1785,37 @@ where
             }
         };
 
+        // Activation Manager: decide whether we should process for the current
+        // or upgraded runtime version.
+        let floor_base_fee_per_gas;
+        let comet_height = request.height as u64;
+        let runtime_version = non_deterministic_data.runtime_version();
+        let network_upgrade_payload = non_deterministic_data.network_upgrade_payload().copied();
+        //
+        match self
+            .activation_manager
+            .on_process_proposal(comet_height, runtime_version)
+            .expect("db cannot fail")
+        {
+            OnProcessProposalDecision::Process { version, conditions: _ } => match version {
+                RUNTIME_VERSION_ACTIVE => {
+                    // Continue; do not set a floor base fee per gas.
+                    debug!("process_proposal: Processing with active version: {version}");
+                    floor_base_fee_per_gas = None;
+                }
+                RUNTIME_VERSION_UPGRADE => {
+                    // Set floor base fee per gas.
+                    debug!("process_proposal: Processing with UPGRADED version: {version}");
+                    floor_base_fee_per_gas = Some(FLOOR_BASE_FEE_PER_GAS);
+                }
+                _ => unreachable!(),
+            },
+            OnProcessProposalDecision::RejectBlock { version, conditions: _ } => {
+                warn!("process_proposal: Rejecting block using Botanix runtime version: {version}");
+                return ResponseProcessProposal { status: VERIFY_REJECT };
+            }
+        }
+
         // Validation done as a result of this call:
         // - botanix consensus package created on the fly and compared to the incoming block EDH
         // - mint validation checks
@@ -1794,6 +1825,9 @@ where
         match build_and_execute(
             txs,
             self.storage.chain_spec.clone(),
+            runtime_version,
+            network_upgrade_payload,
+            floor_base_fee_per_gas,
             &block_fee_recipient_address,
             self.storage.evm_config,
             &self.provider_factory,
@@ -2039,6 +2073,7 @@ where
                 match build_and_execute(
                     txs,
                     self.storage.chain_spec.clone(),
+                    None,
                     &block_fee_recipient_address,
                     self.storage.evm_config,
                     &self.provider_factory,

--- a/crates/consensus/authority/src/comet_bft/abci.rs
+++ b/crates/consensus/authority/src/comet_bft/abci.rs
@@ -202,6 +202,10 @@ impl SnapshotSyncStateLock {
 pub struct BlockWithContext {
     /// The sealed block with peg data
     pub sealed_block_with_peg: SealedBlockWithPeg,
+    /// The Botanix runtime version.
+    pub runtime_version: RuntimeVersion,
+    /// The optional network upgrade payload.
+    pub network_upgrade_payload: Option<NetworkUpgradePayload>,
     /// The execution outcome
     pub exec_outcome: ExecutionOutcome,
     /// The trie updates

--- a/crates/consensus/authority/src/comet_bft/abci.rs
+++ b/crates/consensus/authority/src/comet_bft/abci.rs
@@ -1568,7 +1568,8 @@ where
 
         // Only NDD V1 is supported for block production so validate `block_fee_recipient_address`
         // exists
-        let block_fee_recipient_address = match non_deterministic_data.block_fee_recipient_address {
+        let block_fee_recipient_address = match non_deterministic_data.block_fee_recipient_address()
+        {
             Some(address) => address,
             None => {
                 warn!("Block fee recipient address is not set in process proposal");
@@ -1634,7 +1635,7 @@ where
         };
 
         // check non-deterministic data: btc block hash and aggregate public key
-        if bitcoin_checkpoint_block_hash != non_deterministic_data.bitcoin_block_hash {
+        if bitcoin_checkpoint_block_hash != non_deterministic_data.bitcoin_block_hash() {
             warn!("Bitcoin checkpoint block hash mismatch");
 
             if tracing::enabled!(tracing::Level::WARN) {
@@ -1661,7 +1662,7 @@ where
             return ResponseProcessProposal { status: VERIFY_REJECT };
         }
 
-        if agg_pk != non_deterministic_data.aggregated_public_key {
+        if agg_pk != non_deterministic_data.aggregated_public_key() {
             warn!("Aggregate public key mismatch");
 
             if tracing::enabled!(tracing::Level::WARN) {
@@ -1923,7 +1924,7 @@ where
                 // NDD V0 (no block_fee_recipient_address) is supported only for historical sync on
                 // testnet
                 let block_fee_recipient_address = match non_deterministic_data
-                    .block_fee_recipient_address
+                    .block_fee_recipient_address()
                 {
                     Some(address) => {
                         debug!(%address, "use proposed block fee recipient address");
@@ -1978,8 +1979,8 @@ where
                     &self.provider_factory,
                     &self.storage.bitcoind_factory,
                     self.storage.btc_network,
-                    &non_deterministic_data.bitcoin_block_hash,
-                    &non_deterministic_data.aggregated_public_key,
+                    &non_deterministic_data.bitcoin_block_hash(),
+                    &non_deterministic_data.aggregated_public_key(),
                     block_time,
                 ) {
                     Ok(block_with_context) => {

--- a/crates/consensus/authority/src/comet_bft/abci.rs
+++ b/crates/consensus/authority/src/comet_bft/abci.rs
@@ -2085,7 +2085,13 @@ where
                         debug!("finalize_block: Finalizing block with UPGRADED version: {runtime_version}");
                         Some(FLOOR_BASE_FEE_PER_GAS)
                     }
-                    _ => unreachable!(),
+                    // This software is outdated and just encountered an
+                    // upgraded runtime version; this will be rejected in the
+                    // upcoming `ActivationManager::on_finalize_block(..)` call.
+                    _ => {
+                        warn!("finalize_block: Unrecognized runtime version: {runtime_version}");
+                        Some(FLOOR_BASE_FEE_PER_GAS) // just apply the latest change.
+                    }
                 };
 
                 match build_and_execute(

--- a/crates/consensus/authority/src/comet_bft/abci.rs
+++ b/crates/consensus/authority/src/comet_bft/abci.rs
@@ -4,7 +4,7 @@ use alloy_rpc_types_engine::ForkchoiceState;
 use reth_chain_state::ExecutedBlock;
 use reth_chainspec::{ChainSpec, BOTANIX_TESTNET_CHAIN_ID};
 use reth_db::{
-    models::{self, SnapshotSync, SnapshotSyncId},
+    models::{self, RuntimeVersion, SnapshotSync, SnapshotSyncId},
     Database, DatabaseEnv,
 };
 use reth_provider::{
@@ -108,7 +108,8 @@ use super::proto_debug::{
 use crate::{
     builder::BitcoinCheckpoint,
     comet_bft::{
-        non_deterministic_data::NonDeterministicData, utils::transactions_signed_from_bytes,
+        non_deterministic_data::{NetworkUpgradePayload, NonDeterministicData},
+        utils::transactions_signed_from_bytes,
     },
     excecution_utils::authority_execution_utils::{batch_execute, build_and_execute},
     metrics::AuthorityMetrics,
@@ -448,18 +449,23 @@ where
         ))
     }
 
-    pub(crate) fn non_deterministic_data(&self) -> Result<NonDeterministicData, ConsensusError> {
+    pub(crate) fn non_deterministic_data(
+        &self,
+        runtime_version: RuntimeVersion,
+        network_upgrade_payload: Option<NetworkUpgradePayload>,
+    ) -> Result<NonDeterministicData, ConsensusError> {
         let aggregate_public_key = self.aggregate_public_key()?;
         let block_fee_recipient_address = self
             .block_fee_recipient_address
             .ok_or(ConsensusError::MissingBlockFeeRecipientAddress)?;
 
-        // Only v1 is supported for block production
-        // v0 is only used for historical syncing in testnet
-        let ndd = NonDeterministicData::new_v1(
+        // Construct a NDD using version 2.
+        let ndd = NonDeterministicData::new_v2(
             self.bitcoin_blockhash()?,
             aggregate_public_key,
             block_fee_recipient_address,
+            runtime_version,
+            network_upgrade_payload,
         );
 
         Ok(ndd)
@@ -2467,7 +2473,7 @@ mod tests {
         client: &ABCIClientType,
     ) -> Result<prost::bytes::Bytes, ConsensusError> {
         client
-            .non_deterministic_data()
+            .non_deterministic_data(GENESIS_RUNTIME_VERSION, None)
             .and_then(|ndd| client.serialize_non_deterministic_data_to_bytes(ndd))
     }
 
@@ -2683,7 +2689,8 @@ mod tests {
         let mut request = RequestFinalizeBlock::default();
 
         // first tx should be non-deterministic data
-        let ndd = abci_client.non_deterministic_data().expect("to have ndd");
+        let ndd =
+            abci_client.non_deterministic_data(GENESIS_RUNTIME_VERSION, None).expect("to have ndd");
         let ndd_bytes =
             abci_client.serialize_non_deterministic_data_to_bytes(ndd).expect("to serialize ndd");
 

--- a/crates/consensus/authority/src/comet_bft/mod.rs
+++ b/crates/consensus/authority/src/comet_bft/mod.rs
@@ -1,5 +1,6 @@
 /// ABCI client implementation and consensus engine
 pub mod abci;
+pub mod vote_tracker;
 // NOTE: currently not used. Could be useful later
 pub(crate) mod light_client;
 pub(crate) mod non_deterministic_data;

--- a/crates/consensus/authority/src/comet_bft/non_deterministic_data.rs
+++ b/crates/consensus/authority/src/comet_bft/non_deterministic_data.rs
@@ -30,10 +30,10 @@ const VERSION_1: u16 = 1;
 /// Otherwise VERSION_1.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct NonDeterministicData {
-    pub(crate) version: u16,
-    pub(crate) bitcoin_block_hash: bitcoin::hash_types::BlockHash,
-    pub(crate) aggregated_public_key: secp256k1::PublicKey,
-    pub(crate) block_fee_recipient_address: Option<Address>,
+    version: u16,
+    bitcoin_block_hash: bitcoin::hash_types::BlockHash,
+    aggregated_public_key: secp256k1::PublicKey,
+    block_fee_recipient_address: Option<Address>,
 }
 
 impl NonDeterministicData {
@@ -43,6 +43,21 @@ impl NonDeterministicData {
             Some(_) => VERSION_1,
             None => VERSION_0,
         }
+    }
+
+    /// The Bitcoin block hash.
+    pub(crate) fn bitcoin_block_hash(&self) -> bitcoin::hash_types::BlockHash {
+        self.bitcoin_block_hash
+    }
+
+    /// The aggregate public key.
+    pub(crate) fn aggregated_public_key(&self) -> secp256k1::PublicKey {
+        self.aggregated_public_key
+    }
+
+    /// The block fee recipient, only available in version 1.
+    pub(crate) fn block_fee_recipient_address(&self) -> Option<Address> {
+        self.block_fee_recipient_address
     }
 
     /// Constructor for version 0 (without a fee recipient).

--- a/crates/consensus/authority/src/comet_bft/non_deterministic_data.rs
+++ b/crates/consensus/authority/src/comet_bft/non_deterministic_data.rs
@@ -344,6 +344,7 @@ pub struct NetworkUpgradePayload {
 #[cfg(test)]
 mod tests {
     use bitcoin::{hashes::Hash, BlockHash};
+    use reth_db::models::Vote;
 
     use super::*;
 
@@ -430,7 +431,7 @@ mod tests {
             pk,
             block_fee_recipient_address,
             runtime_version,
-            payload.clone(),
+            payload,
         );
         assert_eq!(ndd.version, VERSION_2);
         assert_eq!(ndd.bitcoin_block_hash, bitcoin_block_hash);
@@ -475,13 +476,85 @@ mod tests {
         let block_fee_recipient_address =
             Address::parse_checksummed("0x43C8bDCb9AFeBB1D834A7de18CC214a6FD1632d9", None)
                 .expect("valid address");
+
         let ndd = NonDeterministicData::new_v1(bitcoin_block_hash, pk, block_fee_recipient_address);
         let res = ndd.serialize().unwrap();
         let mut reader = io::Cursor::new(res);
         let deserialized = NonDeterministicData::deserialize(&mut reader).unwrap();
+
         assert_eq!(deserialized.version, ndd.version);
         assert_eq!(deserialized.bitcoin_block_hash, ndd.bitcoin_block_hash);
         assert_eq!(deserialized.aggregated_public_key, ndd.aggregated_public_key);
         assert_eq!(deserialized.block_fee_recipient_address, ndd.block_fee_recipient_address);
+        assert_eq!(deserialized.runtime_version, ndd.runtime_version);
+        assert_eq!(deserialized.network_upgrade_payload, ndd.network_upgrade_payload);
+    }
+
+    #[test]
+    fn test_non_deterministic_data_serde_v2() {
+        let bitcoin_block_hash = BlockHash::all_zeros();
+        let pk: secp256k1::PublicKey = secp256k1::PublicKey::from_slice(
+            hex::decode("039bef292b80427d355cecb89eda8a50a7d2196a93d73dade5a0c4a07cd334815d")
+                .unwrap()
+                .as_slice(),
+        )
+        .unwrap();
+        let block_fee_recipient_address =
+            Address::parse_checksummed("0x43C8bDCb9AFeBB1D834A7de18CC214a6FD1632d9", None)
+                .expect("valid address");
+
+        let runtime_version = RuntimeVersion::new(1, 0);
+
+        let assert_ndd = |network_upgrade_payload: Option<NetworkUpgradePayload>| {
+            let ndd = NonDeterministicData::new_v2(
+                bitcoin_block_hash,
+                pk,
+                block_fee_recipient_address,
+                runtime_version,
+                network_upgrade_payload,
+            );
+            let res = ndd.serialize().unwrap();
+            let mut reader = io::Cursor::new(res);
+            let deserialized = NonDeterministicData::deserialize(&mut reader).unwrap();
+
+            // TODO (lamafab): This must be updated to `VERSION_2` post-fork.
+            assert_eq!(deserialized.version, VERSION_1);
+            assert_eq!(deserialized.bitcoin_block_hash, ndd.bitcoin_block_hash);
+            assert_eq!(deserialized.aggregated_public_key, ndd.aggregated_public_key);
+            assert_eq!(deserialized.block_fee_recipient_address, ndd.block_fee_recipient_address);
+            assert_eq!(deserialized.runtime_version, ndd.runtime_version);
+            // Check network upgrade payload.
+            assert_eq!(deserialized.network_upgrade_payload, ndd.network_upgrade_payload);
+            assert_eq!(deserialized.network_upgrade_payload, network_upgrade_payload);
+        };
+
+        // Without network upgrade payload
+        let payload = None;
+        assert_ndd(payload);
+
+        // With network upgrade payloads
+        let payload = Some(NetworkUpgradePayload {
+            version: RuntimeVersion::new(2, 5),
+            vote: Vote::Absent,
+            is_compliant: false,
+        });
+
+        assert_ndd(payload);
+
+        let payload = Some(NetworkUpgradePayload {
+            version: RuntimeVersion::new(2, 5),
+            vote: Vote::Nay,
+            is_compliant: true,
+        });
+
+        assert_ndd(payload);
+
+        let payload = Some(NetworkUpgradePayload {
+            version: RuntimeVersion::new(2, 5),
+            vote: Vote::Aye,
+            is_compliant: true,
+        });
+
+        assert_ndd(payload);
     }
 }

--- a/crates/consensus/authority/src/comet_bft/non_deterministic_data.rs
+++ b/crates/consensus/authority/src/comet_bft/non_deterministic_data.rs
@@ -1,11 +1,16 @@
 use crate::activation_manager;
 use bitcoin::consensus::encode::{self, Decodable, Encodable};
+use reth_db::models::{
+    activation_manager::{MajorVersion, MinorVersion},
+    RuntimeVersion,
+};
 use reth_primitives::Address;
 use std::io::{self, Write};
 use thiserror::Error;
 
 /// Errors that can occur when deserializing NonDeterministicData
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub(crate) enum NonDeterministicDataDeserializeError {
     #[error("I/O error")]
     /// I/O error
@@ -16,7 +21,17 @@ pub(crate) enum NonDeterministicDataDeserializeError {
     #[error("invalid version")]
     /// Invalid NonDeterministicData, version
     InvalidVersion,
+    /// Invalid inclusion indicator, equivalent to Some/None
+    #[error("invalid inclusion indicator")]
+    InclusionIndicator,
+    /// // Invalid network upgrade vote
+    #[error("invalid network upgrade vote")]
+    NetworkUpgradePayloadVote,
 }
+
+/// The implied Botanix runtime version at mainnet launch, created
+/// retroactively.
+pub(crate) const GENESIS_RUNTIME_VERSION: RuntimeVersion = RuntimeVersion::new(0, 1);
 
 // Does not require `block_fee_recipient_address` to be present in NDD
 // Only supported on testnet for historical syncing purposes
@@ -24,6 +39,9 @@ const VERSION_0: u16 = 0;
 // Requires `block_fee_recipient_address` to be present in NDD
 // Supported on testnet and mainnet
 const VERSION_1: u16 = 1;
+// Allows for custom runtime version indicators and an optional network upgrade
+// payload.
+const VERSION_2: u16 = 2;
 
 /// Type that encapsulates non-deterministic data needed for consensus.
 /// When `block_fee_recipient_address` is `None`, the instance corresponds to VERSION_0.
@@ -34,15 +52,19 @@ pub(crate) struct NonDeterministicData {
     bitcoin_block_hash: bitcoin::hash_types::BlockHash,
     aggregated_public_key: secp256k1::PublicKey,
     block_fee_recipient_address: Option<Address>,
+    runtime_version: RuntimeVersion,
+    network_upgrade_payload: Option<NetworkUpgradePayload>,
 }
 
 impl NonDeterministicData {
     /// Returns the version based on whether a fee recipient address is present.
     pub(crate) fn version(&self) -> u16 {
-        match self.block_fee_recipient_address {
-            Some(_) => VERSION_1,
-            None => VERSION_0,
-        }
+        self.version
+    }
+
+    /// Returns the version of the Botanix runtime logic.
+    pub(crate) fn runtime_version(&self) -> RuntimeVersion {
+        self.runtime_version
     }
 
     /// The Bitcoin block hash.
@@ -60,6 +82,11 @@ impl NonDeterministicData {
         self.block_fee_recipient_address
     }
 
+    /// The optional network upgrade payload.
+    pub(crate) fn network_upgrade_payload(&self) -> Option<&NetworkUpgradePayload> {
+        self.network_upgrade_payload.as_ref()
+    }
+
     /// Constructor for version 0 (without a fee recipient).
     /// Deprecated in favor of `new_v1`.
     #[allow(dead_code)]
@@ -72,10 +99,13 @@ impl NonDeterministicData {
             bitcoin_block_hash,
             aggregated_public_key,
             block_fee_recipient_address: None,
+            runtime_version: GENESIS_RUNTIME_VERSION,
+            network_upgrade_payload: None,
         }
     }
 
-    /// Constructor for version 1 (with a fee recipient).
+    /// Constructor for version 1 with a fee recipient.
+    #[allow(dead_code)]
     pub(crate) fn new_v1(
         bitcoin_block_hash: bitcoin::hash_types::BlockHash,
         aggregated_public_key: secp256k1::PublicKey,
@@ -86,6 +116,27 @@ impl NonDeterministicData {
             bitcoin_block_hash,
             aggregated_public_key,
             block_fee_recipient_address: Some(block_fee_recipient_address),
+            runtime_version: GENESIS_RUNTIME_VERSION,
+            network_upgrade_payload: None,
+        }
+    }
+
+    /// Constructor for version 2 with a fee recipient, active runtime version
+    /// and an optional network upgrade payload.
+    pub(crate) fn new_v2(
+        bitcoin_block_hash: bitcoin::hash_types::BlockHash,
+        aggregated_public_key: secp256k1::PublicKey,
+        block_fee_recipient_address: Address,
+        runtime_version: RuntimeVersion,
+        network_upgrade_payload: Option<NetworkUpgradePayload>,
+    ) -> Self {
+        Self {
+            version: VERSION_2,
+            bitcoin_block_hash,
+            aggregated_public_key,
+            block_fee_recipient_address: Some(block_fee_recipient_address),
+            runtime_version,
+            network_upgrade_payload,
         }
     }
 
@@ -94,10 +145,63 @@ impl NonDeterministicData {
         let mut writer = Vec::new();
         self.bitcoin_block_hash.consensus_encode(&mut writer)?;
         self.aggregated_public_key.serialize().consensus_encode(&mut writer)?;
-        self.version().consensus_encode(&mut writer)?;
+
         // Version 1 has a block fee recipient address.
-        if let Some(ref address) = self.block_fee_recipient_address {
-            writer.write_all(address.as_slice())?;
+        match self.version {
+            VERSION_0 => {
+                self.version().consensus_encode(&mut writer)?;
+                // Nothing left to do...
+            }
+            VERSION_1 => {
+                self.version().consensus_encode(&mut writer)?;
+
+                // Encode fee recipient address.
+                let address = self
+                    .block_fee_recipient_address
+                    .expect("fee recipient address must be set for NDD version 1");
+
+                writer.write_all(address.as_slice())?;
+            }
+            VERSION_2 => {
+                // TODO (lamafab): This is a hack; we can append extra data to
+                // version 1 without breaking backwards-compatibility. This
+                // should be removed once the migration to version 2 has been
+                // successfully completed.
+                VERSION_1.consensus_encode(&mut writer)?;
+
+                // Encode fee recipient address.
+                let address = self
+                    .block_fee_recipient_address
+                    .expect("fee recipient address must be set for NDD version 2");
+
+                writer.write_all(address.as_slice())?;
+
+                // Serialize runtime version.
+                let RuntimeVersion(MajorVersion(major), MinorVersion(minor)) = self.runtime_version;
+                (major, minor).consensus_encode(&mut writer)?;
+
+                // Serialize network upgrade payload, if available.
+                let Some(upgrade) = self.network_upgrade_payload.as_ref() else {
+                    0u8.consensus_encode(&mut writer)?; // ~= None
+                    return Ok(writer);
+                };
+
+                1u8.consensus_encode(&mut writer)?; // ~= Some(_)
+
+                // Serialize upgrade version
+                let RuntimeVersion(MajorVersion(major), MinorVersion(minor)) = upgrade.version;
+                (major, minor).consensus_encode(&mut writer)?;
+
+                // Serialize upgrade vote
+                match upgrade.vote {
+                    activation_manager::Vote::Absent => 0u8.consensus_encode(&mut writer)?,
+                    activation_manager::Vote::Nay => 1u8.consensus_encode(&mut writer)?,
+                    activation_manager::Vote::Aye => 2u8.consensus_encode(&mut writer)?,
+                };
+
+                upgrade.is_compliant.consensus_encode(&mut writer)?;
+            }
+            _ => unreachable!("invalid NDD version: {}", self.version),
         }
 
         Ok(writer)
@@ -123,6 +227,8 @@ impl NonDeterministicData {
                     bitcoin_block_hash,
                     aggregated_public_key,
                     block_fee_recipient_address: None,
+                    runtime_version: GENESIS_RUNTIME_VERSION,
+                    network_upgrade_payload: None,
                 })
             }
             VERSION_1 => {
@@ -131,15 +237,84 @@ impl NonDeterministicData {
                     encode::Error::ParseFailed("malformed block fee recipient address")
                 })?;
                 let block_fee_recipient_address = Address::from(address_bytes);
+
+                let mut this = Self {
+                    version,
+                    bitcoin_block_hash,
+                    aggregated_public_key,
+                    block_fee_recipient_address: Some(block_fee_recipient_address),
+                    runtime_version: GENESIS_RUNTIME_VERSION,
+                    network_upgrade_payload: None,
+                };
+
+                // TODO (lamafab): This is technically a hack; we can append
+                // extra data to version 1 without breaking
+                // backwards-compatibility. This should be removed once the
+                // migration to version 2 has been successfully completed.
+                if let Ok((runtime_version, network_upgrade_payload)) =
+                    Self::_deserialize_version_2(reader)
+                {
+                    this.runtime_version = runtime_version;
+                    this.network_upgrade_payload = network_upgrade_payload;
+                }
+
+                Ok(this)
+            }
+            VERSION_2 => {
+                let mut address_bytes = [0u8; 20];
+                reader.read_exact(&mut address_bytes).map_err(|_e| {
+                    encode::Error::ParseFailed("malformed block fee recipient address")
+                })?;
+                let block_fee_recipient_address = Address::from(address_bytes);
+
+                // For version 2 this MUST pass.
+                let (runtime_version, network_upgrade_payload) =
+                    Self::_deserialize_version_2(reader)?;
+
                 Ok(Self {
                     version,
                     bitcoin_block_hash,
                     aggregated_public_key,
                     block_fee_recipient_address: Some(block_fee_recipient_address),
+                    runtime_version,
+                    network_upgrade_payload,
                 })
             }
             _ => Err(NonDeterministicDataDeserializeError::InvalidVersion),
         }
+    }
+    fn _deserialize_version_2(
+        reader: &mut impl bitcoin::io::Read,
+    ) -> Result<(RuntimeVersion, Option<NetworkUpgradePayload>), NonDeterministicDataDeserializeError>
+    {
+        // Decode runtime version.
+        let runtime_version = <(u16, u16)>::consensus_decode(reader)?.into();
+
+        // Check whether the network upgrade payload is included.
+        match u8::consensus_decode(reader)? {
+            0 => {
+                // Is NOT included, return.
+                return Ok((runtime_version, None));
+            }
+            1 => {
+                // Is included, proceed...
+            }
+            _ => return Err(NonDeterministicDataDeserializeError::InclusionIndicator),
+        }
+
+        // Decode payload information
+        let upgrade_version = <(u16, u16)>::consensus_decode(reader)?.into();
+        let vote = match u8::consensus_decode(reader)? {
+            0 => activation_manager::Vote::Absent,
+            1 => activation_manager::Vote::Nay,
+            2 => activation_manager::Vote::Aye,
+            _ => return Err(NonDeterministicDataDeserializeError::NetworkUpgradePayloadVote),
+        };
+        let is_compliant = bool::consensus_decode(reader)?;
+
+        let payload = Some(NetworkUpgradePayload { version: upgrade_version, vote, is_compliant });
+
+        Ok((runtime_version, payload))
     }
 }
 
@@ -159,7 +334,7 @@ impl NonDeterministicData {
 ///   the upgrade version. When `true`, the validator has the necessary software version and
 ///   configuration to handle the upgrade. This can be independent of the vote - a validator may
 ///   vote `Nay` but still be prepared to follow the network if the upgrade is adopted.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct NetworkUpgradePayload {
     pub version: activation_manager::RuntimeVersion,
     pub vote: activation_manager::Vote,

--- a/crates/consensus/authority/src/comet_bft/non_deterministic_data.rs
+++ b/crates/consensus/authority/src/comet_bft/non_deterministic_data.rs
@@ -388,6 +388,59 @@ mod tests {
     }
 
     #[test]
+    fn test_non_deterministic_data_new_v2() {
+        let bitcoin_block_hash = BlockHash::all_zeros();
+        let pk = secp256k1::PublicKey::from_slice(
+            hex::decode("039bef292b80427d355cecb89eda8a50a7d2196a93d73dade5a0c4a07cd334815d")
+                .unwrap()
+                .as_slice(),
+        )
+        .unwrap();
+        let block_fee_recipient_address =
+            Address::parse_checksummed("0x43C8bDCb9AFeBB1D834A7de18CC214a6FD1632d9", None)
+                .expect("valid address");
+
+        // Without network upgrade payload.
+        let runtime_version = RuntimeVersion::new(1, 5);
+        let payload = None;
+
+        let ndd = NonDeterministicData::new_v2(
+            bitcoin_block_hash,
+            pk,
+            block_fee_recipient_address,
+            runtime_version,
+            payload,
+        );
+        assert_eq!(ndd.version, VERSION_2);
+        assert_eq!(ndd.bitcoin_block_hash, bitcoin_block_hash);
+        assert_eq!(ndd.aggregated_public_key, pk);
+        assert_eq!(ndd.block_fee_recipient_address, Some(block_fee_recipient_address));
+        assert_eq!(ndd.runtime_version, runtime_version);
+        assert_eq!(ndd.network_upgrade_payload, None);
+
+        // With network upgrade payload.
+        let payload = Some(NetworkUpgradePayload {
+            version: RuntimeVersion::new(2, 5),
+            vote: Vote::Aye,
+            is_compliant: true,
+        });
+
+        let ndd = NonDeterministicData::new_v2(
+            bitcoin_block_hash,
+            pk,
+            block_fee_recipient_address,
+            runtime_version,
+            payload.clone(),
+        );
+        assert_eq!(ndd.version, VERSION_2);
+        assert_eq!(ndd.bitcoin_block_hash, bitcoin_block_hash);
+        assert_eq!(ndd.aggregated_public_key, pk);
+        assert_eq!(ndd.block_fee_recipient_address, Some(block_fee_recipient_address));
+        assert_eq!(ndd.runtime_version, runtime_version);
+        assert_eq!(ndd.network_upgrade_payload, payload); // IS SOME
+    }
+
+    #[test]
     fn test_non_deterministic_data_serde_v0() {
         let bitcoin_block_hash = BlockHash::all_zeros();
         let pk: secp256k1::PublicKey = secp256k1::PublicKey::from_slice(

--- a/crates/consensus/authority/src/comet_bft/non_deterministic_data.rs
+++ b/crates/consensus/authority/src/comet_bft/non_deterministic_data.rs
@@ -360,6 +360,9 @@ mod tests {
         assert_eq!(ndd.version, VERSION_0);
         assert_eq!(ndd.bitcoin_block_hash, bitcoin_block_hash);
         assert_eq!(ndd.aggregated_public_key, pk);
+        assert_eq!(ndd.block_fee_recipient_address, None);
+        assert_eq!(ndd.runtime_version, GENESIS_RUNTIME_VERSION);
+        assert_eq!(ndd.network_upgrade_payload, None);
     }
 
     #[test]
@@ -374,11 +377,14 @@ mod tests {
         let block_fee_recipient_address =
             Address::parse_checksummed("0x43C8bDCb9AFeBB1D834A7de18CC214a6FD1632d9", None)
                 .expect("valid address");
+
         let ndd = NonDeterministicData::new_v1(bitcoin_block_hash, pk, block_fee_recipient_address);
         assert_eq!(ndd.version, VERSION_1);
         assert_eq!(ndd.bitcoin_block_hash, bitcoin_block_hash);
         assert_eq!(ndd.aggregated_public_key, pk);
         assert_eq!(ndd.block_fee_recipient_address, Some(block_fee_recipient_address));
+        assert_eq!(ndd.runtime_version, GENESIS_RUNTIME_VERSION);
+        assert_eq!(ndd.network_upgrade_payload, None);
     }
 
     #[test]
@@ -390,13 +396,18 @@ mod tests {
                 .as_slice(),
         )
         .unwrap();
+
         let ndd = NonDeterministicData::new(bitcoin_block_hash, pk);
         let res = ndd.serialize().unwrap();
         let mut reader = io::Cursor::new(res);
         let deserialized = NonDeterministicData::deserialize(&mut reader).unwrap();
+
         assert_eq!(deserialized.version, ndd.version);
         assert_eq!(deserialized.bitcoin_block_hash, ndd.bitcoin_block_hash);
         assert_eq!(deserialized.aggregated_public_key, ndd.aggregated_public_key);
+        assert_eq!(deserialized.block_fee_recipient_address, ndd.block_fee_recipient_address);
+        assert_eq!(deserialized.runtime_version, ndd.runtime_version);
+        assert_eq!(deserialized.network_upgrade_payload, ndd.network_upgrade_payload);
     }
 
     #[test]

--- a/crates/consensus/authority/src/comet_bft/vote_tracker.rs
+++ b/crates/consensus/authority/src/comet_bft/vote_tracker.rs
@@ -1,0 +1,162 @@
+//! A simple in-memory vote tracker used by the ActivationManager which only
+//! tracks the last vote.
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
+
+use reth_db::models::Vote;
+use reth_primitives::Address;
+use reth_provider::{ActivationManagerReaderWriter, ProviderResult};
+
+/// A simple in-memory vote tracker used by the ActivationManager which only
+/// tracks the last vote.
+#[derive(Debug, Clone, Default)]
+pub struct VoteWatcher {
+    votes: Arc<RwLock<HashMap<Address, VoteEntry>>>,
+}
+
+#[derive(Debug)]
+struct VoteEntry {
+    vote: Vote,
+    is_compliant: bool,
+    botanix_height: u64,
+}
+
+// NOTE: This implementation was essentially copied 1-to-1 from the
+// ActivationManager unit tests.
+impl ActivationManagerReaderWriter<Address> for VoteWatcher {
+    fn update_upgrading_vote(
+        &self,
+        auth: Address,
+        vote: Vote,
+        is_compliant: bool,
+        botanix_height: u64,
+    ) -> ProviderResult<()> {
+        let mut votes = self.votes.write().unwrap();
+
+        #[rustfmt::skip]
+        votes
+            .entry(auth)
+            .and_modify(|e| {
+                e.vote = vote;
+                e.is_compliant = is_compliant;
+                e.botanix_height = botanix_height;
+            })
+            .or_insert(VoteEntry {
+                vote,
+                is_compliant,
+                botanix_height,
+            });
+
+        Ok(())
+    }
+
+    fn get_upgrading_approval_rate_ayes(
+        &self,
+        min_validator_count: usize,
+    ) -> ProviderResult<(usize, usize)> {
+        let votes = self.votes.read().unwrap();
+
+        let total = votes.len().max(min_validator_count);
+        let votes_received = votes.iter().filter(|(_, e)| e.vote == Vote::Aye).count();
+
+        // Calculate percentage (0-100) of votes received
+        let quorum = (votes_received * 100).div_ceil(total);
+
+        Ok((quorum, total))
+    }
+
+    fn get_upgrading_approval_rate_compliance(
+        &self,
+        min_validator_count: usize,
+    ) -> ProviderResult<(usize, usize)> {
+        let votes = self.votes.read().unwrap();
+
+        let total = votes.len().max(min_validator_count);
+        let votes_received = votes.iter().filter(|(_, e)| e.is_compliant).count();
+
+        // Calculate percentage (0-100) of votes received
+        let quorum = (votes_received * 100).div_ceil(total);
+
+        Ok((quorum, total))
+    }
+
+    fn remove_upgrading_votes(&self, botanix_height: u64) -> ProviderResult<usize> {
+        let mut votes = self.votes.write().unwrap();
+
+        let gross_total = votes.len();
+        votes.retain(|_, e| e.botanix_height >= botanix_height);
+
+        Ok(gross_total - votes.len())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_vote_watcher_basic_properties() {
+        let watcher = VoteWatcher::default();
+
+        let alice = Address::from_slice(&[0; 20]);
+        let bob = Address::from_slice(&[1; 20]);
+        let eve = Address::from_slice(&[2; 20]);
+
+        let min_val_count = 10;
+        let botanix_height = 500;
+
+        // Check basic init properties.
+        //
+        let ayes = watcher.get_upgrading_approval_rate_ayes(min_val_count).unwrap();
+        assert_eq!(ayes, (0, min_val_count));
+
+        let compliant = watcher.get_upgrading_approval_rate_compliance(min_val_count).unwrap();
+        assert_eq!(compliant, (0, min_val_count));
+
+        let removed = watcher.remove_upgrading_votes(botanix_height).unwrap();
+        assert_eq!(removed, 0);
+
+        // Track votes.
+        //
+        watcher.update_upgrading_vote(alice, Vote::Aye, true, botanix_height).unwrap();
+        watcher.update_upgrading_vote(bob, Vote::Aye, false, botanix_height).unwrap();
+        watcher.update_upgrading_vote(eve, Vote::Nay, false, botanix_height).unwrap();
+
+        let ayes = watcher.get_upgrading_approval_rate_ayes(min_val_count).unwrap();
+        assert_eq!(ayes, (20, min_val_count)); // 20%
+
+        let compliant = watcher.get_upgrading_approval_rate_compliance(min_val_count).unwrap();
+        assert_eq!(compliant, (10, min_val_count)); // 10%
+
+        // Eve votes again
+        //
+        watcher.update_upgrading_vote(eve, Vote::Aye, true, botanix_height).unwrap();
+
+        let ayes = watcher.get_upgrading_approval_rate_ayes(min_val_count).unwrap();
+        assert_eq!(ayes, (30, min_val_count)); // 30%
+
+        let compliant = watcher.get_upgrading_approval_rate_compliance(min_val_count).unwrap();
+        assert_eq!(compliant, (20, min_val_count)); // 20%
+
+        // Remove votes
+        //
+        let removed = watcher.remove_upgrading_votes(botanix_height).unwrap();
+        assert_eq!(removed, 0);
+
+        let removed = watcher.remove_upgrading_votes(botanix_height + 1).unwrap();
+        assert_eq!(removed, 3); // alice, bob and eve
+
+        // Removed; all is gone
+        //
+        let ayes = watcher.get_upgrading_approval_rate_ayes(min_val_count).unwrap();
+        assert_eq!(ayes, (0, min_val_count));
+
+        let compliant = watcher.get_upgrading_approval_rate_compliance(min_val_count).unwrap();
+        assert_eq!(compliant, (0, min_val_count));
+
+        let removed = watcher.remove_upgrading_votes(botanix_height).unwrap();
+        assert_eq!(removed, 0);
+    }
+}

--- a/crates/consensus/authority/src/excecution_utils.rs
+++ b/crates/consensus/authority/src/excecution_utils.rs
@@ -2,7 +2,7 @@ pub(crate) mod authority_execution_utils {
     use reth_btc_wallet::bitcoind::BitcoindFactory;
     use reth_chainspec::{ChainSpec, EthereumHardforks};
 
-    use reth_db::Database;
+    use reth_db::{models::RuntimeVersion, Database};
     use reth_evm::execute::{BatchExecutor, BlockExecutorProvider, Executor};
     use reth_evm_ethereum::execute::EthBlockExecutor;
     use reth_execution_errors::{
@@ -27,7 +27,7 @@ pub(crate) mod authority_execution_utils {
     use reth_trie::StateRoot;
     use reth_trie_db::DatabaseStateRoot;
 
-    use crate::comet_bft::abci::BlockWithContext;
+    use crate::comet_bft::{abci::BlockWithContext, non_deterministic_data::NetworkUpgradePayload};
     use std::sync::Arc;
     use tendermint_proto::google::protobuf::Timestamp;
 
@@ -39,6 +39,9 @@ pub(crate) mod authority_execution_utils {
     pub(crate) fn build_and_execute<BF, DB>(
         transactions: Vec<TransactionSigned>,
         chain_spec: Arc<ChainSpec>,
+        runtime_version: RuntimeVersion,
+        network_upgrade_payload: Option<NetworkUpgradePayload>,
+        floor_base_fee: Option<u64>,
         block_fee_recipient_address: &Address,
         evm_config: EthEvmConfig,
         database_provider: &ProviderFactory<DB>,
@@ -65,7 +68,7 @@ pub(crate) mod authority_execution_utils {
         );
 
         // Construct block and header
-        let header = build_header_template(
+        let mut header = build_header_template(
             &transactions,
             database_provider,
             bitcoin_checkpoint_block_hash,
@@ -74,6 +77,15 @@ pub(crate) mod authority_execution_utils {
             timestamp,
             block_fee_recipient_address,
         )?;
+
+        debug_assert!(header.base_fee_per_gas.is_some());
+
+        // Set the floor base fee per gas if provided.
+        if let Some(base_fee) = header.base_fee_per_gas.as_mut() {
+            if let Some(floor) = floor_base_fee {
+                *base_fee = (*base_fee).max(floor);
+            }
+        }
 
         let mut block =
             Block { header, body: transactions, ommers: vec![], withdrawals: None, requests: None };
@@ -129,8 +141,13 @@ pub(crate) mod authority_execution_utils {
         )
         .map_err(|e| BlockExecutionError::Validation(BlockValidationError::StateRoot(e)))?;
 
-        let block_with_context =
-            BlockWithContext { sealed_block_with_peg, exec_outcome, trie_updates };
+        let block_with_context = BlockWithContext {
+            sealed_block_with_peg,
+            runtime_version,
+            network_upgrade_payload,
+            exec_outcome,
+            trie_updates,
+        };
 
         if tracing::enabled!(tracing::Level::INFO) {
             let block_with_pegs = &block_with_context.sealed_block_with_peg;
@@ -164,6 +181,8 @@ pub(crate) mod authority_execution_utils {
                     block_slow_hash = ?block.hash_slow(),
                     block_sealed_hash = ?block.hash(),
                     eth_block = ?block,
+                    runtimve_version = ?block_with_context.runtime_version,
+                    network_upgrade_payload = ?block_with_context.network_upgrade_payload,
                     pegins = ?block_with_pegs.pegins(),
                     pegouts = ?block_with_pegs.pegouts(),
                     receipts = ?exec_outcome.receipts,

--- a/crates/storage/db-api/src/models/activation_manager.rs
+++ b/crates/storage/db-api/src/models/activation_manager.rs
@@ -85,6 +85,12 @@ impl From<(u16, u16)> for RuntimeVersion {
     }
 }
 
+impl std::fmt::Display for RuntimeVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}", self.0 .0, self.1 .0)
+    }
+}
+
 /// Represents a major version component of a runtime version.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct MajorVersion(pub u16);

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -54,7 +54,6 @@ reth-trie-db = { workspace = true, features = ["metrics"] }
 revm = { workspace = true }
 
 ## crypto
-secp256k1 = { workspace = true, features = ["global-context", "rand-std", "recovery"] }
 strum = { workspace = true }
 
 # async

--- a/crates/storage/provider/src/traits/activation_manager.rs
+++ b/crates/storage/provider/src/traits/activation_manager.rs
@@ -9,7 +9,7 @@ use reth_errors::ProviderResult;
 /// Implementations should maintain persistence of votes between blocks and handle
 /// the removal of expired votes.
 #[auto_impl::auto_impl(&, Arc, Box)]
-pub trait ActivationManagerReaderWriter: Send + Sync {
+pub trait ActivationManagerReaderWriter<Auth>: Send + Sync {
     /// Records or updates a validator's vote for a network upgrade.
     ///
     /// This method stores a validator's vote and acceptance status for a network upgrade
@@ -27,7 +27,7 @@ pub trait ActivationManagerReaderWriter: Send + Sync {
     /// * `Err` if there was an error recording the vote
     fn update_upgrading_vote(
         &self,
-        auth: secp256k1::PublicKey,
+        auth: Auth,
         vote: Vote,
         is_compliant: bool,
         botanix_height: u64,


### PR DESCRIPTION
So, this hotfix is responsible to setting a minimum base fee per gas (_floor value_), which is a breaking change (hard-fork). It utilizes the `ActivationManager` to coordinate the readiness and timing to set the transition into motion without causing a chain halt.

In order to set this floor value, we cannot just modify the `ChainSpec::base_fee_params_at_timestamp(..)` method since it's part of the higher EIP-1559 fee calculation; we have to bypass that formula entirely. Additionally, since the `ActivationManager` is responsible for coordinating the hard-fork, we do not yet know at what `timestamp` the transition takes place - that's only something we can determine and hard-code retroactively.

Important changes:

* The conditions for the hard-fork to take place: https://github.com/botanix-labs/Macbeth/pull/841/commits/231a6668d8a5d445e8dc89cd826ef364425e1eb7

```rust
if *is_testnet {
    quorum = 100; // 100% ~= 3/3 members must approve
    min_validator_count = 3;
    target_height = 1; // Activate as soon as possible
    our_vote = Vote::Aye;
} else {
    quorum = 100; // 100% ~= 15/15 members must approve
    min_validator_count = 15;
    target_height = 1; // Activate as soon as possible
    our_vote = Vote::Aye;
}
```

* Update the NDD to version 2: https://github.com/botanix-labs/Macbeth/pull/841/commits/67c6c042e6a9fc86ae32b124d0dea06efdba7a50
  * Includes a Botanix _runtime version_ indicator that signals when the floor value has to be set.
  * Includes an (optional) network upgrade payload such that the `ActivationManager` can determine readiness.
  * NOTE: There's currently a _hack_ that version 2 gets (de-)serialized as version 1 in a backwards-compatible way; this should be removed post-fork.
* Implement a simple vote tracker: https://github.com/botanix-labs/Macbeth/pull/841/commits/c3d1329560911383fa63c691508a7b08b4851169
  * This simply tracks the last vote by a Fed member. In a permissionless context, this would track votes over time to determine community sentiment, but it's too early for that.
  * This is used by the `ActivationManager` underneath.
* Update the `base_fee_per_gas` field in the Botanix header before block execution: https://github.com/botanix-labs/Macbeth/pull/841/commits/5b9cd1fc247ff34b83c3f34e211f5e09e3092711
  * Used by ABCI's `process_proposal` and `finalize_block`.
* ABCI state transitions:
  * `prepare_proposal`: https://github.com/botanix-labs/Macbeth/pull/841/commits/dfb2bc591c1e77ef293de26f20269f1531ae97cc
    * Note that this sets the floor value to the attributes that are going to be passed to the default Ethereum payload builder. 
  * `process_proposal`: https://github.com/botanix-labs/Macbeth/pull/841/commits/9f4f715baaa4de347c5a2a4de2f5c6cae59dacea
  * `finalize_block`: https://github.com/botanix-labs/Macbeth/pull/841/commits/b93a595bb52737b3b253c41ce30dbae40aa22fc5
