### PR TITLE
refactor(btc-server): readability improvement for calculate max input

### DIFF
--- a/bin/btc-server/src/wallet/mod.rs
+++ b/bin/btc-server/src/wallet/mod.rs
@@ -14,7 +14,7 @@ pub const SEGWIT_FLAG_WEIGHT: Weight = Weight::from_wu(1);
 pub const SEGWIT_MARKER_WEIGHT: Weight = Weight::from_wu(1);
 
 // The standardness limit for a transaction is 400,000 weight units
-pub const MAX_TX_WEIGHT: u64 = 400_000;
+pub const MAX_BITCOIN_TX_WEIGHT: u64 = 400_000;
 
 // version = 4 bytes * 4 weight units
 // marker = 1 byte * 1 weight unit
@@ -22,7 +22,7 @@ pub const MAX_TX_WEIGHT: u64 = 400_000;
 // ninput = 3 bytes to encode values between 253 to 65,535 * 4 weight units
 // noutput = 3 bytes to encode values between 253 to 65,535 * 4 weight units
 // locktime = 4 bytes * 4 weight units
-pub const MAX_BASE_TX_WEIGHT: u64 = 16 + 1 + 1 + 12 + 12 + 16;
+pub const MAX_BASE_TX_WEIGHT: u64 = 4 * 4 + 1 + 1 + 3 * 4 + 3 * 4 + 4 * 4;
 
 // txid = 32 bytes * 4 weight units
 // vout = 4 bytes * 4 weight units

--- a/bin/btc-server/src/wallet/util.rs
+++ b/bin/btc-server/src/wallet/util.rs
@@ -4,7 +4,7 @@ use frost_secp256k1_tr as frost;
 use thiserror::Error;
 
 use crate::wallet::{
-    MAX_BASE_TX_WEIGHT, MAX_TX_WEIGHT, PER_OUTPUT_MAX_WEIGHT, PER_P2TR_KEYSPEND_WEIGHT,
+    MAX_BASE_TX_WEIGHT, MAX_BITCOIN_TX_WEIGHT, PER_OUTPUT_MAX_WEIGHT, PER_P2TR_KEYSPEND_WEIGHT,
     SEGWIT_FLAG_WEIGHT, SEGWIT_MARKER_WEIGHT, TAPROOT_KEYSPEND_SIGHASH_DEFAULT_WEIGHT,
 };
 
@@ -93,11 +93,11 @@ pub fn calculate_signed_tx_fee_rate(psbt: &Psbt) -> Result<FeeRate, WalletCalcul
 
 /// Returns the maximum number of inputs that can be added to a PSBT without exceeding the maximum
 /// transaction weight.
