### PR TITLE
test: update conflict input test

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -147,7 +147,7 @@ jobs:
           "invalid_pegin",
           "invalid_pegout",
           "block_builder",
-          "test_conflicting_input",
+          "test_prevent_resigning_pegout",
           "test_round1_then_new_signing_session",
           "test_track_mempool",
           "rpc_node"]

--- a/bin/btc-server/src/pegout_scheduler/mod.rs
+++ b/bin/btc-server/src/pegout_scheduler/mod.rs
@@ -402,6 +402,9 @@ impl PegoutScheduler {
     /// This should be called when a tracked tx is reorged or dropped from the mempool.
     /// Its expected the caller will add the pegout outputs back to the pending pegout set. This is
     /// not done by this function Note: will panic if provided txid is not tracked
+    /// Note: Technically we should not untrack a tx simply because it was dropped from our local
+    /// mempool, as it may still be in other nodes mempools and could still get confirmed.
+    /// Leaving this as-is for now as it'll be resolved with the new TEM implementation.
     fn un_track_tx(&mut self, txid: &Txid) -> Result<(), database::Error> {
         let tx = self.txs.get(txid).expect("relevant tx should exist");
         info!("PegoutScheduler::un_track_tx: Untracking txid={}", txid);

--- a/bin/test-suite/src/suite/consensus/frost/mod.rs
+++ b/bin/test-suite/src/suite/consensus/frost/mod.rs
@@ -3,7 +3,6 @@ pub mod error;
 // tests
 pub mod test_batch_pegins;
 pub mod test_block_builder;
-pub mod test_conflicting_input;
 pub mod test_dkg;
 pub mod test_e2e_peer_disconnect;
 pub mod test_frost_e2e;
@@ -11,6 +10,7 @@ pub mod test_frost_e2e_signing_disconnect;
 pub mod test_mempool_gossip;
 pub mod test_pegin_v1;
 pub mod test_pending_pegouts;
+pub mod test_prevent_resigning_pegout;
 pub mod test_round1_then_new_signing_session;
 pub mod test_signing;
 pub mod test_track_mempool;

--- a/bin/test-suite/src/suite/consensus/frost/test_conflicting_input.rs
+++ b/bin/test-suite/src/suite/consensus/frost/test_conflicting_input.rs
@@ -155,8 +155,15 @@ pub async fn test_conflicting_input(
         )
         .await?;
     }
+
+    // assert that the pegout was added to the pending pegouts list
+    assert_eq!(get_pending_pegouts_count(&mut clients[0]).await?, 1);
+
     // signs, broadcasts, and tracks the psbt honoring pending pegouts
     let _tracked_tx = do_signing(&mut clients, &bitcoind, &[1u8; 32]).await?;
+
+    // assert there is a tracked tx
+    assert_eq!(get_tracked_txs_count(&mut clients[0]).await?, 1);
 
     // resend the same pegout notification so it is a pending pegout
     for c in clients.iter_mut() {
@@ -171,28 +178,57 @@ pub async fn test_conflicting_input(
         .await?;
     }
 
-    // Create a new psbt that honors the pending pegout that is already being tracked in the
-    // previous psbt.
+    // assert there is still a tracked tx
+    assert_eq!(get_tracked_txs_count(&mut clients[0]).await?, 1);
 
-    // FAILURE CASES:
-    // 1) Signers will reject the psbt if it contains no conflicting input. This does not happen b/c
-    //    the coordinator will include a conflicting input and signers will validate against this
-    // 2) The network will reject the broadcast psbt if it contains a conflicting input with error
-    //    "txn-mempool-conflict" since the first tx is still in the mempool. This won't happen as we
-    //    will signal for RBF in the pegout inputs.
-    // 3) The network will reject the broadcast psbt if the replacement fee isn't high enough.  We
-    //    are not trying to replace the tx so this is an acceptable failure case as well:
-    //    "insufficient fee, rejecting replacement"
-    // We want failure case 3.
-    if let Err(e) = do_signing(&mut clients, &bitcoind, &[2u8; 32]).await {
-        let error_message = e.to_string();
-        assert!(
-            error_message.contains("insufficient fee, rejecting replacement"),
-            "Unexpected error: {}",
-            error_message
-        );
-        return Ok(());
+    // assert that the pegout was not added to the pending pegouts list, as it's already in the
+    // tracked
+    assert_eq!(get_pending_pegouts_count(&mut clients[0]).await?, 0);
+
+    // generate blocks so that tracked_tx has now been finalized
+    generate_blocks(&bitcoind, 2).await;
+    let checkpoint_block_hash = get_checkpoint_block_hash(&bitcoind)?;
+
+    // resend the same pegout notification so it is a pending pegout
+    for c in clients.iter_mut() {
+        send_pegout_notification(
+            c,
+            checkpoint_block_hash.clone(),
+            amount.to_sat(),
+            1,
+            pegout_id,
+            spk.clone(),
+        )
+        .await?;
     }
 
-    Err(anyhow::anyhow!("expected txn-mempool-conflict error"))
+    // tracked tx should be finalized and untracked
+    assert_eq!(get_tracked_txs_count(&mut clients[0]).await?, 0);
+
+    // assert that the pegout was not added to the pending pegouts list, as it's already finalized
+    assert_eq!(get_pending_pegouts_count(&mut clients[0]).await?, 0);
+
+    Ok(())
+}
+
+pub async fn get_tracked_txs_count(
+    client: &mut client::BtcServerClient<tonic::transport::Channel>,
+) -> anyhow::Result<usize> {
+    let tracked_txs = client
+        .get_tracked_txs(tonic::Request::new(client::Empty {}))
+        .await?
+        .into_inner()
+        .tracked_txs;
+    Ok(tracked_txs.len())
+}
+
+pub async fn get_pending_pegouts_count(
+    client: &mut client::BtcServerClient<tonic::transport::Channel>,
+) -> anyhow::Result<usize> {
+    let pending_pegouts = client
+        .get_pending_pegouts(tonic::Request::new(client::Empty {}))
+        .await?
+        .into_inner()
+        .pending_pegouts;
+    Ok(pending_pegouts.len())
 }

--- a/bin/test-suite/src/suite/consensus/frost/test_prevent_resigning_pegout.rs
+++ b/bin/test-suite/src/suite/consensus/frost/test_prevent_resigning_pegout.rs
@@ -22,10 +22,11 @@ use crate::{
     },
     utils::generate_blocks,
 };
+use btc_server_client as client;
 
 const NUM_PEGINS: usize = 5;
 
-pub async fn test_conflicting_input(
+pub async fn test_prevent_resigning_pegout(
     suite: &ConsensusIntegrationTestSuite,
 ) -> anyhow::Result<(), anyhow::Error> {
     let bitcoind = suite.global_context.bitcoind_rpc();

--- a/bin/test-suite/src/suite/consensus/mod.rs
+++ b/bin/test-suite/src/suite/consensus/mod.rs
@@ -600,14 +600,14 @@ impl Suite for ConsensusIntegrationTestSuite {
                     frost::test_mempool_gossip::test_mempool_gossip
                 )
             }
-            "test_conflicting_input" => run_test!(
+            "test_prevent_resigning_pegout" => run_test!(
                 self,
                 CreateTestConfig {
                     create_bitcoind_node: true,
                     create_btc_servers: true,
                     ..Default::default()
                 },
-                frost::test_conflicting_input::test_conflicting_input
+                frost::test_prevent_resigning_pegout::test_prevent_resigning_pegout
             ),
             "test_round1_then_new_signing_session" => run_test!(
                 self,

--- a/test_runner.sh
+++ b/test_runner.sh
@@ -4,7 +4,7 @@ set -e
 set -o pipefail
 
 # Define the list of strings
-tests_to_run=("dkg_flow" "utxo_commitment" "signing_flow" "test_mempool_gossip" "utxo_sync" "state_sync" "wallet_sync" "frost_e2e_stable" "test_pegin_v1" "invalid_pegin" "invalid_pegout" "block_builder" "test_conflicting_input" "test_round1_then_new_signing_session" "test_track_mempool" "rpc_node")
+tests_to_run=("dkg_flow" "utxo_commitment" "signing_flow" "test_mempool_gossip" "utxo_sync" "state_sync" "wallet_sync" "frost_e2e_stable" "test_pegin_v1" "invalid_pegin" "invalid_pegout" "block_builder" "test_prevent_resigning_pegout" "test_round1_then_new_signing_session" "test_track_mempool" "rpc_node")
 
 exit_codes=()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
During a hotfix we changed the behavior of what happens when a coordinator receives a pegout notification for a pegout that has already been either finalized or broadcasted. Instead of retrying the pegout with a conflicting input, we just don't add the pegout to the pending_pegouts list.

The `test_conflicting_input` fails and needed to be updated.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please provide a link to the issue -->

## What was done?

<!--- Describe your changes in detail -->

-  updating `test_conflicting_input` to `prevent_resigning_pegout` 
    - the scenario is the same, apart from we check that neither finalized pegouts, nor tracked pegouts get re-added to the pending pegout list.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- updated integration test

## Breaking Changes

<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

- None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] I have added or updated relevant unit/integration/functional/e2e tests
-   [ ] I have tested my changes running a local network, and they work as expected
-   [x] I have performed a self-review
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
-   [x] I have made corresponding changes to the documentation if needed
-   [x] I have added assignees and reviewers to this pull request
-   [x] I have added the PR to the project board or linked it to an issue from the board


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Tests
  - Replaced the “conflicting input” case with a “prevent re-signing pegout” scenario.
  - Expanded assertions to verify tracked transaction lifecycle and checkpoint re-notification.
  - Added test utilities to query tracked transactions and pending pegouts.
  - Updated test registry and local test runner to use the new case.

- Documentation
  - Clarified behavior notes around untracking transactions in the pegout scheduler.

- Chores
  - Updated CI e2e matrix to run the new pegout test instead of the removed one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->