### PR TITLE
fix(abci): set version 0 to recover testnet

### DIFF
--- a/crates/consensus/authority/src/comet_bft/abci.rs
+++ b/crates/consensus/authority/src/comet_bft/abci.rs
@@ -699,7 +699,7 @@ where
         ResponseInfo {
             data: String::default(),
             version: VERSION.to_string(),
-            app_version: 1,
+            app_version: 0,
             last_block_height: latest_header.number as i64,
             last_block_app_hash,
         }
@@ -2695,7 +2695,7 @@ mod tests {
 
         assert_eq!(response.data, String::default());
         assert_eq!(response.version, VERSION.to_string());
-        assert_eq!(response.app_version, 1);
+        assert_eq!(response.app_version, 0);
         assert_eq!(response.last_block_height, 0);
         let _response_app_hash_hex = hex::encode(response.last_block_app_hash.to_vec().as_slice());
         assert_eq!(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

This PR recovers testnet from a bug that only manifests when using the command:
`cometbft rollback --hard`

Context:
Cometbft `genesis.json` has a `version` field which we set to
```
"version": {
	"app": "0"
},
```		

But we have a bug in `abci > info()` where we set the version to 1:

```
ResponseInfo {
            data: String::default(),
            version: VERSION.to_string(),
            app_version: 1,
            last_block_height: latest_header.number as i64,
            last_block_app_hash,
        }
```        

The version is stored in `state.db` and used on restarts for cometbft to check that it and it's app have the same version.
Usually this isn't an issue bc once the app (at block 1) returns version 1, state.db updates to version 1.

But when using the rollback command above, the version is rolled back to the genesis version of 0.
This pr sets the abci.info version for 0 to recover testnet.  I'll immediately rollback this change once deployed.

## What was done?

<!--- Describe your changes in detail -->

- Return `app_version: 0` to recover testnet.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Unit and int tests pass
- Tested locally

## Breaking Changes

<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

- None for testnet but would break syncing if deployed to mainnet.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] I have added or updated relevant unit/integration/functional/e2e tests
-   [x] I have tested my changes running a local network, and they work as expected
-   [x] I have performed a self-review
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
-   [x] I have made corresponding changes to the documentation if needed
-   [x] I have added assignees and reviewers to this pull request
-   [x] I have added the PR to the project board or linked it to an issue from the board
