### PR TITLE
fix: remove finalized pegout from pending pegout list

### DIFF
--- a/bin/btc-server/src/bin/main.rs
+++ b/bin/btc-server/src/bin/main.rs
@@ -758,7 +758,7 @@ where
             info!("get_finalized_pegout_ids stream task: Created DB stream.");
 
             while let Some(chunk_result) = stream.next().await {
-                info!(
+                trace!(
                     "get_finalized_pegout_ids stream task: Received chunk from DB stream: {:?}",
                     chunk_result
                 );
@@ -782,7 +782,7 @@ where
                         };
 
                         // send the batch with retries
-                        info!("get_finalized_pegout_ids stream task: Sending chunk {}/{} with {} IDs to client.", chunk_index + 1, total_chunks, batch.data.len());
+                        trace!("get_finalized_pegout_ids stream task: Sending chunk {}/{} with {} IDs to client.", chunk_index + 1, total_chunks, batch.data.len());
                         let fut = || async {
                             let tx = tx.clone();
                             let batch = batch.clone();

--- a/bin/btc-server/src/bin/main.rs
+++ b/bin/btc-server/src/bin/main.rs
@@ -675,14 +675,22 @@ where
             .collect::<Result<Vec<PegoutRequest>, tonic::Status>>();
 
         let pegouts = pegouts?;
-        // Check pegouts are not in the finalized pegout ids list
-        let finalized_pegout_ids: HashSet<_> =
+        // Check pegouts are not in the finalized pegout ids list or are tracked by the Pegout Scheduler
+        let mut broadcasted_pegout_ids: HashSet<_> =
             self.db.get_finalized_pegout_ids().to_status()?.iter().map(|p| p.id).collect();
+        // Get Pegout Scheduler txs and add to hashset
+        let scheduler_txs = self.pegout_scheduler.lock().await.tracked_pegout_request_ids();
+        broadcasted_pegout_ids.extend(scheduler_txs);
         let pegouts_refs: Vec<&PegoutRequest> = pegouts
             .iter()
             .filter(|pegout| {
-                if finalized_pegout_ids.contains(&pegout.id) {
-                    error!("Received a pegout request for finalized id: {:?}", pegout.id);
+                if broadcasted_pegout_ids.contains(&pegout.id) {
+                    error!(
+                        "Received a pegout request for finalized or broadcasted id: L2 txid - {:?}, tx receipt log index - {:?}, bitcoin address - {:?}",
+                        hex::encode(pegout.id.txid),
+                        pegout.id.idx,
+                        bitcoin::Address::from_script(&pegout.spk, self.btc_network)
+                    );
                     return false;
                 }
                 true

--- a/bin/btc-server/src/bin/main.rs
+++ b/bin/btc-server/src/bin/main.rs
@@ -2,7 +2,7 @@
 extern crate log;
 
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashSet},
     fmt::Debug,
     net::{IpAddr, Ipv4Addr, SocketAddr},
     path::Path,
@@ -675,7 +675,20 @@ where
             .collect::<Result<Vec<PegoutRequest>, tonic::Status>>();
 
         let pegouts = pegouts?;
-        let pegouts_refs: Vec<&PegoutRequest> = pegouts.iter().collect();
+        // Check pegouts are not in the finalized pegout ids list
+        let finalized_pegout_ids: HashSet<_> =
+            self.db.get_finalized_pegout_ids().to_status()?.iter().map(|p| p.id).collect();
+        let pegouts_refs: Vec<&PegoutRequest> = pegouts
+            .iter()
+            .filter(|pegout| {
+                if finalized_pegout_ids.contains(&pegout.id) {
+                    error!("Received a pegout request for finalized id: {:?}", pegout.id);
+                    return false;
+                }
+                true
+            })
+            .collect();
+
         self.db.store_pending_pegouts(&pegouts_refs).to_status()?;
         self.db.flush().to_status()?;
         info!("stored pegouts.len(): {:?}", pegouts.len());

--- a/bin/btc-server/src/util.rs
+++ b/bin/btc-server/src/util.rs
@@ -467,10 +467,20 @@ pub(crate) fn validate_outputs(psbt: &Psbt, db: &database::Db) -> Result<(), Val
     }
 
     // check outputs are not in finalized pegouts list
-    let finalized_pegouts_id =
+    let finalized_pegouts_ids =
         db.get_finalized_pegout_ids()?.into_iter().map(|id| id.id).collect::<Vec<_>>();
     for id in &psbt_pegout_ids {
-        if finalized_pegouts_id.contains(id) {
+        let finalized_pegouts_id = finalized_pegouts_ids
+            .iter()
+            .find(|finalized_pegouts_id| *finalized_pegouts_id == id)
+            .cloned();
+
+        if finalized_pegouts_id.is_some() {
+            // Remove the finalized pegout id from the list of pending pegouts so it does not get
+            // processed again.
+            info!("Finalized pegout id txid hash: {}", hex::encode(id.txid));
+            info!("Finalized pegout id tx receipt log index: {}", id.idx);
+            db.remove_pending_pegout(&[*id]).ok();
             return Err(ValidateOutputsError::AlreadyFinalizedPegouts(vec![*id]));
         }
     }


### PR DESCRIPTION
If a finalized pegout is retried in a psbt, the signers will reject the psbt.  But if the finalized pegout isn't removed from the coordinators pending pegout list, no future pegouts will go through since the finalized pegout will always be included.

## Issue being fixed or feature implemented

Remove finalized pegouts from pending pegouts list so the coordinator doesn't include it in future psbts.

## What was done?

<!--- Describe your changes in detail -->

- When a finalized pegout is found in a psbt, remove it from the pending pegouts list so it's never included again.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Current unit and int tests ass

## Breaking Changes

<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

- None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] I have added or updated relevant unit/integration/functional/e2e tests
-   [ ] I have tested my changes running a local network, and they work as expected
-   [x] I have performed a self-review
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
-   [x] I have made corresponding changes to the documentation if needed
-   [x] I have added assignees and reviewers to this pull request
-   [x] I have added the PR to the project board or linked it to an issue from the board
