### PR TITLE
hotfix(abci): Persist runtime version

### DIFF
--- a/crates/consensus/authority/src/activation_manager/mod.rs
+++ b/crates/consensus/authority/src/activation_manager/mod.rs
@@ -656,9 +656,8 @@ where
     /// * `block_version` - The runtime version of the block being finalized
     /// * `block_height` - The height of the block being finalized
     /// * `proposer_address` - The address of the block proposer
-    /// * `proposer_vote` - The proposer's vote on a network upgrade, if any.
-    ///   If `None` or if the vote's version doesn't match the tracked upgrade,
-    ///   it's counted as abstained.
+    /// * `proposer_vote` - The proposer's vote on a network upgrade, if any. If `None` or if the
+    ///   vote's version doesn't match the tracked upgrade, it's counted as abstained.
     ///
     /// # Returns
     /// * `OnFinalizeBlockDecision::Finalize` if the block should be finalized
@@ -693,15 +692,15 @@ where
 
         let mut maybe_upgrade = self.upgrade.write().expect("poisoned lock");
         if let Some(upgrade) = maybe_upgrade.as_ref() {
+            // Prune **all** votes since the decision is now finalized.
+            self.client.remove_upgrading_votes(block_height.saturating_add(1))?;
+
             // Future version detected, reject the block; this node is running an
             // outdated version of this software that cannot handle those finalized
             // blocks.
             if block_version != upgrade.version {
                 return Ok(OnFinalizeBlockDecision::RejectBlockDeadEnd { version: block_version });
             }
-
-            // Prune **all** votes since the decision is now finalized.
-            self.client.remove_upgrading_votes(block_height.saturating_add(1))?;
 
             // For nodes that are explicitly not accepting this upgrade version,
             // reject the block and halt further processing.
@@ -762,6 +761,65 @@ where
         let polling = Polling { ayes, nays, abstained, compliant, total };
 
         Ok(Some((upgrade.version, polling)))
+    }
+
+    /// Forces an upgrade to the specified version if it matches the currently
+    /// tracked upgrade and the node is compliant.
+    ///
+    /// This method bypasses all normal upgrade conditions and immediately
+    /// activates the specified upgrade version. It should only be called when
+    /// the caller is certain that the upgrade has already been activated on the
+    /// network, but the activation manager is unaware of this state (for
+    /// example, due to a node restart after the upgrade was finalized).
+    ///
+    /// This method serves as a fast-track mechanism to synchronize the
+    /// activation manager's internal state with the actual network state
+    /// without waiting for upgraded blocks to be processed through the normal
+    /// consensus flow.
+    ///
+    /// ## Safety
+    ///
+    /// This method should only be used when you are absolutely certain that:
+    /// - The specified upgrade version has already been activated on the network
+    /// - The node is capable of processing blocks with this version
+    /// - The upgrade conditions were previously met through normal consensus
+    ///
+    /// Using this method incorrectly could cause the node to accept or propose blocks
+    /// that the rest of the network rejects.
+    ///
+    /// # Parameters
+    /// * `version` - The runtime version to force activate. Must match the currently tracked
+    ///   upgrade version.
+    ///
+    /// # Returns
+    /// * `true` if the upgrade was successfully forced (version matched, node is compliant)
+    /// * `false` if no upgrade is being tracked, the version doesn't match, or the node is not
+    ///   compliant with the upgrade
+    pub fn force_upgrade_checked(&self, version: RuntimeVersion) -> bool {
+        let maybe_upgrade = self.upgrade.read().expect("poisoned lock");
+        let Some(upgrade) = maybe_upgrade.as_ref() else {
+            return false;
+        };
+
+        if upgrade.version != version {
+            return false;
+        }
+
+        if !upgrade.is_compliant {
+            return false;
+        }
+
+        std::mem::drop(maybe_upgrade);
+
+        // Upgrade is immediately active and mandatory for all future block
+        // production. Update our active version and clear the pending upgrade.
+        let mut upgrade = self.upgrade.write().expect("poisoned lock");
+        *upgrade = None;
+        //
+        let mut active_version = self.active_version.write().expect("poisoned lock");
+        *active_version = version;
+
+        true
     }
 
     /// Validates all conditions required for an upgrade to proceed.

