### PR TITLE
hotfix(metrics): Add metrics to `ActivationManager` & interpret no-shows as `"abstained"`

### DIFF
--- a/crates/consensus/authority/src/activation_manager/mod.rs
+++ b/crates/consensus/authority/src/activation_manager/mod.rs
@@ -261,7 +261,8 @@ pub struct Polling {
     pub ayes: usize,
     /// Number of validators who have voted "Nay" against the upgrade.
     pub nays: usize,
-    /// Number of validators who have abstained from voting (voted "Absent").
+    /// Number of validators who have abstained from voting (or explicitly voted
+    /// "Abstain").
     pub abstained: usize,
     /// Number of validators who are compliant with the upgrade (ready to
     /// accept it).
@@ -835,7 +836,7 @@ where
 
         let abstained_vote = || NetworkUpgradePayload {
             version: upgrade.version,
-            vote: Vote::Absent,
+            vote: Vote::Abstain,
             is_compliant: false,
         };
 

--- a/crates/consensus/authority/src/activation_manager/mod.rs
+++ b/crates/consensus/authority/src/activation_manager/mod.rs
@@ -766,21 +766,32 @@ where
         addr: Auth,
         vote: Option<NetworkUpgradePayload>,
     ) -> ProviderResult<()> {
-        // If the proposer made a vote...
-        let Some(vote) = vote else {
-            return Ok(());
-        };
-
-        // And we're tracking an upgrade...
+        // Check if we're tracking an upgrade.
         let maybe_upgrade = self.upgrade.read().expect("poisoned lock");
         let Some(upgrade) = maybe_upgrade.as_ref() else {
             return Ok(());
         };
 
-        // And the proposers' version matches our upgrade version...
-        if vote.version != upgrade.version {
-            return Ok(());
-        }
+        let abstained_vote = || NetworkUpgradePayload {
+            version: upgrade.version,
+            vote: Vote::Absent,
+            is_compliant: false,
+        };
+
+        // If the proposer provided an explicit vote, we check whether the
+        // version matches our upgrade version. If the version is mismatched or
+        // if no vote is provided at all, then we implicilty mark the vote as
+        // abstained.
+        let vote = if let Some(vote) = vote {
+            if vote.version == upgrade.version {
+                vote
+            } else {
+                abstained_vote()
+            }
+        } else {
+            // Abstained vote
+            abstained_vote()
+        };
 
         // Then track the vote.
         self.client.update_upgrading_vote(addr, vote.vote, vote.is_compliant, block_height)?;

--- a/crates/consensus/authority/src/activation_manager/mod.rs
+++ b/crates/consensus/authority/src/activation_manager/mod.rs
@@ -119,6 +119,11 @@ pub const MIN_VALIDATOR_COUNT: usize = 3;
 /// 3. Switch their configuration to accept the upgrade
 ///
 /// While ensuring votes eventually expire if an upgrade does not proceed.
+//
+// TODO (lamafab): This should probably be based on validator set count, not
+// some specific time period. Measuring sentiment over time and actually
+// validating upgrade conditions are two separate things. Having to validate
+// that many DB entries on each block is too expensive...
 pub const VOTE_RETENTION_PERIOD: u64 = 518_400;
 
 /// The decision returned by the activation manager during the prepare proposal
@@ -649,8 +654,10 @@ where
     /// # Parameters
     /// * `block_version` - The runtime version of the block being finalized
     /// * `block_height` - The height of the block being finalized
-    /// * `proposer_address` - The public key of the block proposer
-    /// * `proposer_vote` - The proposer's vote on a network upgrade, if any
+    /// * `proposer_address` - The address of the block proposer
+    /// * `proposer_vote` - The proposer's vote on a network upgrade, if any.
+    ///   If `None` or if the vote's version doesn't match the tracked upgrade,
+    ///   it's counted as abstained.
     ///
     /// # Returns
     /// * `OnFinalizeBlockDecision::Finalize` if the block should be finalized

--- a/crates/consensus/authority/src/activation_manager/mod.rs
+++ b/crates/consensus/authority/src/activation_manager/mod.rs
@@ -233,16 +233,36 @@ struct NetworkUpgrade {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ConditionList {
     /// Whether the validator is compliant with the upgrade
-    comp_req: bool,
+    pub comp_req: bool,
 
     /// Whether the quorum approval rate for Aye votes has been reached
-    aye_approval_req: bool,
+    pub aye_approval_req: bool,
 
     /// Whether the quorum approval rate for compliant validators has been reached
-    comp_approval_req: bool,
+    pub comp_approval_req: bool,
 
     /// Whether the current block height is at or above the target height
-    block_height_req: bool,
+    pub block_height_req: bool,
+}
+
+/// Current voting statistics for a network upgrade.
+///
+/// This struct provides a snapshot of validator voting activity for a pending
+/// network upgrade, including the breakdown of different vote types and
+/// compliance status.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Polling {
+    /// Number of validators who have voted "Aye" for the upgrade.
+    pub ayes: usize,
+    /// Number of validators who have voted "Nay" against the upgrade.
+    pub nays: usize,
+    /// Number of validators who have abstained from voting (voted "Absent").
+    pub abstained: usize,
+    /// Number of validators who are compliant with the upgrade (ready to
+    /// accept it).
+    pub compliant: usize,
+    /// Total number of distinct validators who have cast any vote.
+    pub total: usize,
 }
 
 impl ConditionList {
@@ -700,6 +720,40 @@ where
         // outdated version of this software that cannot handle those finalized
         // blocks.
         Ok(OnFinalizeBlockDecision::RejectBlockDeadEnd { version: block_version })
+    }
+
+    /// Returns current voting statistics for the tracked network upgrade.
+    ///
+    /// This method provides a snapshot of validator voting activity for the
+    /// currently tracked upgrade, including vote counts and compliance status.
+    /// The returned data can be used for monitoring upgrade progress and
+    /// displaying voting statistics to users.
+    ///
+    /// # Returns
+    /// * `Ok(Some((version, polling)))` if an upgrade is being tracked, where:
+    ///   - `version` is the runtime version of the tracked upgrade
+    ///   - `polling` contains current vote counts and compliance statistics
+    /// * `Ok(None)` if no upgrade is currently being tracked
+    /// * `Err` if there was an error retrieving voting data from the database
+    pub fn get_upgrade_polling(&self) -> ProviderResult<Option<(RuntimeVersion, Polling)>> {
+        let maybe_upgrade = self.upgrade.read().expect("poisoned lock");
+        let Some(upgrade) = maybe_upgrade.as_ref() else {
+            return Ok(None);
+        };
+
+        let (ayes, total) = self.client.get_aye_votes()?;
+        let (nays, t2) = self.client.get_nay_votes()?;
+        let (abstained, t3) = self.client.get_abstained_votes()?;
+        let (compliant, t4) = self.client.get_compliance_count()?;
+
+        debug_assert_eq!(total, t2);
+        debug_assert_eq!(total, t3);
+        debug_assert_eq!(total, t4);
+        debug_assert_eq!(ayes + nays + abstained, total);
+
+        let polling = Polling { ayes, nays, abstained, compliant, total };
+
+        Ok(Some((upgrade.version, polling)))
     }
 
     /// Validates all conditions required for an upgrade to proceed.

--- a/crates/consensus/authority/src/activation_manager/tests/accept_lagging_validator.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/accept_lagging_validator.rs
@@ -54,6 +54,11 @@ fn activation_manager_accept_lagging_validator() {
                 finalize_pass: true,
                 aye_approval_rate: 34,
                 comp_approval_rate: 34,
+                aye_votes: 1,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 1,
+                total_votes: 1,
             },
         )
         // Eve is not configured.
@@ -84,6 +89,11 @@ fn activation_manager_accept_lagging_validator() {
                 finalize_pass: true,
                 aye_approval_rate: 67,
                 comp_approval_rate: 67,
+                aye_votes: 2,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 2,
+                total_votes: 2,
             },
         )
         .expectations_empty(&[EVE])
@@ -115,6 +125,11 @@ fn activation_manager_accept_lagging_validator() {
                 // Votes pruned after upgrade
                 aye_approval_rate: 0,
                 comp_approval_rate: 0,
+                aye_votes: 0,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 0,
+                total_votes: 0,
             },
         )
         // Eve is not configured.
@@ -154,6 +169,11 @@ fn activation_manager_accept_lagging_validator() {
                 finalize_pass: true,
                 aye_approval_rate: 0,
                 comp_approval_rate: 0,
+                aye_votes: 0,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 0,
+                total_votes: 0,
             },
         )
         // Eve REJECTS the upgrade during the backing phase, but ACCEPTS it
@@ -165,6 +185,11 @@ fn activation_manager_accept_lagging_validator() {
                 finalize_pass: true, // Accept
                 aye_approval_rate: 0,
                 comp_approval_rate: 0,
+                aye_votes: 0,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 0,
+                total_votes: 0,
             },
         )
         .build_block();
@@ -187,6 +212,11 @@ fn activation_manager_accept_lagging_validator() {
                 finalize_pass: true,
                 aye_approval_rate: 0,
                 comp_approval_rate: 0,
+                aye_votes: 0,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 0,
+                total_votes: 0,
             },
         )
         .build_blocks_until(21);

--- a/crates/consensus/authority/src/activation_manager/tests/mod.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/mod.rs
@@ -42,19 +42,24 @@ impl ActivationManagerReaderWriter<utils::Address> for Db {
     ) -> ProviderResult<()> {
         let mut votes = self.votes.write().unwrap();
 
-        #[rustfmt::skip]
-        votes
-            .entry(auth)
-            .and_modify(|e| {
+        match votes.entry(auth) {
+            Entry::Occupied(mut e) => {
+                // If the validator has previously voted, their vote will be
+                // updated to the new values if and only if the botanix height
+                // is greater than the existing botanix height.
+                if e.get().botanix_height >= botanix_height {
+                    return Ok(())
+                }
+
+                let e = e.get_mut();
                 e.vote = vote;
                 e.is_compliant = is_compliant;
                 e.botanix_height = botanix_height;
-            })
-            .or_insert(VoteEntry {
-                vote,
-                is_compliant,
-                botanix_height,
-            });
+            }
+            Entry::Vacant(v) => {
+                let _ = v.insert(VoteEntry { vote, is_compliant, botanix_height });
+            }
+        }
 
         Ok(())
     }

--- a/crates/consensus/authority/src/activation_manager/tests/mod.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/mod.rs
@@ -59,6 +59,30 @@ impl ActivationManagerReaderWriter<utils::Address> for Db {
         Ok(())
     }
 
+    fn get_aye_votes(&self) -> ProviderResult<(usize, usize)> {
+        let votes = self.votes.read().unwrap();
+        let ayes = votes.iter().filter(|(_, e)| e.vote == Vote::Aye).count();
+        Ok((ayes, votes.len()))
+    }
+
+    fn get_nay_votes(&self) -> ProviderResult<(usize, usize)> {
+        let votes = self.votes.read().unwrap();
+        let nays = votes.iter().filter(|(_, e)| e.vote == Vote::Nay).count();
+        Ok((nays, votes.len()))
+    }
+
+    fn get_abstained_votes(&self) -> ProviderResult<(usize, usize)> {
+        let votes = self.votes.read().unwrap();
+        let abstains = votes.iter().filter(|(_, e)| e.vote == Vote::Absent).count();
+        Ok((abstains, votes.len()))
+    }
+
+    fn get_compliance_count(&self) -> ProviderResult<(usize, usize)> {
+        let votes = self.votes.read().unwrap();
+        let compliant = votes.iter().filter(|(_, e)| e.is_compliant).count();
+        Ok((compliant, votes.len()))
+    }
+
     fn get_upgrading_approval_rate_ayes(
         &self,
         min_validator_count: usize,

--- a/crates/consensus/authority/src/activation_manager/tests/mod.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/mod.rs
@@ -10,12 +10,12 @@ mod accept_lagging_validator;
 mod reject_ignored_upgrade;
 mod reject_mismatched_vote;
 mod reject_outdated_or_unsupported_version;
-mod utils;
 mod vote_expiration;
 mod vote_majority_nay_compliant_and_reject;
 mod vote_nay_and_accept;
 mod vote_nay_and_reject;
 mod wait_for_compliance;
+mod utils;
 
 /// In-Memory database that integrates the `ActivationManagerReaderWriter` trait.
 #[derive(Clone)]

--- a/crates/consensus/authority/src/activation_manager/tests/mod.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/mod.rs
@@ -1,6 +1,9 @@
 use super::*;
-use reth_provider::ProviderResult;
-use std::{collections::HashMap, sync::Arc};
+use reth_provider::{activation_manager_conformance_tests, ProviderResult};
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    sync::Arc,
+};
 use utils::Address;
 
 mod accept_lagging_validator;
