### PR TITLE
refactor(btc-server): helper method to calculate max inputs for psbt

### DIFF
--- a/bin/btc-server/src/wallet/mod.rs
+++ b/bin/btc-server/src/wallet/mod.rs
@@ -13,6 +13,32 @@ pub const TAPROOT_KEYSPEND_SIGHASH_DEFAULT_WEIGHT: Weight = Weight::from_wu(65);
 pub const SEGWIT_FLAG_WEIGHT: Weight = Weight::from_wu(1);
 pub const SEGWIT_MARKER_WEIGHT: Weight = Weight::from_wu(1);
 
+// The standardness limit for a transaction is 400,000 weight units
+pub const MAX_TX_WEIGHT: u64 = 400_000;
+
+// version = 4 bytes * 4 weight units
+// marker = 1 byte * 1 weight unit
+// flag = 1 byte * 1 weight unit
+// ninput = 3 bytes to encode values between 253 to 65,535 * 4 weight units
+// noutput = 3 bytes to encode values between 253 to 65,535 * 4 weight units
+// locktime = 4 bytes * 4 weight units
+pub const MAX_BASE_TX_WEIGHT: u64 = 16 + 1 + 1 + 12 + 12 + 16;
+
+// txid = 32 bytes * 4 weight units
+// vout = 4 bytes * 4 weight units
+// empty_script_len = 1 byte * 4 weight units
+// sequence = 4 bytes * 4 weight units
+// witness item count = 1 byte * 1 weight units
+// signature = TAPROOT_KEYSPEND_SIGHASH_DEFAULT_WEIGHT
+pub const PER_P2TR_KEYSPEND_WEIGHT: u64 =
+    32 * 4 + 4 * 4 + 1 * 4 + 4 * 4 + 1 + TAPROOT_KEYSPEND_SIGHASH_DEFAULT_WEIGHT.to_wu();
+
+// output_value = 8 bytes * 4 weight units
+// output_script_len = 1 byte * 4 weight units
+// output_script = 34 bytes * 1 weight unit (assuming the longest standard script (p2wsh or p2tr),
+// others are shorter))
+pub const PER_OUTPUT_MAX_WEIGHT: u64 = 8 * 4 + 1 * 4 + 34 * 4;
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/bin/btc-server/src/wallet/util.rs
+++ b/bin/btc-server/src/wallet/util.rs
@@ -4,6 +4,7 @@ use frost_secp256k1_tr as frost;
 use thiserror::Error;
 
 use crate::wallet::{
+    MAX_BASE_TX_WEIGHT, MAX_TX_WEIGHT, PER_OUTPUT_MAX_WEIGHT, PER_P2TR_KEYSPEND_WEIGHT,
     SEGWIT_FLAG_WEIGHT, SEGWIT_MARKER_WEIGHT, TAPROOT_KEYSPEND_SIGHASH_DEFAULT_WEIGHT,
 };
 
@@ -90,6 +91,16 @@ pub fn calculate_signed_tx_fee_rate(psbt: &Psbt) -> Result<FeeRate, WalletCalcul
     Ok(fee_rate)
 }
 
+/// Returns the maximum number of inputs that can be added to a PSBT without exceeding the maximum
+/// transaction weight.
+pub fn max_number_of_psbt_inputs(num_pegouts: u64) -> u64 {
+    let max_outputs = num_pegouts + 1; // +1 for change output
+    let psbt_without_inputs_weight = MAX_BASE_TX_WEIGHT + max_outputs * PER_OUTPUT_MAX_WEIGHT;
+    let max_number_of_inputs =
+        (MAX_TX_WEIGHT - psbt_without_inputs_weight) / PER_P2TR_KEYSPEND_WEIGHT;
+    max_number_of_inputs
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -99,7 +110,11 @@ mod tests {
             add_dummy_signatures_to_psbt, create_random_pegout_id, random_compute_txid,
             random_p2tr_keyspend_script,
         },
-        wallet::psbt::{create_psbt, InputDTO},
+        util::UPPER_PEGOUT_BOUND,
+        wallet::{
+            psbt::{create_psbt, InputDTO},
+            MAX_TX_WEIGHT,
+        },
     };
 
     use bitcoin::{Amount, OutPoint, TapSighashType, TxOut};