--- a/crates/consensus/authority/src/activation_manager/tests/force_upgrade_checked.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/force_upgrade_checked.rs
@@ -1,0 +1,51 @@
+use super::{
+    utils::{ACTIVE_VERSION, UPGRADE_VERSION},
+    *,
+};
+
+#[test]
+fn force_upgrade_checked() {
+    let quorum = 100;
+    let min_validator_count = 3;
+    let target_height = 0;
+    let our_vote = Some(Vote::Aye);
+
+    let manager = ActivationManagerBuilder::new(Db::new(), ACTIVE_VERSION)
+        .build_COMPLIANT_network_upgrade(
+            UPGRADE_VERSION,
+            quorum,
+            min_validator_count,
+            target_height,
+            our_vote,
+        );
+
+    // Propose active version.
+    let res = manager.on_prepare_proposal(100).unwrap();
+    assert_eq!(res.version, ACTIVE_VERSION);
+
+    // Reject upgraded version.
+    let res = manager.on_process_proposal(100, UPGRADE_VERSION).unwrap();
+    assert!(matches!(res, OnProcessProposalDecision::RejectBlock { version: UPGRADE_VERSION, .. }));
+
+    // FORCE wrong upgrade version.
+    manager.force_upgrade_checked(ACTIVE_VERSION);
+
+    // Propose active version
+    let res = manager.on_prepare_proposal(100).unwrap();
+    assert_eq!(res.version, ACTIVE_VERSION);
+
+    // Reject upgraded version.
+    let res = manager.on_process_proposal(100, UPGRADE_VERSION).unwrap();
+    assert!(matches!(res, OnProcessProposalDecision::RejectBlock { version: UPGRADE_VERSION, .. }));
+
+    // FORCE tracked upgrade version; manager will immediately fast-forward to the upgrade.
+    manager.force_upgrade_checked(UPGRADE_VERSION);
+
+    // Propose upgraded version!
+    let res = manager.on_prepare_proposal(100).unwrap();
+    assert_eq!(res.version, UPGRADE_VERSION);
+
+    // Back upgraded version!
+    let res = manager.on_process_proposal(100, UPGRADE_VERSION).unwrap();
+    assert!(matches!(res, OnProcessProposalDecision::Process { version: UPGRADE_VERSION, .. }));
+}

--- a/crates/consensus/authority/src/activation_manager/tests/mod.rs
+++ b/crates/consensus/authority/src/activation_manager/tests/mod.rs
@@ -15,6 +15,7 @@ mod vote_majority_nay_compliant_and_reject;
 mod vote_nay_and_accept;
 mod vote_nay_and_reject;
 mod wait_for_compliance;
+mod force_upgrade_checked;
 mod utils;
 
 /// In-Memory database that integrates the `ActivationManagerReaderWriter` trait.

--- a/crates/consensus/authority/src/builder.rs
+++ b/crates/consensus/authority/src/builder.rs
@@ -28,9 +28,9 @@ use reth_node_core::args::StateSyncArgs;
 use reth_node_ethereum::EthEvmConfig;
 use reth_primitives::{header_ext::HeaderExt, Address};
 use reth_provider::{
-    BlockReaderIdExt, CanonChainTracker, CanonStateSubscriptions, ProviderFactory, SnapshotReader,
-    SnapshotWriter, StagedHeader, StateProviderFactory, WalletStateSyncReader,
-    WalletStateSyncWriter,
+    BlockReaderIdExt, CanonChainTracker, CanonStateSubscriptions, ProviderFactory,
+    RuntimeTransitionsReadWrite, SnapshotReader, SnapshotWriter, StagedHeader,
+    StateProviderFactory, WalletStateSyncReader, WalletStateSyncWriter,
 };
 
 use reth_tasks::TaskExecutor;
@@ -39,7 +39,7 @@ use std::{
     sync::{Arc, RwLock},
 };
 use tokio::sync::RwLock as TokioRwLock;
-use tracing::info;
+use tracing::{info, warn};
 
 pub(crate) type BitcoinCheckpoint = Arc<TokioRwLock<Option<(bitcoin::block::Header, u32)>>>;
 
@@ -87,6 +87,7 @@ where
         + CanonChainTracker
         + CanonStateSubscriptions
         + StagedHeader
+        + RuntimeTransitionsReadWrite
         + 'static,
     EF: BlockExecutorProvider + Clone + 'static,
     BF: BitcoindFactory + Clone + Unpin + 'static,
