### PR TITLE
test(test-suite): check port availability when starting up test nodes

### DIFF
--- a/bin/test-suite/src/suite/consensus/common/btc_server.rs
+++ b/bin/test-suite/src/suite/consensus/common/btc_server.rs
@@ -1,4 +1,4 @@
-use crate::context::GlobalContext;
+use crate::{context::GlobalContext, suite::consensus::common::is_port_free};
 use anyhow::Context;
 use btcserverlib::federation_args::{FedMemberPubKey, FederationTomlConfig};
 use reth::consensus_common::utils::unix_timestamp;
@@ -178,6 +178,15 @@ pub fn spawn_n_btc_server_processes(
         let db_path = Path::new(&temp_db_path).join(format!("db{}", i));
         std::fs::create_dir_all(&db_path).context("failed to create tempdir with db subdir")?;
         let btc_server_port = BTC_SERVER_START_PORT + i;
+
+        if !is_port_free(btc_server_port) {
+            return Err(anyhow::anyhow!(
+                "❌ BTC Server {} needs port {} but it's already in use by another process",
+                i,
+                btc_server_port
+            ));
+        }
+
         let child_process = spawn_btc_server_process(
             global_context.clone(),
             members_keypairs,

--- a/bin/test-suite/src/suite/consensus/common/comet_node.rs
+++ b/bin/test-suite/src/suite/consensus/common/comet_node.rs
@@ -2,7 +2,7 @@ use super::{kill_process_at_port, poa_node::ABCI_PORT_BASE, Scope};
 use crate::{
     context::GlobalContext,
     suite::consensus::common::{
-        create_temp_working_directory, spawn_await_child_process, spawn_child_process,
+        create_temp_working_directory, is_port_free, spawn_await_child_process, spawn_child_process,
     },
 };
 use anyhow::Context;
@@ -452,6 +452,16 @@ pub async fn create_cometbft_nodes(
         let rpc_listen_address = format!("127.0.0.1:{rpc_listen_port}").parse()?;
         let p2p_listen_port = rpc_listen_port - 1;
         let p2p_listen_address = format!("127.0.0.1:{p2p_listen_port}").parse()?;
+
+        for port in [proxy_app_port, rpc_listen_port, p2p_listen_port] {
+            if !is_port_free(port) {
+                return Err(anyhow::anyhow!(
+                    "❌ CometBFT node {} needs port {} but it's already in use by another process",
+                    member_index,
+                    port
+                ));
+            }
+        }
 
         let node_external_address = format!("127.0.0.1:{p2p_listen_port}")
             .parse()

--- a/bin/test-suite/src/suite/consensus/common/mod.rs
+++ b/bin/test-suite/src/suite/consensus/common/mod.rs
@@ -71,7 +71,7 @@ pub fn kill_process_at_port(port: u16) {
 }
 
 pub fn is_port_free(port: u16) -> bool {
-    std::net::TcpListener::bind(("127.0.0.1", port)).is_ok()
+    std::net::TcpListener::bind(("0.0.0.0", port)).is_ok()
 }
 
 pub fn spawn_child_process(

--- a/bin/test-suite/src/suite/consensus/common/mod.rs
+++ b/bin/test-suite/src/suite/consensus/common/mod.rs
@@ -70,6 +70,10 @@ pub fn kill_process_at_port(port: u16) {
     }
 }
 
+pub fn is_port_free(port: u16) -> bool {
+    std::net::TcpListener::bind(("127.0.0.1", port)).is_ok()
+}
+
 pub fn spawn_child_process(
     scope: Scope,
     command: &str,

--- a/bin/test-suite/src/suite/consensus/common/poa_node.rs
+++ b/bin/test-suite/src/suite/consensus/common/poa_node.rs
@@ -5,7 +5,9 @@ use super::{
 use crate::{
     context::GlobalContext,
     it_error_print, it_info_print, it_warn_print,
-    suite::consensus::common::{is_port_free, spawn_child_process, Scope, MINTING_CONTRACT_BYTECODE},
+    suite::consensus::common::{
+        is_port_free, spawn_child_process, Scope, MINTING_CONTRACT_BYTECODE,
+    },
 };
 use anyhow::Context;
 use askama::Template;

--- a/bin/test-suite/src/suite/consensus/common/poa_node.rs
+++ b/bin/test-suite/src/suite/consensus/common/poa_node.rs
@@ -5,7 +5,7 @@ use super::{
 use crate::{
     context::GlobalContext,
     it_error_print, it_info_print, it_warn_print,
-    suite::consensus::common::{spawn_child_process, Scope, MINTING_CONTRACT_BYTECODE},
+    suite::consensus::common::{is_port_free, spawn_child_process, Scope, MINTING_CONTRACT_BYTECODE},
 };
 use anyhow::Context;
 use askama::Template;
@@ -750,6 +750,20 @@ pub async fn create_poa_nodes(
             .cloned()
             .expect("To have keypair information");
 
+        let rpc_port = RPC_PORT_BASE + member_index;
+        let ws_port = WS_PORT_BASE + member_index;
+        let discovery_port = DISCOVERY_PORT_BASE + member_index;
+        let abci_port = ABCI_PORT_BASE + 1000 * member_index;
+        for port in [rpc_port, ws_port, discovery_port, abci_port] {
+            if !is_port_free(port) {
+                return Err(anyhow::anyhow!(
+                    "❌ POA node {} needs port {} but it's already in use by another process",
+                    member_index,
+                    port
+                ));
+            }
+        }
+
         let (test_signal_tx, _test_signal_rx) = channel::<TestSignal>(10);
         let fed_member_config = FederationMemberTestConfig::new(
             member_index,
@@ -765,10 +779,10 @@ pub async fn create_poa_nodes(
             global_context.max_signers,
             global_context.num_snapshots_to_keep,
             member_peerid,
-            RPC_PORT_BASE + member_index,
-            WS_PORT_BASE + member_index,
-            DISCOVERY_PORT_BASE + member_index,
-            ABCI_PORT_BASE + 1000 * member_index,
+            rpc_port,
+            ws_port,
+            discovery_port,
+            abci_port,
             test_signal_tx,
             global_context.botanix_fee_recipient.clone(),
             member_index > poa_instances - 1,

--- a/bin/test-suite/src/suite/consensus/common/rpc_node.rs
+++ b/bin/test-suite/src/suite/consensus/common/rpc_node.rs
@@ -2,7 +2,7 @@ use crate::{
     it_error_print, it_info_print,
     suite::consensus::{
         common::{
-            poa_node::FederationMemberTestConfig, spawn_child_process, Scope,
+            is_port_free, poa_node::FederationMemberTestConfig, spawn_child_process, Scope,
             MINTING_CONTRACT_BYTECODE,
         },
         GlobalContext,
@@ -324,8 +324,25 @@ pub async fn create_rpc_nodes(
         let pk = secp256k1::PublicKey::from_secret_key(&secp, &secret_key);
         let rpc_peer_id = pk2id(&pk);
 
+        // Note: make sure we start port assigning after poa servers
+        let rpc_port = RPC_PORT_BASE + global_context.fed_instances + member_index;
+        let ws_port = WS_PORT_BASE + global_context.fed_instances + member_index;
+        let discovery_port = DISCOVERY_PORT_BASE + global_context.fed_instances + member_index;
+        let abci_port = ABCI_PORT_BASE + 1000 * (global_context.fed_instances + member_index);
+
+        for port in [rpc_port, ws_port, discovery_port, abci_port] {
+            if !is_port_free(port) {
+                return Err(anyhow::anyhow!(
+                    "❌ RPC node {} needs port {} but it's already in use by another process",
+                    member_index,
+                    port
+                ));
+            }
+        }
+
         let rpc_node = NonFederationMemberTestConfig::new(
-            global_context.fed_instances + member_index, // indexing follows up from poa nodes onwards
+            global_context.fed_instances + member_index, /* indexing follows up from poa nodes
+                                                          * onwards */
             secret_key,
             tx.clone(),
             global_context.bitcoind_url.clone(),
@@ -333,16 +350,13 @@ pub async fn create_rpc_nodes(
             global_context.bitcoind_pass.clone(),
             rpc_peer_id,
             global_context.botanix_fee_recipient.clone(),
-            RPC_PORT_BASE + global_context.fed_instances + member_index, /* Note: make sure we
-                                                                          * start port assigning
-                                                                          * after poa servers */
-    WS_PORT_BASE + global_context.fed_instances + member_index, /* Note: make sure we
-                                                                          * start port assigning
-                                                                          * after poa servers */
-            DISCOVERY_PORT_BASE + global_context.fed_instances + member_index, /* Note: make sure we start port assigning after poa servers */
-            ABCI_PORT_BASE + 1000 * (global_context.fed_instances + member_index),
+            rpc_port,
+            ws_port,
+            discovery_port,
+            abci_port,
             global_context.lst_fee_receiver.clone(),
-        ).await?;
+        )
+        .await?;
         rpc_members.insert(member_index, rpc_node);
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
If another local process was occupying a port, the tests would fail without a clear reason.

## What was done?

<!--- Describe your changes in detail -->

- check that ports are available when creating test nodes

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Reproduced the issue locally by running a conflicting process on port 8000 and verified that the test exited early with:

```
2025-08-13T22:56:15.660879Z  INFO (>>>>>>>>>>> IT_SUITE <<<<<<<<<<<<) "Starting btc servers ..."
2025-08-13T22:56:15.661476Z ERROR Error creating local context ❌ BTC Server 0 needs port 8000 but it's already in use by another process
2025-08-13T22:56:15.661508Z  INFO (FullRun) ConsensusIntegrationTestSuite: frost::test_frost_e2e::frost_e2e_stable Running...
2025-08-13T22:56:15.661938Z  INFO (>>>>>>>>>>> IT_SUITE <<<<<<<<<<<<) Pegin Confirmation Depth 1
2025-08-13T22:56:20.663938Z ERROR Test suite panicked PanicHookInfo { payload: Any { .. }, location: Location { file: "bin/test-suite/src/suite/consensus/frost/test_frost_e2e.rs", line: 40, col: 10 }, can_unwind: true, force_no_backtrace: false }
```

## Breaking Changes

<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

- None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] I have added or updated relevant unit/integration/functional/e2e tests
-   [ ] I have tested my changes running a local network, and they work as expected
-   [x] I have performed a self-review
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
-   [x] I have made corresponding changes to the documentation if needed
-   [x] I have added assignees and reviewers to this pull request
-   [x] I have added the PR to the project board or linked it to an issue from the board


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added pre-flight port availability checks and a lightweight port-check utility used across BTC server, CometBFT, POA, and RPC node creation.
  - Clear early error messages now surface when required ports are already in use, preventing conflicting startups.
- **Refactor**
  - Standardized per-node port calculation and pass explicit port values into node configuration to ensure consistency between checks and runtime.
- **Tests**
  - Improved reliability of test runs by proactively detecting and avoiding port conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->