@@ -129,56 +132,24 @@ impl ActivationManagerReaderWriter<utils::Address> for Db {
 }
 
 #[test]
-fn activation_manager_basic_db_interface() {
-    let db = Db::new();
-
-    // Generate addresses
+fn unit_test_db_conformance() {
     let alice = b"alice".to_vec();
     let bob = b"bob".to_vec();
     let eve = b"eve".to_vec();
 
-    let min_validator_count = 3;
+    #[rustfmt::skip]
+    activation_manager_conformance_tests::assert_threshold_rates(
+        alice.clone(),
+        bob.clone(),
+        eve.clone(),
+        Db::new(),
+    );
 
-    // Alice votes Aye, is not compliant
-    db.update_upgrading_vote(alice, Vote::Aye, false, 0).unwrap();
-    let res = db.get_upgrading_approval_rate_ayes(min_validator_count).unwrap();
-    assert_eq!(res, (34, 3));
-    let res = db.get_upgrading_approval_rate_compliance(min_validator_count).unwrap();
-    assert_eq!(res, (0, 3));
-
-    // Bob votes Nay, is not compliant
-    db.update_upgrading_vote(bob, Vote::Nay, false, 0).unwrap();
-    let res = db.get_upgrading_approval_rate_ayes(min_validator_count).unwrap();
-    assert_eq!(res, (34, 3));
-    let res = db.get_upgrading_approval_rate_compliance(min_validator_count).unwrap();
-    assert_eq!(res, (0, 3));
-
-    // Eve votes Aye, IS compliant
-    db.update_upgrading_vote(eve, Vote::Aye, true, 0).unwrap();
-    let res = db.get_upgrading_approval_rate_ayes(min_validator_count).unwrap();
-    assert_eq!(res, (67, 3));
-    let res = db.get_upgrading_approval_rate_compliance(min_validator_count).unwrap();
-    assert_eq!(res, (34, 3));
-
-    // Adjust minimum voter count (ABOVE total votes)
-    let min_validator_count = 5;
-    let res = db.get_upgrading_approval_rate_ayes(min_validator_count).unwrap();
-    assert_eq!(res, (40, 5));
-    let res = db.get_upgrading_approval_rate_compliance(min_validator_count).unwrap();
-    assert_eq!(res, (20, 5));
-
-    // Adjust minimum voter count (BELOW total votes)
-    let min_validator_count = 1;
-    let res = db.get_upgrading_approval_rate_ayes(min_validator_count).unwrap();
-    assert_eq!(res, (67, 3));
-    let res = db.get_upgrading_approval_rate_compliance(min_validator_count).unwrap();
-    assert_eq!(res, (34, 3));
-
-    // Remove votes
-    let res = db.remove_upgrading_votes(1).unwrap();
-    assert_eq!(res, 3);
-    let res = db.get_upgrading_approval_rate_ayes(min_validator_count).unwrap();
-    assert_eq!(res, (0, 1));
-    let res = db.get_upgrading_approval_rate_compliance(min_validator_count).unwrap();
-    assert_eq!(res, (0, 1));
+    #[rustfmt::skip]
+    activation_manager_conformance_tests::assert_polling(
+        alice,
+        bob,
+        eve,
+        Db::new()
+    );
 }

--- a/crates/consensus/authority/src/activation_manager/tests/mod.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/mod.rs
@@ -81,7 +81,7 @@ impl ActivationManagerReaderWriter<utils::Address> for Db {
 
     fn get_abstained_votes(&self) -> ProviderResult<(usize, usize)> {
         let votes = self.votes.read().unwrap();
-        let abstains = votes.iter().filter(|(_, e)| e.vote == Vote::Absent).count();
+        let abstains = votes.iter().filter(|(_, e)| e.vote == Vote::Abstain).count();
         Ok((abstains, votes.len()))
     }
 

--- a/crates/consensus/authority/src/activation_manager/tests/reject_ignored_upgrade.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/reject_ignored_upgrade.rs
@@ -55,6 +55,11 @@ fn activation_manager_reject_ignored_upgrade() {
                 finalize_pass: true,
                 aye_approval_rate: 34,
                 comp_approval_rate: 34,
+                aye_votes: 1,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 1,
+                total_votes: 1,
             },
         )
         // Eve DOES NOT participate in voting.
@@ -65,6 +70,11 @@ fn activation_manager_reject_ignored_upgrade() {
                 finalize_pass: true,
                 aye_approval_rate: 0,
                 comp_approval_rate: 0,
+                aye_votes: 0,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 0,
+                total_votes: 0,
             },
         )
         .build_block();
@@ -93,6 +103,11 @@ fn activation_manager_reject_ignored_upgrade() {
                 finalize_pass: true,
                 aye_approval_rate: 67,
                 comp_approval_rate: 67,
+                aye_votes: 2,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 2,
+                total_votes: 2,
             },
         )
         .expectations(
@@ -102,6 +117,11 @@ fn activation_manager_reject_ignored_upgrade() {
                 finalize_pass: true,
                 aye_approval_rate: 0,
                 comp_approval_rate: 0,
+                aye_votes: 0,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 0,
+                total_votes: 0,
             },
         )
         .build_block();
@@ -130,6 +150,11 @@ fn activation_manager_reject_ignored_upgrade() {
                 finalize_pass: true,
                 aye_approval_rate: 67,
                 comp_approval_rate: 67,
+                aye_votes: 2,
+                nay_votes: 0,
+                abstained_votes: 1, // Eve is counted as abstained
+                compliant_count: 2,
+                total_votes: 3,
             },
         )
         .expectations(
@@ -139,6 +164,11 @@ fn activation_manager_reject_ignored_upgrade() {
                 finalize_pass: true,
                 aye_approval_rate: 0,
                 comp_approval_rate: 0,
+                aye_votes: 0,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 0,
+                total_votes: 0,
             },
         )
         .build_block();
@@ -169,6 +199,11 @@ fn activation_manager_reject_ignored_upgrade() {
                 // Votes pruned after upgrade
                 aye_approval_rate: 0,
                 comp_approval_rate: 0,
+                aye_votes: 0,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 0,
+                total_votes: 0,
             },
         )
         // Eve REJECTS the upgrade.
@@ -179,6 +214,11 @@ fn activation_manager_reject_ignored_upgrade() {
                 finalize_pass: false, // Reject!
                 aye_approval_rate: 0,
                 comp_approval_rate: 0,
+                aye_votes: 0,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 0,
+                total_votes: 0,
             },
         )
         .build_block();
@@ -199,6 +239,11 @@ fn activation_manager_reject_ignored_upgrade() {
                 finalize_pass: true,
                 aye_approval_rate: 0,
                 comp_approval_rate: 0,
+                aye_votes: 0,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 0,
+                total_votes: 0,
             },
         )
         // Eve REJECTS the upgrade.
@@ -209,6 +254,11 @@ fn activation_manager_reject_ignored_upgrade() {
                 finalize_pass: false, // Reject!
                 aye_approval_rate: 0,
                 comp_approval_rate: 0,
+                aye_votes: 0,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 0,
+                total_votes: 0,
             },
         )
         .build_blocks_until(21);

--- a/crates/consensus/authority/src/activation_manager/tests/reject_mismatched_vote.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/reject_mismatched_vote.rs
@@ -53,9 +53,14 @@ fn activation_manager_reject_mismatched_vote() {
                 finalize_pass: true,
                 aye_approval_rate: 34,
                 comp_approval_rate: 34,
+                aye_votes: 1,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 1,
+                total_votes: 1,
             },
         )
-        // Eve does not count Alices' vote (different version).
+        // Eve counts Alices' vote as abstained (different version)
         .expectations(
             &[EVE],
             Expectations {
@@ -63,6 +68,11 @@ fn activation_manager_reject_mismatched_vote() {
                 finalize_pass: true,
                 aye_approval_rate: 0,
                 comp_approval_rate: 0,
+                aye_votes: 0,
+                nay_votes: 0,
+                abstained_votes: 1,
+                compliant_count: 0,
+                total_votes: 1,
             },
         )
         .build_block();
@@ -91,9 +101,14 @@ fn activation_manager_reject_mismatched_vote() {
                 finalize_pass: true,
                 aye_approval_rate: 67,
                 comp_approval_rate: 67,
+                aye_votes: 2,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 2,
+                total_votes: 2,
             },
         )
-        // Eve does not count Bobs' vote (different version).
+        // Eve counts Bobs' vote as abstained (different version)
         .expectations(
             &[EVE],
             Expectations {
@@ -101,6 +116,11 @@ fn activation_manager_reject_mismatched_vote() {
                 finalize_pass: true,
                 aye_approval_rate: 0,
                 comp_approval_rate: 0,
+                aye_votes: 0,
+                nay_votes: 0,
+                abstained_votes: 2,
+                compliant_count: 0,
+                total_votes: 2,
             },
         )
         .build_block();
@@ -121,7 +141,7 @@ fn activation_manager_reject_mismatched_vote() {
                 block_height_req: false,
             },
         )
-        // Alice and Bob DO NOT count Eves' vote (different version).
+        // Alice and Bob count Eves' vote as abstained (different version).
         .expectations(
             &[ALICE, BOB],
             Expectations {
@@ -129,6 +149,11 @@ fn activation_manager_reject_mismatched_vote() {
                 finalize_pass: true,
                 aye_approval_rate: 67,
                 comp_approval_rate: 67,
+                aye_votes: 2,
+                nay_votes: 0,
+                abstained_votes: 1,
+                compliant_count: 2,
+                total_votes: 3,
             },
         )
         // Eve counts his own vote
@@ -139,6 +164,11 @@ fn activation_manager_reject_mismatched_vote() {
                 finalize_pass: true,
                 aye_approval_rate: 34,
                 comp_approval_rate: 34,
+                aye_votes: 1,
+                nay_votes: 0,
+                abstained_votes: 2,
+                compliant_count: 1,
+                total_votes: 3,
             },
         )
         .build_block();
@@ -168,6 +198,11 @@ fn activation_manager_reject_mismatched_vote() {
                 finalize_pass: true,
                 aye_approval_rate: 67,
                 comp_approval_rate: 67,
+                aye_votes: 2,
+                nay_votes: 0,
+                abstained_votes: 1,
+                compliant_count: 2,
+                total_votes: 3,
             },
         )
         .expectations(
@@ -177,6 +212,11 @@ fn activation_manager_reject_mismatched_vote() {
                 finalize_pass: true,
                 aye_approval_rate: 34,
                 comp_approval_rate: 34,
+                aye_votes: 1,
+                nay_votes: 0,
+                abstained_votes: 2,
+                compliant_count: 1,
+                total_votes: 3,
             },
         )
         .build_blocks_until(21);

--- a/crates/consensus/authority/src/activation_manager/tests/reject_outdated_or_unsupported_version.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/reject_outdated_or_unsupported_version.rs
@@ -52,6 +52,11 @@ fn activation_manager_reject_outdated_or_unsupported_version() {
                 finalize_pass: true,
                 aye_approval_rate: 34,
                 comp_approval_rate: 34,
+                aye_votes: 1,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 1,
+                total_votes: 1,
             },
         )
         .build_block();
