### PR TITLE
feat(wallet): use SIGHASH_DEFAULT instead of SIGHASH_ALL in pegout tx

### DIFF
--- a/bin/btc-server/src/coordinator/mod.rs
+++ b/bin/btc-server/src/coordinator/mod.rs
@@ -249,7 +249,7 @@ pub async fn finalize_signing(
 
         // Note: we don't need to add the internal key here for a key spend path
         // as the output key is derived from the scriptpubkey
-        let hash_ty = bitcoin::sighash::TapSighashType::All;
+        let hash_ty = bitcoin::sighash::TapSighashType::Default;
         let sighash_type = bitcoin::psbt::PsbtSighashType::from(hash_ty);
         psbt_input.sighash_type = Some(sighash_type);
         psbt_input.tap_key_sig =

--- a/bin/btc-server/src/wallet/coin_selection.rs
+++ b/bin/btc-server/src/wallet/coin_selection.rs
@@ -3,7 +3,7 @@ use crate::{
     wallet::{
         psbt::PegoutId as PegoutIdBytes,
         util::{calculate_signed_tx_weight, WalletCalculationError},
-        TAPROOT_KEYSPEND_SATISFACTION_WEIGHT,
+        TAPROOT_KEYSPEND_SIGHASH_DEFAULT_WEIGHT,
     },
 };
 use bdk_wallet::coin_selection::{
@@ -442,7 +442,7 @@ fn sanity_check_psbt(
 /// Convert a UTXO to BDK's WeightedUtxo format
 fn utxo_to_bdk(utxo: &Utxo) -> bdk_wallet::WeightedUtxo {
     bdk_wallet::WeightedUtxo {
-        satisfaction_weight: TAPROOT_KEYSPEND_SATISFACTION_WEIGHT,
+        satisfaction_weight: TAPROOT_KEYSPEND_SIGHASH_DEFAULT_WEIGHT,
         utxo: bdk_wallet::Utxo::Local(bdk_wallet::LocalOutput {
             outpoint: utxo.outpoint.to_bdk(),
             txout: bdk_wallet::bitcoin::TxOut {
@@ -838,7 +838,7 @@ mod tests {
         );
 
         let mut psbt_with_signatures = psbt.clone();
-        add_dummy_signatures_to_psbt(&mut psbt_with_signatures, TapSighashType::All);
+        add_dummy_signatures_to_psbt(&mut psbt_with_signatures, TapSighashType::Default);
         let fee_rate = psbt_with_signatures.fee_rate().expect("should not fail");
         assert_eq!(fee_rate, scenario.fee_rate);
     }

--- a/bin/btc-server/src/wallet/mod.rs
+++ b/bin/btc-server/src/wallet/mod.rs
@@ -7,6 +7,7 @@ use bitcoin::Weight;
 
 /// The weight needed to satisfy a taproot output using keyspend.
 pub const TAPROOT_KEYSPEND_SATISFACTION_WEIGHT: Weight = Weight::from_wu(66);
+pub const TAPROOT_KEYSPEND_SIGHASH_DEFAULT_WEIGHT: Weight = Weight::from_wu(65);
 
 // Two base weights for segwit transactions
 pub const SEGWIT_FLAG_WEIGHT: Weight = Weight::from_wu(1);
@@ -28,5 +29,14 @@ mod test {
             Descriptor::Tr(miniscript::descriptor::Tr::new(key_pair.public_key(), None).unwrap());
         let weight = desc.max_weight_to_satisfy().unwrap();
         assert_eq!(weight, TAPROOT_KEYSPEND_SATISFACTION_WEIGHT);
+    }
+
+    #[test]
+    fn taproot_keyspend_sighash_default_weights() {
+        // Sighash default is 1 less weight unit as the sighash type is omitted from the signature
+        assert_eq!(
+            TAPROOT_KEYSPEND_SATISFACTION_WEIGHT - Weight::from_wu(1),
+            TAPROOT_KEYSPEND_SIGHASH_DEFAULT_WEIGHT
+        );
     }
 }

--- a/bin/btc-server/src/wallet/psbt.rs
+++ b/bin/btc-server/src/wallet/psbt.rs
@@ -381,7 +381,7 @@ pub(crate) fn calculate_sighash(
     let sighash = sighashcache.taproot_key_spend_signature_hash(
         input_index,
         &bitcoin::sighash::Prevouts::All(&prevouts),
-        TapSighashType::All,
+        TapSighashType::Default,
     )?;
 
     Ok(sighash)

--- a/bin/btc-server/src/wallet/util.rs
+++ b/bin/btc-server/src/wallet/util.rs
@@ -4,7 +4,7 @@ use frost_secp256k1_tr as frost;
 use thiserror::Error;
 
 use crate::wallet::{
-    SEGWIT_FLAG_WEIGHT, SEGWIT_MARKER_WEIGHT, TAPROOT_KEYSPEND_SATISFACTION_WEIGHT,
+    SEGWIT_FLAG_WEIGHT, SEGWIT_MARKER_WEIGHT, TAPROOT_KEYSPEND_SIGHASH_DEFAULT_WEIGHT,
 };
 
 #[derive(Debug, Error)]
@@ -65,7 +65,7 @@ pub fn calculate_signed_tx_weight(psbt: &Psbt) -> Result<Weight, WalletCalculati
     // calculate the weight of the signatures (assuming all inputs are p2tr)
     let num_inputs = psbt.inputs.len();
     let per_input_witness_item_count = Weight::from_wu(1);
-    let total_signature_weight = (TAPROOT_KEYSPEND_SATISFACTION_WEIGHT +
+    let total_signature_weight = (TAPROOT_KEYSPEND_SIGHASH_DEFAULT_WEIGHT +
         per_input_witness_item_count)
         .checked_mul(num_inputs as u64)
         .ok_or(WalletCalculationError::WeightOverflow)?; // or changeoverflow
@@ -114,7 +114,7 @@ mod tests {
 
         for (name, psbt) in test_cases {
             let mut psbt_with_signatures = psbt;
-            add_dummy_signatures_to_psbt(&mut psbt_with_signatures, TapSighashType::All);
+            add_dummy_signatures_to_psbt(&mut psbt_with_signatures, TapSighashType::Default);
             let tx = psbt_with_signatures.clone().extract_tx().expect("Failed to extract tx");
 
             let expected_fee_rate = psbt_with_signatures.fee_rate().unwrap();

--- a/bin/test-suite/src/suite/consensus/frost/test_frost_e2e.rs
+++ b/bin/test-suite/src/suite/consensus/frost/test_frost_e2e.rs
@@ -264,5 +264,12 @@ pub async fn frost_e2e_stable(
     it_info_print!("Expected fee: ", expected_fee);
     assert_eq!(actual_fee, Amount::from_sat(expected_fee));
 
+    // Verify witness signatures are 64 bytes (Taproot signature size when using SIGHASH_DEFAULT)
+    for input in pegout_tx.input.iter() {
+        let witness_item = &input.witness[0];
+        it_info_print!("Input witness (signature) length:", witness_item.len());
+        assert_eq!(witness_item.len(), 64);
+    }
+
     Ok(())
 }

--- a/bin/test-suite/src/suite/consensus/frost/test_signing.rs
+++ b/bin/test-suite/src/suite/consensus/frost/test_signing.rs
@@ -128,6 +128,13 @@ pub async fn do_signing(
     // TODO add some assertions for psbt here
     let final_tx = coord_psbt.clone().extract_tx()?;
 
+    // Verify witness signatures are 64 bytes (Taproot signature size when using SIGHASH_DEFAULT)
+    for input in final_tx.input.iter() {
+        let witness_item = &input.witness[0];
+        it_info_print!("Input witness (signature) length:", witness_item.len());
+        assert_eq!(witness_item.len(), 64);
+    }
+
     Ok(final_tx)
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please provide a link to the issue -->

https://github.com/botanix-labs/botanix/issues/1076

Replacing `SIGHASH_ALL` in the final pegout signature(s) with `SIGHASH_DEFAULT`

## What was done?

<!--- Describe your changes in detail -->

- replace the pegout suffix `SIGHASH_ALL` (`0x01`) with the implicit `SIGHASH_DEFAULT` (no bytes) to save 1 byte of tx size per signature.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- updated unit and integration tests. Will test on devnet/testnet and verify the transactions are valid and there is no sighash_all in the signatures

## Breaking Changes

<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

- none

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] I have added or updated relevant unit/integration/functional/e2e tests
-   [ ] I have tested my changes running a local network, and they work as expected
-   [x] I have performed a self-review
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
-   [x] I have made corresponding changes to the documentation if needed
-   [x] I have added assignees and reviewers to this pull request
-   [x] I have added the PR to the project board or linked it to an issue from the board


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy in transaction weight and signature calculations for Taproot keyspend transactions by updating the signature hash type and satisfaction weight constants.  
* **Tests**
  * Added a new test to verify the updated Taproot keyspend signature weight calculation.
  * Enhanced signature verification tests to ensure Taproot signatures use the expected default sighash type and correct signature length.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->