### PR TITLE
refactor(peers): add upstream trusted peers logic

### DIFF
--- a/crates/net/network-types/src/peers/config.rs
+++ b/crates/net/network-types/src/peers/config.rs
@@ -24,6 +24,9 @@ pub const DEFAULT_MAX_COUNT_PEERS_INBOUND: u32 = 30;
 /// This restricts how many outbound dials can be performed concurrently.
 pub const DEFAULT_MAX_COUNT_CONCURRENT_OUTBOUND_DIALS: usize = 15;
 
+/// A temporary timeout for ips on incoming connection attempts.
+pub const INBOUND_IP_THROTTLE_DURATION: Duration = Duration::from_secs(30);
+
 /// The durations to use when a backoff should be applied to a peer.
 ///
 /// See also [`BackoffKind`].
@@ -128,6 +131,9 @@ pub struct PeersConfig {
     /// Connect to or accept from trusted nodes only?
     #[cfg_attr(feature = "serde", serde(alias = "connect_trusted_nodes_only"))]
     pub trusted_nodes_only: bool,
+    /// Interval to update trusted nodes DNS resolution
+    #[cfg_attr(feature = "serde", serde(with = "humantime_serde"))]
+    pub trusted_nodes_resolution_interval: Duration,
     /// Maximum number of backoff attempts before we give up on a peer and dropping.
     ///
     /// The max time spent of a peer before it's removed from the set is determined by the
@@ -155,6 +161,11 @@ pub struct PeersConfig {
     ///
     /// The backoff duration increases with number of backoff attempts.
     pub backoff_durations: PeerBackoffDurations,
+    /// How long to temporarily ban ips on incoming connection attempts.
+    ///
+    /// This acts as an IP based rate limit.
+    #[cfg_attr(feature = "serde", serde(default, with = "humantime_serde"))]
+    pub incoming_ip_throttle_duration: Duration,
 }
 
 impl Default for PeersConfig {
@@ -169,8 +180,10 @@ impl Default for PeersConfig {
             backoff_durations: Default::default(),
             trusted_nodes: Default::default(),
             trusted_nodes_only: false,
+            trusted_nodes_resolution_interval: Duration::from_secs(60 * 60),
             basic_nodes: Default::default(),
             max_backoff_count: 5,
+            incoming_ip_throttle_duration: INBOUND_IP_THROTTLE_DURATION,
         }
     }
 }

--- a/crates/net/network-types/src/peers/mod.rs
+++ b/crates/net/network-types/src/peers/mod.rs
@@ -8,7 +8,7 @@ pub use config::{ConnectionsConfig, PeersConfig};
 pub use reputation::{Reputation, ReputationChange, ReputationChangeKind, ReputationChangeWeights};
 
 use reth_ethereum_forks::ForkId;