@@ -220,5 +235,70 @@ mod tests {
         outputs.push(output1);
 
         create_psbt(inputs, outputs, None)
+    }
+
+    fn create_signed_tx(num_inputs: u64, num_outputs: u64) -> Psbt {
+        let mut inputs = vec![];
+        for _ in 0..num_inputs {
+            let input = create_random_input(10_000);
+            inputs.push(input);
+        }
+
+        let mut outputs = vec![];
+        for _ in 0..num_outputs {
+            let output = (
+                TxOut {
+                    value: Amount::from_sat(10_000),
+                    script_pubkey: random_p2tr_keyspend_script(), // Recipient script
+                },
+                create_random_pegout_id().as_bytes(),
+            );
+            outputs.push(output);
+        }
+
+        let mut psbt = create_psbt(inputs, outputs, None);
+        add_dummy_signatures_to_psbt(&mut psbt, TapSighashType::Default);
+        psbt // with signatures
+    }
+
+    #[test]
+    fn test_max_number_of_psbt_inputs() {
+        let max_number_of_inputs = max_number_of_psbt_inputs(UPPER_PEGOUT_BOUND as u64);
+        println!("max number of pegout inputs: {}", max_number_of_inputs); // 1364
+
+        // Test 1: Create a pegout with exactly the max number of inputs
+        let tx = create_signed_tx(max_number_of_inputs, UPPER_PEGOUT_BOUND as u64);
+        let tx_weight = tx.clone().extract_tx().expect("Failed to extract tx").weight();
+
+        // The tx weight should be just below the max transaction weight
+        assert!(tx_weight.to_wu() <= MAX_TX_WEIGHT, "tx weight: {}", tx_weight.to_wu());
+
+        // Test 2: Create a pegout with one more input than the max number of inputs
+        let tx = create_signed_tx(max_number_of_inputs + 1, UPPER_PEGOUT_BOUND as u64);
+
+        let tx_weight = tx.clone().extract_tx().expect("Failed to extract tx").weight();
+
+        // The tx weight should be above the max transaction weight
+        assert!(tx_weight.to_wu() > MAX_TX_WEIGHT, "tx weight: {}", tx_weight.to_wu());
+    }
+
+    #[test]
+    fn test_max_number_of_psbt_inputs_for_sweep() {
+        let max_number_of_inputs = max_number_of_psbt_inputs(0);
+        println!("max number of sweep inputs: {}", max_number_of_inputs); // 1738
+
+        // Test 1: Create a sweep with max number of inputs
+        let tx = create_signed_tx(max_number_of_inputs, 1);
+        let tx_weight = tx.clone().extract_tx().expect("Failed to extract tx").weight();
+
+        // The tx weight should be just below the max transaction weight
+        assert!(tx_weight.to_wu() <= MAX_TX_WEIGHT, "tx weight: {}", tx_weight.to_wu());
+
+        // Test 2: Create a sweep with one more input than the max number of inputs
+        let tx = create_signed_tx(max_number_of_inputs + 1, 1);
+        let tx_weight = tx.clone().extract_tx().expect("Failed to extract tx").weight();
+
+        // The tx weight should be above the max transaction weight
+        assert!(tx_weight.to_wu() > MAX_TX_WEIGHT, "tx weight: {}", tx_weight.to_wu());
     }
 }


### PR DESCRIPTION
related to: https://github.com/botanix-labs/botanix/issues/1104

A new helper method to calculate the maximum number of inputs a psbt can have while staying under bitcoin's transaction weight limit, for a specified number of outputs.

- Unit tests calculate and verify this limit.
    - 1364 inputs for a pegout with 500 pegouts (+1 change output) 
    - 1738 inputs for a sweep tx with one output
    
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please provide a link to the issue -->

## What was done?

<!--- Describe your changes in detail -->

- new helper method and unit tests

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- unit tests

## Breaking Changes

<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

- none

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] I have added or updated relevant unit/integration/functional/e2e tests
-   [ ] I have tested my changes running a local network, and they work as expected
-   [x] I have performed a self-review
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
-   [x] I have made corresponding changes to the documentation if needed
-   [x] I have added assignees and reviewers to this pull request
-   [x] I have added the PR to the project board or linked it to an issue from the board


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Transactions now automatically respect maximum weight limits; large batches are reduced to fit. If even a single-output transaction is too large, a clear error is returned.
  - PSBT logs now include destination addresses for outputs, improving observability.
- Error Handling
  - Added specific errors for wallet calculation issues and oversized transactions for clearer feedback.
- Tests
  - Added tests validating maximum input counts and transaction weight compliance for pegout and sweep scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->