@@ -79,6 +84,11 @@ fn activation_manager_reject_outdated_or_unsupported_version() {
                 finalize_pass: true,
                 aye_approval_rate: 67,
                 comp_approval_rate: 67,
+                aye_votes: 2,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 2,
+                total_votes: 2,
             },
         )
         .build_block();
@@ -106,6 +116,11 @@ fn activation_manager_reject_outdated_or_unsupported_version() {
                 finalize_pass: true,
                 aye_approval_rate: 100,
                 comp_approval_rate: 100,
+                aye_votes: 3,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 3,
+                total_votes: 3,
             },
         )
         .build_block();
@@ -135,6 +150,11 @@ fn activation_manager_reject_outdated_or_unsupported_version() {
                 // Votes pruned after upgrade
                 aye_approval_rate: 0,
                 comp_approval_rate: 0,
+                aye_votes: 0,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 0,
+                total_votes: 0,
             },
         )
         .build_block();
@@ -166,6 +186,11 @@ fn activation_manager_reject_outdated_or_unsupported_version() {
                 finalize_pass: true, // Accept
                 aye_approval_rate: 0,
                 comp_approval_rate: 0,
+                aye_votes: 0,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 0,
+                total_votes: 0,
             },
         )
         // Eve (producer) accepts the outdated block.
@@ -176,6 +201,11 @@ fn activation_manager_reject_outdated_or_unsupported_version() {
                 finalize_pass: true,
                 aye_approval_rate: 0,
                 comp_approval_rate: 0,
+                aye_votes: 0,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 0,
+                total_votes: 0,
             },
         )
         .build_blocks_until(21);
@@ -196,6 +226,11 @@ fn activation_manager_reject_outdated_or_unsupported_version() {
                 finalize_pass: true,
                 aye_approval_rate: 0,
                 comp_approval_rate: 0,
+                aye_votes: 0,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 0,
+                total_votes: 0,
             },
         )
         // Eve REJECTS the upgraded blocks, both during the backing and
@@ -208,6 +243,11 @@ fn activation_manager_reject_outdated_or_unsupported_version() {
                 finalize_pass: false, // Reject!
                 aye_approval_rate: 0,
                 comp_approval_rate: 0,
+                aye_votes: 0,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 0,
+                total_votes: 0,
             },
         )
         .build_blocks_until(41);

--- a/crates/consensus/authority/src/activation_manager/tests/utils.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/utils.rs
@@ -1,7 +1,7 @@
 use super::Db;
 use crate::activation_manager::{
     ActivationManager, ActivationManagerBuilder, ConditionList, OnFinalizeBlockDecision,
-    OnPrepareProposalDecision, OnProcessProposalDecision, VOTE_RETENTION_PERIOD,
+    OnPrepareProposalDecision, OnProcessProposalDecision, Polling, VOTE_RETENTION_PERIOD,
 };
 use reth_db::models::activation_manager::{RuntimeVersion, Vote};
 use reth_provider::ActivationManagerReaderWriter;
@@ -279,6 +279,17 @@ pub(super) struct Expectations {
     pub(super) aye_approval_rate: usize,
     /// The expected percentage (0-100) of compliant validators
     pub(super) comp_approval_rate: usize,
+    /// The expected number of validators who voted "Aye"
+    pub(super) aye_votes: usize,
+    /// The expected number of validators who voted "Nay"
+    pub(super) nay_votes: usize,
+    /// The expected number of validators who abstained from voting
+    pub(super) abstained_votes: usize,
+    /// The expected number of validators who are compliant with the upgrade
+    pub(super) compliant_count: usize,
+    /// The expected total number of distinct validators who have voted,
+    /// including abstained votes.
+    pub(super) total_votes: usize,
 }
 
 /// Fixture for testing the block proposal and validation flow.
@@ -512,6 +523,18 @@ impl ProposingTestFixture<'_> {
 
             assert_eq!(ayes, expect.aye_approval_rate, "ayes approval_rate mismatch");
             assert_eq!(compliance, expect.comp_approval_rate, "compliant approval_rate mismatch");
+
+            // Verify polling
+            let (_, polling) = manager.get_upgrade_polling().unwrap().unwrap_or((
+                RuntimeVersion::from((0, 0)), // throwaway
+                Polling { ayes: 0, nays: 0, abstained: 0, compliant: 0, total: 0 },
+            ));
+
+            assert_eq!(polling.ayes, expect.aye_votes, "aye votes mismatch");
+            assert_eq!(polling.nays, expect.nay_votes, "nay votes mismatch");
+            assert_eq!(polling.abstained, expect.abstained_votes, "abstain votes mismatch");
+            assert_eq!(polling.compliant, expect.compliant_count, "compliant count mismatch");
+            assert_eq!(polling.total, expect.total_votes, "total votes mismatch");
         }
 
         self.i.block_height += 1;

--- a/crates/consensus/authority/src/activation_manager/tests/utils.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/utils.rs
@@ -51,12 +51,10 @@ pub(super) struct UpgradeTestFixture {
     required_approval_rate: usize,
     /// The minimum number of distinct validators required to participate in voting
     min_validator_count: usize,
-
     /// The current block height in the simulation
     block_height: u64,
     /// How long votes are retained before expiring (in blocks)
     vote_retention_period: u64,
-
     /// The public keys representing each validator's identity
     addrs: [Address; 3],
     /// In-memory databases for each validator
@@ -300,12 +298,10 @@ pub(super) struct Expectations {
 /// finalizing blocks.
 pub(super) struct ProposingTestFixture<'a> {
     i: &'a mut UpgradeTestFixture,
-
     /// The index of the validator proposing the current block
     proposer_index: usize,
     /// The runtime version expected in the proposal
     expected_proposal_version: RuntimeVersion,
-
     /// Expectations for each validator's behavior when processing the block
     expectations: [Option<Expectations>; 3],
     /// Expected upgrade conditions for each validator
@@ -413,8 +409,6 @@ impl ProposingTestFixture<'_> {
     /// 4. Verifies that all validators behave according to expectations
     /// 5. Advances the block height
     fn do_build_block(&mut self) {
-        dbg!(self.i.block_height);
-
         let proposer = self.i.managers[self.proposer_index].as_mut().unwrap();
         let proposer_addr = self.i.addrs[self.proposer_index].clone();
 
@@ -446,17 +440,14 @@ impl ProposingTestFixture<'_> {
 
         // Each party processes and finalizes the block
         for (i, (manager, db)) in self.i.managers.iter_mut().zip(self.i.dbs.iter()).enumerate() {
-            let auth_idx = i;
-            dbg!(auth_idx);
-
             let Some(manager) = manager.as_mut() else {
                 assert!(
                     self.expectations[i].is_none(),
-                    "expected expectations for non-existent manager"
+                    "expectations set for non-existent manager"
                 );
                 assert!(
                     self.expected_conditions[i].is_none(),
-                    "expected conditions for non-existent manager"
+                    "conditions set for non-existent manager"
                 );
 
                 continue;

--- a/crates/consensus/authority/src/activation_manager/tests/vote_expiration.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/vote_expiration.rs
@@ -51,6 +51,11 @@ fn activation_manager_vote_expiration() {
                 finalize_pass: true,
                 aye_approval_rate: 34,
                 comp_approval_rate: 34,
+                aye_votes: 1,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 1,
+                total_votes: 1,
             },
         )
         .build_block();
@@ -78,6 +83,11 @@ fn activation_manager_vote_expiration() {
                 finalize_pass: true,
                 aye_approval_rate: 67,
                 comp_approval_rate: 67,
+                aye_votes: 2,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 2,
+                total_votes: 2,
             },
         )
         .build_block();
@@ -105,6 +115,11 @@ fn activation_manager_vote_expiration() {
                 finalize_pass: true,
                 aye_approval_rate: 100,
                 comp_approval_rate: 100,
+                aye_votes: 3,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 3,
+                total_votes: 3,
             },
         )
         .build_block();
@@ -135,6 +150,11 @@ fn activation_manager_vote_expiration() {
                 finalize_pass: true,
                 aye_approval_rate: 100,
                 comp_approval_rate: 100,
+                aye_votes: 3,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 3,
+                total_votes: 3,
             },
         )
         .build_blocks_until(12);
@@ -164,6 +184,11 @@ fn activation_manager_vote_expiration() {
                 // NOTE: Bob's vote expired!
                 aye_approval_rate: 67,
                 comp_approval_rate: 67,
+                aye_votes: 2,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 2,
+                total_votes: 2,
             },
         )
         .build_block();
@@ -193,6 +218,11 @@ fn activation_manager_vote_expiration() {
                 // NOTE: Eve's vote expired!
                 aye_approval_rate: 34,
                 comp_approval_rate: 34,
+                aye_votes: 1,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 1,
+                total_votes: 1,
             },
         )
         .build_block();
@@ -220,6 +250,11 @@ fn activation_manager_vote_expiration() {
                 finalize_pass: true,
                 aye_approval_rate: 34,
                 comp_approval_rate: 34,
+                aye_votes: 1,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 1,
+                total_votes: 1,
             },
         )
         .build_blocks_until(20);
@@ -248,6 +283,11 @@ fn activation_manager_vote_expiration() {
                 finalize_pass: true,
                 aye_approval_rate: 34,
                 comp_approval_rate: 34,
+                aye_votes: 1,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 1,
+                total_votes: 1,
             },
         )
         .build_blocks_until(31);

--- a/crates/consensus/authority/src/activation_manager/tests/vote_majority_nay_compliant_and_reject.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/vote_majority_nay_compliant_and_reject.rs
@@ -9,7 +9,7 @@ use reth_db::models::activation_manager::Vote;
 ///
 /// This test verifies that:
 /// 1. All validators are configured to accept an upgrade (is_compliant = true)
-/// 2. ALICE votes Aye, but BOB and EVE vote Nay
+/// 2. ALICE votes Aye, but BOB votes Nay and EVE votes Abstain
 /// 3. Despite having 100% of validators being compliant with the upgrade, it does not activate
 ///    because the Aye vote approval_rate (only 34%) is below the required quorum
 /// 4. This demonstrates that both acceptance and explicit Aye votes are required for an upgrade to
@@ -25,7 +25,7 @@ fn activation_manager_vote_majority_nay_compliant_and_reject() {
     let mut f = UpgradeTestFixture::new(upgrade_height, required_approval_rate)
         .setup_compliant_validator(ALICE, Vote::Aye)
         .setup_compliant_validator(BOB, Vote::Nay)
-        .setup_compliant_validator(EVE, Vote::Nay);
+        .setup_compliant_validator(EVE, Vote::Absent);
 
     assert_eq!(f.next_height(), 0);
 
@@ -51,6 +51,11 @@ fn activation_manager_vote_majority_nay_compliant_and_reject() {
                 finalize_pass: true,
                 aye_approval_rate: 34,
                 comp_approval_rate: 34,
+                aye_votes: 1,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 1,
+                total_votes: 1,
             },
         )
         .build_block();
@@ -78,6 +83,11 @@ fn activation_manager_vote_majority_nay_compliant_and_reject() {
                 finalize_pass: true,
                 aye_approval_rate: 34,
                 comp_approval_rate: 67,
+                aye_votes: 1,
+                nay_votes: 1,
+                abstained_votes: 0,
+                compliant_count: 2,
+                total_votes: 2,
             },
         )
         .build_block();
@@ -85,7 +95,7 @@ fn activation_manager_vote_majority_nay_compliant_and_reject() {
     assert_eq!(f.next_height(), 2);
 
     //
-    // Block 2: Eve proposes and votes Nay, but is willing to upgrade.
+    // Block 2: Eve proposes and votes Abstain, but is willing to upgrade.
     //
 
     f.start_proposal(EVE, ACTIVE_VERSION)
@@ -105,6 +115,11 @@ fn activation_manager_vote_majority_nay_compliant_and_reject() {
                 finalize_pass: true,
                 aye_approval_rate: 34,
                 comp_approval_rate: 100,
+                aye_votes: 1,
+                nay_votes: 1,
+                abstained_votes: 1,
+                compliant_count: 3,
+                total_votes: 3,
             },
         )
         .build_block();