@@ -120,6 +121,17 @@ where
     ) -> Result<Self, AuthorityConsensusBuilderError> {
         // only a federation node has a btc_server
         let is_fed_node = btc_server_factory.is_some();
+
+        // Check the local database if a runtime upgrade has occurred which the
+        // ActivationManager does not know about.
+        if let Some(runtime_version) =
+            client.get_last_runtime_version().expect("local db must be available")
+        {
+            let was_forced = activation_manager.force_upgrade_checked(runtime_version);
+            if was_forced {
+                warn!("Detected completed network upgrade to version '{runtime_version}' that was unknown to initiated ActivationManager");
+            }
+        }
 
         let mut latest_header = client
             .latest_header()

--- a/crates/consensus/authority/src/comet_bft/abci.rs
+++ b/crates/consensus/authority/src/comet_bft/abci.rs
@@ -8,7 +8,8 @@ use reth_db::{
     Database, DatabaseEnv,
 };
 use reth_provider::{
-    providers::BlockchainProvider2, BlockWriter, CanonChainTracker, ExecutionOutcome, StagedHeader,
+    providers::BlockchainProvider2, BlockWriter, CanonChainTracker, ExecutionOutcome,
+    RuntimeTransitionsReadWrite, StagedHeader,
 };
 use reth_trie::{updates::TrieUpdates, StateRoot};
 use reth_trie_db::DatabaseStateRoot;
@@ -2439,6 +2440,12 @@ where
                         )?;
 
                         db_rw.insert_staged_header(new_header.hash(), header_with_pegs)?;
+
+                        // Track the last known runtime version.
+                        db_rw.insert_runtime_upgrade_version(
+                            new_header.number,
+                            sealed_block_with_context.runtime_version,
+                        )?;
 
                         db_rw.commit()?;
 

--- a/crates/storage/db-api/src/models/activation_manager.rs
+++ b/crates/storage/db-api/src/models/activation_manager.rs
@@ -4,6 +4,8 @@ use reth_codecs::{add_arbitrary_tests, Compact};
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 
+use crate::table::{Compress, Decompress};
+
 /// Represents a validator's vote on a network upgrade proposal.
 ///
 /// Validators can explicitly vote in favor of an upgrade (`Aye`),