-pub fn max_number_of_psbt_inputs(num_pegouts: u64) -> u64 {
-    let max_outputs = num_pegouts + 1; // +1 for change output
-    let psbt_without_inputs_weight = MAX_BASE_TX_WEIGHT + max_outputs * PER_OUTPUT_MAX_WEIGHT;
+pub fn max_number_of_psbt_inputs(num_outputs: u64) -> u64 {
+    let num_outputs = num_outputs;
+    let psbt_without_inputs_weight = MAX_BASE_TX_WEIGHT + num_outputs * PER_OUTPUT_MAX_WEIGHT;
     let max_number_of_inputs =
-        (MAX_TX_WEIGHT - psbt_without_inputs_weight) / PER_P2TR_KEYSPEND_WEIGHT;
+        (MAX_BITCOIN_TX_WEIGHT - psbt_without_inputs_weight) / PER_P2TR_KEYSPEND_WEIGHT;
     max_number_of_inputs
 }
 
@@ -113,7 +113,7 @@ mod tests {
         util::UPPER_PEGOUT_BOUND,
         wallet::{
             psbt::{create_psbt, InputDTO},
-            MAX_TX_WEIGHT,
+            MAX_BITCOIN_TX_WEIGHT,
         },
     };
 
@@ -264,41 +264,38 @@ mod tests {
     #[test]
     fn test_max_number_of_psbt_inputs() {
         let max_number_of_inputs = max_number_of_psbt_inputs(UPPER_PEGOUT_BOUND as u64);
-        println!("max number of pegout inputs: {}", max_number_of_inputs); // 1364
+        println!("max number of pegout inputs: {}", max_number_of_inputs);
 
         // Test 1: Create a pegout with exactly the max number of inputs
         let tx = create_signed_tx(max_number_of_inputs, UPPER_PEGOUT_BOUND as u64);
         let tx_weight = tx.clone().extract_tx().expect("Failed to extract tx").weight();
 
         // The tx weight should be just below the max transaction weight
-        assert!(tx_weight.to_wu() <= MAX_TX_WEIGHT, "tx weight: {}", tx_weight.to_wu());
+        assert!(tx_weight.to_wu() <= MAX_BITCOIN_TX_WEIGHT, "tx weight: {}", tx_weight.to_wu());
 
         // Test 2: Create a pegout with one more input than the max number of inputs
         let tx = create_signed_tx(max_number_of_inputs + 1, UPPER_PEGOUT_BOUND as u64);
-
         let tx_weight = tx.clone().extract_tx().expect("Failed to extract tx").weight();
 
         // The tx weight should be above the max transaction weight
-        assert!(tx_weight.to_wu() > MAX_TX_WEIGHT, "tx weight: {}", tx_weight.to_wu());
+        assert!(tx_weight.to_wu() > MAX_BITCOIN_TX_WEIGHT, "tx weight: {}", tx_weight.to_wu());
     }
 
     #[test]
     fn test_max_number_of_psbt_inputs_for_sweep() {
-        let max_number_of_inputs = max_number_of_psbt_inputs(0);
+        let max_number_of_inputs = max_number_of_psbt_inputs(1);
         println!("max number of sweep inputs: {}", max_number_of_inputs); // 1738
 
         // Test 1: Create a sweep with max number of inputs
         let tx = create_signed_tx(max_number_of_inputs, 1);
         let tx_weight = tx.clone().extract_tx().expect("Failed to extract tx").weight();
-
         // The tx weight should be just below the max transaction weight
-        assert!(tx_weight.to_wu() <= MAX_TX_WEIGHT, "tx weight: {}", tx_weight.to_wu());
+        assert!(tx_weight.to_wu() <= MAX_BITCOIN_TX_WEIGHT, "tx weight: {}", tx_weight.to_wu());
 
         // Test 2: Create a sweep with one more input than the max number of inputs
         let tx = create_signed_tx(max_number_of_inputs + 1, 1);
         let tx_weight = tx.clone().extract_tx().expect("Failed to extract tx").weight();
 
-        // The tx weight should be above the max transaction weight
-        assert!(tx_weight.to_wu() > MAX_TX_WEIGHT, "tx weight: {}", tx_weight.to_wu());
+        assert!(tx_weight.to_wu() > MAX_BITCOIN_TX_WEIGHT, "tx weight: {}", tx_weight.to_wu());
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please provide a link to the issue -->

## What was done?

<!--- Describe your changes in detail -->

- small refactor to improve readability. Merging this in before a follow up PR on max tx weight limit, just to make the follow up easier to review

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

-

## Breaking Changes

<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

-

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] I have added or updated relevant unit/integration/functional/e2e tests
-   [ ] I have tested my changes running a local network, and they work as expected
-   [x] I have performed a self-review
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
-   [x] I have made corresponding changes to the documentation if needed
-   [x] I have added assignees and reviewers to this pull request
-   [x] I have added the PR to the project board or linked it to an issue from the board


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved calculation of maximum PSBT inputs to use the provided number of outputs directly, ensuring transactions stay within Bitcoin weight limits.

- Refactor
  - Renamed a public constant to more clearly reflect Bitcoin transaction weight semantics and updated related references.

- Chores
  - Rewrote base weight expression for clarity without changing its computed value; updated tests and imports accordingly.

- Style
  - Minor formatting cleanups with no functional impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->