@@ -133,6 +148,11 @@ fn activation_manager_vote_majority_nay_compliant_and_reject() {
                 finalize_pass: true,
                 aye_approval_rate: 34,
                 comp_approval_rate: 100,
+                aye_votes: 1,
+                nay_votes: 1,
+                abstained_votes: 1,
+                compliant_count: 3,
+                total_votes: 3,
             },
         )
         .build_blocks_until(21);

--- a/crates/consensus/authority/src/activation_manager/tests/vote_majority_nay_compliant_and_reject.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/vote_majority_nay_compliant_and_reject.rs
@@ -25,7 +25,7 @@ fn activation_manager_vote_majority_nay_compliant_and_reject() {
     let mut f = UpgradeTestFixture::new(upgrade_height, required_approval_rate)
         .setup_compliant_validator(ALICE, Vote::Aye)
         .setup_compliant_validator(BOB, Vote::Nay)
-        .setup_compliant_validator(EVE, Vote::Absent);
+        .setup_compliant_validator(EVE, Vote::Abstain);
 
     assert_eq!(f.next_height(), 0);
 

--- a/crates/consensus/authority/src/activation_manager/tests/vote_nay_and_accept.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/vote_nay_and_accept.rs
@@ -52,6 +52,11 @@ fn activation_manager_vote_nay_and_accept() {
                 finalize_pass: true,
                 aye_approval_rate: 34,
                 comp_approval_rate: 34,
+                aye_votes: 1,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 1,
+                total_votes: 1,
             },
         )
         .build_block();
@@ -79,6 +84,11 @@ fn activation_manager_vote_nay_and_accept() {
                 finalize_pass: true,
                 aye_approval_rate: 67,
                 comp_approval_rate: 67,
+                aye_votes: 2,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 2,
+                total_votes: 2,
             },
         )
         .build_block();
@@ -107,6 +117,11 @@ fn activation_manager_vote_nay_and_accept() {
                 // NOTE: Eve: votes Nay, but is compliant
                 aye_approval_rate: 67,
                 comp_approval_rate: 100,
+                aye_votes: 2,
+                nay_votes: 1,
+                abstained_votes: 0,
+                compliant_count: 3,
+                total_votes: 3,
             },
         )
         .build_block();
@@ -136,6 +151,11 @@ fn activation_manager_vote_nay_and_accept() {
                 // Votes pruned after upgrade
                 aye_approval_rate: 0,
                 comp_approval_rate: 0,
+                aye_votes: 0,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 0,
+                total_votes: 0,
             },
         )
         .build_block();
@@ -156,6 +176,11 @@ fn activation_manager_vote_nay_and_accept() {
                 finalize_pass: true,
                 aye_approval_rate: 0,
                 comp_approval_rate: 0,
+                aye_votes: 0,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 0,
+                total_votes: 0,
             },
         )
         .build_blocks_until(21);

--- a/crates/consensus/authority/src/activation_manager/tests/vote_nay_and_reject.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/vote_nay_and_reject.rs
@@ -61,6 +61,11 @@ fn activation_manager_vote_nay_and_reject() {
                 finalize_pass: true,
                 aye_approval_rate: 34,
                 comp_approval_rate: 34,
+                aye_votes: 1,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 1,
+                total_votes: 1,
             },
         )
         .build_block();
@@ -98,6 +103,11 @@ fn activation_manager_vote_nay_and_reject() {
                 finalize_pass: true,
                 aye_approval_rate: 67,
                 comp_approval_rate: 67,
+                aye_votes: 2,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 2,
+                total_votes: 2,
             },
         )
         .build_block();
@@ -137,6 +147,11 @@ fn activation_manager_vote_nay_and_reject() {
                 // NOTE: Eve: votes Nay and rejects.
                 aye_approval_rate: 67,
                 comp_approval_rate: 67,
+                aye_votes: 2,
+                nay_votes: 1,
+                abstained_votes: 0,
+                compliant_count: 2, // Not compliant
+                total_votes: 3,
             },
         )
         .build_block();
@@ -179,6 +194,11 @@ fn activation_manager_vote_nay_and_reject() {
                 // Votes pruned after upgrade
                 aye_approval_rate: 0,
                 comp_approval_rate: 0,
+                aye_votes: 0,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 0,
+                total_votes: 0,
             },
         )
         // Eve REJECTS the upgrade.
@@ -190,6 +210,11 @@ fn activation_manager_vote_nay_and_reject() {
                 // Votes pruned after upgrade
                 aye_approval_rate: 0,
                 comp_approval_rate: 0,
+                aye_votes: 0,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 0,
+                total_votes: 0,
             },
         )
         .build_block();
@@ -210,6 +235,11 @@ fn activation_manager_vote_nay_and_reject() {
                 finalize_pass: true,
                 aye_approval_rate: 0,
                 comp_approval_rate: 0,
+                aye_votes: 0,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 0,
+                total_votes: 0,
             },
         )
         // Eve REJECTS the upgrade.
@@ -220,6 +250,11 @@ fn activation_manager_vote_nay_and_reject() {
                 finalize_pass: false, // Reject!
                 aye_approval_rate: 0,
                 comp_approval_rate: 0,
+                aye_votes: 0,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 0,
+                total_votes: 0,
             },
         )
         .build_blocks_until(21);

--- a/crates/consensus/authority/src/activation_manager/tests/wait_for_compliance.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/wait_for_compliance.rs
@@ -53,6 +53,11 @@ fn activation_manager_wait_for_compliance() {
                 finalize_pass: true,
                 aye_approval_rate: 34,
                 comp_approval_rate: 0,
+                aye_votes: 1,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 0, // Not compliant!
+                total_votes: 1,
             },
         )
         .build_block();
@@ -82,6 +87,11 @@ fn activation_manager_wait_for_compliance() {
                 finalize_pass: true,
                 aye_approval_rate: 67,
                 comp_approval_rate: 0,
+                aye_votes: 2,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 0,
+                total_votes: 2,
             },
         )
         .build_block();
@@ -97,8 +107,6 @@ fn activation_manager_wait_for_compliance() {
             &[ALICE, BOB, EVE],
             ConditionList {
                 comp_req: false,
-                // NOTE: signaling validators simply use `u64::MAX` as the
-                // approval_rate.
                 comp_approval_req: false,
                 aye_approval_req: false,
                 block_height_req: false,
@@ -111,6 +119,11 @@ fn activation_manager_wait_for_compliance() {
                 finalize_pass: true,
                 aye_approval_rate: 100,
                 comp_approval_rate: 0,
+                aye_votes: 3,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 0,
+                total_votes: 3,
             },
         )
         .build_block();
@@ -148,6 +161,11 @@ fn activation_manager_wait_for_compliance() {
                 finalize_pass: true,
                 aye_approval_rate: 100,
                 comp_approval_rate: 34,
+                aye_votes: 3,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 1, // Compliance count starts!
+                total_votes: 3,
             },
         )
         .build_block();
@@ -175,6 +193,11 @@ fn activation_manager_wait_for_compliance() {
                 finalize_pass: true,
                 aye_approval_rate: 100,
                 comp_approval_rate: 67,
+                aye_votes: 3,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 2,
+                total_votes: 3,
             },
         )
         .build_block();
@@ -203,6 +226,11 @@ fn activation_manager_wait_for_compliance() {
                 // Votes pruned after upgrade
                 aye_approval_rate: 0,
                 comp_approval_rate: 0,
+                aye_votes: 0,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 0,
+                total_votes: 0,
             },
         )
         .build_block();
@@ -223,6 +251,11 @@ fn activation_manager_wait_for_compliance() {
                 finalize_pass: true,
                 aye_approval_rate: 0,
                 comp_approval_rate: 0,
+                aye_votes: 0,
+                nay_votes: 0,
+                abstained_votes: 0,
+                compliant_count: 0,
+                total_votes: 0,
             },
         )
         .build_blocks_until(21);

--- a/crates/consensus/authority/src/comet_bft/abci.rs
+++ b/crates/consensus/authority/src/comet_bft/abci.rs
@@ -2155,6 +2155,21 @@ where
             }
         }
 
+        // Metrics
+        //
+        // Only create metrics if there's an actual upgrade event ongoing.
+        if let Some((upgrade_version, polling)) =
+            self.activation_manager.get_upgrade_polling().expect("db cannot fail")
+        {
+            // Track the raw vote by the proposer. Note that the proposer might
+            // be voting for a different version than the one we're interested
+            // in, or for none at all. The rendered metric is labeled accurately.
+            self.metrics.runtime_upgrade_vote(&proposer_address, &proposer_vote);
+
+            // Track the polling results for the specific version we're interested in.
+            self.metrics.runtime_upgrade_polling(&upgrade_version, &polling);
+        }
+
         // Rpc node needs to store aggregate public key from block height 1
         let block_height = block_with_context.sealed_block_with_peg.block().number;
         let sealed_block_with_peg_binding = block_with_context.sealed_block_with_peg.clone();

--- a/crates/consensus/authority/src/comet_bft/abci.rs
+++ b/crates/consensus/authority/src/comet_bft/abci.rs
@@ -2132,15 +2132,15 @@ where
         // Activation Manager: decide whether we're willing to accept
         // the runtime version.
         //
-        // Note that lagging validators will automatically accept an
-        // upgrade as long as they're specifically configured to do so
-        // (non-default behavior) - whether the upgrade conditions are
-        // met or not.
+        // Note that lagging validators will automatically accept an upgrade as
+        // long as they're specifically configured to do so (non-default
+        // behavior), whether - from their perspective - the upgrade conditions
+        // are met or not.
         let comet_height = request.height as u64;
         let runtime_version = block_with_context.runtime_version;
         let proposer_address = Address::from_slice(&request.proposer_address);
         let proposer_vote = block_with_context.network_upgrade_payload;
-        //
+
         match self
             .activation_manager
             .on_finalize_block(runtime_version, comet_height, proposer_address, proposer_vote)