@@ -60,7 +62,7 @@ impl std::fmt::Display for Vote {
 /// 1. Nodes can determine whether a version is an upgrade or downgrade
 /// 2. The activation manager can enforce one-way upgrade progression
 /// 3. Historical blocks during sync can be validated against appropriate version thresholds
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RuntimeVersion(
     /// Major version component, incremented for breaking changes (hard fork)
     pub MajorVersion,
@@ -72,6 +74,32 @@ impl RuntimeVersion {
     /// Creates a new runtime version from major and minor components.
     pub const fn new(major: u16, minor: u16) -> Self {
         Self(MajorVersion(major), MinorVersion(minor))
+    }
+}
+
+impl Compress for RuntimeVersion {
+    type Compressed = Vec<u8>;
+
+    fn compress_to_buf<B: bytes::BufMut + AsMut<[u8]>>(self, buf: &mut B) {
+        buf.put_u16_le(self.0 .0); // major
+        buf.put_u16_le(self.1 .0); // minor
+    }
+}
+
+impl Decompress for RuntimeVersion {
+    fn decompress<B: AsRef<[u8]>>(
+        value: B,
+    ) -> Result<Self, reth_storage_errors::db::DatabaseError> {
+        let v = value.as_ref();
+
+        if v.len() < 4 {
+            unreachable!("passed on wrong value to decompress");
+        }
+
+        let major = u16::from_le_bytes(v[0..2].try_into().expect("size must be valid"));
+        let minor = u16::from_le_bytes(v[2..4].try_into().expect("size must be valid"));
+
+        Ok(Self(MajorVersion(major), MinorVersion(minor)))
     }
 }
 
@@ -103,11 +131,11 @@ impl std::fmt::Display for RuntimeVersion {
 }
 
 /// Represents a major version component of a runtime version.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct MajorVersion(pub u16);
 
 /// Represents a minor version component of a runtime version.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct MinorVersion(pub u16);
 
 #[test]
@@ -133,4 +161,16 @@ fn runtime_version_ordering() {
     assert!(v1_0 > v0_10);
     assert!(v0_10 > v0_1);
     assert!(v0_1 > v0_0);
+}
+
+#[test]
+fn test_runtime_version_compress_decompress() {
+    let original = RuntimeVersion::new(1234, 5678);
+    let mut buf = vec![];
+
+    original.compress_to_buf(&mut buf);
+    assert_eq!(buf.len(), 4);
+
+    let decompressed = RuntimeVersion::decompress(buf).unwrap();
+    assert_eq!(original, decompressed);
 }

--- a/crates/storage/db/src/tables/mod.rs
+++ b/crates/storage/db/src/tables/mod.rs
@@ -27,7 +27,7 @@ use reth_db_api::{
         client_version::ClientVersion,
         staged_header::HeaderWithPegs,
         storage_sharded_key::StorageShardedKey,
-        AccountBeforeTx, CompactU256, PeerID, ShardedKey, StoredBlockBodyIndices,
+        AccountBeforeTx, CompactU256, PeerID, RuntimeVersion, ShardedKey, StoredBlockBodyIndices,
         StoredBlockWithdrawals, WalletStateSyncRecord,
     },
     table::{Decode, DupSort, Encode, Table},
@@ -319,6 +319,10 @@ tables! {
     /// Store staged headers, used to persist pegins and pegouts after
     /// finalizing a block.
     table StagedHeader<Key = B256, Value = HeaderWithPegs>;
+
+    /// Stores runtime version transitions across blocks encountered during
+    /// finalization.
+    table RuntimeTransitions<Key = BlockNumber, Value = RuntimeVersion>;
 
     /// Store chunk id to chunk data.
     table Chunks<Key = ChunkId, Value = SnapshotChunk>;

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -4,9 +4,10 @@ use crate::{
     CanonStateSubscriptions, ChainSpecProvider, ChangeSetReader, DatabaseProviderFactory,
     DatabaseProviderRO, EvmEnvProvider, FinalizedBlockReader, HeaderProvider, ProviderError,
     ProviderFactory, PruneCheckpointReader, ReceiptProvider, ReceiptProviderIdExt,
-    RequestsProvider, SnapshotReader, SnapshotWriter, StageCheckpointReader, StagedHeader,
-    StateProviderBox, StateProviderFactory, StaticFileProviderFactory, TransactionVariant,
-    TransactionsProvider, WalletStateSyncReader, WalletStateSyncWriter, WithdrawalsProvider,
+    RequestsProvider, RuntimeTransitionsReadWrite, SnapshotReader, SnapshotWriter,
+    StageCheckpointReader, StagedHeader, StateProviderBox, StateProviderFactory,
+    StaticFileProviderFactory, TransactionVariant, TransactionsProvider, WalletStateSyncReader,
+    WalletStateSyncWriter, WithdrawalsProvider,
 };
 use alloy_rpc_types_engine::ForkchoiceState;
 use reth_chain_state::{
@@ -1729,6 +1730,29 @@ where
 
     fn get_staged_headers(&self) -> ProviderResult<Vec<(B256, HeaderWithPegs)>> {
         self.database.get_staged_headers()
+    }
+}
+
+impl<DB> RuntimeTransitionsReadWrite for BlockchainProvider2<DB>
+where
+    DB: Database + Sync + Send,
+{
+    fn insert_runtime_upgrade_version(
+        &self,
+        height: BlockNumber,
+        version: reth_db::models::RuntimeVersion,
+    ) -> ProviderResult<bool> {
+        self.database.insert_runtime_upgrade_version(height, version)
+    }
+
+    fn get_runtime_versions(
+        &self,
+    ) -> ProviderResult<Vec<(BlockNumber, reth_db::models::RuntimeVersion)>> {
+        self.database.get_runtime_versions()
+    }
+
+    fn get_last_runtime_version(&self) -> ProviderResult<Option<reth_db::models::RuntimeVersion>> {
+        self.database.get_last_runtime_version()
     }
 }
 

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -4,9 +4,10 @@ use crate::{
     traits::{BlockSource, ReceiptProvider},
     BlockHashReader, BlockNumReader, BlockReader, ChainSpecProvider, DatabaseProviderFactory,
     EvmEnvProvider, HeaderProvider, HeaderSyncGap, HeaderSyncGapProvider, ProviderError,
-    PruneCheckpointReader, RequestsProvider, SnapshotReader, SnapshotWriter, StageCheckpointReader,
-    StagedHeader, StateProviderBox, StaticFileProviderFactory, TransactionVariant,
-    TransactionsProvider, WalletStateSyncReader, WalletStateSyncWriter, WithdrawalsProvider,
+    PruneCheckpointReader, RequestsProvider, RuntimeTransitionsReadWrite, SnapshotReader,
+    SnapshotWriter, StageCheckpointReader, StagedHeader, StateProviderBox,
+    StaticFileProviderFactory, TransactionVariant, TransactionsProvider, WalletStateSyncReader,
+    WalletStateSyncWriter, WithdrawalsProvider,
 };
 use reth_chainspec::{ChainInfo, ChainSpec, EthChainSpec};
 use reth_db::{
@@ -928,7 +929,6 @@ impl<DB, Spec> Clone for ProviderFactory<DB, Spec> {
 impl<DB: Database> StagedHeader for ProviderFactory<DB> {
     fn insert_staged_header(&self, id: B256, header: HeaderWithPegs) -> ProviderResult<()> {
         let provider = self.provider_rw()?;
-
         provider.insert_staged_header(id, header)?;
 
         provider.commit()?;
@@ -938,7 +938,6 @@ impl<DB: Database> StagedHeader for ProviderFactory<DB> {
 
     fn remove_staged_header(&self, id: B256) -> ProviderResult<bool> {
         let provider = self.provider_rw()?;
-
         let is_removed = provider.remove_staged_header(id)?;
 
         if is_removed {
@@ -950,6 +949,33 @@ impl<DB: Database> StagedHeader for ProviderFactory<DB> {
 
     fn get_staged_headers(&self) -> ProviderResult<Vec<(B256, HeaderWithPegs)>> {
         self.provider_rw()?.get_staged_headers()
+    }
+}
+
+impl<DB: Database> RuntimeTransitionsReadWrite for ProviderFactory<DB> {
+    fn insert_runtime_upgrade_version(
+        &self,
+        height: BlockNumber,
+        version: reth_db::models::RuntimeVersion,
+    ) -> ProviderResult<bool> {
+        let provider = self.provider_rw()?;
+        let did_change = provider.insert_runtime_upgrade_version(height, version)?;
+
+        if did_change {
+            provider.commit()?;
+        }
+
+        Ok(did_change)
+    }
+
+    fn get_runtime_versions(
+        &self,
+    ) -> ProviderResult<Vec<(BlockNumber, reth_db::models::RuntimeVersion)>> {
+        self.provider_rw()?.get_runtime_versions()
+    }
+
+    fn get_last_runtime_version(&self) -> ProviderResult<Option<reth_db::models::RuntimeVersion>> {
+        self.provider_rw()?.get_last_runtime_version()
     }
 }
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -11,10 +11,10 @@ use crate::{
     FinalizedBlockWriter, HashingWriter, HeaderProvider, HeaderSyncGap, HeaderSyncGapProvider,
     HistoricalStateProvider, HistoryWriter, LatestStateProvider, OriginalValuesKnown,
     ProviderError, PruneCheckpointReader, PruneCheckpointWriter, RequestsProvider, RevertsInit,
-    SnapshotReader, SnapshotWriter, StageCheckpointReader, StagedHeader, StateChangeWriter,
-    StateProviderBox, StateWriter, StatsReader, StorageReader, StorageTrieWriter,
-    TransactionVariant, TransactionsProvider, TransactionsProviderExt, TrieWriter,
-    WalletStateSyncReader, WalletStateSyncWriter, WithdrawalsProvider,
+    RuntimeTransitionsReadWrite, SnapshotReader, SnapshotWriter, StageCheckpointReader,
+    StagedHeader, StateChangeWriter, StateProviderBox, StateWriter, StatsReader, StorageReader,
+    StorageTrieWriter, TransactionVariant, TransactionsProvider, TransactionsProviderExt,
+    TrieWriter, WalletStateSyncReader, WalletStateSyncWriter, WithdrawalsProvider,
 };
 use itertools::{izip, Itertools};
 use rayon::slice::ParallelSliceMut;
@@ -22,8 +22,8 @@ use reth_chainspec::{ChainInfo, ChainSpec, EthereumHardforks};
 use reth_db::{
     cursor::DbDupCursorRW,
     models::{
-        ChunkId, HeaderWithPegs, PeerID, Snapshot, SnapshotChunk, SnapshotId, SnapshotSync,
-        SnapshotSyncId, UuidID, WalletStateSyncRecord,
+        ChunkId, HeaderWithPegs, PeerID, RuntimeVersion, Snapshot, SnapshotChunk, SnapshotId,
+        SnapshotSync, SnapshotSyncId, UuidID, WalletStateSyncRecord,
     },
     tables, BlockNumberList, PlainAccountState, PlainStorageState,
 };
@@ -4118,6 +4118,54 @@ impl<TX: DbTxMut + DbTx> StagedHeader for DatabaseProvider<TX> {
             .cursor_read::<tables::StagedHeader>()?
             .walk(None)?
             .collect::<Result<Vec<(B256, HeaderWithPegs)>, _>>()
+            .map_err(ProviderError::Database)
+    }
+}
+
+/// The key where we keep the highest known runtime version. We have roughly ~3
+/// trillion years time before this becomes a problem.
+const LATEST_RUNTIME_KEY: BlockNumber = u64::MAX;
+
+impl<TX: DbTxMut + DbTx> RuntimeTransitionsReadWrite for DatabaseProvider<TX> {
+    fn insert_runtime_upgrade_version(
+        &self,
+        height: BlockNumber,
+        version: RuntimeVersion,
+    ) -> ProviderResult<bool> {
+        let latest = self.tx.get::<tables::RuntimeTransitions>(LATEST_RUNTIME_KEY)?;
+
+        // Only record the highest seen runtime versions.
+        if let Some(latest) = latest {
+            if latest >= version {
+                return Ok(false)
+            }
+        };
+
+        // Insert runtime version transition.
+        self.tx.put::<tables::RuntimeTransitions>(LATEST_RUNTIME_KEY, version)?;
+        self.tx.put::<tables::RuntimeTransitions>(height, version)?;
+
+        Ok(true)
+    }
+
+    fn get_runtime_versions(&self) -> ProviderResult<Vec<(BlockNumber, RuntimeVersion)>> {
+        self.tx
+            .cursor_read::<tables::RuntimeTransitions>()?
+            .walk(None)?
+            .filter(|e| {
+                let Ok((key, _)) = e else {
+                    return true;
+                };
+
+                key != &LATEST_RUNTIME_KEY
+            })
+            .collect::<Result<Vec<(BlockNumber, RuntimeVersion)>, _>>()
+            .map_err(ProviderError::Database)
+    }
+
+    fn get_last_runtime_version(&self) -> ProviderResult<Option<RuntimeVersion>> {
+        self.tx
+            .get::<tables::RuntimeTransitions>(LATEST_RUNTIME_KEY)
             .map_err(ProviderError::Database)
     }
 }

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -3,10 +3,11 @@ use crate::{
     BlockSource, BlockchainTreePendingStateProvider, CanonChainTracker, CanonStateNotifications,
     CanonStateSubscriptions, ChainSpecProvider, ChangeSetReader, DatabaseProviderFactory,
     EvmEnvProvider, FinalizedBlockReader, FullExecutionDataProvider, HeaderProvider, ProviderError,
-    PruneCheckpointReader, ReceiptProvider, ReceiptProviderIdExt, RequestsProvider, SnapshotReader,
-    SnapshotWriter, StageCheckpointReader, StagedHeader, StateProviderBox, StateProviderFactory,
-    StaticFileProviderFactory, TransactionVariant, TransactionsProvider, TreeViewer,
-    WalletStateSyncReader, WalletStateSyncWriter, WithdrawalsProvider,
+    PruneCheckpointReader, ReceiptProvider, ReceiptProviderIdExt, RequestsProvider,
+    RuntimeTransitionsReadWrite, SnapshotReader, SnapshotWriter, StageCheckpointReader, StagedHeader,
+    StateProviderBox, StateProviderFactory, StaticFileProviderFactory, TransactionVariant,
+    TransactionsProvider, TreeViewer, WalletStateSyncReader, WalletStateSyncWriter,
+    WithdrawalsProvider,
 };
 use reth_blockchain_tree_api::{
     error::{CanonicalError, InsertBlockError},
@@ -726,6 +727,29 @@ where
 
     fn get_staged_headers(&self) -> ProviderResult<Vec<(B256, HeaderWithPegs)>> {
         self.database.provider_rw()?.get_staged_headers()
+    }
+}
+
+impl<DB> RuntimeTransitionsReadWrite for BlockchainProvider<DB>
+where
+    DB: Database,
+{
+    fn insert_runtime_upgrade_version(
+        &self,
+        height: BlockNumber,
+        version: reth_db::models::RuntimeVersion,
+    ) -> ProviderResult<bool> {
+        self.database.provider_rw()?.insert_runtime_upgrade_version(height, version)
+    }
+
+    fn get_runtime_versions(
+        &self,
+    ) -> ProviderResult<Vec<(BlockNumber, reth_db::models::RuntimeVersion)>> {
+        self.database.provider_rw()?.get_runtime_versions()
+    }
+
+    fn get_last_runtime_version(&self) -> ProviderResult<Option<reth_db::models::RuntimeVersion>> {
+        self.database.provider_rw()?.get_last_runtime_version()
     }
 }
 

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -5,9 +5,10 @@ use super::{
 };
 use crate::{
     to_range, BlockHashReader, BlockNumReader, BlockReader, BlockSource, DatabaseProvider,
-    HeaderProvider, ReceiptProvider, RequestsProvider, SnapshotReader, SnapshotWriter,
-    StageCheckpointReader, StagedHeader, StatsReader, TransactionVariant, TransactionsProvider,
-    TransactionsProviderExt, WalletStateSyncReader, WalletStateSyncWriter, WithdrawalsProvider,
+    HeaderProvider, ReceiptProvider, RequestsProvider, RuntimeTransitionsReadWrite, SnapshotReader,
+    SnapshotWriter, StageCheckpointReader, StagedHeader, StatsReader, TransactionVariant,
+    TransactionsProvider, TransactionsProviderExt, WalletStateSyncReader, WalletStateSyncWriter,
+    WithdrawalsProvider,
 };
 use dashmap::DashMap;
 use parking_lot::RwLock;
@@ -15,8 +16,8 @@ use reth_chainspec::ChainInfo;
 use reth_db::{
     lockfile::StorageLock,
     models::{
-        ChunkId, HeaderWithPegs, PeerID, Snapshot, SnapshotChunk, SnapshotId, SnapshotSync,
-        SnapshotSyncId, UuidID, WalletStateSyncRecord,
+        ChunkId, HeaderWithPegs, PeerID, RuntimeVersion, Snapshot, SnapshotChunk, SnapshotId,
+        SnapshotSync, SnapshotSyncId, UuidID, WalletStateSyncRecord,
     },
     static_file::{iter_static_files, HeaderMask, ReceiptMask, StaticFileCursor, TransactionMask},
     tables,
@@ -1754,6 +1755,24 @@ impl StagedHeader for StaticFileProvider {
     }
 
     fn get_staged_headers(&self) -> ProviderResult<Vec<(B256, HeaderWithPegs)>> {
+        Err(ProviderError::UnsupportedProvider)
+    }
+}
+
+impl RuntimeTransitionsReadWrite for StaticFileProvider {
+    fn insert_runtime_upgrade_version(
+        &self,
+        _height: BlockNumber,
+        _version: RuntimeVersion,
+    ) -> ProviderResult<bool> {
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    fn get_runtime_versions(&self) -> ProviderResult<Vec<(BlockNumber, RuntimeVersion)>> {
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    fn get_last_runtime_version(&self) -> ProviderResult<Option<RuntimeVersion>> {
         Err(ProviderError::UnsupportedProvider)
     }
 }

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -37,10 +37,10 @@ use crate::{
     traits::{BlockSource, ReceiptProvider},
     AccountReader, BlockHashReader, BlockIdReader, BlockNumReader, BlockReader, BlockReaderIdExt,
     ChainSpecProvider, ChangeSetReader, EvmEnvProvider, HeaderProvider, PruneCheckpointReader,
-    ReceiptProviderIdExt, RequestsProvider, SnapshotReader, SnapshotWriter, StageCheckpointReader,
-    StagedHeader, StateProvider, StateProviderBox, StateProviderFactory, StateRootProvider,
-    StaticFileProviderFactory, TransactionVariant, TransactionsProvider, WalletStateSyncReader,
-    WalletStateSyncWriter, WithdrawalsProvider,
+    ReceiptProviderIdExt, RequestsProvider, RuntimeTransitionsReadWrite, SnapshotReader,
+    SnapshotWriter, StageCheckpointReader, StagedHeader, StateProvider, StateProviderBox,
+    StateProviderFactory, StateRootProvider, StaticFileProviderFactory, TransactionVariant,
+    TransactionsProvider, WalletStateSyncReader, WalletStateSyncWriter, WithdrawalsProvider,
 };
 
 /// Supports various api interfaces for testing purposes.
@@ -326,6 +326,26 @@ impl StagedHeader for NoopProvider {
 
     fn get_staged_headers(&self) -> ProviderResult<Vec<(B256, reth_db::models::HeaderWithPegs)>> {
         Ok(vec![])
+    }
+}
+
+impl RuntimeTransitionsReadWrite for NoopProvider {
+    fn insert_runtime_upgrade_version(
+        &self,
+        _height: BlockNumber,
+        _version: reth_db::models::RuntimeVersion,
+    ) -> ProviderResult<bool> {
+        Ok(false)
+    }
+
+    fn get_runtime_versions(
+        &self,
+    ) -> ProviderResult<Vec<(BlockNumber, reth_db::models::RuntimeVersion)>> {
+        Ok(vec![])
+    }
+
+    fn get_last_runtime_version(&self) -> ProviderResult<Option<reth_db::models::RuntimeVersion>> {
+        Ok(None)
     }
 }
 

--- a/crates/storage/provider/src/traits/mod.rs
+++ b/crates/storage/provider/src/traits/mod.rs
@@ -60,3 +60,6 @@ pub use finalized_block::{FinalizedBlockReader, FinalizedBlockWriter};
 
 mod staged_header;
 pub use staged_header::StagedHeader;
+
+mod runtime_transitions;
+pub use runtime_transitions::RuntimeTransitionsReadWrite;

--- a/crates/storage/provider/src/traits/runtime_transitions.rs
+++ b/crates/storage/provider/src/traits/runtime_transitions.rs
@@ -1,0 +1,27 @@
+use reth_db::models::RuntimeVersion;
+use reth_errors::ProviderResult;
+use reth_primitives::BlockNumber;
+
+#[auto_impl::auto_impl(&, Arc, Box)]
+/// Provides read and write operations for tracking runtime version transitions
+/// across blocks encountered during finalization.
+pub trait RuntimeTransitionsReadWrite: Send + Sync {
+    /// Records a runtime upgrade at the specified block height.
+    ///
+    /// This method tracks runtime version transitions by storing the highest
+    /// runtime version seen at each block height. If a version lower than or
+    /// equal to the currently stored highest version is provided, it will be
+    /// ignored.
+    ///
+    /// Returns `true` if the provided version is the highest seen and has been
+    /// recorded.
+    fn insert_runtime_upgrade_version(
+        &self,
+        height: BlockNumber,
+        version: RuntimeVersion,
+    ) -> ProviderResult<bool>;
+    /// Retrieves the complete history of recorded runtime version transitions.
+    fn get_runtime_versions(&self) -> ProviderResult<Vec<(BlockNumber, RuntimeVersion)>>;
+    /// Retrieves the most recent (highest) runtime version that has been recorded.
+    fn get_last_runtime_version(&self) -> ProviderResult<Option<RuntimeVersion>>;
+}


### PR DESCRIPTION
Discussed internally.

This essentially persists the latest runtime version in storage via the finalized commit in `ABCIDriver`. On startup, the `AuthorityConsensusBuilder` checks the local database and fast-tracks the upgrade if appropriate. I tested this locally with a 3/3 federation and it works as expected.

```
2025-07-20T22:48:57.912367Z  WARN Detected completed network upgrade to version '0.2' that was unknown to initiated ActivationManager 
```

**Important commits:**

* Fast-tracking mechanism for `ActivationManager`: https://github.com/botanix-labs/Macbeth/pull/860/commits/8cee94d5d74fd99db0fb94bf3fcf96cbde0a74ca
* `ABCIDriver` & `AuthorityConsensusBuilder` persistence layer: https://github.com/botanix-labs/Macbeth/pull/860/commits/62737bceb235c3f30c016633c756d32d993d346e

Btw, we should dump that `reth-db` for our custom logic ASAP.