-use tracing::trace;
+use tracing::debug;
 
 use crate::{
     is_banned_reputation, PeerAddr, PeerConnectionState, PeerKind, ReputationChangeOutcome,
@@ -76,31 +76,35 @@ impl Peer {
 
     /// Resets the reputation of the peer to the default value. This always returns
     /// [`ReputationChangeOutcome::None`].
-    pub fn reset_reputation(&mut self) -> ReputationChangeOutcome {
+    pub const fn reset_reputation(&mut self) -> ReputationChangeOutcome {
         self.reputation = DEFAULT_REPUTATION;
 
         ReputationChangeOutcome::None
     }
 
     /// Applies a reputation change to the peer and returns what action should be taken.
-    pub fn apply_reputation(&mut self, reputation: i32) -> ReputationChangeOutcome {
+    pub fn apply_reputation(
+        &mut self,
+        reputation: i32,
+        kind: ReputationChangeKind,
+    ) -> ReputationChangeOutcome {
         let previous = self.reputation;
         // we add reputation since negative reputation change decrease total reputation
         self.reputation = previous.saturating_add(reputation);
 
-        trace!(target: "net::peers", reputation=%self.reputation, banned=%self.is_banned(), "applied reputation change");
+        debug!(target: "net::peers", reputation=%self.reputation, banned=%self.is_banned(), ?kind, "applied reputation change");
 
         if self.state.is_connected() && self.is_banned() {
             self.state.disconnect();
-            return ReputationChangeOutcome::DisconnectAndBan
+            return ReputationChangeOutcome::DisconnectAndBan;
         }
 
         if self.is_banned() && !is_banned_reputation(previous) {
-            return ReputationChangeOutcome::Ban
+            return ReputationChangeOutcome::Ban;
         }
 
         if !self.is_banned() && is_banned_reputation(previous) {
-            return ReputationChangeOutcome::Unban
+            return ReputationChangeOutcome::Unban;
         }
 
         ReputationChangeOutcome::None
@@ -120,7 +124,7 @@ impl Peer {
 
     /// Unbans the peer by resetting its reputation
     #[inline]
-    pub fn unban(&mut self) {
+    pub const fn unban(&mut self) {
         self.reputation = DEFAULT_REPUTATION
     }
 

--- a/crates/net/network-types/src/peers/reputation.rs
+++ b/crates/net/network-types/src/peers/reputation.rs
@@ -13,7 +13,7 @@ pub const BANNED_REPUTATION: i32 = 50 * REPUTATION_UNIT;
 const REMOTE_DISCONNECT_REPUTATION_CHANGE: i32 = 4 * REPUTATION_UNIT;
 
 /// The reputation change to apply to a peer that we failed to connect to.
-const FAILED_TO_CONNECT_REPUTATION_CHANGE: i32 = 25 * REPUTATION_UNIT;
+pub const FAILED_TO_CONNECT_REPUTATION_CHANGE: i32 = 25 * REPUTATION_UNIT;
 
 /// The reputation change to apply to a peer that failed to respond in time.
 const TIMEOUT_REPUTATION_CHANGE: i32 = 4 * REPUTATION_UNIT;
@@ -46,6 +46,13 @@ pub const MAX_TRUSTED_PEER_REPUTATION_CHANGE: Reputation = 2 * REPUTATION_UNIT;
 #[inline]
 pub const fn is_banned_reputation(reputation: i32) -> bool {
     reputation < BANNED_REPUTATION
+}
+
+/// Returns `true` if the given reputation is below the [`FAILED_TO_CONNECT_REPUTATION_CHANGE`]
+/// threshold
+#[inline]
+pub const fn is_connection_failed_reputation(reputation: i32) -> bool {
+    reputation < FAILED_TO_CONNECT_REPUTATION_CHANGE
 }
 
 /// The type that tracks the reputation score.
@@ -129,6 +136,21 @@ pub struct ReputationChangeWeights {
 // === impl ReputationChangeWeights ===
 
 impl ReputationChangeWeights {
+    /// Creates a new instance that doesn't penalize any kind of reputation change.
+    pub const fn zero() -> Self {
+        Self {
+            bad_block: 0,
+            bad_transactions: 0,
+            already_seen_transactions: 0,
+            bad_message: 0,
+            timeout: 0,
+            bad_protocol: 0,
+            failed_to_connect: 0,
+            dropped: 0,
+            bad_announcement: 0,
+        }
+    }
+
     /// Returns the quantifiable [`ReputationChange`] for the given [`ReputationChangeKind`] using
     /// the configured weights
     pub fn change(&self, kind: ReputationChangeKind) -> ReputationChange {

--- a/crates/net/network-types/src/peers/state.rs
+++ b/crates/net/network-types/src/peers/state.rs
@@ -31,6 +31,12 @@ impl PeerConnectionState {
         }
     }
 
+    /// Returns true if this is the idle state.
+    #[inline]
+    pub const fn is_idle(&self) -> bool {
+        matches!(self, Self::Idle)
+    }
+
     /// Returns true if this is an active incoming connection.
     #[inline]
     pub const fn is_incoming(&self) -> bool {

--- a/crates/net/network/src/lib.rs
+++ b/crates/net/network/src/lib.rs
@@ -139,6 +139,7 @@ mod network;
 mod session;
 mod state;
 mod swarm;
+mod trusted_peers_resolver;
 
 pub use reth_eth_wire::{DisconnectReason, HelloMessageWithProtocols};
 pub use reth_network_api::{

--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -1,5 +1,28 @@
 //! Peer related implementations
 
+use crate::{
+    error::SessionError,
+    session::{Direction, PendingSessionHandshakeError},
+    swarm::NetworkConnectionState,
+    trusted_peers_resolver::TrustedPeersResolver,
+};
+use futures::StreamExt;
+
+use reth_chainspec::ForkId;
+use reth_eth_wire::{errors::EthStreamError, DisconnectReason};
+use reth_net_banlist::BanList;
+use reth_network_api::test_utils::{PeerCommand, PeersHandle};
+use reth_network_peers::{NodeRecord, PeerId};
+use reth_network_types::{
+    peers::{
+        config::PeerBackoffDurations,
+        reputation::{
+            is_connection_failed_reputation, DEFAULT_REPUTATION, MAX_TRUSTED_PEER_REPUTATION_CHANGE,
+        },
+    },
+    ConnectionsConfig, Peer, PeerAddr, PeerConnectionState, PeerKind, PeersConfig,
+    ReputationChangeKind, ReputationChangeOutcome, ReputationChangeWeights,
+};
 use std::{
     collections::{hash_map::Entry, HashMap, HashSet, VecDeque},
     fmt::Display,
@@ -8,21 +31,6 @@ use std::{
     task::{Context, Poll},
     time::Duration,
 };
-
-use futures::StreamExt;
-use reth_eth_wire::{errors::EthStreamError, DisconnectReason};
-use reth_net_banlist::BanList;
-use reth_network_api::test_utils::{PeerCommand, PeersHandle};
-use reth_network_peers::{NodeRecord, PeerId};
-use reth_network_types::{
-    peers::{
-        config::PeerBackoffDurations,
-        reputation::{DEFAULT_REPUTATION, MAX_TRUSTED_PEER_REPUTATION_CHANGE},
-    },
-    ConnectionsConfig, Peer, PeerAddr, PeerConnectionState, PeerKind, PeersConfig,
-    ReputationChangeKind, ReputationChangeOutcome, ReputationChangeWeights,
-};
-use reth_primitives::ForkId;
 use thiserror::Error;
 use tokio::{
     sync::mpsc,
@@ -30,12 +38,6 @@ use tokio::{
 };
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{trace, warn};
-
-use crate::{
-    error::SessionError,
-    session::{Direction, PendingSessionHandshakeError},
-    swarm::NetworkConnectionState,
-};
 
 /// Maintains the state of _all_ the peers known to the network.
 ///
@@ -52,6 +54,9 @@ pub struct PeersManager {
     /// This tracks peer ids that are considered trusted, but for which we don't necessarily have
     /// an address: [`Self::add_trusted_peer_id`]
     trusted_peer_ids: HashSet<PeerId>,
+    /// A resolver used to periodically resolve DNS names for trusted peers. This updates the
+    /// peer's address when the DNS records change.
+    trusted_peers_resolver: TrustedPeersResolver,
     /// Copy of the sender half, so new [`PeersHandle`] can be created on demand.
     manager_tx: mpsc::UnboundedSender<PeerCommand>,
     /// Receiver half of the command channel.
@@ -84,6 +89,8 @@ pub struct PeersManager {
     max_backoff_count: u8,
     /// Tracks the connection state of the node
     net_connection_state: NetworkConnectionState,
+    /// How long to temporarily ban ip on an incoming connection attempt.
+    incoming_ip_throttle_duration: Duration,
 }
 
 impl PeersManager {
@@ -98,8 +105,10 @@ impl PeersManager {
             backoff_durations,
             trusted_nodes,
             trusted_nodes_only,
+            trusted_nodes_resolution_interval,
             basic_nodes,
             max_backoff_count,
+            incoming_ip_throttle_duration,
         } = config;
         let (manager_tx, handle_rx) = mpsc::unbounded_channel();
         let now = Instant::now();
@@ -110,7 +119,7 @@ impl PeersManager {
         let mut peers = HashMap::with_capacity(trusted_nodes.len() + basic_nodes.len());
         let mut trusted_peer_ids = HashSet::with_capacity(trusted_nodes.len());
 
-        for trusted_peer in trusted_nodes {
+        for trusted_peer in &trusted_nodes {
             match trusted_peer.resolve_blocking() {
                 Ok(NodeRecord { address, tcp_port, udp_port, id }) => {
                     trusted_peer_ids.insert(id);
@@ -133,6 +142,10 @@ impl PeersManager {
         Self {
             peers,
             trusted_peer_ids,
+            trusted_peers_resolver: TrustedPeersResolver::new(
+                trusted_nodes,
+                tokio::time::interval(trusted_nodes_resolution_interval), // 1 hour
+            ),
             manager_tx,
             handle_rx: UnboundedReceiverStream::new(handle_rx),
             queued_actions: Default::default(),
@@ -148,6 +161,7 @@ impl PeersManager {
             last_tick: Instant::now(),
             max_backoff_count,
             net_connection_state: NetworkConnectionState::default(),
+            incoming_ip_throttle_duration,
         }
     }
 
@@ -218,6 +232,11 @@ impl PeersManager {
         self.backed_off_peers.len()
     }
 
+    /// Returns the number of idle trusted peers.
+    fn num_idle_trusted_peers(&self) -> usize {
+        self.peers.iter().filter(|(_, peer)| peer.kind.is_trusted() && peer.state.is_idle()).count()
+    }
+
     /// Invoked when a new _incoming_ tcp connection is accepted.
     ///
     /// returns an error if the inbound ip address is on the ban list
@@ -226,14 +245,42 @@ impl PeersManager {
         addr: IpAddr,
     ) -> Result<(), InboundConnectionError> {
         if self.ban_list.is_banned_ip(&addr) {
-            return Err(InboundConnectionError::IpBanned)
+            return Err(InboundConnectionError::IpBanned);
         }
 
-        if !self.connection_info.has_in_capacity() && self.trusted_peer_ids.is_empty() {
-            // if we don't have any inbound slots and no trusted peers, we don't accept any new
-            // connections
-            return Err(InboundConnectionError::ExceedsCapacity)
+        // check if we even have slots for a new incoming connection
+        if !self.connection_info.has_in_capacity() {
+            if self.trusted_peer_ids.is_empty() {
+                // if we don't have any incoming slots and no trusted peers, we don't accept any new
+                // connections
+                return Err(InboundConnectionError::ExceedsCapacity);
+            }
+
+            // there's an edge case here where no incoming connections besides from trusted peers
+            // are allowed (max_inbound == 0), in which case we still need to allow new pending
+            // incoming connections until all trusted peers are connected.
+            let num_idle_trusted_peers = self.num_idle_trusted_peers();
+            if num_idle_trusted_peers <= self.trusted_peer_ids.len() {
+                // we still want to limit concurrent pending connections
+                let max_inbound =
+                    self.trusted_peer_ids.len().max(self.connection_info.config.max_inbound);
+                if self.connection_info.num_pending_in < max_inbound {
+                    self.connection_info.inc_pending_in();
+                    return Ok(());
+                }
+            }
+
+            // all trusted peers are either connected or connecting
+            return Err(InboundConnectionError::ExceedsCapacity);
         }
+
+        // also cap the incoming connections we can process at once
+        if !self.connection_info.has_in_pending_capacity() {
+            return Err(InboundConnectionError::ExceedsCapacity);
+        }
+
+        // apply the rate limit
+        self.throttle_incoming_ip(addr);
 
         self.connection_info.inc_pending_in();
         Ok(())
@@ -241,12 +288,12 @@ impl PeersManager {
 
     /// Invoked when a previous call to [`Self::on_incoming_pending_session`] succeeded but it was
     /// rejected.
-    pub(crate) fn on_incoming_pending_session_rejected_internally(&mut self) {
+    pub(crate) const fn on_incoming_pending_session_rejected_internally(&mut self) {
         self.connection_info.decr_pending_in();
     }
 
     /// Invoked when a pending session was closed.
-    pub(crate) fn on_incoming_pending_session_gracefully_closed(&mut self) {
+    pub(crate) const fn on_incoming_pending_session_gracefully_closed(&mut self) {
         self.connection_info.decr_pending_in()
     }
 
@@ -281,28 +328,25 @@ impl PeersManager {
         // on_incoming_pending_session. We also check if the peer is in the backoff list here.
         if self.ban_list.is_banned_peer(&peer_id) {
             self.queued_actions.push_back(PeerAction::DisconnectBannedIncoming { peer_id });
-            return
+            return;
         }
 
         // check if the peer is trustable or not
         let mut is_trusted = self.trusted_peer_ids.contains(&peer_id);
         if self.trusted_nodes_only && !is_trusted {
             self.queued_actions.push_back(PeerAction::DisconnectUntrustedIncoming { peer_id });
-            return
+            return;
         }
 
         // start a new tick, so the peer is not immediately rewarded for the time since last tick
         self.tick();
-
-        let has_in_capacity = self.connection_info.has_in_capacity();
-        self.connection_info.inc_in();
 
         match self.peers.entry(peer_id) {
             Entry::Occupied(mut entry) => {
                 let peer = entry.get_mut();
                 if peer.is_banned() {
                     self.queued_actions.push_back(PeerAction::DisconnectBannedIncoming { peer_id });
-                    return
+                    return;
                 }
                 // it might be the case that we're also trying to connect to this peer at the same
                 // time, so we need to adjust the state here
@@ -324,6 +368,10 @@ impl PeersManager {
             }
         }
 
+        let has_in_capacity = self.connection_info.has_in_capacity();
+        // increment new incoming connection
+        self.connection_info.inc_in();
+
         // disconnect the peer if we don't have capacity for more inbound connections
         if !is_trusted && !has_in_capacity {
             self.queued_actions.push_back(PeerAction::Disconnect {
@@ -340,7 +388,7 @@ impl PeersManager {
             if peer.is_trusted() || peer.is_static() {
                 // For misbehaving trusted or static peers, we provide a bit more leeway when
                 // penalizing them.
-                ban_duration = self.backoff_durations.medium;
+                ban_duration = self.backoff_durations.low / 2;
             }
         }
 
@@ -351,6 +399,12 @@ impl PeersManager {
     /// Bans the IP temporarily with the configured ban timeout
     fn ban_ip(&mut self, ip: IpAddr) {
         self.ban_list.ban_ip_until(ip, std::time::Instant::now() + self.ban_duration);
+    }
+
+    /// Bans the IP temporarily to rate limit inbound connection attempts per IP.
+    fn throttle_incoming_ip(&mut self, ip: IpAddr) {
+        self.ban_list
+            .ban_ip_until(ip, std::time::Instant::now() + self.incoming_ip_throttle_duration);
     }
 
     /// Temporarily puts the peer in timeout by inserting it into the backedoff peers set
@@ -413,12 +467,12 @@ impl PeersManager {
                     // exempt trusted and static peers from reputation slashing for
                     if matches!(
                         rep,
-                        ReputationChangeKind::Dropped |
-                            ReputationChangeKind::BadAnnouncement |
-                            ReputationChangeKind::Timeout |
-                            ReputationChangeKind::AlreadySeenTransaction
+                        ReputationChangeKind::Dropped
+                            | ReputationChangeKind::BadAnnouncement
+                            | ReputationChangeKind::Timeout
+                            | ReputationChangeKind::AlreadySeenTransaction
                     ) {
-                        return
+                        return;
                     }
 
                     // also be less strict with the reputation slashing for trusted peers
@@ -427,10 +481,10 @@ impl PeersManager {
                         reputation_change = MAX_TRUSTED_PEER_REPUTATION_CHANGE;
                     }
                 }
-                peer.apply_reputation(reputation_change)
+                peer.apply_reputation(reputation_change, rep)
             }
         } else {
-            return
+            return;
         };
 
         match outcome {
@@ -484,7 +538,7 @@ impl PeersManager {
                     // session to that peer
                     entry.get_mut().severe_backoff_counter = 0;
                     entry.get_mut().state = PeerConnectionState::Idle;
-                    return
+                    return;
                 }
             }
             Entry::Vacant(_) => return,
@@ -529,7 +583,13 @@ impl PeersManager {
         if let Some(peer) = self.peers.get(peer_id) {
             if peer.state.is_incoming() {
                 // we already have an active connection to the peer, so we can ignore this error
-                return
+                return;
+            }
+
+            if peer.is_trusted() && is_connection_failed_reputation(peer.reputation) {
+                // trigger resolution task for trusted peer since multiple connection failures
+                // occurred
+                self.trusted_peers_resolver.interval.reset_immediately();
             }
         }
 
@@ -549,39 +609,52 @@ impl PeersManager {
             trace!(target: "net::peers", ?remote_addr, ?peer_id, %err, "fatal connection error");
             // remove the peer to which we can't establish a connection due to protocol related
             // issues.
-            if let Some((peer_id, peer)) = self.peers.remove_entry(peer_id) {
-                self.connection_info.decr_state(peer.state);
-                self.queued_actions.push_back(PeerAction::PeerRemoved(peer_id));
+            if let Entry::Occupied(mut entry) = self.peers.entry(*peer_id) {
+                self.connection_info.decr_state(entry.get().state);
+                // only remove if the peer is not trusted
+                if entry.get().is_trusted() {
+                    entry.get_mut().state = PeerConnectionState::Idle;
+                } else {
+                    entry.remove();
+                    self.queued_actions.push_back(PeerAction::PeerRemoved(*peer_id));
+                    // If the error is caused by a peer that should be banned from discovery
+                    if err.merits_discovery_ban() {
+                        self.queued_actions.push_back(PeerAction::DiscoveryBanPeerId {
+                            peer_id: *peer_id,
+                            ip_addr: remote_addr.ip(),
+                        })
+                    }
+                }
             }
 
             // ban the peer
             self.ban_peer(*peer_id);
-
-            // If the error is caused by a peer that should be banned from discovery
-            if err.merits_discovery_ban() {
-                self.queued_actions.push_back(PeerAction::DiscoveryBanPeerId {
-                    peer_id: *peer_id,
-                    ip_addr: remote_addr.ip(),
-                })
-            }
         } else {
             let mut backoff_until = None;
             let mut remove_peer = false;
 
             if let Some(peer) = self.peers.get_mut(peer_id) {
                 if let Some(kind) = err.should_backoff() {
-                    // Increment peer.backoff_counter
-                    if kind.is_severe() {
-                        peer.severe_backoff_counter = peer.severe_backoff_counter.saturating_add(1);
+                    if peer.is_trusted() || peer.is_static() {
+                        // provide a bit more leeway for trusted peers and use a lower backoff so
+                        // that we keep re-trying them after backing off shortly
+                        let backoff = self.backoff_durations.low / 2;
+                        backoff_until = Some(std::time::Instant::now() + backoff);
+                    } else {
+                        // Increment peer.backoff_counter
+                        if kind.is_severe() {
+                            peer.severe_backoff_counter =
+                                peer.severe_backoff_counter.saturating_add(1);
+                        }
+
+                        let backoff_time =
+                            self.backoff_durations.backoff_until(kind, peer.severe_backoff_counter);
+
+                        // The peer has signaled that it is currently unable to process any more
+                        // connections, so we will hold off on attempting any new connections for a
+                        // while
+                        backoff_until = Some(backoff_time);
                     }
-
-                    let backoff_time =
-                        self.backoff_durations.backoff_until(kind, peer.severe_backoff_counter);
-
-                    // The peer has signaled that it is currently unable to process any more
-                    // connections, so we will hold off on attempting any new connections for a
-                    // while
-                    backoff_until = Some(backoff_time);
                 } else {
                     // If the error was not a backoff error, we reduce the peer's reputation
                     let reputation_change = self.reputation_weights.change(reputation_change);
@@ -591,9 +664,12 @@ impl PeersManager {
                 self.connection_info.decr_state(peer.state);
                 peer.state = PeerConnectionState::Idle;
 
-                if peer.severe_backoff_counter > self.max_backoff_count && !peer.is_trusted() {
+                if peer.severe_backoff_counter > self.max_backoff_count
+                    && !peer.is_trusted()
+                    && !peer.is_static()
+                {
                     // mark peer for removal if it has been backoff too many times and is _not_
-                    // trusted
+                    // trusted or static
                     remove_peer = true;
                 }
             }
@@ -616,7 +692,7 @@ impl PeersManager {
     ///
     /// If the session was an outgoing connection, this means that the peer initiated a connection
     /// to us at the same time and this connection is already established.
-    pub(crate) fn on_already_connected(&mut self, direction: Direction) {
+    pub(crate) const fn on_already_connected(&mut self, direction: Direction) {
         match direction {
             Direction::Incoming => {
                 // need to decrement the ingoing counter
@@ -655,7 +731,7 @@ impl PeersManager {
     /// Called for a newly discovered trusted peer.
     ///
     /// If the peer already exists, then the address and kind will be updated.
-    #[allow(dead_code)]
+    #[cfg_attr(not(test), expect(dead_code))]
     pub(crate) fn add_trusted_peer(&mut self, peer_id: PeerId, addr: PeerAddr) {
         self.add_peer_kind(peer_id, PeerKind::Trusted, addr, None)
     }
@@ -671,7 +747,7 @@ impl PeersManager {
         fork_id: Option<ForkId>,
     ) {
         if self.ban_list.is_banned(&peer_id, &addr.tcp().ip()) {
-            return
+            return;
         }
 
         match self.peers.entry(peer_id) {
@@ -706,7 +782,7 @@ impl PeersManager {
     pub(crate) fn remove_peer(&mut self, peer_id: PeerId) {
         let Entry::Occupied(entry) = self.peers.entry(peer_id) else { return };
         if entry.get().is_trusted() {
-            return
+            return;
         }
         let mut peer = entry.remove();
 
@@ -719,7 +795,7 @@ impl PeersManager {
             // was disconnected, this prevents the case where the session is scheduled for
             // disconnect but the node is immediately rediscovered, See also
             // [`Self::on_disconnected()`]
-            peer.remove_after_disconnect = !self.trusted_peer_ids.contains(&peer_id);
+            peer.remove_after_disconnect = true;
             peer.state.disconnect();
             self.peers.insert(peer_id, peer);
             self.queued_actions.push_back(PeerAction::Disconnect {
@@ -729,11 +805,69 @@ impl PeersManager {
         }
     }
 
+    /// Connect to the given peer. NOTE: if the maximum number out outbound sessions is reached,
+    /// this won't do anything. See `reth_network::SessionManager::dial_outbound`.
+    #[cfg_attr(not(test), expect(dead_code))]
+    pub(crate) fn add_and_connect(
+        &mut self,
+        peer_id: PeerId,
+        addr: PeerAddr,
+        fork_id: Option<ForkId>,
+    ) {
+        self.add_and_connect_kind(peer_id, PeerKind::Basic, addr, fork_id)
+    }
+
+    /// Connects a peer and its address with the given kind.
+    ///
+    /// Note: This is invoked on demand via an external command received by the manager
+    pub(crate) fn add_and_connect_kind(
+        &mut self,
+        peer_id: PeerId,
+        kind: PeerKind,
+        addr: PeerAddr,
+        fork_id: Option<ForkId>,
+    ) {
+        if self.ban_list.is_banned(&peer_id, &addr.tcp().ip()) {
+            return;
+        }
+
+        match self.peers.entry(peer_id) {
+            Entry::Occupied(mut entry) => {
+                let peer = entry.get_mut();
+                peer.kind = kind;
+                peer.fork_id = fork_id;
+                peer.addr = addr;
+
+                if peer.state == PeerConnectionState::Idle {
+                    // Try connecting again.
+                    peer.state = PeerConnectionState::PendingOut;
+                    self.connection_info.inc_pending_out();
+                    self.queued_actions
+                        .push_back(PeerAction::Connect { peer_id, remote_addr: addr.tcp() });
+                }
+            }
+            Entry::Vacant(entry) => {
+                trace!(target: "net::peers", ?peer_id, addr=?addr.tcp(), "connects new node");
+                let mut peer = Peer::with_kind(addr, kind);
+                peer.state = PeerConnectionState::PendingOut;
+                peer.fork_id = fork_id;
+                entry.insert(peer);
+                self.connection_info.inc_pending_out();
+                self.queued_actions
+                    .push_back(PeerAction::Connect { peer_id, remote_addr: addr.tcp() });
+            }
+        }
+
+        if kind.is_trusted() {
+            self.trusted_peer_ids.insert(peer_id);
+        }
+    }
+
     /// Removes the tracked node from the trusted set.
     pub(crate) fn remove_peer_from_trusted_set(&mut self, peer_id: PeerId) {
         let Entry::Occupied(mut entry) = self.peers.entry(peer_id) else { return };
         if !entry.get().is_trusted() {
-            return
+            return;
         }
 
         let peer = entry.get_mut();
@@ -753,23 +887,23 @@ impl PeersManager {
     /// Returns `None` if no peer is available.
     fn best_unconnected(&mut self) -> Option<(PeerId, &mut Peer)> {
         let mut unconnected = self.peers.iter_mut().filter(|(_, peer)| {
-            !peer.is_backed_off() &&
-                !peer.is_banned() &&
-                peer.state.is_unconnected() &&
-                (!self.trusted_nodes_only || peer.is_trusted())
+            !peer.is_backed_off()
+                && !peer.is_banned()
+                && peer.state.is_unconnected()
+                && (!self.trusted_nodes_only || peer.is_trusted())
         });
 
         // keep track of the best peer, if there's one
         let mut best_peer = unconnected.next()?;
 
         if best_peer.1.is_trusted() || best_peer.1.is_static() {
-            return Some((*best_peer.0, best_peer.1))
+            return Some((*best_peer.0, best_peer.1));
         }
 
         for maybe_better in unconnected {
             // if the peer is trusted or static, return it immediately
             if maybe_better.1.is_trusted() || maybe_better.1.is_static() {
-                return Some((*maybe_better.0, maybe_better.1))
+                return Some((*maybe_better.0, maybe_better.1));
             }
 
             // otherwise we keep track of the best peer using the reputation
@@ -790,7 +924,7 @@ impl PeersManager {
 
         if !self.net_connection_state.is_active() {
             // nothing to fill
-            return
+            return;
         }
 
         // as long as there are slots available fill them with the best peers
@@ -813,8 +947,23 @@ impl PeersManager {
         }
     }
 
+    fn on_resolved_peer(&mut self, peer_id: PeerId, new_record: NodeRecord) {
+        if let Some(peer) = self.peers.get_mut(&peer_id) {
+            let new_addr = PeerAddr::new_with_ports(
+                new_record.address,
+                new_record.tcp_port,
+                Some(new_record.udp_port),
+            );
+
+            if peer.addr != new_addr {
+                peer.addr = new_addr;
+                trace!(target: "net::peers", ?peer_id, addr=?peer.addr, "Updated resolved trusted peer address");
+            }
+        }
+    }
+
     /// Keeps track of network state changes.
-    pub fn on_network_state_change(&mut self, state: NetworkConnectionState) {
+    pub const fn on_network_state_change(&mut self, state: NetworkConnectionState) {
         self.net_connection_state = state;
     }
 
@@ -824,7 +973,7 @@ impl PeersManager {
     }
 
     /// Sets `net_connection_state` to `ShuttingDown`.
-    pub fn on_shutdown(&mut self) {
+    pub const fn on_shutdown(&mut self) {
         self.net_connection_state = NetworkConnectionState::ShuttingDown;
     }
 
@@ -836,7 +985,7 @@ impl PeersManager {
         loop {
             // drain buffered actions
             if let Some(action) = self.queued_actions.pop_front() {
-                return Poll::Ready(action)
+                return Poll::Ready(action);
             }
 
             while let Poll::Ready(Some(cmd)) = self.handle_rx.poll_next_unpin(cx) {
@@ -875,7 +1024,7 @@ impl PeersManager {
                         if let Some(peer) = self.peers.get_mut(peer_id) {
                             peer.backed_off = false;
                         }
-                        return false
+                        return false;
                     }
                     true
                 })
@@ -885,8 +1034,12 @@ impl PeersManager {
                 self.fill_outbound_slots();
             }
 
+            if let Poll::Ready((peer_id, new_record)) = self.trusted_peers_resolver.poll(cx) {
+                self.on_resolved_peer(peer_id, new_record);
+            }
+
             if self.queued_actions.is_empty() {
-                return Poll::Pending
+                return Poll::Pending;
             }
         }
     }
@@ -921,18 +1074,23 @@ impl ConnectionInfo {
         Self { config, num_outbound: 0, num_pending_out: 0, num_inbound: 0, num_pending_in: 0 }
     }
 
-    ///  Returns `true` if there's still capacity for a new outgoing connection.
+    ///  Returns `true` if there's still capacity to perform an outgoing connection.
     const fn has_out_capacity(&self) -> bool {
-        self.num_pending_out < self.config.max_concurrent_outbound_dials &&
-            self.num_outbound < self.config.max_outbound
+        self.num_pending_out < self.config.max_concurrent_outbound_dials
+            && self.num_outbound < self.config.max_outbound
     }
 
-    ///  Returns `true` if there's still capacity for a new incoming connection.
+    ///  Returns `true` if there's still capacity to accept a new incoming connection.
     const fn has_in_capacity(&self) -> bool {
         self.num_inbound < self.config.max_inbound
     }
 
-    fn decr_state(&mut self, state: PeerConnectionState) {
+    /// Returns `true` if we can handle an additional incoming pending connection.
+    const fn has_in_pending_capacity(&self) -> bool {
+        self.num_pending_in < self.config.max_inbound
+    }
+
+    const fn decr_state(&mut self, state: PeerConnectionState) {
         match state {
             PeerConnectionState::Idle => {}
             PeerConnectionState::DisconnectingIn | PeerConnectionState::In => self.decr_in(),
@@ -941,35 +1099,35 @@ impl ConnectionInfo {
         }
     }
 
-    fn decr_out(&mut self) {
+    const fn decr_out(&mut self) {
         self.num_outbound -= 1;
     }
 
-    fn inc_out(&mut self) {
+    const fn inc_out(&mut self) {
         self.num_outbound += 1;
     }
 
-    fn inc_pending_out(&mut self) {
+    const fn inc_pending_out(&mut self) {
         self.num_pending_out += 1;
     }
 
-    fn inc_in(&mut self) {
+    const fn inc_in(&mut self) {
         self.num_inbound += 1;
     }
 
-    fn inc_pending_in(&mut self) {
+    const fn inc_pending_in(&mut self) {
         self.num_pending_in += 1;
     }
 
-    fn decr_in(&mut self) {
+    const fn decr_in(&mut self) {
         self.num_inbound -= 1;
     }
 
-    fn decr_pending_out(&mut self) {
+    const fn decr_pending_out(&mut self) {
         self.num_pending_out -= 1;
     }
 
-    fn decr_pending_in(&mut self) {
+    const fn decr_pending_in(&mut self) {
         self.num_pending_in -= 1;
     }
 }
@@ -1047,16 +1205,6 @@ impl Display for InboundConnectionError {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        collections::HashSet,
-        future::{poll_fn, Future},
-        io,
-        net::{IpAddr, Ipv4Addr, SocketAddr},
-        pin::Pin,
-        task::{Context, Poll},
-        time::Duration,
-    };
-
     use reth_eth_wire::{
         errors::{EthHandshakeError, EthStreamError, P2PHandshakeError, P2PStreamError},
         DisconnectReason,
@@ -1065,13 +1213,22 @@ mod tests {
     use reth_network_api::Direction;
     use reth_network_peers::{PeerId, TrustedPeer};
     use reth_network_types::{
-        peers::reputation::DEFAULT_REPUTATION, BackoffKind, ReputationChangeKind,
+        peers::reputation::DEFAULT_REPUTATION, BackoffKind, Peer, ReputationChangeKind,
     };
     use reth_primitives::B512;
+    use std::{
+        future::{poll_fn, Future},
+        io,
+        net::{IpAddr, Ipv4Addr, SocketAddr},
+        pin::Pin,
+        task::{Context, Poll},
+        time::Duration,
+    };
     use url::Host;
 
     use super::PeersManager;
     use crate::{
+        error::SessionError,
         peers::{
             ConnectionInfo, InboundConnectionError, PeerAction, PeerAddr, PeerBackoffDurations,
             PeerConnectionState,
@@ -1551,6 +1708,110 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_reject_incoming_at_pending_capacity() {
+        let mut peers = PeersManager::default();
+
+        for count in 1..=peers.connection_info.config.max_inbound {
+            let socket_addr =
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 1, count as u8)), 8008);
+            assert!(peers.on_incoming_pending_session(socket_addr.ip()).is_ok());
+            assert_eq!(peers.connection_info.num_pending_in, count);
+        }
+        assert!(peers.connection_info.has_in_capacity());
+        assert!(!peers.connection_info.has_in_pending_capacity());
+
+        let socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 1, 100)), 8008);
+        assert!(peers.on_incoming_pending_session(socket_addr.ip()).is_err());
+    }
+
+    #[tokio::test]
+    async fn test_reject_incoming_at_pending_capacity_trusted_peers() {
+        let mut peers = PeersManager::new(PeersConfig::test().with_max_inbound(2));
+        let trusted = PeerId::random();
+        peers.add_trusted_peer_id(trusted);
+
+        // connect the trusted peer
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 1, 0)), 8008);
+        assert!(peers.on_incoming_pending_session(addr.ip()).is_ok());
+        peers.on_incoming_session_established(trusted, addr);
+
+        match event!(peers) {
+            PeerAction::PeerAdded(id) => {
+                assert_eq!(id, trusted);
+            }
+            _ => unreachable!(),
+        }
+
+        // saturate the remaining inbound slots with untrusted peers
+        let mut connected_untrusted_peer_ids = Vec::new();
+        for i in 0..(peers.connection_info.config.max_inbound - 1) {
+            let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 1, (i + 1) as u8)), 8008);
+            assert!(peers.on_incoming_pending_session(addr.ip()).is_ok());
+            let peer_id = PeerId::random();
+            peers.on_incoming_session_established(peer_id, addr);
+            connected_untrusted_peer_ids.push(peer_id);
+
+            match event!(peers) {
+                PeerAction::PeerAdded(id) => {
+                    assert_eq!(id, peer_id);
+                }
+                _ => unreachable!(),
+            }
+        }
+
+        let mut pending_addrs = Vec::new();
+
+        // saturate available slots
+        for i in 0..2 {
+            let socket_addr =
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 1, (i + 10) as u8)), 8008);
+            assert!(peers.on_incoming_pending_session(socket_addr.ip()).is_ok());
+
+            pending_addrs.push(socket_addr);
+        }
+
+        assert_eq!(peers.connection_info.num_pending_in, 2);
+
+        // try to handle additional incoming connections at capacity
+        for i in 0..2 {
+            let socket_addr =
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 1, (i + 20) as u8)), 8008);
+            assert!(peers.on_incoming_pending_session(socket_addr.ip()).is_err());
+        }
+
+        let err = PendingSessionHandshakeError::Eth(EthStreamError::P2PStreamError(
+            P2PStreamError::HandshakeError(P2PHandshakeError::Disconnected(
+                DisconnectReason::UselessPeer,
+            )),
+        ));
+
+        // Remove all pending peers
+        for pending_addr in pending_addrs {
+            peers.on_incoming_pending_session_dropped(pending_addr, &err);
+        }
+
+        println!("num_pending_in: {}", peers.connection_info.num_pending_in);
+
+        println!(
+            "num_inbound: {}, has_in_capacity: {}",
+            peers.connection_info.num_inbound,
+            peers.connection_info.has_in_capacity()
+        );
+
+        // disconnect a connected peer
+        peers.on_active_session_gracefully_closed(connected_untrusted_peer_ids[0]);
+
+        println!(
+            "num_inbound: {}, has_in_capacity: {}",
+            peers.connection_info.num_inbound,
+            peers.connection_info.has_in_capacity()
+        );
+
+        let socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 1, 99)), 8008);
+        assert!(peers.on_incoming_pending_session(socket_addr.ip()).is_ok());
+    }
+
+    #[tokio::test]
     async fn test_closed_incoming() {
         let socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 1, 2)), 8008);
         let mut peers = PeersManager::default();
@@ -1778,7 +2039,7 @@ mod tests {
 
             let p = peers.peers.get(&peer).unwrap();
             if p.is_banned() {
-                break
+                break;
             }
         }
 
@@ -1856,6 +2117,64 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_fatal_outgoing_connection_error_trusted() {
+        let peer = PeerId::random();
+        let config = PeersConfig::test()
+            .with_trusted_nodes(vec![TrustedPeer {
+                host: Host::Ipv4(Ipv4Addr::new(127, 0, 1, 2)),
+                tcp_port: 8008,
+                udp_port: 8008,
+                id: peer,
+            }])
+            .with_trusted_nodes_only(true);
+        let mut peers = PeersManager::new(config);
+        let socket_addr = peers.peers.get(&peer).unwrap().addr.tcp();
+
+        match event!(peers) {
+            PeerAction::Connect { peer_id, remote_addr } => {
+                assert_eq!(peer_id, peer);
+                assert_eq!(remote_addr, socket_addr);
+            }
+            _ => unreachable!(),
+        }
+
+        let p = peers.peers.get(&peer).unwrap();
+        assert_eq!(p.state, PeerConnectionState::PendingOut);
+
+        assert_eq!(peers.num_outbound_connections(), 0);
+
+        let err = PendingSessionHandshakeError::Eth(EthStreamError::EthHandshakeError(
+            EthHandshakeError::NonStatusMessageInHandshake,
+        ));
+        assert!(err.is_fatal_protocol_error());
+
+        peers.on_outgoing_pending_session_dropped(&socket_addr, &peer, &err);
+        assert_eq!(peers.num_outbound_connections(), 0);
+
+        // try tmp ban peer
+        match event!(peers) {
+            PeerAction::BanPeer { peer_id } => {
+                assert_eq!(peer_id, peer);
+            }
+            err => unreachable!("{err:?}"),
+        }
+
+        // ensure we still have trusted peer
+        assert!(peers.peers.contains_key(&peer));
+
+        // await for the ban to expire
+        tokio::time::sleep(peers.backoff_durations.medium).await;
+
+        match event!(peers) {
+            PeerAction::Connect { peer_id, remote_addr } => {
+                assert_eq!(peer_id, peer);
+                assert_eq!(remote_addr, socket_addr);
+            }
+            err => unreachable!("{err:?}"),
+        }
+    }
+
+    #[tokio::test]
     async fn test_outgoing_connection_error() {
         let peer = PeerId::random();
         let socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 1, 2)), 8008);
@@ -1926,7 +2245,7 @@ mod tests {
     async fn test_discovery_ban_list() {
         let ip = IpAddr::V4(Ipv4Addr::new(127, 0, 1, 2));
         let socket_addr = SocketAddr::new(ip, 8008);
-        let ban_list = BanList::new(HashSet::new(), vec![ip]);
+        let ban_list = BanList::new(vec![], vec![ip]);
         let config = PeersConfig::default().with_ban_list(ban_list);
         let mut peer_manager = PeersManager::new(config);
         peer_manager.add_peer(B512::default(), PeerAddr::from_tcp(socket_addr), None);
@@ -1938,7 +2257,7 @@ mod tests {
     async fn test_on_pending_ban_list() {
         let ip = IpAddr::V4(Ipv4Addr::new(127, 0, 1, 2));
         let socket_addr = SocketAddr::new(ip, 8008);
-        let ban_list = BanList::new(HashSet::new(), vec![ip]);
+        let ban_list = BanList::new(vec![], vec![ip]);
         let config = PeersConfig::test().with_ban_list(ban_list);
         let mut peer_manager = PeersManager::new(config);
         let a = peer_manager.on_incoming_pending_session(socket_addr.ip());
@@ -1959,7 +2278,7 @@ mod tests {
         let ip = IpAddr::V4(Ipv4Addr::new(127, 0, 1, 2));
         let socket_addr = SocketAddr::new(ip, 8008);
         let given_peer_id = PeerId::random();
-        let ban_list = BanList::new(vec![given_peer_id], HashSet::new());
+        let ban_list = BanList::new(vec![given_peer_id], vec![]);
         let config = PeersConfig::test().with_ban_list(ban_list);
         let mut peer_manager = PeersManager::new(config);
         assert!(peer_manager.on_incoming_pending_session(socket_addr.ip()).is_ok());
@@ -2174,6 +2493,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_incoming_rate_limit() {
+        let config = PeersConfig {
+            incoming_ip_throttle_duration: Duration::from_millis(100),
+            ..PeersConfig::test()
+        };
+        let mut peers = PeersManager::new(config);
+
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(168, 0, 1, 2)), 8009);
+        assert!(peers.on_incoming_pending_session(addr.ip()).is_ok());
+        assert_eq!(
+            peers.on_incoming_pending_session(addr.ip()).unwrap_err(),
+            InboundConnectionError::IpBanned
+        );
+
+        peers.release_interval.reset_immediately();
+        tokio::time::sleep(peers.incoming_ip_throttle_duration).await;
+
+        // await unban
+        poll_fn(|cx| loop {
+            if peers.poll(cx).is_pending() {
+                return Poll::Ready(());
+            }
+        })
+        .await;
+
+        assert!(peers.on_incoming_pending_session(addr.ip()).is_ok());
+        assert_eq!(
+            peers.on_incoming_pending_session(addr.ip()).unwrap_err(),
+            InboundConnectionError::IpBanned
+        );
+    }
+
+    #[tokio::test]
     async fn test_tick() {
         let ip = IpAddr::V4(Ipv4Addr::new(127, 0, 1, 2));
         let socket_addr = SocketAddr::new(ip, 8008);
@@ -2220,23 +2572,6 @@ mod tests {
 
         peers.on_active_session_gracefully_closed(peer_id);
         assert!(!peers.peers.contains_key(&peer_id))
-    }
-
-    #[tokio::test]
-    async fn test_remove_incoming_after_disconnect_trusted_peer() {
-        let peer_id = PeerId::random();
-        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 1, 2)), 8009);
-        let mut peers = PeersManager::default();
-
-        peers.add_trusted_peer(peer_id, PeerAddr::from_tcp(addr));
-        peers.on_incoming_pending_session(addr.ip()).unwrap();
-        peers.on_incoming_session_established(peer_id, addr);
-        let peer = peers.peers.get(&peer_id).unwrap();
-        assert_eq!(peer.state, PeerConnectionState::In);
-        assert!(!peer.remove_after_disconnect);
-
-        peers.on_active_session_gracefully_closed(peer_id);
-        assert!(peers.peers.contains_key(&peer_id))
     }
 
     #[tokio::test]
@@ -2397,5 +2732,168 @@ mod tests {
 
         // no more pending outbound connections
         assert_eq!(peer_manager.connection_info.num_pending_out, 0);
+    }
+
+    #[tokio::test]
+    async fn test_connect() {
+        let peer = PeerId::random();
+        let socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 1, 2)), 8008);
+        let mut peers = PeersManager::default();
+        peers.add_and_connect(peer, PeerAddr::from_tcp(socket_addr), None);
+        assert_eq!(peers.peers.get(&peer).unwrap().state, PeerConnectionState::PendingOut);
+
+        match event!(peers) {
+            PeerAction::Connect { peer_id, remote_addr } => {
+                assert_eq!(peer_id, peer);
+                assert_eq!(remote_addr, socket_addr);
+            }
+            _ => unreachable!(),
+        }
+
+        let (record, _) = peers.peer_by_id(peer).unwrap();
+        assert_eq!(record.tcp_addr(), socket_addr);
+        assert_eq!(record.udp_addr(), socket_addr);
+
+        // connect again
+        peers.add_and_connect(peer, PeerAddr::from_tcp(socket_addr), None);
+
+        let (record, _) = peers.peer_by_id(peer).unwrap();
+        assert_eq!(record.tcp_addr(), socket_addr);
+        assert_eq!(record.udp_addr(), socket_addr);
+    }
+
+    #[tokio::test]
+    async fn test_incoming_connection_from_banned() {
+        let peer = PeerId::random();
+        let socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 1, 2)), 8008);
+        let config = PeersConfig::test().with_max_inbound(3);
+        let mut peers = PeersManager::new(config);
+        peers.add_peer(peer, PeerAddr::from_tcp(socket_addr), None);
+
+        match event!(peers) {
+            PeerAction::PeerAdded(peer_id) => {
+                assert_eq!(peer_id, peer);
+            }
+            _ => unreachable!(),
+        }
+        match event!(peers) {
+            PeerAction::Connect { peer_id, .. } => {
+                assert_eq!(peer_id, peer);
+            }
+            _ => unreachable!(),
+        }
+
+        poll_fn(|cx| {
+            assert!(peers.poll(cx).is_pending());
+            Poll::Ready(())
+        })
+        .await;
+
+        // simulate new connection drops with error
+        loop {
+            peers.on_active_session_dropped(
+                &socket_addr,
+                &peer,
+                &EthStreamError::InvalidMessage(reth_eth_wire::message::MessageError::Invalid(
+                    reth_eth_wire::EthVersion::Eth68,
+                    reth_eth_wire::EthMessageID::Status,
+                )),
+            );
+
+            if peers.peers.get(&peer).unwrap().is_banned() {
+                break;
+            }
+
+            assert!(peers.on_incoming_pending_session(socket_addr.ip()).is_ok());
+            peers.on_incoming_session_established(peer, socket_addr);
+
+            match event!(peers) {
+                PeerAction::Connect { peer_id, .. } => {
+                    assert_eq!(peer_id, peer);
+                }
+                _ => unreachable!(),
+            }
+        }
+
+        assert!(peers.peers.get(&peer).unwrap().is_banned());
+
+        // fill all incoming slots
+        for _ in 0..peers.connection_info.config.max_inbound {
+            assert!(peers.on_incoming_pending_session(socket_addr.ip()).is_ok());
+            peers.on_incoming_session_established(peer, socket_addr);
+
+            match event!(peers) {
+                PeerAction::DisconnectBannedIncoming { peer_id } => {
+                    assert_eq!(peer_id, peer);
+                }
+                _ => unreachable!(),
+            }
+        }
+
+        poll_fn(|cx| {
+            assert!(peers.poll(cx).is_pending());
+            Poll::Ready(())
+        })
+        .await;
+
+        assert_eq!(peers.connection_info.num_inbound, 0);
+
+        let new_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 1, 3)), 8008);
+
+        // Assert we can still accept new connections
+        assert!(peers.on_incoming_pending_session(new_addr.ip()).is_ok());
+        assert_eq!(peers.connection_info.num_pending_in, 1);
+
+        // the triggered DisconnectBannedIncoming will result in dropped connections, assert that
+        // connection info is updated via the peer's state which would be a noop here since the
+        // banned peer's state is idle
+        peers.on_active_session_gracefully_closed(peer);
+        assert_eq!(peers.connection_info.num_inbound, 0);
+    }
+
+    #[tokio::test]
+    async fn test_add_pending_connect() {
+        let peer = PeerId::random();
+        let socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 1, 2)), 8008);
+        let mut peers = PeersManager::default();
+        peers.add_and_connect(peer, PeerAddr::from_tcp(socket_addr), None);
+        assert_eq!(peers.peers.get(&peer).unwrap().state, PeerConnectionState::PendingOut);
+        assert_eq!(peers.connection_info.num_pending_out, 1);
+    }
+
+    #[tokio::test]
+    async fn test_dns_updates_peer_address() {
+        let peer_id = PeerId::random();
+        let initial_socket = SocketAddr::new("1.1.1.1".parse::<IpAddr>().unwrap(), 8008);
+        let updated_ip = "2.2.2.2".parse::<IpAddr>().unwrap();
+
+        let trusted = TrustedPeer {
+            host: url::Host::Ipv4("2.2.2.2".parse().unwrap()),
+            tcp_port: 8008,
+            udp_port: 8008,
+            id: peer_id,
+        };
+
+        let config = PeersConfig::test().with_trusted_nodes(vec![trusted.clone()]);
+        let mut manager = PeersManager::new(config);
+        manager
+            .trusted_peers_resolver
+            .set_interval(tokio::time::interval(Duration::from_millis(1)));
+
+        manager.peers.insert(
+            peer_id,
+            Peer::trusted(PeerAddr::new_with_ports(initial_socket.ip(), 8008, Some(8008))),
+        );
+
+        for _ in 0..100 {
+            let _ = event!(manager);
+            if manager.peers.get(&peer_id).unwrap().addr.tcp().ip() == updated_ip {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        let updated_peer = manager.peers.get(&peer_id).unwrap();
+        assert_eq!(updated_peer.addr.tcp().ip(), updated_ip);
     }
 }

--- a/crates/net/network/src/session/handle.rs
+++ b/crates/net/network/src/session/handle.rs
@@ -2,6 +2,7 @@
 
 use std::{io, net::SocketAddr, sync::Arc, time::Instant};
 
+use crate::session::CapabilityMessage;
 use reth_ecies::ECIESError;
 use reth_eth_wire::{
     capability::CapabilityMessage, errors::EthStreamError, Capabilities, DisconnectReason,

--- a/crates/net/network/src/session/handle.rs
+++ b/crates/net/network/src/session/handle.rs
@@ -2,7 +2,6 @@
 
 use std::{io, net::SocketAddr, sync::Arc, time::Instant};
 
-use crate::session::CapabilityMessage;
 use reth_ecies::ECIESError;
 use reth_eth_wire::{
     capability::CapabilityMessage, errors::EthStreamError, Capabilities, DisconnectReason,

--- a/crates/net/network/src/trusted_peers_resolver.rs
+++ b/crates/net/network/src/trusted_peers_resolver.rs
@@ -1,0 +1,67 @@
+//! Periodically resolves DNS records for a set of trusted peers and emits updates as they complete
+
+use futures::{future::BoxFuture, ready, stream::FuturesUnordered, FutureExt, StreamExt};
+use reth_network_peers::{NodeRecord, PeerId, TrustedPeer};
+use std::{
+    io,
+    task::{Context, Poll},
+};
+use tokio::time::Interval;
+use tracing::warn;
+
+/// `TrustedPeersResolver` periodically spawns DNS resolution tasks for trusted peers.
+/// It returns a resolved (`PeerId`, `NodeRecord`) update when one of its in‑flight tasks completes.
+#[derive(Debug)]
+pub struct TrustedPeersResolver {
+    /// The list of trusted peers to resolve.
+    pub trusted_peers: Vec<TrustedPeer>,
+    /// The timer that triggers a new resolution cycle.
+    pub interval: Interval,
+    /// Futures for currently in‑flight resolution tasks.
+    pub pending: FuturesUnordered<BoxFuture<'static, (PeerId, Result<NodeRecord, io::Error>)>>,
+}
+
+impl TrustedPeersResolver {
+    /// Create a new resolver with the given trusted peers and resolution interval.
+    pub fn new(trusted_peers: Vec<TrustedPeer>, resolve_interval: Interval) -> Self {
+        Self { trusted_peers, interval: resolve_interval, pending: FuturesUnordered::new() }
+    }
+
+    /// Update the resolution interval (useful for testing purposes)
+    #[allow(dead_code)]
+    pub fn set_interval(&mut self, interval: Interval) {
+        self.interval = interval;
+    }
+
+    /// Poll the resolver.
+    /// When the interval ticks, new resolution futures for each trusted peer are spawned.
+    /// If a future completes successfully, it returns the resolved (`PeerId`, `NodeRecord`).
+    pub fn poll(&mut self, cx: &mut Context<'_>) -> Poll<(PeerId, NodeRecord)> {
+        if self.trusted_peers.is_empty() {
+            return Poll::Pending;
+        }
+
+        if self.interval.poll_tick(cx).is_ready() {
+            self.pending.clear();
+
+            for trusted in self.trusted_peers.iter().cloned() {
+                let peer_id = trusted.id;
+                let task = async move {
+                    let result = trusted.resolve().await;
+                    (peer_id, result)
+                }
+                .boxed();
+                self.pending.push(task);
+            }
+        }
+
+        match ready!(self.pending.poll_next_unpin(cx)) {
+            Some((peer_id, Ok(record))) => Poll::Ready((peer_id, record)),
+            Some((peer_id, Err(e))) => {
+                warn!(target: "net::peers", "Failed to resolve trusted peer {:?}: {:?}", peer_id, e);
+                Poll::Pending
+            }
+            None => Poll::Pending,
+        }
+    }
+}


### PR DESCRIPTION
This is related to the develop pr: https://github.com/botanix-labs/Macbeth/pull/912

It's adding back the upstream trusted peer logic that was rolled back yesterday.