--- a/crates/consensus/authority/src/comet_bft/non_deterministic_data.rs
+++ b/crates/consensus/authority/src/comet_bft/non_deterministic_data.rs
@@ -194,7 +194,7 @@ impl NonDeterministicData {
 
                 // Serialize upgrade vote
                 match upgrade.vote {
-                    activation_manager::Vote::Absent => 0u8.consensus_encode(&mut writer)?,
+                    activation_manager::Vote::Abstain => 0u8.consensus_encode(&mut writer)?,
                     activation_manager::Vote::Nay => 1u8.consensus_encode(&mut writer)?,
                     activation_manager::Vote::Aye => 2u8.consensus_encode(&mut writer)?,
                 };
@@ -305,7 +305,7 @@ impl NonDeterministicData {
         // Decode payload information
         let upgrade_version = <(u16, u16)>::consensus_decode(reader)?.into();
         let vote = match u8::consensus_decode(reader)? {
-            0 => activation_manager::Vote::Absent,
+            0 => activation_manager::Vote::Abstain,
             1 => activation_manager::Vote::Nay,
             2 => activation_manager::Vote::Aye,
             _ => return Err(NonDeterministicDataDeserializeError::NetworkUpgradePayloadVote),
@@ -328,7 +328,7 @@ impl NonDeterministicData {
 ///
 /// * `version` - The specific runtime version that this vote applies to.
 ///
-/// * `vote` - The validator's explicit opinion on the upgrade (Aye/Nay/Absent).
+/// * `vote` - The validator's explicit opinion on the upgrade (Aye/Nay/Abstain).
 ///
 /// * `is_compliant` - Indicates whether the validator is technically ready to process blocks with
 ///   the upgrade version. When `true`, the validator has the necessary software version and
@@ -535,7 +535,7 @@ mod tests {
         // With network upgrade payloads
         let payload = Some(NetworkUpgradePayload {
             version: RuntimeVersion::new(2, 5),
-            vote: Vote::Absent,
+            vote: Vote::Abstain,
             is_compliant: false,
         });
 

--- a/crates/consensus/authority/src/comet_bft/vote_tracker.rs
+++ b/crates/consensus/authority/src/comet_bft/vote_tracker.rs
@@ -71,7 +71,7 @@ impl ActivationManagerReaderWriter<Address> for VoteWatcher {
 
     fn get_abstained_votes(&self) -> ProviderResult<(usize, usize)> {
         let votes = self.votes.read().unwrap();
-        let abstains = votes.iter().filter(|(_, e)| e.vote == Vote::Absent).count();
+        let abstains = votes.iter().filter(|(_, e)| e.vote == Vote::Abstain).count();
         Ok((abstains, votes.len()))
     }
 

--- a/crates/consensus/authority/src/comet_bft/vote_tracker.rs
+++ b/crates/consensus/authority/src/comet_bft/vote_tracker.rs
@@ -1,7 +1,7 @@
 //! A simple in-memory vote tracker used by the ActivationManager which only
 //! tracks the last vote.
 use std::{
-    collections::HashMap,
+    collections::{hash_map::Entry, HashMap},
     sync::{Arc, RwLock},
 };
 
@@ -35,19 +35,24 @@ impl ActivationManagerReaderWriter<Address> for VoteWatcher {
     ) -> ProviderResult<()> {
         let mut votes = self.votes.write().unwrap();
 
-        #[rustfmt::skip]
-        votes
-            .entry(auth)
-            .and_modify(|e| {
+        match votes.entry(auth) {
+            Entry::Occupied(mut e) => {
+                // If the validator has previously voted, their vote will be
+                // updated to the new values if and only if the botanix height
+                // is greater than the existing botanix height.
+                if e.get().botanix_height >= botanix_height {
+                    return Ok(())
+                }
+
+                let e = e.get_mut();
                 e.vote = vote;
                 e.is_compliant = is_compliant;
                 e.botanix_height = botanix_height;
-            })
-            .or_insert(VoteEntry {
-                vote,
-                is_compliant,
-                botanix_height,
-            });
+            }
+            Entry::Vacant(v) => {
+                let _ = v.insert(VoteEntry { vote, is_compliant, botanix_height });
+            }
+        }
 
         Ok(())
     }

--- a/crates/consensus/authority/src/comet_bft/vote_tracker.rs
+++ b/crates/consensus/authority/src/comet_bft/vote_tracker.rs
@@ -124,68 +124,26 @@ impl ActivationManagerReaderWriter<Address> for VoteWatcher {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use reth_provider::activation_manager_conformance_tests;
 
     #[test]
-    fn test_vote_watcher_basic_properties() {
-        let watcher = VoteWatcher::default();
-
+    fn vote_watcher_db_conformance() {
         let alice = Address::from_slice(&[0; 20]);
         let bob = Address::from_slice(&[1; 20]);
         let eve = Address::from_slice(&[2; 20]);
 
-        let min_val_count = 10;
-        let botanix_height = 500;
+        activation_manager_conformance_tests::assert_threshold_rates(
+            alice,
+            bob,
+            eve,
+            VoteWatcher::default(),
+        );
 
-        // Check basic init properties.
-        //
-        let ayes = watcher.get_upgrading_approval_rate_ayes(min_val_count).unwrap();
-        assert_eq!(ayes, (0, min_val_count));
-
-        let compliant = watcher.get_upgrading_approval_rate_compliance(min_val_count).unwrap();
-        assert_eq!(compliant, (0, min_val_count));
-
-        let removed = watcher.remove_upgrading_votes(botanix_height).unwrap();
-        assert_eq!(removed, 0);
-
-        // Track votes.
-        //
-        watcher.update_upgrading_vote(alice, Vote::Aye, true, botanix_height).unwrap();
-        watcher.update_upgrading_vote(bob, Vote::Aye, false, botanix_height).unwrap();
-        watcher.update_upgrading_vote(eve, Vote::Nay, false, botanix_height).unwrap();
-
-        let ayes = watcher.get_upgrading_approval_rate_ayes(min_val_count).unwrap();
-        assert_eq!(ayes, (20, min_val_count)); // 20%
-
-        let compliant = watcher.get_upgrading_approval_rate_compliance(min_val_count).unwrap();
-        assert_eq!(compliant, (10, min_val_count)); // 10%
-
-        // Eve votes again
-        //
-        watcher.update_upgrading_vote(eve, Vote::Aye, true, botanix_height).unwrap();
-
-        let ayes = watcher.get_upgrading_approval_rate_ayes(min_val_count).unwrap();
-        assert_eq!(ayes, (30, min_val_count)); // 30%
-
-        let compliant = watcher.get_upgrading_approval_rate_compliance(min_val_count).unwrap();
-        assert_eq!(compliant, (20, min_val_count)); // 20%
-
-        // Remove votes
-        //
-        let removed = watcher.remove_upgrading_votes(botanix_height).unwrap();
-        assert_eq!(removed, 0);
-
-        let removed = watcher.remove_upgrading_votes(botanix_height + 1).unwrap();
-        assert_eq!(removed, 3); // alice, bob and eve
-
-        // Removed; all is gone
-        //
-        let ayes = watcher.get_upgrading_approval_rate_ayes(min_val_count).unwrap();
-        assert_eq!(ayes, (0, min_val_count));
-
-        let compliant = watcher.get_upgrading_approval_rate_compliance(min_val_count).unwrap();
-        assert_eq!(compliant, (0, min_val_count));
-
-        let removed = watcher.remove_upgrading_votes(botanix_height).unwrap();
-        assert_eq!(removed, 0);
+        activation_manager_conformance_tests::assert_polling(
+            alice,
+            bob,
+            eve,
+            VoteWatcher::default(),
+        );
     }
 }

--- a/crates/consensus/authority/src/comet_bft/vote_tracker.rs
+++ b/crates/consensus/authority/src/comet_bft/vote_tracker.rs
@@ -52,6 +52,30 @@ impl ActivationManagerReaderWriter<Address> for VoteWatcher {
         Ok(())
     }
 
+    fn get_aye_votes(&self) -> ProviderResult<(usize, usize)> {
+        let votes = self.votes.read().unwrap();
+        let ayes = votes.iter().filter(|(_, e)| e.vote == Vote::Aye).count();
+        Ok((ayes, votes.len()))
+    }
+
+    fn get_nay_votes(&self) -> ProviderResult<(usize, usize)> {
+        let votes = self.votes.read().unwrap();
+        let nays = votes.iter().filter(|(_, e)| e.vote == Vote::Nay).count();
+        Ok((nays, votes.len()))
+    }
+
+    fn get_abstained_votes(&self) -> ProviderResult<(usize, usize)> {
+        let votes = self.votes.read().unwrap();
+        let abstains = votes.iter().filter(|(_, e)| e.vote == Vote::Absent).count();
+        Ok((abstains, votes.len()))
+    }
+
+    fn get_compliance_count(&self) -> ProviderResult<(usize, usize)> {
+        let votes = self.votes.read().unwrap();
+        let compliant = votes.iter().filter(|(_, e)| e.is_compliant).count();
+        Ok((compliant, votes.len()))
+    }
+
     fn get_upgrading_approval_rate_ayes(
         &self,
         min_validator_count: usize,

--- a/crates/consensus/authority/src/comet_bft/vote_tracker.rs
+++ b/crates/consensus/authority/src/comet_bft/vote_tracker.rs
@@ -1,4 +1,4 @@
-//! A simple in-memory vote tracker used by the ActivationManager which only
+//! A simple in-memory vote tracker used by the ActivationManager that only
 //! tracks the last vote.
 use std::{
     collections::{hash_map::Entry, HashMap},
@@ -9,7 +9,7 @@ use reth_db::models::Vote;
 use reth_primitives::Address;
 use reth_provider::{ActivationManagerReaderWriter, ProviderResult};
 
-/// A simple in-memory vote tracker used by the ActivationManager which only
+/// A simple in-memory vote tracker used by the ActivationManager that only
 /// tracks the last vote.
 #[derive(Debug, Clone, Default)]
 pub struct VoteWatcher {

--- a/crates/consensus/authority/src/metrics.rs
+++ b/crates/consensus/authority/src/metrics.rs
@@ -1,8 +1,13 @@
 //! Module for providing authority metrics.
+use crate::{
+    activation_manager::Polling, comet_bft::non_deterministic_data::NetworkUpgradePayload,
+};
+use reth_db::models::RuntimeVersion;
 use reth_metrics::{
     metrics::{Counter, Gauge},
     Metrics,
 };
+use reth_primitives::Address;
 
 /// Metrics for the entire network, handled by `NetworkManager`
 #[derive(Clone, Metrics)]
@@ -38,6 +43,70 @@ pub struct AuthorityMetrics {
 
     /// Number of commet processd\ed proposals
     pub(crate) commet_processed_proposals: Counter,
+}
+
+impl AuthorityMetrics {
+    /// Create metrics for federation member vote for a given proposal.
+    pub fn runtime_upgrade_vote(&self, member: &Address, payload: &Option<NetworkUpgradePayload>) {
+        if let Some(p) = payload {
+            metrics::gauge!(
+                "authority_runtime_upgrade_vote_details",
+                "version" => p.version.to_string(),
+                "member" => member.to_string(),
+                "vote" => p.vote.to_string(),
+                "is_compliant" => p.is_compliant.to_string(),
+            )
+            .set(1.0);
+        }
+
+        metrics::gauge!(
+            "authority_runtime_upgrade_vote_included",
+            "member" => member.to_string()
+        )
+        .set(if payload.is_some() { 1.0 } else { 0.0 });
+    }
+
+    /// Create metrics for the runtime upgrade polling results.
+    pub fn runtime_upgrade_polling(&self, upgrade: &RuntimeVersion, polling: &Polling) {
+        let p = polling;
+
+        // Metrics for each individual requirement.
+        metrics::gauge!(
+            "authority_runtime_upgrade_polling",
+            "version" => upgrade.to_string(),
+            "type" => "ayes"
+        )
+        .set(p.ayes as f64);
+
+        metrics::gauge!(
+            "authority_runtime_upgrade_polling",
+            "version" => upgrade.to_string(),
+            "type" => "nays"
+        )
+        .set(p.nays as f64);
+
+        metrics::gauge!(
+            "authority_runtime_upgrade_polling",
+            "version" => upgrade.to_string(),
+            "type" => "abstained"
+        )
+        .set(p.abstained as f64);
+
+        metrics::gauge!(
+            "authority_runtime_upgrade_polling",
+            "version" => upgrade.to_string(),
+            "type" => "compliant"
+        )
+        .set(p.compliant as f64);
+
+        // Summy metric; all-passing.
+        metrics::gauge!(
+            "authority_runtime_upgrade_polling",
+            "version" => upgrade.to_string(),
+            "type" => "total"
+        )
+        .set(p.total as f64);
+    }
 }
 
 /// Measures the duration of executing the given code block. The duration is added to the given

--- a/crates/storage/db-api/src/models/activation_manager.rs
+++ b/crates/storage/db-api/src/models/activation_manager.rs
@@ -35,6 +35,17 @@ pub enum Vote {
     Absent,
 }
 
+impl std::fmt::Display for Vote {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Aye => "Aye",
+            Self::Nay => "Nay",
+            Self::Absent => "Absent",
+        };
+        write!(f, "{}", s)
+    }
+}
+
 /// Represents a protocol version in the Botanix blockchain.
 ///
 /// A runtime version consists of two components:

--- a/crates/storage/db-api/src/models/activation_manager.rs
+++ b/crates/storage/db-api/src/models/activation_manager.rs
@@ -7,7 +7,7 @@ use std::cmp::Ordering;
 /// Represents a validator's vote on a network upgrade proposal.
 ///
 /// Validators can explicitly vote in favor of an upgrade (`Aye`),
-/// against an upgrade (`Nay`), or can abstain from voting (`Absent`).
+/// against an upgrade (`Nay`), or can abstain from voting (`Abstain`).
 ///
 /// Votes are included in block proposals via the `NetworkUpgradePayload`
 /// in the Non-Deterministic Data (NDD) transaction. These votes are then
@@ -27,12 +27,12 @@ pub enum Vote {
     /// opposition while still being counted in voting statistics.
     Nay,
 
-    /// Explicit abstention from voting. An `Absent` vote functions the same as
+    /// Explicit abstention from voting. An `Abstain` vote functions the same as
     /// `Nay` in quorum calculations, but communicates the validator's intent to
     /// abstain rather than actively oppose the upgrade. It still counts as
     /// participation in the voting process.
     #[default]
-    Absent,
+    Abstain,
 }
 
 impl std::fmt::Display for Vote {
@@ -40,7 +40,7 @@ impl std::fmt::Display for Vote {
         let s = match self {
             Self::Aye => "Aye",
             Self::Nay => "Nay",
-            Self::Absent => "Absent",
+            Self::Abstain => "Abstain",
         };
         write!(f, "{}", s)
     }

--- a/crates/storage/provider/src/traits/activation_manager.rs
+++ b/crates/storage/provider/src/traits/activation_manager.rs
@@ -33,6 +33,59 @@ pub trait ActivationManagerReaderWriter<Auth>: Send + Sync {
         botanix_height: u64,
     ) -> ProviderResult<()>;
 
+    /// Returns the count of validators who have voted "Aye" and the total
+    /// number of validators who have voted.
+    ///
+    /// This method counts all validators who have cast an "Aye" vote for the
+    /// network upgrade, regardless of their compliance status.
+    ///
+    /// # Returns
+    /// * `Ok((aye_count, total_voters))` where:
+    ///   - `aye_count` is the number of validators who voted "Aye"
+    ///   - `total_voters` is the total number of distinct validators who have cast any vote
+    /// * `Err` if there was an error retrieving the vote counts
+    fn get_aye_votes(&self) -> ProviderResult<(usize, usize)>;
+
+    /// Returns the count of validators who have voted "Nay" and the total
+    /// number of validators who have voted.
+    ///
+    /// This method counts all validators who have cast a "Nay" vote for the
+    /// network upgrade, regardless of their compliance status.
+    ///
+    /// # Returns
+    /// * `Ok((nay_count, total_voters))` where:
+    ///   - `nay_count` is the number of validators who voted "Nay"
+    ///   - `total_voters` is the total number of distinct validators who have cast any vote
+    /// * `Err` if there was an error retrieving the vote counts
+    fn get_nay_votes(&self) -> ProviderResult<(usize, usize)>;
+
+    /// Returns the count of validators who have abstained from voting and the
+    /// total number of validators who have voted.
+    ///
+    /// This method counts all validators who have cast an "Absent" (abstain)
+    /// vote for the network upgrade, regardless of their compliance status.
+    ///
+    /// # Returns
+    /// * `Ok((abstain_count, total_voters))` where:
+    ///   - `abstain_count` is the number of validators who voted "Absent" (abstained)
+    ///   - `total_voters` is the total number of distinct validators who have cast any vote
+    /// * `Err` if there was an error retrieving the vote counts
+    fn get_abstained_votes(&self) -> ProviderResult<(usize, usize)>;
+
+    /// Returns the count of validators who are compliant with the upgrade and
+    /// the total number of validators who have voted.
+    ///
+    /// This method counts all validators who have indicated they are ready to
+    /// accept the upgrade by setting `is_compliant` to `true` when casting
+    /// their vote, regardless of whether they voted "Aye", "Nay", or "Absent".
+    ///
+    /// # Returns
+    /// * `Ok((compliant_count, total_voters))` where:
+    ///   - `compliant_count` is the number of validators who are compliant with the upgrade
+    ///   - `total_voters` is the total number of distinct validators who have cast any vote
+    /// * `Err` if there was an error retrieving the compliance counts
+    fn get_compliance_count(&self) -> ProviderResult<(usize, usize)>;
+
     /// Calculates the approval rate of validators signaling support (voting Aye) for an upgrade.
     ///
     /// This method calculates the percentage of validators voting "Aye" out of the total

--- a/crates/storage/provider/src/traits/activation_manager.rs
+++ b/crates/storage/provider/src/traits/activation_manager.rs
@@ -147,3 +147,319 @@ pub trait ActivationManagerReaderWriter<Auth>: Send + Sync {
     /// * `Err` if there was an error removing votes
     fn remove_upgrading_votes(&self, botanix_height: u64) -> ProviderResult<usize>;
 }
+
+/// Test utilities for validating `ActivationManagerReaderWriter` implementations.
+///
+/// This module provides conformance tests that verify the correct behavior of any
+/// implementation of the `ActivationManagerReaderWriter` trait. These tests ensure
+/// that voting mechanics, approval rate calculations, vote expiration, and data
+/// consistency work as expected across different storage backends.
+pub mod tests {
+    use super::*;
+
+    /// Tests approval rate calculations and vote management behavior.
+    ///
+    /// This function validates that an `ActivationManagerReaderWriter`
+    /// implementation correctly handles:
+    /// - Recording votes with different compliance statuses
+    /// - Calculating approval rates for both "Aye" votes and compliance
+    /// - Handling minimum validator count thresholds in rate calculations
+    /// - Updating votes only when block height increases
+    /// - Removing expired votes based on block height
+    /// - Using ceiling division for percentage calculations
+    ///
+    /// The test covers scenarios with varying minimum validator counts (above
+    /// and below actual vote counts) and verifies that vote removal correctly
+    /// affects approval rates.
+    ///
+    /// # Parameters
+    /// * `alice` - First validator identifier for testing
+    /// * `bob` - Second validator identifier for testing
+    /// * `eve` - Third validator identifier for testing
+    /// * `db` - The empty database instance to test
+    pub fn assert_threshold_rates<Auth, DB: ActivationManagerReaderWriter<Auth>>(
+        alice: Auth,
+        bob: Auth,
+        eve: Auth,
+        db: DB,
+    ) where
+        Auth: Clone,
+    {
+        let min_validator_count = 3;
+
+        // Alice votes Aye, is not compliant
+        db.update_upgrading_vote(alice, Vote::Aye, false, 1).unwrap();
+        let res = db.get_upgrading_approval_rate_ayes(min_validator_count).unwrap();
+        assert_eq!(res, (34, 3));
+        let res = db.get_upgrading_approval_rate_compliance(min_validator_count).unwrap();
+        assert_eq!(res, (0, 3));
+
+        // Bob votes Nay, is not compliant
+        db.update_upgrading_vote(bob, Vote::Nay, false, 1).unwrap();
+        let res = db.get_upgrading_approval_rate_ayes(min_validator_count).unwrap();
+        assert_eq!(res, (34, 3));
+        let res = db.get_upgrading_approval_rate_compliance(min_validator_count).unwrap();
+        assert_eq!(res, (0, 3));
+
+        // Eve votes Abstain, is not compliant
+        db.update_upgrading_vote(eve.clone(), Vote::Absent, false, 1).unwrap();
+        let res = db.get_upgrading_approval_rate_ayes(min_validator_count).unwrap();
+        assert_eq!(res, (34, 3));
+        let res = db.get_upgrading_approval_rate_compliance(min_validator_count).unwrap();
+        assert_eq!(res, (0, 3));
+
+        // Eve votes Aye, IS compliant - NOT counted, reused height
+        db.update_upgrading_vote(eve.clone(), Vote::Aye, true, 1).unwrap();
+        let res = db.get_upgrading_approval_rate_ayes(min_validator_count).unwrap();
+        assert_eq!(res, (34, 3));
+        let res = db.get_upgrading_approval_rate_compliance(min_validator_count).unwrap();
+        assert_eq!(res, (0, 3));
+
+        // Eve votes Aye, IS compliant - IS counted, incremented height
+        db.update_upgrading_vote(eve.clone(), Vote::Aye, true, 2).unwrap();
+        let res = db.get_upgrading_approval_rate_ayes(min_validator_count).unwrap();
+        assert_eq!(res, (67, 3));
+        let res = db.get_upgrading_approval_rate_compliance(min_validator_count).unwrap();
+        assert_eq!(res, (34, 3));
+
+        // Adjust minimum voter count (ABOVE total votes)
+        let min_validator_count = 5;
+        let res = db.get_upgrading_approval_rate_ayes(min_validator_count).unwrap();
+        assert_eq!(res, (40, 5));
+        let res = db.get_upgrading_approval_rate_compliance(min_validator_count).unwrap();
+        assert_eq!(res, (20, 5));
+
+        // Adjust minimum voter count (BELOW total votes)
+        let min_validator_count = 1;
+        let res = db.get_upgrading_approval_rate_ayes(min_validator_count).unwrap();
+        assert_eq!(res, (67, 3));
+        let res = db.get_upgrading_approval_rate_compliance(min_validator_count).unwrap();
+        assert_eq!(res, (34, 3));
+
+        // Remove votes
+        let min_validator_count = 3;
+
+        // > Height 0
+        let res = db.remove_upgrading_votes(0).unwrap();
+        assert_eq!(res, 0); // None removed
+        let res = db.get_upgrading_approval_rate_ayes(min_validator_count).unwrap();
+        assert_eq!(res, (67, 3));
+        let res = db.get_upgrading_approval_rate_compliance(min_validator_count).unwrap();
+        assert_eq!(res, (34, 3));
+
+        // > Height 1
+        let res = db.remove_upgrading_votes(1).unwrap();
+        assert_eq!(res, 0); // None removed
+        let res = db.get_upgrading_approval_rate_ayes(min_validator_count).unwrap();
+        assert_eq!(res, (67, 3));
+        let res = db.get_upgrading_approval_rate_compliance(min_validator_count).unwrap();
+        assert_eq!(res, (34, 3));
+
+        // > Height 2
+        let res = db.remove_upgrading_votes(2).unwrap();
+        assert_eq!(res, 2); // Alice and Bob removed
+        let res = db.get_upgrading_approval_rate_ayes(min_validator_count).unwrap();
+        assert_eq!(res, (34, 3));
+        let res = db.get_upgrading_approval_rate_compliance(min_validator_count).unwrap();
+        assert_eq!(res, (34, 3));
+
+        // > Height 3
+        let res = db.remove_upgrading_votes(3).unwrap();
+        assert_eq!(res, 1); // Eve removed
+        let res = db.get_upgrading_approval_rate_ayes(min_validator_count).unwrap();
+        assert_eq!(res, (0, 3));
+        let res = db.get_upgrading_approval_rate_compliance(min_validator_count).unwrap();
+        assert_eq!(res, (0, 3));
+    }
+
+    /// Tests raw vote counting and compliance tracking functionality.
+    ///
+    /// This function validates that an `ActivationManagerReaderWriter`
+    /// implementation correctly handles:
+    /// - Counting individual vote types (Aye, Nay, Absent)
+    /// - Tracking compliance status independently of vote choice
+    /// - Maintaining consistent total voter counts across all query methods
+    /// - Replacing previous votes when block height increases
+    /// - Removing votes based on block height expiration
+    /// - Ensuring vote updates only occur with higher block heights
+    ///
+    /// The test verifies that all vote counting methods return consistent total
+    /// counts and that vote replacement works correctly when validators change
+    /// their votes at higher block heights.
+    ///
+    /// # Parameters
+    /// * `alice` - First validator identifier for testing
+    /// * `bob` - Second validator identifier for testing
+    /// * `eve` - Third validator identifier for testing
+    /// * `db` - The empty database instance to test
+    pub fn assert_polling<Auth, DB: ActivationManagerReaderWriter<Auth>>(
+        alice: Auth,
+        bob: Auth,
+        eve: Auth,
+        db: DB,
+    ) where
+        Auth: Clone,
+    {
+        // Alice votes Aye, is not compliant
+        db.update_upgrading_vote(alice, Vote::Aye, false, 1).unwrap();
+        let (ayes, total) = db.get_aye_votes().unwrap();
+        let (nays, t2) = db.get_nay_votes().unwrap();
+        let (abstains, t3) = db.get_abstained_votes().unwrap();
+        let (compliance, t4) = db.get_compliance_count().unwrap();
+
+        assert_eq!(ayes, 1); // Alice
+        assert_eq!(nays, 0);
+        assert_eq!(abstains, 0);
+        assert_eq!(compliance, 0);
+
+        assert_eq!(total, 1);
+        assert_eq!(total, t2);
+        assert_eq!(total, t3);
+        assert_eq!(total, t4);
+
+        // Bob votes Nay, is not compliant
+        db.update_upgrading_vote(bob, Vote::Nay, false, 1).unwrap();
+        let (ayes, total) = db.get_aye_votes().unwrap();
+        let (nays, t2) = db.get_nay_votes().unwrap();
+        let (abstains, t3) = db.get_abstained_votes().unwrap();
+        let (compliance, t4) = db.get_compliance_count().unwrap();
+
+        assert_eq!(ayes, 1); // Alice
+        assert_eq!(nays, 1); // Bob
+        assert_eq!(abstains, 0);
+        assert_eq!(compliance, 0);
+
+        assert_eq!(total, 2);
+        assert_eq!(total, t2);
+        assert_eq!(total, t3);
+        assert_eq!(total, t4);
+
+        // Eve votes Abstain, is not compliant
+        db.update_upgrading_vote(eve.clone(), Vote::Absent, false, 1).unwrap();
+        let (ayes, total) = db.get_aye_votes().unwrap();
+        let (nays, t2) = db.get_nay_votes().unwrap();
+        let (abstains, t3) = db.get_abstained_votes().unwrap();
+        let (compliance, t4) = db.get_compliance_count().unwrap();
+
+        assert_eq!(ayes, 1); // Alice
+        assert_eq!(nays, 1); // Bob
+        assert_eq!(abstains, 1); // Eve
+        assert_eq!(compliance, 0);
+
+        assert_eq!(total, 3);
+        assert_eq!(total, t2);
+        assert_eq!(total, t3);
+        assert_eq!(total, t4);
+
+        // Eve votes Aye, is compliant - NOT counted, reused height
+        db.update_upgrading_vote(eve.clone(), Vote::Aye, true, 1).unwrap();
+        let (ayes, total) = db.get_aye_votes().unwrap();
+        let (nays, t2) = db.get_nay_votes().unwrap();
+        let (abstains, t3) = db.get_abstained_votes().unwrap();
+        let (compliance, t4) = db.get_compliance_count().unwrap();
+
+        assert_eq!(ayes, 1); // Alice
+        assert_eq!(nays, 1); // Bob
+        assert_eq!(abstains, 1); // Eve
+        assert_eq!(compliance, 0);
+
+        assert_eq!(total, 3);
+        assert_eq!(total, t2);
+        assert_eq!(total, t3);
+        assert_eq!(total, t4);
+
+        // Eve votes Aye, is compliant - IS counted, incremented height
+        db.update_upgrading_vote(eve.clone(), Vote::Aye, true, 2).unwrap();
+        let (ayes, total) = db.get_aye_votes().unwrap();
+        let (nays, t2) = db.get_nay_votes().unwrap();
+        let (abstains, t3) = db.get_abstained_votes().unwrap();
+        let (compliance, t4) = db.get_compliance_count().unwrap();
+
+        assert_eq!(ayes, 2); // Alice, Eve
+        assert_eq!(nays, 1); // Bob
+        assert_eq!(abstains, 0); // Eve's previous vote got replaced!
+        assert_eq!(compliance, 1); // Eve
+
+        assert_eq!(total, 3);
+        assert_eq!(total, t2);
+        assert_eq!(total, t3);
+        assert_eq!(total, t4);
+
+        // Remove votes
+        // > Height 0
+        let res = db.remove_upgrading_votes(0).unwrap();
+        assert_eq!(res, 0); // None removed
+
+        let (ayes, total) = db.get_aye_votes().unwrap();
+        let (nays, t2) = db.get_nay_votes().unwrap();
+        let (abstains, t3) = db.get_abstained_votes().unwrap();
+        let (compliance, t4) = db.get_compliance_count().unwrap();
+
+        assert_eq!(ayes, 2); // Alice, Eve
+        assert_eq!(nays, 1); // Bob
+        assert_eq!(abstains, 0);
+        assert_eq!(compliance, 1); // Eve
+
+        assert_eq!(total, 3);
+        assert_eq!(total, t2);
+        assert_eq!(total, t3);
+        assert_eq!(total, t4);
+
+        // > Height 1
+        let res = db.remove_upgrading_votes(1).unwrap();
+        assert_eq!(res, 0); // None removed
+
+        let (ayes, total) = db.get_aye_votes().unwrap();
+        let (nays, t2) = db.get_nay_votes().unwrap();
+        let (abstains, t3) = db.get_abstained_votes().unwrap();
+        let (compliance, t4) = db.get_compliance_count().unwrap();
+
+        assert_eq!(ayes, 2); // Alice, Eve
+        assert_eq!(nays, 1); // Bob
+        assert_eq!(abstains, 0);
+        assert_eq!(compliance, 1); // Eve
+
+        assert_eq!(total, 3);
+        assert_eq!(total, t2);
+        assert_eq!(total, t3);
+        assert_eq!(total, t4);
+
+        // > Height 2
+        let res = db.remove_upgrading_votes(2).unwrap();
+        assert_eq!(res, 2); // Alice and Bob removed
+                            //
+        let (ayes, total) = db.get_aye_votes().unwrap();
+        let (nays, t2) = db.get_nay_votes().unwrap();
+        let (abstains, t3) = db.get_abstained_votes().unwrap();
+        let (compliance, t4) = db.get_compliance_count().unwrap();
+
+        assert_eq!(ayes, 1); // Eve
+        assert_eq!(nays, 0);
+        assert_eq!(abstains, 0);
+        assert_eq!(compliance, 1); // Eve
+
+        assert_eq!(total, 1);
+        assert_eq!(total, t2);
+        assert_eq!(total, t3);
+        assert_eq!(total, t4);
+
+        // > Height 3
+        let res = db.remove_upgrading_votes(3).unwrap();
+        assert_eq!(res, 1); // Eve removed
+
+        let (ayes, total) = db.get_aye_votes().unwrap();
+        let (nays, t2) = db.get_nay_votes().unwrap();
+        let (abstains, t3) = db.get_abstained_votes().unwrap();
+        let (compliance, t4) = db.get_compliance_count().unwrap();
+
+        assert_eq!(ayes, 0);
+        assert_eq!(nays, 0);
+        assert_eq!(abstains, 0);
+        assert_eq!(compliance, 0);
+
+        assert_eq!(total, 0);
+        assert_eq!(total, t2);
+        assert_eq!(total, t3);
+        assert_eq!(total, t4);
+    }
+}

--- a/crates/storage/provider/src/traits/activation_manager.rs
+++ b/crates/storage/provider/src/traits/activation_manager.rs
@@ -12,9 +12,10 @@ use reth_errors::ProviderResult;
 pub trait ActivationManagerReaderWriter<Auth>: Send + Sync {
     /// Records or updates a validator's vote for a network upgrade.
     ///
-    /// This method stores a validator's vote and acceptance status for a network upgrade
-    /// at the given block height. If the validator has previously voted, their vote
-    /// will be updated to the new values.
+    /// This method stores a validator's vote and acceptance status for a
+    /// network upgrade at the given block height. If the validator has
+    /// previously voted, their vote will be updated to the new values if and
+    /// only if the botanix height is greater than the existing botanix height.
     ///
     /// # Parameters
     /// * `auth` - The public key identifying the validator
@@ -91,18 +92,23 @@ pub trait ActivationManagerReaderWriter<Auth>: Send + Sync {
     /// This method calculates the percentage of validators voting "Aye" out of the total
     /// number of validators who have cast votes, regardless of their compliance status.
     ///
-    /// The formula used is: `(aye_votes * 100 + total_votes - 1) / total_votes`
+    /// The formula used is:
+    /// ```
+    /// let total = total_votes.max(min_validator_count);
+    /// let rate = (aye_votes * 100 + total - 1) / total
+    /// ```
     /// This implements ceiling division to round up to the nearest percentage point.
     ///
     /// # Parameters
     /// * `min_validator_count` - The minimum number of validators required to calculate the
-    ///   approval rate. `total_votes` is be set to this value if the total number of votes is less
-    ///   than this.
+    ///   approval rate. `total` is set to that value if the total number of votes is less than
+    ///   that.
     ///
     /// # Returns
-    /// * `Ok((approval_rate, total_votes))` where:
+    /// * `Ok((approval_rate, total))` where:
     ///   - `approval_rate` is the percentage (0-100) of Aye votes
-    ///   - `total_votes` is the number of distinct validators who have voted
+    ///   - `total` is the number of distinct validators who have voted or `min_validator_count`,
+    ///     whichever is greater.
     /// * `Err` if there was an error calculating the approval rate
     fn get_upgrading_approval_rate_ayes(
         &self,
@@ -115,18 +121,23 @@ pub trait ActivationManagerReaderWriter<Auth>: Send + Sync {
     /// with the upgrade out of the total number of validators who have cast
     /// votes, regardless of whether they voted Aye or Nay.
     ///
-    /// The formula used is: `(compliant_votes * 100 + total_votes - 1) / total_votes`
+    /// The formula used is:
+    /// ```
+    /// let total = total_votes.max(min_validator_count);
+    /// let rate = (compliant_votes * 100 + total - 1) / total
+    /// ```
     /// This implements ceiling division to round up to the nearest percentage point.
     ///
     /// # Parameters
     /// * `min_validator_count` - The minimum number of validators required to calculate the
-    ///   approval rate. `total_votes` is be set to this value if the total number of votes is less
-    ///   than this.
+    ///   approval rate. `total` is set to that value if the total number of votes is less than
+    ///   that.
     ///
     /// # Returns
     /// * `Ok((approval_rate, total_votes))` where:
     ///   - `approval_rate` is the percentage (0-100) of accepting validators
-    ///   - `total_votes` is the number of distinct validators who have voted
+    ///   - `total` is the number of distinct validators who have voted or `min_validator_count`,
+    ///     whichever is greater.
     /// * `Err` if there was an error calculating the approval
     fn get_upgrading_approval_rate_compliance(
         &self,

--- a/crates/storage/provider/src/traits/activation_manager.rs
+++ b/crates/storage/provider/src/traits/activation_manager.rs
@@ -63,12 +63,12 @@ pub trait ActivationManagerReaderWriter<Auth>: Send + Sync {
     /// Returns the count of validators who have abstained from voting and the
     /// total number of validators who have voted.
     ///
-    /// This method counts all validators who have cast an "Absent" (abstain)
+    /// This method counts all validators who have cast an "Abstain"
     /// vote for the network upgrade, regardless of their compliance status.
     ///
     /// # Returns
     /// * `Ok((abstain_count, total_voters))` where:
-    ///   - `abstain_count` is the number of validators who voted "Absent" (abstained)
+    ///   - `abstain_count` is the number of validators who voted "Abstain"
     ///   - `total_voters` is the total number of distinct validators who have cast any vote
     /// * `Err` if there was an error retrieving the vote counts
     fn get_abstained_votes(&self) -> ProviderResult<(usize, usize)>;
@@ -78,7 +78,7 @@ pub trait ActivationManagerReaderWriter<Auth>: Send + Sync {
     ///
     /// This method counts all validators who have indicated they are ready to
     /// accept the upgrade by setting `is_compliant` to `true` when casting
-    /// their vote, regardless of whether they voted "Aye", "Nay", or "Absent".
+    /// their vote, regardless of whether they voted "Aye", "Nay", or "Abstain".
     ///
     /// # Returns
     /// * `Ok((compliant_count, total_voters))` where:
@@ -213,7 +213,7 @@ pub mod tests {
         assert_eq!(res, (0, 3));
 
         // Eve votes Abstain, is not compliant
-        db.update_upgrading_vote(eve.clone(), Vote::Absent, false, 1).unwrap();
+        db.update_upgrading_vote(eve.clone(), Vote::Abstain, false, 1).unwrap();
         let res = db.get_upgrading_approval_rate_ayes(min_validator_count).unwrap();
         assert_eq!(res, (34, 3));
         let res = db.get_upgrading_approval_rate_compliance(min_validator_count).unwrap();
@@ -287,7 +287,7 @@ pub mod tests {
     ///
     /// This function validates that an `ActivationManagerReaderWriter`
     /// implementation correctly handles:
-    /// - Counting individual vote types (Aye, Nay, Absent)
+    /// - Counting individual vote types (Aye, Nay, Abstain)
     /// - Tracking compliance status independently of vote choice
     /// - Maintaining consistent total voter counts across all query methods
     /// - Replacing previous votes when block height increases
@@ -346,7 +346,7 @@ pub mod tests {
         assert_eq!(total, t4);
 
         // Eve votes Abstain, is not compliant
-        db.update_upgrading_vote(eve.clone(), Vote::Absent, false, 1).unwrap();
+        db.update_upgrading_vote(eve.clone(), Vote::Abstain, false, 1).unwrap();
         let (ayes, total) = db.get_aye_votes().unwrap();
         let (nays, t2) = db.get_nay_votes().unwrap();
         let (abstains, t3) = db.get_abstained_votes().unwrap();

--- a/crates/storage/provider/src/traits/activation_manager.rs
+++ b/crates/storage/provider/src/traits/activation_manager.rs
@@ -93,7 +93,7 @@ pub trait ActivationManagerReaderWriter<Auth>: Send + Sync {
     /// number of validators who have cast votes, regardless of their compliance status.
     ///
     /// The formula used is:
-    /// ```
+    /// ```text
     /// let total = total_votes.max(min_validator_count);
     /// let rate = (aye_votes * 100 + total - 1) / total
     /// ```
@@ -122,7 +122,7 @@ pub trait ActivationManagerReaderWriter<Auth>: Send + Sync {
     /// votes, regardless of whether they voted Aye or Nay.
     ///
     /// The formula used is:
-    /// ```
+    /// ```text
     /// let total = total_votes.max(min_validator_count);
     /// let rate = (compliant_votes * 100 + total - 1) / total
     /// ```
@@ -227,7 +227,7 @@ pub mod tests {
         assert_eq!(res, (0, 3));
 
         // Eve votes Aye, IS compliant - IS counted, incremented height
-        db.update_upgrading_vote(eve.clone(), Vote::Aye, true, 2).unwrap();
+        db.update_upgrading_vote(eve, Vote::Aye, true, 2).unwrap();
         let res = db.get_upgrading_approval_rate_ayes(min_validator_count).unwrap();
         assert_eq!(res, (67, 3));
         let res = db.get_upgrading_approval_rate_compliance(min_validator_count).unwrap();
@@ -380,7 +380,7 @@ pub mod tests {
         assert_eq!(total, t4);
 
         // Eve votes Aye, is compliant - IS counted, incremented height
-        db.update_upgrading_vote(eve.clone(), Vote::Aye, true, 2).unwrap();
+        db.update_upgrading_vote(eve, Vote::Aye, true, 2).unwrap();
         let (ayes, total) = db.get_aye_votes().unwrap();
         let (nays, t2) = db.get_nay_votes().unwrap();
         let (abstains, t3) = db.get_abstained_votes().unwrap();

--- a/crates/storage/provider/src/traits/mod.rs
+++ b/crates/storage/provider/src/traits/mod.rs
@@ -10,7 +10,9 @@ mod block;
 pub use block::*;
 
 mod activation_manager;
-pub use activation_manager::ActivationManagerReaderWriter;
+pub use activation_manager::{
+    tests as activation_manager_conformance_tests, ActivationManagerReaderWriter,
+};
 
 mod snapshot;
 pub use snapshot::*;


### PR DESCRIPTION
Follow-up PR to #841.

Those look like a lot of changes, but those are mostly unit-test adjustments and other various cleanups. This PR is **best reviewed on a per-commit basis**, which I will guide you through. **This will take less than 5 minutes.**

But first, lets talk about the main goal of this PR; metrics, which can easily be fetched via e.g.

```console
$ curl -s http://127.0.0.1:9001/metrics | grep "authority_runtime_upgrade"
```

## Polling

This type clearly shows the polling results of a runtime upgrade proposal:

```console
# TYPE reth_runtime_upgrade_polling gauge
reth_authority_runtime_upgrade_polling{version="0.2",type="compliant"} 4
reth_authority_runtime_upgrade_polling{version="0.2",type="ayes"} 3
reth_authority_runtime_upgrade_polling{version="0.2",type="abstained"} 1
reth_authority_runtime_upgrade_polling{version="0.2",type="nays"} 0
reth_authority_runtime_upgrade_polling{version="0.2",type="total"} 4
```

This shows the unique votes by block producers. Block producers that do not vote (no-shows) are interpreted implicitly as `"abstained"`. It is also guaranteed that `total = ayes + nays + abstained`. The independant `compliant` entry indicates whether the block producer has deployed the necessary software to handle the upgrade, no matter which way they voted.

## Vote Details

There are two types that show information about casted votes:

```console
# TYPE reth_runtime_upgrade_vote_details gauge
reth_authority_runtime_upgrade_vote_details{version="0.2",member="0xdBaFceb3A386e5956B93E1059C574a4b117DA514",vote="Aye",is_compliant="true"} 1
reth_authority_runtime_upgrade_vote_details{version="0.2",member="0x8F6019107E599C815f534B7f376f1f58BD093CE3",vote="Abstain",is_compliant="true"} 1
reth_authority_runtime_upgrade_vote_details{version="0.2",member="0xCad6083d17db87dc7AAff88209D27297Cf9f8671",vote="Aye",is_compliant="true"} 1
reth_authority_runtime_upgrade_vote_details{version="0.2",member="0xfFB5659220bD8e8E69B84EdAe502019511d7E990",vote="Aye",is_compliant="true"} 1

# TYPE reth_runtime_upgrade_vote_included gauge
reth_authority_runtime_upgrade_vote_included{member="0x8F6019107E599C815f534B7f376f1f58BD093CE3"} 1
reth_authority_runtime_upgrade_vote_included{member="0xfFB5659220bD8e8E69B84EdAe502019511d7E990"} 1
reth_authority_runtime_upgrade_vote_included{member="0xCad6083d17db87dc7AAff88209D27297Cf9f8671"} 1
reth_authority_runtime_upgrade_vote_included{member="0xdBaFceb3A386e5956B93E1059C574a4b117DA514"} 1
```

The first type - `*_vote_details` - shows the explicit voting payload by a block producer as provided in the block - **assuming it's provided**. If the block producer does cast an explicit vote, the corresponding `*_vote_included` metric will be produced with the value set to `1`. If no such vote is available (no-show), the first metric `*_vote_details` **is skipped** and the corresponding `*_vote_included` is produced with the value set to `0`. 

This is slighly different from the polling metric where a no-show is interpreted as `"abstained"` implicitly.

# Walk-through

Internally, the most significant change is that no-shows are now interpreted implicitly as _abstained_, which does change the `total_votes` value and is **technically a breaking-change** - but only if `total_votes` is above the `min_validator_count` requirement. Therefore in our case, where we insist on a 100% quorum with a min validator count of 16 (which is also the max, hence `total_votes` is **always** `16`), in our current setup nothing changes about the effective behavior. The required approval/compliance-rate calculations are hence fully compatible with those provided in the previous PR #841. All fed members will agree at what specific point all upgrade conditions are met (cc @scottmillner).

## Most important changes

* Expand `ActivationMangerReaderWriter` database with polling methods:
  * Trait implementation: https://github.com/botanix-labs/Macbeth/commit/a726c4326d73dd71e780a6adca2e3848596b60a2
  * Implement trait methods for unit-test db and `VoteWatcher`: https://github.com/botanix-labs/Macbeth/commit/5ffeda471cc3ef9d9011007c080d3e8a7b70d02b
* Expand `ActivationManager`
  * Interpret empty votes as abstained votes implicitly instead of just dropping: https://github.com/botanix-labs/Macbeth/commit/3f74432cbb4b0199266bd953ad9c73519e929102
  * Expose `Polling` results, to be used for metrics: https://github.com/botanix-labs/Macbeth/commit/56eadb582eb75df9423d97627de79c47040653f3
* Expand `AuthorityMetrics`:
  * Add two methods for creating the metrics, call from ABCI: https://github.com/botanix-labs/Macbeth/commit/2de109dba4e2367ee92e473a248beac3fc231803

## Unit test changes (not so important)

* Introduce conformance tests for `ActivationMangerReaderWriter` using generic type; reuse from unit test db and `VoteWatcher`: https://github.com/botanix-labs/Macbeth/commit/b4b61c9d99d58fd853b00532105ccbec04dd90f5
* Add expected polling check to fixture structure: https://github.com/botanix-labs/Macbeth/commit/2675a613095961a848608230266ca482a3e5399e
* Test polling behavior of `ActivationManager` (adjust all exiting tests):
  * `reject_ignored_upgrade`: https://github.com/botanix-labs/Macbeth/commit/f274750ca724bab5f91e5479d7e0c1377f686da1
    * Eve ignores the upgrade; Alice and Bob interpret that as `"abstained"`
  * `reject_mismatched_vote`: https://github.com/botanix-labs/Macbeth/commit/59c4463baaa7a8b046ab43a0e79de905319dc495
    * Alice and Bob track one version, Eve tracks another.
    * Alice and Bob interpret Eve as `"abstained"`, while Eve interprets Alice and Bob as `"abstained"`
  * `accept_lagging_validator`: https://github.com/botanix-labs/Macbeth/commit/17d400049f51321566b5b3ffe8a30601537f97ea
    * Nothing interesting changed.
  * `reject_outdated_or_unsupported_version`: https://github.com/botanix-labs/Macbeth/commit/bf8a37fa53630a02544e49740d0e48d82709e781
    * Nothing interesting changed.
  * `vote_expiration`: https://github.com/botanix-labs/Macbeth/commit/3d7bb83f83805f6666000ecb37f081f8430d69b8
    * Nothing interesting changed.
  * `vote_majority_nay_compliant_and_reject`: https://github.com/botanix-labs/Macbeth/commit/b17e17bb49b9ac67b8da7c6044df7c3abf2e6e8b
    * Nothing interesting changed.
  * `vote_nay_and_accept`: https://github.com/botanix-labs/Macbeth/commit/ee2cbe8afe9d4a14fdfd0202d0ada89fe0edc509
    * Nothing interesting changed.
  * `vote_nay_and_reject`: https://github.com/botanix-labs/Macbeth/commit/e524935879573e8d313ff356e88f185a74dfaf93
    * Nothing interesting changed.
  * `wait_for_compliance`: https://github.com/botanix-labs/Macbeth/commit/f3dc15979f221c4624faa3c03055e795bf221558
    * Nothing interesting changed.
 
## Misc (not important)

* Minor doc changes: https://github.com/botanix-labs/Macbeth/commit/0710e1ebf388160533ba33ab912d17d8aa45ff21
* Mass-rename `Vote::Absent` to `Vote::Abstain`: https://github.com/botanix-labs/Macbeth/commit/8401e693b7bb41419c23eae6ea9b269055a6298d