### PR TITLE
feat(btc-server): signal RBF in pegout transaction

### DIFF
--- a/bin/btc-server/src/wallet/psbt.rs
+++ b/bin/btc-server/src/wallet/psbt.rs
@@ -329,7 +329,7 @@ pub(crate) fn create_psbt(
             .iter()
             .map(|u| bitcoin::TxIn {
                 previous_output: u.outpoint,
-                sequence: bitcoin::Sequence::MAX,
+                sequence: bitcoin::Sequence::ENABLE_RBF_NO_LOCKTIME,
                 script_sig: bitcoin::ScriptBuf::new(),
                 witness: Default::default(),
             })

--- a/bin/test-suite/src/suite/consensus/frost/test_conflicting_input.rs
+++ b/bin/test-suite/src/suite/consensus/frost/test_conflicting_input.rs
@@ -178,16 +178,16 @@ pub async fn test_conflicting_input(
     // 1) Signers will reject the psbt if it contains no conflicting input. This does not happen b/c
     //    the coordinator will include a conflicting input and signers will validate against this
     // 2) The network will reject the broadcast psbt if it contains a conflicting input with error
-    //    "txn-mempool-conflict" since the first tx is still in the mempool.
+    //    "txn-mempool-conflict" since the first tx is still in the mempool. This won't happen as we
+    //    will signal for RBF in the pegout inputs.
     // 3) The network will reject the broadcast psbt if the replacement fee isn't high enough.  We
     //    are not trying to replace the tx so this is an acceptable failure case as well:
     //    "insufficient fee, rejecting replacement"
-    // We want failure case 2 or 3.
+    // We want failure case 3.
     if let Err(e) = do_signing(&mut clients, &bitcoind, &[2u8; 32]).await {
         let error_message = e.to_string();
         assert!(
-            error_message.contains("txn-mempool-conflict") ||
-                error_message.contains("insufficient fee, rejecting replacement"),
+            error_message.contains("insufficient fee, rejecting replacement"),
             "Unexpected error: {}",
             error_message
         );


### PR DESCRIPTION
Without signaling RBF, retrying a pegout will always get rejected if it conflicts with the original transaction in our mempool, regardless of the new fee rate.

Signaling RBF allows new pegouts to replace old ones when they have a higher fee. 

This situation is relevant when the replacement pegout happens when the overall fee rate is higher than when the original pegout was created.

Note that full RBF is enabled by default in newer releases of bitcoin core, but we have nothing to lose by signaling for it anyway.

<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
https://github.com/botanix-labs/botanix/issues/1102

## What was done?

<!--- Describe your changes in detail -->

- Signalling RBF in pegout inputs

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Updating integration tests and manually verifying

## Breaking Changes

<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

- None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] I have added or updated relevant unit/integration/functional/e2e tests
-   [ ] I have tested my changes running a local network, and they work as expected
-   [x] I have performed a self-review
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
-   [x] I have made corresponding changes to the documentation if needed
-   [x] I have added assignees and reviewers to this pull request
-   [x] I have added the PR to the project board or linked it to an issue from the board


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Newly created transactions are now Replace-By-Fee (RBF) enabled by default, allowing fee increases or replacements of unconfirmed transactions to speed confirmations; confirmed transactions unaffected.

* **Tests**
  * Test suite updated to reflect RBF signaling for pegout inputs and to narrow expected failure modes to fee-related rejections rather than mempool-conflict situations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->