### PR TITLE
fix(rpc): Remove additional encoding for rpc utxo scripts

### DIFF
--- a/bin/btc-server/src/database/mod.rs
+++ b/bin/btc-server/src/database/mod.rs
@@ -20,7 +20,7 @@ use bitcoin::{
 use btc_server_client::SigningStatus;
 use frost_secp256k1_tr as frost;
 use futures::Stream;
-use log::info;
+use log::{info, warn};
 use miniscript::psbt::PsbtExt;
 use serde::{Deserialize, Serialize};
 use sled::transaction::{ConflictableTransactionError, TransactionError};
@@ -1022,6 +1022,29 @@ impl Db {
     }
 }
 
+fn parse_p2tr_script_with_fallback(script_bytes: &[u8]) -> ScriptBuf {
+    // Parse as raw script bytes (expected format)
+    let script_from_raw = ScriptBuf::from_bytes(script_bytes.to_vec());
+    if script_from_raw.is_p2tr() {
+        return script_from_raw;
+    }
+
+    // Fallback: Handle legacy consensus-encoded format (with length prefix)
+    // Provides backwards compatibility in case other node services are still
+    // using the old encoding format (see https://github.com/botanix-labs/Macbeth/pull/949)
+    if let Ok(script_from_consensus) = bitcoin::consensus::deserialize::<ScriptBuf>(script_bytes) {
+        warn!("Received RpcUtxo with legacy consensus-encoded script format");
+        if script_from_consensus.is_p2tr() {
+            return script_from_consensus;
+        }
+    }
+
+    // If neither format produces a valid P2TR script, return the raw script
+    // as it may be a non-p2tr script
+    warn!("Received RpcUtxo with non-p2tr script format");
+    script_from_raw
+}
+
 impl TryFrom<RpcUtxo> for Utxo {
     type Error = Error;
 
@@ -1039,7 +1062,7 @@ impl TryFrom<RpcUtxo> for Utxo {
         let script_pubkey = tx_out
             .script_pubkey
             .ok_or_else(|| Error::RpcToDbMap("Script Pub Key is None".to_string()))?;
-        let script = ScriptBuf::from_bytes(script_pubkey.script);
+        let script = parse_p2tr_script_with_fallback(&script_pubkey.script);
 
         // create the utxo
         Ok(Utxo::new(
@@ -1272,9 +1295,9 @@ mod tests {
     #[test]
     fn utxo_rpc_conversion_round_trip() {
         // Test round-trip conversion: DbUtxo -> RpcUtxo -> DbUtxo
+        use crate::test_utils::{random_compute_txid, random_p2tr_keyspend_script};
 
-        let tx = create_tx(1, 1, None);
-        let txid = tx.compute_txid();
+        let txid = random_compute_txid();
 
         // Test cases: (eth_address, utxo_version, description)
         let test_cases = [
@@ -1282,23 +1305,84 @@ mod tests {
             (None, None, "without eth address or version"),
         ];
 
-        for (eth_address, utxo_version, description) in test_cases.iter() {
-            let original_utxo = Utxo::new(
-                OutPoint::new(txid, 0),
-                tx.output.get(0).expect("one output").clone(),
+        for (vout, (eth_address, utxo_version, description)) in test_cases.iter().enumerate() {
+            // Create a proper taproot TxOut instead of using create_tx which generates P2WPKH
+            let taproot_output = TxOut {
+                value: Amount::from_sat(1000),
+                script_pubkey: random_p2tr_keyspend_script(),
+            };
+
+            let original_db_utxo = Utxo::new(
+                OutPoint::new(txid, vout as u32),
+                taproot_output,
                 *eth_address,
                 *utxo_version,
             );
 
-            let rpc_utxo = RpcUtxo::try_from(original_utxo.clone()).unwrap();
+            let rpc_utxo = RpcUtxo::try_from(original_db_utxo.clone()).unwrap();
             let recovered_utxo = Utxo::try_from(rpc_utxo).unwrap();
 
             assert_eq!(
-                original_utxo, recovered_utxo,
+                original_db_utxo, recovered_utxo,
                 "Round-trip conversion should preserve all data ({})",
                 description
             );
         }
+    }
+
+    #[test]
+    fn utxo_rpc_conversion_with_script_len_prefix() {
+        // Test to make sure we can still parse messages using the old RpcUtxo script format,
+        // which included the length prefix. see https://github.com/botanix-labs/Macbeth/pull/949
+        use bitcoin::consensus::encode::Encodable;
+
+        // Create a taproot script using the existing helper
+        let raw_script = crate::test_utils::random_p2tr_keyspend_script();
+
+        // Create script bytes using the OLD way (consensus encoding with length prefix)
+        let mut consensus_encoded_bytes = vec![];
+        raw_script.consensus_encode(&mut consensus_encoded_bytes).unwrap();
+
+        // Create a mock RpcUtxo with the consensus-encoded script bytes
+        let rpc_utxo = RpcUtxo {
+            outpoint: Some(RpcOutPoint {
+                txid: vec![0; 32], // dummy txid
+                vout: 0,
+            }),
+            output: Some(RpcTxOut {
+                value: 1000,
+                script_pubkey: Some(RpcScriptBuf {
+                    script: consensus_encoded_bytes, // OLD format with length prefix
+                }),
+            }),
+            eth_address: String::new(),
+        };
+
+        // Test that conversion from OLD format works successfully
+        let recovered_utxo = Utxo::try_from(rpc_utxo).unwrap();
+        assert_eq!(raw_script, recovered_utxo.output.script_pubkey);
+    }
+
+    #[test]
+    fn test_parse_p2tr_script_with_fallback() {
+        use bitcoin::consensus::encode::Encodable;
+
+        let script = crate::test_utils::random_p2tr_keyspend_script();
+
+        // Test raw bytes (current format)
+        let raw_bytes = script.to_bytes();
+        let parsed_raw = parse_p2tr_script_with_fallback(&raw_bytes);
+        assert_eq!(script, parsed_raw);
+
+        // Test consensus-encoded bytes (legacy format)
+        let mut consensus_bytes = vec![];
+        script.consensus_encode(&mut consensus_bytes).unwrap();
+        let parsed_consensus = parse_p2tr_script_with_fallback(&consensus_bytes);
+        assert_eq!(script, parsed_consensus);
+
+        // Test invalid script bytes
+        let invalid_bytes = vec![0x00, 0x14]; // Not a taproot script
+        assert!(!parse_p2tr_script_with_fallback(&invalid_bytes).is_p2tr());
     }
 
     #[test]

--- a/bin/btc-server/src/database/mod.rs
+++ b/bin/btc-server/src/database/mod.rs
@@ -1039,8 +1039,7 @@ impl TryFrom<RpcUtxo> for Utxo {
         let script_pubkey = tx_out
             .script_pubkey
             .ok_or_else(|| Error::RpcToDbMap("Script Pub Key is None".to_string()))?;
-        let script = bitcoin::consensus::deserialize::<ScriptBuf>(&script_pubkey.script)
-            .map_err(|_| Error::RpcToDbMap("Unparsable ScriptBuf".to_string()))?;
+        let script = ScriptBuf::from_bytes(script_pubkey.script);
 
         // create the utxo
         Ok(Utxo::new(
@@ -1064,11 +1063,9 @@ impl TryFrom<Utxo> for RpcUtxo {
     type Error = Error;
 
     fn try_from(item: Utxo) -> Result<Self, Self::Error> {
-        let mut script_pk = vec![];
-        item.output
-            .script_pubkey
-            .consensus_encode(&mut script_pk)
-            .map_err(|_e| Error::RpcToDbMap("Failed to serialize scriptpubkey".to_string()))?;
+        // Use script bytes directly without additional consensus encoding
+        // The script is already in the correct format from the database
+        let script_pk = item.output.script_pubkey.to_bytes();
 
         Ok(RpcUtxo {
             outpoint: Some(RpcOutPoint {
@@ -1092,7 +1089,7 @@ mod tests {
 
     use crate::{
         pegout_scheduler::{PegoutRequest, Tx},
-        test_utils::{create_random_pegout_id, create_tx, random_p2wpkh_script, setup_db},
+        test_utils::{create_random_pegout_id, create_tx, random_p2wpkh_scriptpubkey, setup_db},
     };
     use std::{collections::HashSet, time::SystemTime};
 
@@ -1113,7 +1110,7 @@ mod tests {
         let pegout_id = PegoutId::new([0; 32], 0);
         let req = pegout_scheduler::PegoutRequest {
             id: pegout_id,
-            spk: ScriptBuf::from_bytes(vec![0x01, 0x02, 0x03]),
+            spk: random_p2wpkh_scriptpubkey(),
             value: Amount::from_sat(1000),
             botanix_height: 1,
             timestamp: None,
@@ -1149,7 +1146,7 @@ mod tests {
             let pegout_id = PegoutId::new([i as u8; 32], 0);
             let req = pegout_scheduler::PegoutRequest {
                 id: pegout_id,
-                spk: random_p2wpkh_script(),
+                spk: random_p2wpkh_scriptpubkey(),
                 value: Amount::from_sat(100_000),
                 botanix_height: 50 - i,
                 timestamp: None,
@@ -1196,7 +1193,7 @@ mod tests {
             let pegout_id = create_random_pegout_id();
             let req = pegout_scheduler::PegoutRequest {
                 id: pegout_id,
-                spk: random_p2wpkh_script(),
+                spk: random_p2wpkh_scriptpubkey(),
                 value: Amount::from_sat(100_000),
                 botanix_height: 1,
                 timestamp: None,
@@ -1226,7 +1223,7 @@ mod tests {
             let pegout_id = create_random_pegout_id();
             let req = pegout_scheduler::PegoutRequest {
                 id: pegout_id,
-                spk: random_p2wpkh_script(),
+                spk: random_p2wpkh_scriptpubkey(),
                 value: Amount::from_sat(100_000),
                 botanix_height: 1,
                 timestamp: None,
@@ -1255,7 +1252,7 @@ mod tests {
             let pegout_id = PegoutId::new([i as u8; 32], 0);
             let req = pegout_scheduler::PegoutRequest {
                 id: pegout_id,
-                spk: random_p2wpkh_script(),
+                spk: random_p2wpkh_scriptpubkey(),
                 value: Amount::from_sat(100_000),
                 botanix_height: 1,
                 timestamp: None,

--- a/bin/btc-server/src/database/mod.rs
+++ b/bin/btc-server/src/database/mod.rs
@@ -1270,28 +1270,35 @@ mod tests {
     }
 
     #[test]
-    fn from_db_utxo_to_rpc_utxo() {
-        let tx = create_tx(1, 1, None);
-        let utxo = Utxo::new(
-            OutPoint::new(tx.compute_txid(), 0),
-            tx.output.get(0).expect("one output").clone(),
-            Some([0; 20]),
-            None,
-        );
-        let rpc_utxo = RpcUtxo::try_from(utxo.clone()).unwrap();
-        let utxo2 = Utxo::try_from(rpc_utxo).unwrap();
-        assert!(utxo == utxo2);
+    fn utxo_rpc_conversion_round_trip() {
+        // Test round-trip conversion: DbUtxo -> RpcUtxo -> DbUtxo
 
-        // Without eth address
-        let utxo = Utxo::new(
-            OutPoint::new(tx.compute_txid(), 2),
-            tx.output.get(0).expect("one output").clone(),
-            None,
-            None,
-        );
-        let rpc_utxo = RpcUtxo::try_from(utxo.clone()).unwrap();
-        let utxo2 = Utxo::try_from(rpc_utxo).unwrap();
-        assert!(utxo == utxo2);
+        let tx = create_tx(1, 1, None);
+        let txid = tx.compute_txid();
+
+        // Test cases: (eth_address, utxo_version, description)
+        let test_cases = [
+            (Some([0; 20]), Some(UtxoVersion::V1), "with eth address and version"),
+            (None, None, "without eth address or version"),
+        ];
+
+        for (eth_address, utxo_version, description) in test_cases.iter() {
+            let original_utxo = Utxo::new(
+                OutPoint::new(txid, 0),
+                tx.output.get(0).expect("one output").clone(),
+                *eth_address,
+                *utxo_version,
+            );
+
+            let rpc_utxo = RpcUtxo::try_from(original_utxo.clone()).unwrap();
+            let recovered_utxo = Utxo::try_from(rpc_utxo).unwrap();
+
+            assert_eq!(
+                original_utxo, recovered_utxo,
+                "Round-trip conversion should preserve all data ({})",
+                description
+            );
+        }
     }
 
     #[test]

--- a/bin/btc-server/src/test_utils/mod.rs
+++ b/bin/btc-server/src/test_utils/mod.rs
@@ -334,7 +334,7 @@ pub fn create_tx(num_inputs: usize, num_outputs: usize, change: Option<TxOut>) -
     let mut outputs = vec![];
     for _ in 0..num_outputs {
         outputs
-            .push(TxOut { value: Amount::from_sat(1000), script_pubkey: random_p2wpkh_script() });
+            .push(TxOut { value: Amount::from_sat(1000), script_pubkey: random_p2wpkh_scriptpubkey() });
     }
 
     if let Some(change) = change {
@@ -416,7 +416,7 @@ pub fn store_pending_pegout(db: &database::Db) -> PegoutId {
     let pegout_request = PegoutRequest {
         id: pegout_id,
         value: Amount::from_sat(1000),
-        spk: random_p2wpkh_script(),
+        spk: random_p2wpkh_scriptpubkey(),
         botanix_height: 0,
         timestamp: None,
     };

--- a/bin/btc-server/src/test_utils/mod.rs
+++ b/bin/btc-server/src/test_utils/mod.rs
@@ -333,8 +333,10 @@ pub fn create_tx(num_inputs: usize, num_outputs: usize, change: Option<TxOut>) -
 
     let mut outputs = vec![];
     for _ in 0..num_outputs {
-        outputs
-            .push(TxOut { value: Amount::from_sat(1000), script_pubkey: random_p2wpkh_scriptpubkey() });
+        outputs.push(TxOut {
+            value: Amount::from_sat(1000),
+            script_pubkey: random_p2wpkh_scriptpubkey(),
+        });
     }
 
     if let Some(change) = change {

--- a/bin/btc-server/src/util.rs
+++ b/bin/btc-server/src/util.rs
@@ -746,10 +746,7 @@ mod tests {
         assert!(total_outputs == Amount::ZERO);
 
         let res = validate_psbt(&psbt, NO_FLAGS, 2, &db);
-        assert_eq!(
-            res.unwrap_err(),
-            ValidatePSBTError::FeeSanityCheck(Amount::from_sat(2332), Amount::ZERO)
-        );
+        assert!(matches!(res.unwrap_err(), ValidatePSBTError::FeeSanityCheck(_, Amount::ZERO)));
     }
 
     #[test]

--- a/bin/btc-server/src/util.rs
+++ b/bin/btc-server/src/util.rs
@@ -748,7 +748,7 @@ mod tests {
         let res = validate_psbt(&psbt, NO_FLAGS, 2, &db);
         assert_eq!(
             res.unwrap_err(),
-            ValidatePSBTError::FeeSanityCheck(Amount::from_sat(2346), Amount::ZERO)
+            ValidatePSBTError::FeeSanityCheck(Amount::from_sat(2332), Amount::ZERO)
         );
     }
 

--- a/bin/test-suite/src/suite/consensus/frost/test_pending_pegouts.rs
+++ b/bin/test-suite/src/suite/consensus/frost/test_pending_pegouts.rs
@@ -137,7 +137,8 @@ pub async fn test_pending_pegouts(suite: &ConsensusIntegrationTestSuite) -> Resu
         let pegout_id = PegoutId::from_bytes(&pegout_id_bytes).unwrap();
 
         let pk = bitcoin::PrivateKey::generate(bitcoin::Network::Regtest).public_key(&secp);
-        let spk = pk.p2wpkh_script_code().expect("valid pk");
+        let wpk = pk.wpubkey_hash().expect("valid wpubkey hash");
+        let spk = bitcoin::ScriptBuf::new_p2wpkh(&wpk);
 
         send_pegout_notification(
             &mut clients[0],

--- a/bin/test-suite/src/suite/consensus/frost/test_prevent_resigning_pegout.rs
+++ b/bin/test-suite/src/suite/consensus/frost/test_prevent_resigning_pegout.rs
@@ -140,7 +140,8 @@ pub async fn test_prevent_resigning_pegout(
     let secp = bitcoin::secp256k1::Secp256k1::new();
     let sk = bitcoin::PrivateKey::generate(bitcoin::Network::Regtest);
     let pk = sk.public_key(&secp);
-    let spk = pk.p2wpkh_script_code().expect("valid pk");
+    let wpk = pk.wpubkey_hash().expect("valid wpubkey hash");
+    let spk = bitcoin::ScriptBuf::new_p2wpkh(&wpk);
 
     // Notify some pending pegouts
     let amount = bitcoin::Amount::from_sat(100_000);

--- a/bin/test-suite/src/suite/consensus/frost/test_round1_then_new_signing_session.rs
+++ b/bin/test-suite/src/suite/consensus/frost/test_round1_then_new_signing_session.rs
@@ -209,7 +209,8 @@ pub async fn test_round1_then_new_signing_session(
     let secp = bitcoin::secp256k1::Secp256k1::new();
     let sk = bitcoin::PrivateKey::generate(bitcoin::Network::Regtest);
     let pk = sk.public_key(&secp);
-    let spk = pk.p2wpkh_script_code().expect("valid pk");
+    let wpk = pk.wpubkey_hash().expect("valid wpubkey hash");
+    let spk = bitcoin::ScriptBuf::new_p2wpkh(&wpk);
 
     // Notify some pending pegouts
     let amount = bitcoin::Amount::from_sat(100_000);

--- a/bin/test-suite/src/suite/consensus/frost/test_signing.rs
+++ b/bin/test-suite/src/suite/consensus/frost/test_signing.rs
@@ -265,7 +265,8 @@ pub async fn test_many_inputs_signing(
     let secp = bitcoin::secp256k1::Secp256k1::new();
     let sk = bitcoin::PrivateKey::generate(bitcoin::Network::Regtest);
     let pk = sk.public_key(&secp);
-    let spk = pk.p2wpkh_script_code().expect("valid pk");
+    let wpk = pk.wpubkey_hash().expect("valid wpubkey hash");
+    let spk = bitcoin::ScriptBuf::new_p2wpkh(&wpk);
 
     // Calling do_signing should fail as we have no pending pegouts
     let err_res = do_signing(&mut clients, &bitcoind, &[0u8; 32])
@@ -315,7 +316,8 @@ pub async fn test_many_inputs_signing(
         // get new a key
         let sk = bitcoin::PrivateKey::generate(bitcoin::Network::Regtest);
         let pk = sk.public_key(&secp);
-        let spk = pk.p2wpkh_script_code().expect("valid pk");
+        let wpk = pk.wpubkey_hash().expect("valid wpubkey hash");
+        let spk = bitcoin::ScriptBuf::new_p2wpkh(&wpk);
 
         pending_pegouts.push((pegout_id, amount, spk.clone(), pegout_id));
     }
@@ -424,7 +426,8 @@ pub async fn test_many_inputs_signing(
                                                       // get new a key
     let sk = bitcoin::PrivateKey::generate(bitcoin::Network::Regtest);
     let pk = sk.public_key(&secp);
-    let spk = pk.p2wpkh_script_code().expect("valid pk");
+    let wpk = pk.wpubkey_hash().expect("valid wpubkey hash");
+    let spk = bitcoin::ScriptBuf::new_p2wpkh(&wpk);
 
     // update the checkpoint blockhash
     let checkpoint_block_hash = get_checkpoint_block_hash(&bitcoind)?;

--- a/bin/test-suite/src/suite/consensus/frost/test_track_mempool.rs
+++ b/bin/test-suite/src/suite/consensus/frost/test_track_mempool.rs
@@ -123,7 +123,8 @@ pub async fn test_track_mempool(
     let sk = bitcoin::PrivateKey::generate(bitcoin::Network::Regtest);
     let pk = sk.public_key(&secp);
 
-    let spk = pk.p2wpkh_script_code().expect("valid pk");
+    let wpk = pk.wpubkey_hash().expect("valid wpubkey hash");
+    let spk = bitcoin::ScriptBuf::new_p2wpkh(&wpk);
 
     // Notify there is a pending pegout
     for c in clients.iter_mut() {

--- a/bin/test-suite/src/utils.rs
+++ b/bin/test-suite/src/utils.rs
@@ -84,12 +84,11 @@ pub async fn send_pegin_notification(
     vout: u32,
     amount: u64,
 ) -> Result<(), Error> {
-    let mut prev_out_bytes = Vec::new();
-    address.script_pubkey().consensus_encode(&mut prev_out_bytes).unwrap();
+    let script_bytes = address.script_pubkey().to_bytes();
     let utxos = [btc_server_client::Utxo {
         output: Some(btc_server_client::TxOut {
             value: Amount::from_sat(amount).to_sat(),
-            script_pubkey: Some(btc_server_client::ScriptBuf { script: prev_out_bytes }),
+            script_pubkey: Some(btc_server_client::ScriptBuf { script: script_bytes }),
         }),
         outpoint: Some(btc_server_client::OutPoint { txid: txid.to_vec(), vout }),
         eth_address,
@@ -129,12 +128,11 @@ pub async fn send_pegins_notifications(
         let btc_address = btc_addresses[i].clone();
         let amount = amounts[i];
 
-        let mut prev_out_bytes = Vec::new();
-        btc_address.script_pubkey().consensus_encode(&mut prev_out_bytes).unwrap();
+        let script_bytes = btc_address.script_pubkey().to_bytes();
         utxos.push(btc_server_client::Utxo {
             output: Some(btc_server_client::TxOut {
                 value: Amount::from_sat(amount).to_sat(),
-                script_pubkey: Some(btc_server_client::ScriptBuf { script: prev_out_bytes }),
+                script_pubkey: Some(btc_server_client::ScriptBuf { script: script_bytes }),
             }),
             outpoint: Some(btc_server_client::OutPoint { txid: txid.to_vec(), vout: 1 }),
             eth_address,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please provide a link to the issue -->

There was a consistency in the format of the `script` field in `RpcUtxo` and `DbUtxo`. This would be potentially confusing down the line when using a grpc endpoint that uses `RpcUtxo`.



## What was done?

<!--- Describe your changes in detail -->

Now the format is consistent, so both structs store the scriptpubkey without the the length prefix. i.e. a p2tr script just starts with `OP_1`, not `0x22`.

To maintain backward compatibility, the method `TryFrom<RpcUtxo> for DbUtxo` will first interpret the RpcUtxo script with the new format, and if the result is not a valid p2tr script, fallback to interpreting it with the prefix. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Unit and integration tests

## Breaking Changes

<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

- None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] I have added or updated relevant unit/integration/functional/e2e tests
-   [ ] I have tested my changes running a local network, and they work as expected
-   [x] I have performed a self-review
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
-   [x] I have made corresponding changes to the documentation if needed
-   [x] I have added assignees and reviewers to this pull request
-   [x] I have added the PR to the project board or linked it to an issue from the board


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Improved compatibility when reading/writing Bitcoin scripts: supports both raw Taproot and legacy-encoded formats, reducing deserialization issues.
- Improvements
  - Added warning logs when legacy script formats are detected to aid operators.
- Bug Fixes
  - More reliable UTXO conversions with robust round-trip handling across script formats.
- Tests
  - Updated test suites to use proper scriptPubKey generation and direct byte encoding.
  - Added tests covering fallback parsing and round-trip conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->