### PR TITLE
fix/change outputs/add back missing outputs

### DIFF
--- a/bin/btc-server/src/pegout_scheduler/mod.rs
+++ b/bin/btc-server/src/pegout_scheduler/mod.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 use crate::{
-    database::FinalizedPegout,
+    database::{FinalizedPegout, Utxo},
     pegout_id::PegoutId,
     telemetry::Telemetry,
     update_telemetry_error,
@@ -22,7 +22,7 @@ use crate::{
     },
 };
 use bitcoin::{Amount, Block, BlockHash, OutPoint, ScriptBuf, Transaction, TxOut, Txid};
-use bitcoincore_rpc::RpcApi;
+use bitcoincore_rpc::{json::ScanTxOutRequest, RpcApi};
 use log::{debug, error, info, trace, warn};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -219,6 +219,8 @@ pub struct PegoutScheduler {
     last_finalized: BlockHash,
     /// Database handle
     db: database::Db,
+    /// Whether we should scan for missing change outputs
+    scan_for_change_outputs: bool,
 }
 
 impl PegoutScheduler {
@@ -237,6 +239,7 @@ impl PegoutScheduler {
             last_blocks: VecDeque::with_capacity(conf_window as usize),
             last_finalized,
             db,
+            scan_for_change_outputs: true,
         };
 
         ret.last_blocks.push_back(BlockInfo {
@@ -687,6 +690,65 @@ impl PegoutScheduler {
         Ok(())
     }
 
+    /// Add missing change outputs to the UTXO set.
+    ///
+    /// This is a temporary fix to ensure change outputs are added back to the UTXO set.
+    /// Args:
+    /// - `bitcoind`: The RPC client to use to scan the UTXO set.
+    ///   Returns:
+    /// - `Ok(())` if successful.
+    /// - `Err(SyncError)` if there was an error.
+    pub fn add_missing_change_outputs(&mut self, bitcoind: &impl RpcApi) -> Result<(), SyncError> {
+        info!("PegoutScheduler::add_missing_change_outputs: Adding missing change outputs to the UTXO set.");
+
+        // Get the UTXO set from the db
+        let utxos = self.db.get_all_utxos()?;
+        if utxos.is_empty() {
+            info!("PegoutScheduler::add_missing_change_outputs: No UTXOs found in the database.");
+            return Ok(());
+        }
+        info!(
+            "PegoutScheduler::add_missing_change_outputs: Found {} UTXOs in the database.",
+            utxos.len()
+        );
+        // This is safe because of the empty check above
+        let utxo_version = utxos[0].version;
+
+        // Get the unspent utxo for the change address
+        let change_address = ScanTxOutRequest::Single(
+            "addr(bc1p780f20323vt8nq0f42hr7q59dh2fr3p3uz3h2d9rskdpszt0at5qc3rk74)".to_string(),
+        );
+        let change_utxos = bitcoind.scan_tx_out_set_blocking(&[change_address])?.unspents;
+
+        // Add back missing change outputs to the UTXO set
+        let mut missing_utxos = Vec::new();
+        for unspent in change_utxos {
+            let utxo = Utxo {
+                outpoint: OutPoint { txid: unspent.txid, vout: unspent.vout },
+                output: TxOut { value: unspent.amount, script_pubkey: unspent.script_pub_key },
+                eth_address: None,     // Assuming this is None for change outputs
+                version: utxo_version, // Set to appropriate default or version
+            };
+
+            // Check if this UTXO already exists in the database
+            if !utxos.contains(&utxo) {
+                info!(
+                    "PegoutScheduler::add_missing_change_outputs: Adding missing change UTXO: {:?}",
+                    utxo
+                );
+                missing_utxos.push(utxo);
+            }
+        }
+        let missing_utxo_refs: Vec<&Utxo> = missing_utxos.iter().collect();
+        info!(
+            "PegoutScheduler::add_missing_change_outputs: Storing {} missing change outputs.",
+            missing_utxo_refs.len()
+        );
+        self.db.store_utxos(&missing_utxo_refs)?;
+
+        Ok(())
+    }
+
     /// Sync with new blocks and stop when the [checkpoint] block gets finalized.
     ///
     /// We take the database closure to reduce coupling with database module.
@@ -712,6 +774,16 @@ impl PegoutScheduler {
         if is_syncing(bitcoind)? {
             update_telemetry_error!(telemetry, SyncError::NodeNotSynced);
             return Err(SyncError::NodeNotSynced);
+        }
+
+        // Add back missing change outputs to the utxo set.
+        // TODO(Scott): This is a temporary fix to ensure change outputs are added back
+        // to the UTXO set. We will remove this logic in another release.
+        // Check if we have any missing change outputs
+        if self.scan_for_change_outputs {
+            // Setting to false immediately to avoid infinite retrying
+            self.scan_for_change_outputs = false;
+            self.add_missing_change_outputs(bitcoind)?;
         }
 
         // First find the latest block that we have that is still in the blockchain.

--- a/bin/btc-server/src/pegout_scheduler/mod.rs
+++ b/bin/btc-server/src/pegout_scheduler/mod.rs
@@ -958,6 +958,8 @@ pub enum BlockError {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use bitcoin::{
         absolute::LockTime,
         blockdata::{
@@ -1576,5 +1578,44 @@ mod tests {
 
         // assert there are no tracked txs
         assert_eq!(pegout_scheduler.txs.len(), 0);
+    }
+
+    #[test]
+    fn test_add_missing_change_outputs() {
+        let db = setup_db().0;
+        let mut pegout_scheduler =
+            PegoutScheduler::new(101, vec![], bitcoin::BlockHash::all_zeros(), db.clone());
+
+        // Add utxo to db
+        let tx = create_tx(2, 1, None);
+        let utxo = Utxo::new(
+            OutPoint::new(tx.compute_txid(), 0),
+            tx.output.get(0).unwrap().clone(),
+            None,
+            None,
+        );
+        db.store_utxos(&[&utxo]).unwrap();
+        db.flush().unwrap();
+
+        let mock_bitcoind = MockBitcoind::new();
+        let result = pegout_scheduler.add_missing_change_outputs(&mock_bitcoind);
+        assert!(result.is_ok());
+
+        let utxos = db.get_all_utxos().unwrap();
+
+        // There should be 2 UTXOs now
+        assert_eq!(utxos.len(), 2);
+
+        // This is the txid returned from mock bitcoind
+        let target_txid = bitcoin::Txid::from_str(
+            "0101010101010101010101010101010101010101010101010101010101010101",
+        )
+        .unwrap();
+        // Check that the missing change output was added back
+        assert!(
+            utxos.iter().any(|utxo| utxo.outpoint.txid == target_txid),
+            "Expected to find UTXO with txid {}, but it was not found in the collection",
+            target_txid
+        );
     }
 }

--- a/bin/btc-server/src/pegout_scheduler/mod.rs
+++ b/bin/btc-server/src/pegout_scheduler/mod.rs
@@ -723,20 +723,44 @@ impl PegoutScheduler {
         // Add back missing change outputs to the UTXO set
         let mut missing_utxos = Vec::new();
         for unspent in change_utxos {
+            info!(
+                "PegoutScheduler::add_missing_change_outputs: Found unspent change output: {:?}",
+                unspent
+            );
+
+            // Create a UTXO for the change output
             let utxo = Utxo {
                 outpoint: OutPoint { txid: unspent.txid, vout: unspent.vout },
                 output: TxOut { value: unspent.amount, script_pubkey: unspent.script_pub_key },
-                eth_address: None,     // Assuming this is None for change outputs
-                version: utxo_version, // Set to appropriate default or version
+                eth_address: None, // Assuming this is None for change outputs
+                version: utxo_version,
             };
 
-            // Check if this UTXO already exists in the database
-            if !utxos.contains(&utxo) {
+            // Check if this UTXO already exists in the database by outpoint
+            let outpoints = utxos.iter().map(|u| u.outpoint).collect::<HashSet<_>>();
+            if !outpoints.contains(&utxo.outpoint) {
                 info!(
                     "PegoutScheduler::add_missing_change_outputs: Adding missing change UTXO: {:?}",
                     utxo
                 );
                 missing_utxos.push(utxo);
+            } else {
+                // Sanity check that the utxo we create does match the utxo from the db.
+                // This ensures that we're creating the correct change outputs.
+                let utxo_is_exact_match = utxos.contains(&utxo);
+                if !utxo_is_exact_match {
+                    let db_utxo = utxos
+                        .iter()
+                        .find(|u| u.outpoint == utxo.outpoint)
+                        .expect("utxo should exist in db");
+
+                    error!(
+                        "PegoutScheduler::add_missing_change_outputs: UTXO from db does not match the one we created: {:?} != {:?}",
+                        db_utxo, utxo
+                    );
+
+                    return Err(SyncError::IncorrectChangeOutputCreated);
+                }
             }
         }
         let missing_utxo_refs: Vec<&Utxo> = missing_utxos.iter().collect();
@@ -948,6 +972,8 @@ pub enum SyncError {
     TrackedTxNotInBlock(Txid),
     #[error("deeply confirmed tx not finalized: {0}")]
     DeeplyConfirmedTxNotFinalized(Txid),
+    #[error("incorrect change output created")]
+    IncorrectChangeOutputCreated,
 }
 
 #[derive(Debug, Error)]

--- a/bin/btc-server/src/test_utils/mod.rs
+++ b/bin/btc-server/src/test_utils/mod.rs
@@ -227,6 +227,10 @@ impl bitcoincore_rpc::RpcApi for MockBitcoind {
             return Ok(serde_json::from_str(&format!("{{\"hash\": \"0000000000000000000000000000000000000000000000000000000000000000\", \"confirmations\": 680000, \"size\": 1024, \"strippedsize\": 1000, \"weight\": 4000, \"height\": 680000, \"version\": 1, \"version_hex\": \"01000000\", \"merkleroot\": \"0000000000000000000000000000000000000000000000000000000000000000\", \"tx\": [\"{}\"], \"time\": 1680000000, \"mediantime\": 1679999500, \"nonce\": 123456789, \"bits\": \"1a00ffff\", \"difficulty\": 1.0, \"chainwork\": \"0000000000000000000000000000000000000000000000000000000000000000\", \"nTx\": 1, \"previousblockhash\": \"0000000000000000000000000000000000000000000000000000000000000000\", \"nextblockhash\": \"0000000000000000000000000000000000000000000000000000000000000000\"}}", txid)).unwrap());
         }
 
+        if method == "scantxoutset" {
+            return Ok(serde_json::from_str("{\"success\": true, \"txouts\": 1, \"height\": 680000, \"bestblock\": \"0000000000000000000000000000000000000000000000000000000000000000\", \"unspents\": [{\"txid\": \"0101010101010101010101010101010101010101010101010101010101010101\", \"vout\": 0, \"scriptPubKey\": \"\", \"desc\": \"addr(bc1p780f20323vt8nq0f42hr7q59dh2fr3p3uz3h2d9rskdpszt0at5qc3rk74)\",  \"amount\": 0.001, \"height\": 680000 }], \"total_amount\": 0.001}").unwrap());
+        }
+
         unimplemented!()
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Pegout scheduler is incorrectly removing change outputs from the utxo set.  Another PR fixes this: https://github.com/botanix-labs/Macbeth/pull/842

But we still need to add those change outputs back to the utxo set. 

## What was done?

On startup, btc server.sync_until() will scan the L1 for unspent utxos for the multisig change address and add back any missing ones to the db.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Added a unit test and tested locally

## Breaking Changes

<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

- None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] I have added or updated relevant unit/integration/functional/e2e tests
-   [ ] I have tested my changes running a local network, and they work as expected
-   [ ] I have performed a self-review
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
-   [ ] I have made corresponding changes to the documentation if needed
-   [ ] I have added assignees and reviewers to this pull request
-   [ ] I have added the PR to the project board or linked it to an issue from the board
