### PR TITLE
feat(wallet-sweep): session id and retry

### DIFF
--- a/bin/btc-server/src/bin/main.rs
+++ b/bin/btc-server/src/bin/main.rs
@@ -30,6 +30,7 @@ use btcserverlib::{
     signer::{
         self,
         error::{SigningError, SigningRound1Error, SigningRound2Error},
+        SigningSessionId,
     },
     telemetry::Telemetry,
     util::{
@@ -678,28 +679,10 @@ where
         Ok(())
     }
 
-    /// Helper function to determine if a PSBT is a sweep transaction
-    /// Sweep PSBTs have exactly one output and no pegout IDs
-    fn is_sweep_psbt(psbt: &Psbt, signing_session_id: &[u8; 32]) -> bool {
-        // Primary detection: check if signing session ID ends with "SWEEP_SIGNING"
-        if signing_session_id.ends_with(b"SWEEP_SIGNING") {
-            return true;
-        }
-
-        // Secondary detection: sweep PSBTs have exactly one output and no pegout metadata
-        if psbt.outputs.len() != 1 {
-            return false;
-        }
-
-        // Check if PSBT has pegout IDs (pegout PSBTs have this, sweep PSBTs don't)
-        let pegout_ids = psbt.pegout_ids();
-        pegout_ids.is_empty()
-    }
-
     /// Handle sweep-specific cleanup after successful transaction broadcast
     async fn handle_sweep_transaction_success(
         &self,
-        signing_session_id: &[u8; 32],
+        signing_session_id: SigningSessionId,
         tx_id: Option<bitcoin::Txid>,
         psbt: &Psbt,
     ) -> Result<(), tonic::Status> {
@@ -733,7 +716,7 @@ where
             telemetry.update_signing_success_rate_metrics(
                 self.btc_network,
                 self.config.identifier,
-                *signing_session_id,
+                signing_session_id,
             );
         }
 
@@ -923,9 +906,12 @@ where
     ) -> Result<tonic::Response<rpc::GetSigningStatusResponse>, tonic::Status> {
         self.validate_jwt(&req)?;
         let req = req.into_inner();
-        let signing_session_id =
-            handle_signing_error!(self, req, parse_signing_session_id(&req.signing_session_id));
-        let signing_status = self.db.get_signing_status(&signing_session_id).to_status()?;
+        let signing_session_id = handle_signing_error!(
+            self,
+            req,
+            SigningSessionId::try_from(req.signing_session_id.as_slice())
+        );
+        let signing_status = self.db.get_signing_status(signing_session_id).to_status()?;
 
         let res =
             tonic::Response::new(rpc::GetSigningStatusResponse { status: signing_status.into() });
@@ -1189,8 +1175,11 @@ where
             "Received round1 signing package request for signing session id: {:?}",
             hex::encode(req.signing_session_id.clone())
         );
-        let signing_session_id =
-            handle_signing_error!(self, req, parse_signing_session_id(&req.signing_session_id));
+        let signing_session_id = handle_signing_error!(
+            self,
+            req,
+            SigningSessionId::try_from(req.signing_session_id.as_slice())
+        );
 
         // Check if we have already provided nonces for the current session
         let mut nonces_lock = self.frost_round1_nonces.lock().await;
@@ -1265,8 +1254,11 @@ where
         // Validate PSBT
         let req = req.into_inner();
         info!("Received round2 signing package request");
-        let signing_session_id =
-            handle_signing_error!(self, req, parse_signing_session_id(&req.signing_session_id));
+        let signing_session_id = handle_signing_error!(
+            self,
+            req,
+            SigningSessionId::try_from(req.signing_session_id.as_slice())
+        );
 
         let mut psbt = match Psbt::deserialize(req.psbt.as_slice()).to_status() {
             Ok(psbt) => psbt,
@@ -1398,33 +1390,41 @@ where
         self.validate_jwt(&req)?;
         let req = req.into_inner();
         info!(
-            "Received finalize signing request with signing session id: {:?}",
-            hex::encode(req.signing_session_id.clone())
+            "Received finalize signing request with signing session id: {}",
+            hex::encode(&req.signing_session_id),
         );
-        let signing_session_id =
-            handle_signing_error!(self, req, parse_signing_session_id(&req.signing_session_id));
+        let signing_session_id = handle_signing_error!(
+            self,
+            req,
+            SigningSessionId::try_from(req.signing_session_id.as_ref())
+        );
 
         let _tx_lock = self.tx_lock.lock().await;
         let psbt =
-            coordinator::finalize_signing(&signing_session_id, &self.db).await.map_err(|e| {
+            coordinator::finalize_signing(signing_session_id, &self.db).await.map_err(|e| {
                 internal!(
-                    "Failed to finalize signing: {}, signing session id: {:?}",
+                    "Failed to finalize signing: {}, signing session id: {}",
                     e,
-                    hex::encode(signing_session_id)
+                    signing_session_id
                 )
             })?;
-
-        // Detect if this is a sweep transaction
-        let is_sweep = Self::is_sweep_psbt(&psbt, &signing_session_id);
 
         // This should be a ready to broadcast tx
         let tx = psbt.clone().extract_tx().to_status()?;
         let tx_bytes = bitcoin::consensus::encode::serialize(&tx);
 
-        if is_sweep {
-            info!("Signed sweep tx to be broadcast: {}", hex::encode(&tx_bytes));
+        if signing_session_id.is_sweep_session() {
+            trace!(
+                "Signed sweep tx to be broadcast for session {}: {}",
+                signing_session_id,
+                hex::encode(&tx_bytes),
+            );
         } else {
-            info!("Signed pegout tx to be broadcast: {}", hex::encode(&tx_bytes));
+            trace!(
+                "Signed pegout tx to be broadcas for session {}: {}",
+                signing_session_id,
+                hex::encode(&tx_bytes),
+            );
         }
 
         let tx_id = match measure_rpc_latency!(
@@ -1458,9 +1458,9 @@ where
         .to_status()?;
 
         // Handle post-broadcast cleanup based on transaction type
-        if is_sweep {
+        if signing_session_id.is_sweep_session() {
             // Handle sweep transaction completion
-            self.handle_sweep_transaction_success(&signing_session_id, tx_id, &psbt).await?;
+            self.handle_sweep_transaction_success(signing_session_id, tx_id, &psbt).await?;
         } else {
             // Handle pegout transaction completion (existing logic)
             let pegout_ids = psbt
@@ -1534,8 +1534,11 @@ where
             "Received make tx request for signing session id: {:?}",
             hex::encode(req.signing_session_id.clone())
         );
-        let signing_session_id =
-            handle_signing_error!(self, req, parse_signing_session_id(&req.signing_session_id));
+        let signing_session_id = handle_signing_error!(
+            self,
+            req,
+            SigningSessionId::try_from(req.signing_session_id.as_ref())
+        );
 
         let checkpoint = match BlockHash::from_slice(&req.checkpoint_block_hash) {
             Ok(checkpoint) => checkpoint,
@@ -1686,7 +1689,7 @@ where
         handle_signing_error!(
             self,
             req.signing_session_id.try_into().expect("valid signing session id"),
-            self.db.update_psbt(&signing_session_id, &psbt),
+            self.db.update_psbt(signing_session_id, &psbt),
             check_only
         );
 
@@ -1733,10 +1736,13 @@ where
             "Received to sign package request, signing session id: {:?}",
             hex::encode(req.signing_session_id.clone())
         );
-        let signing_session_id =
-            handle_signing_error!(self, req, parse_signing_session_id(&req.signing_session_id));
+        let signing_session_id = handle_signing_error!(
+            self,
+            req,
+            SigningSessionId::try_from(req.signing_session_id.as_slice())
+        );
 
-        let psbt = match coordinator::get_to_sign(&signing_session_id, &self.db, self.min_signers)
+        let psbt = match coordinator::get_to_sign(signing_session_id, &self.db, self.min_signers)
             .to_status()
         {
             Ok(psbt) => psbt,
@@ -1803,8 +1809,11 @@ where
             "Received new round1 signing package for signing session id: {:?}",
             hex::encode(req.signing_session_id.clone())
         );
-        let signing_session_id =
-            handle_signing_error!(self, req, parse_signing_session_id(&req.signing_session_id));
+        let signing_session_id = handle_signing_error!(
+            self,
+            req,
+            SigningSessionId::try_from(req.signing_session_id.as_slice())
+        );
 
         let frost_id = handle_signing_error!(self, req, deserialize_frost_peer_id(req.identifier));
 
@@ -1824,7 +1833,7 @@ where
         };
 
         if let Err(e) = coordinator::add_round1_signing(
-            &signing_session_id,
+            signing_session_id,
             frost_id,
             &psbt,
             &self.db,
@@ -1847,7 +1856,7 @@ where
             telemetry.update_round1_signing_metrics(
                 self.btc_network,
                 self.config.identifier,
-                &signing_session_id,
+                signing_session_id,
                 req.psbt.as_slice().len(),
                 start.elapsed().as_millis(),
             )
@@ -1878,8 +1887,11 @@ where
         };
 
         info!("Received round2 signing package");
-        let signing_session_id =
-            handle_signing_error!(self, req, parse_signing_session_id(&req.signing_session_id));
+        let signing_session_id = handle_signing_error!(
+            self,
+            req,
+            SigningSessionId::try_from(req.signing_session_id.as_slice())
+        );
 
         let frost_id = handle_signing_error!(self, req, deserialize_frost_peer_id(req.identifier));
 
@@ -1899,7 +1911,7 @@ where
         };
 
         if let Err(e) = coordinator::add_round2_signing(
-            &signing_session_id,
+            signing_session_id,
             frost_id,
             &psbt,
             &self.db,
@@ -1922,7 +1934,7 @@ where
             telemetry.update_round2_signing_metrics(
                 self.btc_network,
                 self.config.identifier,
-                &signing_session_id,
+                signing_session_id,
                 req.psbt.as_slice().len(),
                 start.elapsed().as_millis(),
             )
@@ -2270,6 +2282,7 @@ where
                     }
                 }
             }
+            // TODO: We need to send empty status as well
             Ok(None) => {}
             Err(_) => {
                 error!("subscribe_to_wallet_sweep_session_updates: failed to get existing wallet sweep session bytes");
@@ -2284,6 +2297,7 @@ where
             let mut subscriber = db.subscribe_to_wallet_sweep_session_updates();
 
             while let Some(event) = (&mut subscriber).await {
+                // TODO: We need to send remove as well
                 if let Event::Insert { key, value } = event {
                     match tx
                         .send(Ok(WalletSweepSessionUpdateResponse {

--- a/bin/btc-server/src/coordinator/mod.rs
+++ b/bin/btc-server/src/coordinator/mod.rs
@@ -5,6 +5,7 @@ use crate::{
     database::{Db, Error as DbError, Utxo},
     pegout_id::PegoutId,
     pegout_scheduler::Tx,
+    signer::SigningSessionId,
     util::{validate_psbt, NO_FLAGS, ROUND1, ROUND1_TRANSITION, ROUND2},
     wallet::{
         coin_selection,
@@ -24,7 +25,7 @@ pub mod error;
 const MIN_RELAY_FEE_RATE_SAT_VB: u64 = 1;
 
 pub fn add_round1_signing(
-    signing_session_id: &[u8; 32],
+    signing_session_id: SigningSessionId,
     frost_id: frost::Identifier,
     psbt: &Psbt,
     db: &Db,
@@ -57,7 +58,7 @@ pub fn add_round1_signing(
 }
 
 pub fn add_round2_signing(
-    signing_session_id: &[u8; 32],
+    signing_session_id: SigningSessionId,
     frost_id: frost::Identifier,
     psbt: &Psbt,
     db: &Db,
@@ -179,7 +180,7 @@ pub fn make_tx(
 /// signers nothing needs to be added to it as the signers all provided their signing
 /// commitments already and the coordinator just need to verify them
 pub fn get_to_sign(
-    signing_session_id: &[u8; 32],
+    signing_session_id: SigningSessionId,
     db: &Db,
     min_signers: u16,
 ) -> Result<Psbt, CoordinatorError> {
@@ -205,7 +206,7 @@ pub fn get_to_sign(
 
 /// Returns finalized and ready to broadcast tx
 pub async fn finalize_signing(
-    signing_session_id: &[u8; 32],
+    signing_session_id: SigningSessionId,
     db: &Db,
 ) -> Result<Psbt, CoordinatorError> {
     // Lock here to prevent a make_tx that uses utxos that will be removed

--- a/bin/btc-server/src/database/mod.rs
+++ b/bin/btc-server/src/database/mod.rs
@@ -28,6 +28,7 @@ pub mod error;
 mod sweep;
 pub mod version;
 
+use crate::signer::SigningSessionId;
 pub use error::Error;
 use version::UtxoVersion;
 
@@ -182,9 +183,13 @@ impl Db {
     }
 
     /// Adds a PSBT to the database.
-    pub fn update_psbt(&self, signing_session_id: &[u8; 32], psbt: &Psbt) -> Result<usize, Error> {
+    pub fn update_psbt(
+        &self,
+        signing_session_id: SigningSessionId,
+        psbt: &Psbt,
+    ) -> Result<usize, Error> {
         let mut bytes = Vec::new();
-        if let Some(b) = self.psbt.get(&signing_session_id[..])? {
+        if let Some(b) = self.psbt.get(&signing_session_id)? {
             // if there is an existing psbt then we merge the new psbt with the existing one
             let mut existing_psbt = ciborium::from_reader::<Psbt, _>(b.as_ref())?;
             existing_psbt.combine(psbt.clone())?;
@@ -192,15 +197,15 @@ impl Db {
         } else {
             ciborium::into_writer(psbt, &mut bytes).expect("writing to buffer");
         }
-        self.psbt.insert(&signing_session_id[..], &bytes[..])?;
+        self.psbt.insert(&signing_session_id, &bytes[..])?;
         Ok(bytes.len())
     }
 
     /// Get PSBT from the database.
     /// Returns None if the PSBT is not found.
     /// Rertrieves psbt using signing_session_id
-    pub fn get_psbt(&self, signing_session_id: &[u8; 32]) -> Result<Option<Psbt>, Error> {
-        if let Some(b) = self.psbt.get(&signing_session_id[..])? {
+    pub fn get_psbt(&self, signing_session_id: SigningSessionId) -> Result<Option<Psbt>, Error> {
+        if let Some(b) = self.psbt.get(&signing_session_id)? {
             let ret = ciborium::from_reader::<Psbt, _>(b.as_ref())?;
             Ok(Some(ret))
         } else {
@@ -209,13 +214,13 @@ impl Db {
     }
 
     /// Get signing session ids from db
-    pub fn get_session_ids(&self, max_results: u32) -> Result<Vec<[u8; 32]>, Error> {
+    pub fn get_session_ids(&self, max_results: u32) -> Result<Vec<SigningSessionId>, Error> {
         let mut ret = Vec::new();
         let mut results = 0;
         for res in self.psbt.iter() {
             let (k, _) = res?;
-            let signing_session_id: [u8; 32] =
-                k.to_vec().as_slice().try_into().map_err(Error::Serialization)?;
+            let signing_session_id = SigningSessionId::try_from(k.as_ref())
+                .map_err(|e| Error::Database(e.to_string()))?;
             results += 1;
             if max_results == results {
                 break;
@@ -227,7 +232,7 @@ impl Db {
 
     pub fn get_signing_status(
         &self,
-        signing_session_id: &[u8; 32],
+        signing_session_id: SigningSessionId,
     ) -> Result<SigningStatus, Error> {
         match self.get_psbt(signing_session_id)? {
             Some(psbt) => {
@@ -1718,8 +1723,9 @@ mod tests {
 
         let tx = create_tx(2, 1, None);
         let psbt = Psbt::from_unsigned_tx(tx).unwrap();
-        let signing_session_id: [u8; 32] = [0; 32];
-        db.update_psbt(&signing_session_id, &psbt).unwrap();
+        let signing_session_id = SigningSessionId::new_pegout_session(&[0; 32]);
+
+        db.update_psbt(signing_session_id, &psbt).unwrap();
         db.flush().unwrap();
 
         let signing_session_ids = db.get_session_ids(10).unwrap();
@@ -1732,12 +1738,12 @@ mod tests {
 
         let tx = create_tx(2, 1, None);
         let psbt = Psbt::from_unsigned_tx(tx).unwrap();
-        let signing_session_id: [u8; 32] = [0; 32];
-        db.update_psbt(&signing_session_id, &psbt).unwrap();
+        let signing_session_id = SigningSessionId::new_pegout_session(&[0; 32]);
+        db.update_psbt(signing_session_id, &psbt).unwrap();
         db.flush().unwrap();
 
         let signing_session_id = db.get_session_ids(10).unwrap().first().cloned().unwrap();
-        let signing_status = db.get_signing_status(&signing_session_id).unwrap();
+        let signing_status = db.get_signing_status(signing_session_id).unwrap();
         assert!(signing_status == SigningStatus::Running);
     }
 

--- a/bin/btc-server/src/signer/error.rs
+++ b/bin/btc-server/src/signer/error.rs
@@ -11,6 +11,8 @@ pub enum SigningError {
     Round1(#[from] SigningRound1Error),
     #[error("round 2 error: {0}")]
     Round2(#[from] SigningRound2Error),
+    #[error("invalid signing session id")]
+    InvalidSigningSessionId,
 }
 
 #[derive(Debug, Error)]

--- a/bin/btc-server/src/signer/mod.rs
+++ b/bin/btc-server/src/signer/mod.rs
@@ -17,6 +17,9 @@ use crate::{
 };
 
 pub mod error;
+pub mod session_id;
+
+pub use session_id::{SigningSessionId, SigningSessionType};
 
 pub fn get_round1_signing_package(
     psbt: &mut Psbt,

--- a/bin/btc-server/src/signer/session_id.rs
+++ b/bin/btc-server/src/signer/session_id.rs
@@ -1,0 +1,302 @@
+use crate::signer::error::SigningError;
+use std::fmt::Display;
+
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SigningSessionType {
+    Pegout = 0x00,
+    Sweep = 0x01,
+}
+
+// Store as [type(1 byte), payload(32 bytes)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SigningSessionId([u8; 33]);
+
+// TODO: For backward compatibility, pegout session ID must be 32 and sweep session ID must be 33
+//  bytes.
+
+impl SigningSessionId {
+    pub fn new(unique_payload: &[u8; 32], session_type: SigningSessionType) -> Self {
+        let mut data = [0u8; 33];
+
+        data[0] = session_type as u8;
+        data[1..33].copy_from_slice(unique_payload);
+
+        Self(data)
+    }
+
+    pub fn new_pegout_session(unique_payload: &[u8; 32]) -> Self {
+        Self::new(unique_payload, SigningSessionType::Pegout)
+    }
+
+    pub fn new_sweep_session(unique_payload: &[u8; 32]) -> Self {
+        Self::new(unique_payload, SigningSessionType::Sweep)
+    }
+
+    pub fn unique_payload(&self) -> [u8; 32] {
+        let mut payload = [0u8; 32];
+        payload.copy_from_slice(&self.0[1..33]);
+        payload
+    }
+
+    pub fn session_type(&self) -> SigningSessionType {
+        match self.0[0] {
+            0x00 => SigningSessionType::Pegout,
+            0x01 => SigningSessionType::Sweep,
+            _ => unreachable!("Invalid session type in data"),
+        }
+    }
+
+    pub fn is_sweep_session(&self) -> bool {
+        self.session_type() == SigningSessionType::Sweep
+    }
+
+    pub fn is_pegout_session(&self) -> bool {
+        self.session_type() == SigningSessionType::Pegout
+    }
+
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.0.to_vec()
+    }
+}
+
+impl From<SigningSessionId> for Vec<u8> {
+    fn from(value: SigningSessionId) -> Self {
+        value.to_vec()
+    }
+}
+
+impl TryFrom<&[u8]> for SigningSessionId {
+    type Error = SigningError;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        if value.len() != 33 {
+            return Err(SigningError::InvalidSigningSessionId);
+        }
+
+        let session_type = match value.first().ok_or(SigningError::InvalidSigningSessionId)? {
+            0x00 => SigningSessionType::Pegout,
+            0x01 => SigningSessionType::Sweep,
+            _ => return Err(SigningError::InvalidSigningSessionId),
+        };
+
+        let mut session_id_array = [0u8; 32];
+        session_id_array.copy_from_slice(&value[1..33]);
+
+        Ok(SigningSessionId::new(&session_id_array, session_type))
+    }
+}
+
+impl TryFrom<Vec<u8>> for SigningSessionId {
+    type Error = SigningError;
+
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        SigningSessionId::try_from(value.as_slice())
+    }
+}
+
+impl AsRef<[u8]> for SigningSessionId {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl Display for SigningSessionId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", hex::encode(self.0))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod new {
+        use super::*;
+
+        #[test]
+        fn test_new_with_pegout_type() {
+            let payload = [1u8; 32];
+            let session_id = SigningSessionId::new(&payload, SigningSessionType::Pegout);
+
+            assert_eq!(session_id.session_type(), SigningSessionType::Pegout);
+            assert_eq!(session_id.unique_payload(), payload);
+        }
+
+        #[test]
+        fn test_new_with_sweep_type() {
+            let payload = [2u8; 32];
+            let session_id = SigningSessionId::new(&payload, SigningSessionType::Sweep);
+
+            assert_eq!(session_id.session_type(), SigningSessionType::Sweep);
+            assert_eq!(session_id.unique_payload(), payload);
+        }
+    }
+
+    mod to_vec {
+        use super::*;
+
+        #[test]
+        fn test_to_vec_pegout() {
+            let payload = [42u8; 32];
+            let session_id = SigningSessionId::new(&payload, SigningSessionType::Pegout);
+
+            let vec = session_id.to_vec();
+            assert_eq!(vec.len(), 33);
+            assert_eq!(vec[0], 0x00); // Pegout type
+            assert_eq!(&vec[1..33], &payload);
+        }
+
+        #[test]
+        fn test_to_vec_sweep() {
+            let payload = [123u8; 32];
+            let session_id = SigningSessionId::new(&payload, SigningSessionType::Sweep);
+
+            let vec = session_id.to_vec();
+            assert_eq!(vec.len(), 33);
+            assert_eq!(vec[0], 0x01); // Sweep type
+            assert_eq!(&vec[1..33], &payload);
+        }
+    }
+
+    mod into_vec {
+        use super::*;
+
+        #[test]
+        fn test_pegout_into_vec() {
+            let payload = [55u8; 32];
+            let session_id = SigningSessionId::new(&payload, SigningSessionType::Pegout);
+
+            let vec: Vec<u8> = session_id.into();
+            assert_eq!(vec.len(), 33);
+            assert_eq!(vec[0], 0x00);
+            assert_eq!(&vec[1..33], &payload);
+        }
+
+        #[test]
+        fn test_sweep_into_vec() {
+            let payload = [77u8; 32];
+            let session_id = SigningSessionId::new(&payload, SigningSessionType::Sweep);
+
+            let vec: Vec<u8> = session_id.into();
+            assert_eq!(vec.len(), 33);
+            assert_eq!(vec[0], 0x01);
+            assert_eq!(&vec[1..33], &payload);
+        }
+    }
+
+    mod try_from_slice {
+        use super::*;
+
+        #[test]
+        fn test_try_from_valid_pegout() {
+            let payload = [111u8; 32];
+            let mut data = [0u8; 33];
+            data[0] = 0x00; // Pegout
+            data[1..33].copy_from_slice(&payload);
+
+            let session_id = SigningSessionId::try_from(data.as_slice()).unwrap();
+            assert_eq!(session_id.session_type(), SigningSessionType::Pegout);
+            assert_eq!(session_id.unique_payload(), payload);
+        }
+
+        #[test]
+        fn test_try_from_valid_sweep() {
+            let payload = [222u8; 32];
+            let mut data = [0u8; 33];
+            data[0] = 0x01; // Sweep
+            data[1..33].copy_from_slice(&payload);
+
+            let session_id = SigningSessionId::try_from(data.as_slice()).unwrap();
+            assert_eq!(session_id.session_type(), SigningSessionType::Sweep);
+            assert_eq!(session_id.unique_payload(), payload);
+        }
+
+        #[test]
+        fn test_try_from_empty_slice() {
+            let data: &[u8] = &[];
+            let result = SigningSessionId::try_from(data);
+            assert!(matches!(result, Err(SigningError::InvalidSigningSessionId)));
+        }
+
+        #[test]
+        fn test_try_from_too_short() {
+            let data = [0u8; 32]; // Only 32 bytes instead of 33
+            let result = SigningSessionId::try_from(data.as_slice());
+            assert!(matches!(result, Err(SigningError::InvalidSigningSessionId)));
+        }
+
+        #[test]
+        fn test_try_from_too_long() {
+            let data = [0u8; 34]; // 34 bytes instead of 33
+            let result = SigningSessionId::try_from(data.as_slice());
+            assert!(matches!(result, Err(SigningError::InvalidSigningSessionId)));
+        }
+
+        #[test]
+        fn test_try_from_invalid_session_type() {
+            let mut data = [0u8; 33];
+            data[0] = 0x02; // Invalid session type
+
+            let result = SigningSessionId::try_from(data.as_slice());
+            assert!(matches!(result, Err(SigningError::InvalidSigningSessionId)));
+        }
+
+        #[test]
+        fn test_try_from_max_invalid_session_type() {
+            let mut data = [0u8; 33];
+            data[0] = 255; // Invalid session type
+
+            let result = SigningSessionId::try_from(data.as_slice());
+            assert!(matches!(result, Err(SigningError::InvalidSigningSessionId)));
+        }
+
+        #[test]
+        fn test_try_from_roundtrip_pegout() {
+            let payload = [42u8; 32];
+            let original = SigningSessionId::new(&payload, SigningSessionType::Pegout);
+            let vec = original.to_vec();
+            let reconstructed = SigningSessionId::try_from(vec.as_slice()).unwrap();
+
+            assert_eq!(original.session_type(), reconstructed.session_type());
+            assert_eq!(original.unique_payload(), reconstructed.unique_payload());
+        }
+
+        #[test]
+        fn test_try_from_roundtrip_sweep() {
+            let payload = [84u8; 32];
+            let original = SigningSessionId::new(&payload, SigningSessionType::Sweep);
+            let vec = original.to_vec();
+            let reconstructed = SigningSessionId::try_from(vec.as_slice()).unwrap();
+
+            assert_eq!(original.session_type(), reconstructed.session_type());
+            assert_eq!(original.unique_payload(), reconstructed.unique_payload());
+        }
+    }
+
+    mod as_ref {
+        use super::*;
+
+        #[test]
+        fn test_as_ref_pegout() {
+            let payload = [13u8; 32];
+            let session_id = SigningSessionId::new(&payload, SigningSessionType::Pegout);
+
+            let slice: &[u8] = session_id.as_ref();
+            assert_eq!(slice.len(), 33);
+            assert_eq!(slice[0], 0x00); // Pegout type
+            assert_eq!(&slice[1..33], &payload);
+        }
+
+        #[test]
+        fn test_as_ref_sweep() {
+            let payload = [97u8; 32];
+            let session_id = SigningSessionId::new(&payload, SigningSessionType::Sweep);
+
+            let slice: &[u8] = session_id.as_ref();
+            assert_eq!(slice.len(), 33);
+            assert_eq!(slice[0], 0x01); // Sweep type
+            assert_eq!(&slice[1..33], &payload);
+        }
+    }
+}

--- a/bin/btc-server/src/telemetry/mod.rs
+++ b/bin/btc-server/src/telemetry/mod.rs
@@ -1,6 +1,7 @@
 mod metrics;
 mod system;
 
+use crate::signer::SigningSessionId;
 use log::error;
 use metrics::BtcServerMetrics;
 use parking_lot::RwLock;
@@ -50,7 +51,7 @@ impl Telemetry {
         &self,
         btc_chain: bitcoin::Network,
         self_id: u16,
-        session_id: &[u8; 32],
+        session_id: SigningSessionId,
         data_size: usize,
         latency_millis: u128,
     ) {
@@ -89,7 +90,7 @@ impl Telemetry {
         &self,
         btc_chain: bitcoin::Network,
         self_id: u16,
-        session_id: &[u8; 32],
+        session_id: SigningSessionId,
         data_size: usize,
         latency_millis: u128,
     ) {
@@ -232,7 +233,7 @@ impl Telemetry {
         &self,
         btc_chain: bitcoin::Network,
         self_id: u16,
-        session_id: [u8; 32],
+        session_id: SigningSessionId,
     ) {
         self.maybe_use_metrics(|metrics| {
             metrics
@@ -250,7 +251,7 @@ impl Telemetry {
         &self,
         btc_chain: bitcoin::Network,
         self_id: u16,
-        session_id: [u8; 32],
+        session_id: SigningSessionId,
         error: &str,
     ) {
         self.maybe_use_metrics(|metrics| {

--- a/crates/botanix-storage/src/models/wallet_sweep.rs
+++ b/crates/botanix-storage/src/models/wallet_sweep.rs
@@ -1,8 +1,10 @@
 use bitcoin::{address::NetworkUnchecked, Address, Network};
 use bytes::Buf;
-use reth_db_api::table::{Compress, Decompress};
+use reth_db_api::table::{Compress, Decode, Decompress, Encode};
 use reth_primitives::{keccak256, B256};
+use reth_storage_errors::db::DatabaseError;
 use serde::{Deserialize, Serialize};
+use std::ops::Deref;
 // TODO: TBD
 
 /// Unique identifier for a wallet sweep session.

--- a/crates/consensus/authority/src/builder.rs
+++ b/crates/consensus/authority/src/builder.rs
@@ -98,7 +98,7 @@ where
     EF: BlockExecutorProvider + Clone + 'static,
     BF: BitcoindFactory + Clone + Unpin + 'static,
     BD: botanix_btc_wallet::bitcoind::RpcApiExt + Send + Sync + 'static,
-    Source: RandomSource + Clone,
+    Source: RandomSource + Clone + Send + Sync + 'static,
 {
     /// Creates a new builder instance to configure all parts.
     #[allow(clippy::too_many_arguments)]

--- a/crates/consensus/authority/src/frost_task.rs
+++ b/crates/consensus/authority/src/frost_task.rs
@@ -23,7 +23,10 @@ use botanix_storage::{
 use btc_server_client::{
     BtcServerExtendedApi, ConsensusCheckpointRequest, GrpcClientError, PendingPegout, Utxo,
 };
-use btcserverlib::wallet::psbt::frost_id_from_bytes;
+use btcserverlib::{
+    signer::session_id::{SigningSessionId, SigningSessionType},
+    wallet::psbt::frost_id_from_bytes,
+};
 use futures::{pin_mut, StreamExt};
 use reth_chainspec::ChainSpec;
 use reth_db::table::Decompress;
@@ -263,6 +266,8 @@ where
     ) {
         debug_assert_eq!(header_hash, header.hash_slow());
 
+        // TODO: This could abort our sweep signing session
+
         info!(
             target: "consensus::authority::frost_task::handle_canon_state_commit",
             "Handling canon state commit for block number {:?}", header.number
@@ -407,11 +412,11 @@ where
             "Validated psbt successfully"
         );
 
-        // Initiate signing session.
-        if let Err(e) = self
-            .signing_state_machine
-            .initate_signing_session(header_hash, psbt_payload.psbt, SigningPsbtType::Pegout)
-            .await
+        // Initiate signing session
+        let session_id = SigningSessionId::new_pegout_session(&*header_hash);
+
+        if let Err(e) =
+            self.signing_state_machine.initiate_signing_session(session_id, psbt_payload.psbt).await
         {
             error!(
                 target: "consensus::authority::frost_task::handle_canon_state_commit",
@@ -663,7 +668,7 @@ where
                     PeerMessageResponse::Signing(signing_response) => {
                         let SigningResponse { response_type, signing_session_id, psbt, psbt_type } =
                             signing_response;
-                        let signing_session_id = match FixedBytes::try_from(
+                        let signing_session_id = match SigningSessionId::try_from(
                             signing_session_id.as_slice(),
                         ) {
                             Ok(signing_session_id) => signing_session_id,

--- a/crates/consensus/authority/src/signing.rs
+++ b/crates/consensus/authority/src/signing.rs
@@ -7,6 +7,7 @@ use btc_server_client::{
 };
 use frost_secp256k1_tr as frost;
 
+use btcserverlib::signer::{SigningSessionId, SigningSessionType};
 use reth_chainspec::ChainSpec;
 use reth_consensus_common::utils::{current_inturn_index, is_inturn, unix_timestamp};
 use reth_network::frost::{
@@ -22,7 +23,7 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 use tokio::sync::{mpsc::error::SendError, RwLock};
 use tracing::{error, info, warn};
 
-type SigningStatesMap = Arc<RwLock<HashMap<[u8; 32], SigningSession>>>;
+type SigningStatesMap = Arc<RwLock<HashMap<SigningSessionId, SigningSession>>>;
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum Error {
@@ -101,7 +102,7 @@ impl SigningState {
 pub(crate) struct SigningSession {
     #[allow(dead_code)]
     /// The id of the signing session
-    session_id: [u8; 32],
+    session_id: SigningSessionId,
     /// The state of the session
     state: SigningState,
     /// The index of the session coordinator
@@ -109,8 +110,6 @@ pub(crate) struct SigningSession {
     #[allow(dead_code)]
     /// The original session payload
     original_psbt: Option<Vec<u8>>,
-    /// The type of PSBT being signed (Pegout or Sweep)
-    psbt_type: SigningPsbtType,
 }
 
 impl SigningSession {
@@ -126,7 +125,7 @@ pub(crate) struct SigningStateMachine<ToFrostMan, Source, BtcServerClient> {
     chain_spec: Arc<ChainSpec>,
     btc_client: BtcServerClient,
     frost_handle: ToFrostMan,
-    signing_states: Arc<RwLock<HashMap<[u8; 32], SigningSession>>>,
+    signing_states: SigningStatesMap,
     personal_frost_identifier: frost::Identifier,
     frost_config: FrostConfig,
     random_source_provider: Source,
@@ -168,7 +167,7 @@ where
     /// Inserts a signing state into the state machine
     pub(crate) async fn update_signing_state(
         &mut self,
-        session_id: [u8; 32],
+        session_id: SigningSessionId,
         signing_state: SigningState,
     ) {
         if !self.signing_states.read().await.contains_key(&session_id) {
@@ -180,55 +179,46 @@ where
     }
 
     /// Checks if a signing session exists or not yet
-    pub(crate) async fn signing_session_exists(&mut self, session_id: [u8; 32]) -> bool {
+    pub(crate) async fn signing_session_exists(&mut self, session_id: SigningSessionId) -> bool {
         self.signing_states.read().await.contains_key(&session_id)
     }
 
     /// Inserts a new signing session
     pub(crate) async fn insert_new_signing_session(
         &mut self,
-        session_id: [u8; 32],
+        session_id: SigningSessionId,
         coordinator_index: u64,
         original_psbt: Option<Vec<u8>>,
         signing_state: SigningState,
-        psbt_type: SigningPsbtType,
     ) {
         if self.signing_states.read().await.contains_key(&session_id) {
             return;
         }
         self.signing_states.write().await.insert(
             session_id,
-            SigningSession {
-                session_id,
-                state: signing_state,
-                coordinator_index,
-                original_psbt,
-                psbt_type,
-            },
+            SigningSession { session_id, state: signing_state, coordinator_index, original_psbt },
         );
     }
 
     /// Returns the original psbt into the state machine
-    pub(crate) async fn get_signing_session(&self, session_id: [u8; 32]) -> Option<SigningSession> {
+    pub(crate) async fn get_signing_session(
+        &self,
+        session_id: SigningSessionId,
+    ) -> Option<SigningSession> {
         self.signing_states.read().await.get(&session_id).cloned()
-    }
-
-    /// Gets the PSBT type for a signing session
-    pub(crate) async fn get_psbt_type(&self, session_id: [u8; 32]) -> Option<SigningPsbtType> {
-        self.signing_states.read().await.get(&session_id).map(|session| session.psbt_type)
     }
 
     /// Removes a signing session
     pub(crate) async fn remove_signing_session(
         &mut self,
-        session_id: [u8; 32],
+        session_id: SigningSessionId,
     ) -> Option<SigningSession> {
         self.signing_states.write().await.remove(&session_id)
     }
 
     #[allow(dead_code)]
     /// Check if the session id is in a failed state
-    pub(crate) async fn is_failed_state(&self, session_id: &[u8; 32]) -> bool {
+    pub(crate) async fn is_failed_state(&self, session_id: &SigningSessionId) -> bool {
         self.signing_states
             .read()
             .await
@@ -238,7 +228,7 @@ where
     }
 
     /// Check if the session id is in a round1 state
-    pub(crate) async fn is_round1_state(&self, session_id: &[u8; 32]) -> bool {
+    pub(crate) async fn is_round1_state(&self, session_id: &SigningSessionId) -> bool {
         self.signing_states
             .read()
             .await
@@ -248,7 +238,7 @@ where
     }
 
     /// Check if the session id is in a round2 state
-    pub(crate) async fn is_round2_state(&self, session_id: &[u8; 32]) -> bool {
+    pub(crate) async fn is_round2_state(&self, session_id: &SigningSessionId) -> bool {
         self.signing_states
             .read()
             .await
@@ -266,14 +256,14 @@ where
 {
     async fn get_round1_signing_package(
         &mut self,
-        signing_session_id: FixedBytes<32>,
+        session_id: SigningSessionId,
         psbt: Vec<u8>,
     ) -> Result<SigningPackage, Error> {
         let round1_payload = self
             .btc_client
             .get_round1_signing_package(SigningPackageRequest {
                 psbt,
-                signing_session_id: signing_session_id.to_vec(),
+                signing_session_id: session_id.into(),
             })
             .await;
 
@@ -286,14 +276,14 @@ where
 
     async fn get_round2_signing_package(
         &mut self,
-        signing_session_id: FixedBytes<32>,
+        session_id: SigningSessionId,
         psbt: Vec<u8>,
     ) -> Result<SigningPackage, Error> {
         let round2_payload = self
             .btc_client
             .get_round2_signing_package(SigningPackageRequest {
                 psbt,
-                signing_session_id: signing_session_id.to_vec(),
+                signing_session_id: session_id.into(),
             })
             .await;
 
@@ -307,7 +297,7 @@ where
     async fn new_round1_signing_package(
         &mut self,
         frost_identifier: &frost::Identifier,
-        signing_session_id: FixedBytes<32>,
+        session_id: SigningSessionId,
         psbt: Vec<u8>,
     ) -> Result<(), Error> {
         let new_round1_signing_package = self
@@ -315,7 +305,7 @@ where
             .new_round1_signing_package(SigningPackage {
                 identifier: frost_identifier.serialize().to_vec(),
                 psbt,
-                signing_session_id: signing_session_id.to_vec(),
+                signing_session_id: session_id.into(),
             })
             .await;
 
@@ -329,7 +319,7 @@ where
     async fn new_round2_signing_package(
         &mut self,
         frost_identifier: &frost::Identifier,
-        signing_session_id: FixedBytes<32>,
+        session_id: SigningSessionId,
         psbt: Vec<u8>,
     ) -> Result<(), Error> {
         let new_round2_signing_package = self
@@ -337,7 +327,7 @@ where
             .new_round2_signing_package(SigningPackage {
                 identifier: frost_identifier.serialize().to_vec(),
                 psbt,
-                signing_session_id: signing_session_id.to_vec(),
+                signing_session_id: session_id.into(),
             })
             .await;
 
@@ -350,12 +340,12 @@ where
 
     async fn get_to_sign_package(
         &mut self,
-        signing_session_id: FixedBytes<32>,
+        session_id: SigningSessionId,
     ) -> Result<SigningPackage, Error> {
         let package = match self
             .btc_client
             .get_to_sign_package(btc_server_client::ToSignRequest {
-                signing_session_id: signing_session_id.to_vec(),
+                signing_session_id: session_id.to_vec(),
             })
             .await
         {
@@ -367,12 +357,12 @@ where
 
     async fn finalize_signing(
         &mut self,
-        signing_session_id: FixedBytes<32>,
+        session_id: SigningSessionId,
     ) -> Result<FinalizeSigningResponse, Error> {
         let finalized_signing = match self
             .btc_client
             .finalize_signing(btc_server_client::FinalizeSigningRequest {
-                signing_session_id: signing_session_id.to_vec(),
+                signing_session_id: session_id.into(),
             })
             .await
         {
@@ -470,9 +460,12 @@ where
         &mut self,
         signing_package: SigningPackage,
         response_type: SigningEventResponseType,
-        psbt_type: SigningPsbtType,
     ) -> Result<(), Error> {
-        let SigningPackage { identifier: _, signing_session_id, psbt } = signing_package;
+        let SigningPackage { identifier: _, signing_session_id: session_id_vec, psbt } =
+            signing_package;
+
+        let session_id = SigningSessionId::try_from(session_id_vec.as_slice())
+            .or(Err(Error::InvalidSigningSessionId))?;
 
         let fut = || async {
             // get all connected peers
@@ -489,9 +482,12 @@ where
                 if connected_peer.frost_identifier != self.personal_frost_identifier {
                     let resp = PeerMessageResponse::Signing(SigningResponse {
                         response_type,
-                        signing_session_id: signing_session_id.clone(),
+                        signing_session_id: session_id_vec.clone(),
                         psbt: psbt.clone(),
-                        psbt_type,
+                        psbt_type: match session_id.session_type() {
+                            SigningSessionType::Pegout => SigningPsbtType::Pegout,
+                            SigningSessionType::Sweep => SigningPsbtType::Sweep,
+                        },
                     });
                     connected_peer
                         .peer_commands_tx
@@ -510,18 +506,15 @@ where
 
     // ====================================== 1 =========================================
     // Coordinator initiates a new signing session
-    pub(crate) async fn initate_signing_session(
+    pub(crate) async fn initiate_signing_session(
         &mut self,
-        signing_session_id: FixedBytes<32>,
+        session_id: SigningSessionId,
         psbt: Vec<u8>,
-        psbt_type: SigningPsbtType,
     ) -> Result<(), Error> {
-        let session_id = parse_signing_session_id(&signing_session_id)?;
-
         // the coordinator is always expected to be us in this case, i.e. None
         let coordinator = self.get_coordinator_peer_data().await?;
         if coordinator.is_some() {
-            error!(target: "consensus::authority::signing::initate_signing_session", "A non-coordinator is trying to (re)initiate a signing process!");
+            error!(target: "consensus::authority::signing::initiate_signing_session", "A non-coordinator is trying to (re)initiate a signing process!");
             return Ok(());
         }
 
@@ -537,7 +530,7 @@ where
                     self.remove_signing_session(session_id).await;
                     self.metrics.signing_sessions.decrement(1);
 
-                    error!(target: "consensus::authority::signing::initate_signing_session", "A coordinator re-triggered an existing signing session!");
+                    error!(target: "consensus::authority::signing::initiate_signing_session", "A coordinator re-triggered an existing signing session!");
                     return Err(Error::CoordinatorRetriggeredSession);
                 }
             }
@@ -549,23 +542,21 @@ where
                     self.frost_config.authority_index as u64,
                     Some(psbt.clone()),
                     SigningState::Initial,
-                    psbt_type,
                 )
                 .await;
                 self.metrics.signing_sessions.increment(1);
             }
         }
 
-        info!(target: "consensus::authority::signing::initate_signing_session", "starting signing session with id {:?}", session_id);
+        info!(target: "consensus::authority::signing::initiate_signing_session", "starting signing session with id {:?}", session_id);
 
         // As the cord we generate round 1 nonces and save them
         // then we send the psbt to other peers
-        let signing_round1_package =
-            self.get_round1_signing_package(signing_session_id, psbt).await?;
+        let signing_round1_package = self.get_round1_signing_package(session_id, psbt).await?;
         let my_frost_identifier = self.personal_frost_identifier;
         self.new_round1_signing_package(
             &my_frost_identifier,
-            signing_session_id,
+            session_id,
             signing_round1_package.clone().psbt,
         )
         .await?;
@@ -577,11 +568,10 @@ where
             .gossip_to_peers(
                 signing_round1_package,
                 SigningEventResponseType::SignerRound1SigningPackage,
-                psbt_type,
             )
             .await
         {
-            error!(target: "consensus::authority::signing::initate_signing_session", "Error gossiping round 1 to peers {:?}", e);
+            error!(target: "consensus::authority::signing::initiate_signing_session", "Error gossiping round 1 to peers {:?}", e);
             self.update_signing_state(session_id, SigningState::Failed).await;
             return Err(e);
         }
@@ -592,11 +582,9 @@ where
     pub(crate) async fn signer_process_round1(
         &mut self,
         identifier: &frost::Identifier,
-        signing_session_id: FixedBytes<32>,
+        session_id: SigningSessionId,
         psbt: Vec<u8>,
     ) -> Result<(), Error> {
-        let session_id = parse_signing_session_id(&signing_session_id)?;
-
         // get coordinator, and check if we are the coordinator
         let (coordinator_peer_data, coordinator_id) = match self.get_coordinator_peer_data().await?
         {
@@ -617,20 +605,8 @@ where
         // no already existing signing session found
         if !self.signing_session_exists(session_id).await {
             // insert a new signing session
-            // Determine PSBT type based on session ID pattern
-            let psbt_type = if signing_session_id.as_slice().ends_with(b"SWEEP_SIGNING") {
-                SigningPsbtType::Sweep
-            } else {
-                SigningPsbtType::Pegout
-            };
-            self.insert_new_signing_session(
-                session_id,
-                coordinator_id,
-                None,
-                SigningState::Round1,
-                psbt_type,
-            )
-            .await;
+            self.insert_new_signing_session(session_id, coordinator_id, None, SigningState::Round1)
+                .await;
             self.metrics.signing_sessions.increment(1);
             // abort any previous session
             // coordinator should only send this request once and should always be in round 1
@@ -647,10 +623,7 @@ where
 
         // add the transmitted round 1 package data (the original psbt package - there is only 1x of
         // them)
-        let signing_package_round1 = match self
-            .get_round1_signing_package(signing_session_id, psbt)
-            .await
-        {
+        let signing_package_round1 = match self.get_round1_signing_package(session_id, psbt).await {
             Ok(signing_package_round1) => signing_package_round1,
             Err(e) => {
                 error!(target: "consensus::authority::signing::signer_process_round1", "Error adding round 2 signing package {:?}", e);
@@ -663,12 +636,14 @@ where
 
         // Broadcast signing round 1 to the coordinator
         if coordinator_frost_identifier != self.personal_frost_identifier {
-            let psbt_type = self.get_psbt_type(session_id).await.unwrap_or(SigningPsbtType::Pegout);
             let resp = PeerMessageResponse::Signing(SigningResponse {
                 response_type: SigningEventResponseType::CoordinatorRound1SigningPackage,
-                signing_session_id: signing_package_round1.signing_session_id.clone(),
-                psbt: signing_package_round1.psbt.clone(),
-                psbt_type,
+                signing_session_id: session_id.to_vec(),
+                psbt: signing_package_round1.psbt,
+                psbt_type: match session_id.session_type() {
+                    SigningSessionType::Pegout => SigningPsbtType::Pegout,
+                    SigningSessionType::Sweep => SigningPsbtType::Sweep,
+                },
             });
 
             retry_future(
@@ -692,11 +667,9 @@ where
     pub(crate) async fn coordinator_process_round1(
         &mut self,
         frost_identifier: &frost::Identifier,
-        signing_session_id: FixedBytes<32>,
+        session_id: SigningSessionId,
         psbt: Vec<u8>,
     ) -> Result<(), Error> {
-        let session_id = parse_signing_session_id(&signing_session_id)?;
-
         info!(target: "consensus::authority::signing::coordinator_process_round1", "signing session id {:?}", session_id);
         // return if we are not in round 1 or not a coordinator
         if !self.is_round1_state(&session_id).await {
@@ -722,37 +695,28 @@ where
         }
 
         // add the transmitted round 1 package data
-        if let Err(e) =
-            self.new_round1_signing_package(frost_identifier, signing_session_id, psbt).await
-        {
+        if let Err(e) = self.new_round1_signing_package(frost_identifier, session_id, psbt).await {
             error!(target: "consensus::authority::signing::coordinator_process_round1","Error adding round 1 signing package {:?}", e);
             return Ok(());
         }
         self.metrics.received_round1_signing_packages.increment(1);
 
         // try to generate signing package
-        if let Ok(to_sign_payload) = self.get_to_sign_package(signing_session_id).await {
+        if let Ok(to_sign_payload) = self.get_to_sign_package(session_id).await {
             // we should add the cord partial sig
-            let cord_round2 = self
-                .get_round2_signing_package(signing_session_id, to_sign_payload.psbt.clone())
+            let cord_round2 =
+                self.get_round2_signing_package(session_id, to_sign_payload.psbt.clone()).await?;
+            self.new_round2_signing_package(&my_frost_identifier, session_id, cord_round2.psbt)
                 .await?;
-            self.new_round2_signing_package(
-                &my_frost_identifier,
-                signing_session_id,
-                cord_round2.psbt,
-            )
-            .await?;
             self.metrics.received_round2_signing_packages.increment(1);
 
             self.update_signing_state(session_id, SigningState::Round2).await;
             // if ok, send to all peers
             // TODO we really just need to send to all signers that responded to the round 1
-            let psbt_type = self.get_psbt_type(session_id).await.unwrap_or(SigningPsbtType::Pegout);
             if let Err(e) = self
                 .gossip_to_peers(
                     to_sign_payload.clone(),
                     SigningEventResponseType::SignerRound2SigningPackage,
-                    psbt_type,
                 )
                 .await
             {
@@ -772,11 +736,9 @@ where
     pub(crate) async fn signer_process_round2(
         &mut self,
         frost_identifier: &frost::Identifier,
-        signing_session_id: FixedBytes<32>,
+        session_id: SigningSessionId,
         psbt: Vec<u8>,
     ) -> Result<(), Error> {
-        let session_id = parse_signing_session_id(&signing_session_id)?;
-
         // get coordinator
         let (coordinator_peer_data, coordinator_id) = match self.get_coordinator_peer_data().await?
         {
@@ -806,24 +768,24 @@ where
         }
 
         // add the transmitted round 2 package data
-        let signing_package_round2 =
-            match self.get_round2_signing_package(signing_session_id, psbt).await {
-                Ok(signing_package_round2) => signing_package_round2,
-                Err(e) => {
-                    error!("Error adding round 2 signing package {:?}", e);
-                    self.update_signing_state(session_id, SigningState::Failed).await;
-                    return Err(e);
-                }
-            };
+        let signing_package_round2 = match self.get_round2_signing_package(session_id, psbt).await {
+            Ok(signing_package_round2) => signing_package_round2,
+            Err(e) => {
+                error!("Error adding round 2 signing package {:?}", e);
+                self.update_signing_state(session_id, SigningState::Failed).await;
+                return Err(e);
+            }
+        };
 
         // Broadcast signing round 2 to the coordinator
-
-        let psbt_type = self.get_psbt_type(session_id).await.unwrap_or(SigningPsbtType::Pegout);
         let resp = PeerMessageResponse::Signing(SigningResponse {
             response_type: SigningEventResponseType::CoordinatorRound2SigningPackage,
-            signing_session_id: signing_package_round2.signing_session_id.clone(),
-            psbt: signing_package_round2.psbt.clone(),
-            psbt_type,
+            signing_session_id: session_id.to_vec(),
+            psbt: signing_package_round2.psbt,
+            psbt_type: match session_id.session_type() {
+                SigningSessionType::Pegout => SigningPsbtType::Pegout,
+                SigningSessionType::Sweep => SigningPsbtType::Sweep,
+            },
         });
 
         retry_future(
@@ -846,11 +808,9 @@ where
     pub(crate) async fn coordinator_process_round2(
         &mut self,
         frost_identifier: &frost::Identifier,
-        signing_session_id: FixedBytes<32>,
+        session_id: SigningSessionId,
         psbt: Vec<u8>,
     ) -> Result<(), Error> {
-        let session_id = parse_signing_session_id(&signing_session_id)?;
-
         // return if we are not in round 2 or not a coordinator
         if !self.is_round2_state(&session_id).await {
             warn!(target: "consensus::authority::signing::coordinator_process_round2", "is not in round2");
@@ -880,9 +840,7 @@ where
         }
 
         // add the transmitted round 2 package data
-        if let Err(e) =
-            self.new_round2_signing_package(frost_identifier, signing_session_id, psbt).await
-        {
+        if let Err(e) = self.new_round2_signing_package(frost_identifier, session_id, psbt).await {
             error!(target: "consensus::authority::signing::coordinator_process_round2", "Error adding round 2 signing package {:?}", e);
             self.update_signing_state(session_id, SigningState::Failed).await;
             return Err(e);
@@ -891,7 +849,7 @@ where
         self.metrics.received_round2_signing_packages.increment(1);
 
         // try to finalize the signing
-        if let Ok(_sign_payload) = self.finalize_signing(signing_session_id).await {
+        if let Ok(_sign_payload) = self.finalize_signing(session_id).await {
             info!(target: "consensus::authority::signing::coordinator_process_round2", "signing finalized!");
             self.metrics.finalized_signings.increment(1);
             self.update_signing_state(session_id, SigningState::Finalized).await;

--- a/crates/consensus/authority/src/utils.rs
+++ b/crates/consensus/authority/src/utils.rs
@@ -455,7 +455,7 @@ pub(crate) enum GenerateSigningSesssionIdError {
 }
 
 /// Generates a signing session id using a uuid v4 generator
-#[allow(dead_code)]
+#[cfg(test)]
 pub(crate) fn generate_signing_session_id(
 ) -> Result<SigningSessionId, GenerateSigningSesssionIdError> {
     let id = Uuid::new_v4();

--- a/crates/consensus/authority/src/wallet_sweep_task.rs
+++ b/crates/consensus/authority/src/wallet_sweep_task.rs
@@ -2,20 +2,23 @@ use crate::{signing::SigningStateMachine, Storage};
 use botanix_authority_metrics::AuthorityMetrics;
 use botanix_authority_rsp::RandomSource;
 use botanix_storage::{
-    models::WalletSweepSession, WalletSweepSessionReader, WalletSweepSessionWriter,
+    models::{WalletSweepSession, WalletSweepSessionId},
+    WalletSweepSessionReader, WalletSweepSessionWriter,
 };
 use botanix_wallet_sweep::create_psbt_async;
 use btc_server_client::{BtcServerExtendedApi, WalletSweepSessionUpdateResponse};
+use btcserverlib::signer::{SigningSessionId, SigningSessionType};
 use futures::pin_mut;
 use futures_util::StreamExt;
 use reth_chain_state::CanonStateSubscriptions;
 use reth_db::table::Decompress;
 use reth_network::frost::{manager::ToFrostManager, SigningPsbtType};
-use reth_primitives::alloy_primitives::FixedBytes;
+use reth_primitives::{alloy_primitives::FixedBytes, keccak256};
 use reth_provider::{BlockReaderIdExt, StateProviderFactory};
-use std::sync::Arc;
+use std::{ops::Deref, sync::Arc};
 use tracing::{debug, error, info, trace, warn};
 
+#[derive(Clone)]
 pub struct WalletSweepTask<EF, BF, RDB, BDB, ToFrostMan, Source, BtcServerClient> {
     // Frost network Handler
     signing_state_machine: SigningStateMachine<ToFrostMan, Source, BtcServerClient>,
@@ -25,18 +28,19 @@ pub struct WalletSweepTask<EF, BF, RDB, BDB, ToFrostMan, Source, BtcServerClient
     btc_server: BtcServerClient,
     // Authority Metrics
     metrics: Arc<AuthorityMetrics>,
+    signing_session_id: Arc<tokio::sync::Mutex<Option<SigningSessionId>>>,
 }
 
 impl<EF, BF, RDB, BDB, ToFrostMan, Source, BtcServerClient>
     WalletSweepTask<EF, BF, RDB, BDB, ToFrostMan, Source, BtcServerClient>
 where
-    EF: 'static + Send + Sync,
-    BF: 'static + Send + Sync,
-    RDB: 'static + Send + Sync,
+    EF: Clone + 'static + Send + Sync,
+    BF: Clone + 'static + Send + Sync,
+    RDB: Clone + 'static + Send + Sync,
     BDB: WalletSweepSessionReader + WalletSweepSessionWriter + Clone + 'static + Send + Sync,
     ToFrostMan: Clone + 'static + Send + Sync + ToFrostManager,
     BtcServerClient: BtcServerExtendedApi + Clone,
-    Source: RandomSource + Clone,
+    Source: RandomSource + Clone + Send + Sync + 'static,
 {
     pub fn new(
         signing_state_machine: SigningStateMachine<ToFrostMan, Source, BtcServerClient>,
@@ -44,7 +48,13 @@ where
         btc_server: BtcServerClient,
         metrics: Arc<AuthorityMetrics>,
     ) -> Self {
-        Self { signing_state_machine, storage, btc_server, metrics }
+        Self {
+            signing_state_machine,
+            storage,
+            btc_server,
+            metrics,
+            signing_session_id: Arc::new(tokio::sync::Mutex::new(None)),
+        }
     }
 
     /// Check for wallet sweep sessions and create PSBTs directly for FROST signing
@@ -52,46 +62,38 @@ where
         &mut self,
         session_update: WalletSweepSessionUpdateResponse,
     ) {
-        let session_id =
+        let session_id: WalletSweepSessionId =
             session_update.session_id.as_slice().try_into().expect("todo: handle error");
 
-        // skip this update if the session already exists
-        if self
-            .storage
-            .botanix_database_factory
-            .is_wallet_sweep_session_exists(session_id)
-            .expect("todo: handle error")
-        {
-            trace!(target: "consensus::authority::frost_task::WalletSweepTask", "Skip wallet sweep session update - session already exists");
+        trace!(
+            sweep_session_id = hex::encode(&session_id),
+            "Update wallet sweep session from btc-server"
+        );
 
-            return;
-        }
-
-        // check if we another session and reject it first
+        // Check if we had another session
         match self.storage.botanix_database_factory.get_wallet_sweep_session() {
             Ok(Some((existing_session_id, _))) => {
-                warn!(
-                    new_session_id = hex::encode(&session_id),
-                    existing_session_id = hex::encode(&existing_session_id),
-                    "another wallet sweep session already exist. reject it first"
-                );
+                if existing_session_id == session_id {
+                    trace!(
+                        sweep_session_id = hex::encode(&session_id),
+                        "Wallet sweep session already exists. Skip update"
+                    );
 
-                // TODO: Reject exising session
-
-                // // Check if we already have a signing session for this sweep
-                // if self.signing_state_machine.signing_session_exists(signing_session_id).await {
-                //     trace!(target:
-                // "consensus::authority::frost_task::check_and_initiate_sweep_signing",
-                //    "Signing session already exists for sweep: {}",
-                // hex::encode(&signing_session_id));     return;
-                // }
+                    return;
+                } else {
+                    debug!(
+                        new_sweep_session_id = hex::encode(&session_id),
+                        existing_sweep_session_id = hex::encode(&existing_session_id),
+                        "Another wallet sweep session already exist. It will be replaced with the new one"
+                    );
+                }
             }
             Err(e) => {
                 error!("failed to fetch current wallet sweep session from database: {e}");
 
                 return;
             }
-            _ => {}
+            Ok(None) => {}
         };
 
         let session = match WalletSweepSession::decompress(session_update.session_bytes) {
@@ -105,66 +107,29 @@ where
 
         self.storage
             .botanix_database_factory
-            .update_wallet_sweep_session(session)
+            .update_wallet_sweep_session(session.clone())
             .expect("failed to update wallet sweep session");
-
-        // The logic bellow is only for the coordinator
-        if !self.signing_state_machine.is_coordinator() {
-            trace!("Not coordinator, waiting for sweep PSBT from coordinator");
-
-            return;
-        }
-
-        // TODO: We need to run it periodically to check if we have a session
-        //  and restart it if it fails
-        self.initiate_signing_session().await;
     }
 
-    async fn initiate_signing_session(&mut self) {
-        let (session_id, sweep_session) =
-            match self.storage.botanix_database_factory.get_wallet_sweep_session() {
-                Ok(Some((session_id, session))) => (session_id, session),
-                Err(e) => {
-                    error!("failed to fetch current wallet sweep session from database: {e}");
+    async fn initiate_signing_session(
+        &mut self,
+        sweep_session_id: WalletSweepSessionId,
+        sweep_session: WalletSweepSession,
+    ) -> Option<SigningSessionId> {
+        let signing_session_id = generate_signing_session_id(sweep_session_id);
 
-                    return;
-                }
-                _ => {
-                    trace!("No wallet sweep session found, skipping signing initiation");
-
-                    // Do nothing if the session doesn't exist
-                    return;
-                }
-            };
-
-        // Check if we already have a signing session for this sweep
-        if let Some(signing_session) =
-            self.signing_state_machine.get_signing_session(*session_id).await
-        {
-            if signing_session.state().has_failed() {
-                // It's failed, so we remove it
-                debug!(
-                    session_id = hex::encode(&session_id),
-                    "Signing session has failed, removing and retrying"
-                );
-
-                self.signing_state_machine.remove_signing_session(*session_id).await;
-            } else {
-                // It's still active, so we skip
-                trace!(
-                    session_id = hex::encode(&session_id),
-                    "Signing session already exists and is active, skipping initiation"
-                );
-
-                return;
-            }
-        }
+        info!(
+            sweep_session_id = hex::encode(&sweep_session_id),
+            signing_session_id = hex::encode(&signing_session_id),
+            "Initiating FROST signing for sweep PSBT"
+        );
 
         // Create the sweep PSBT
         let sweep_psbt = match create_psbt_async(sweep_session, &mut self.btc_server).await {
             Ok(psbt) => {
                 trace!(
-                    session_id = hex::encode(&session_id),
+                    sweep_session_id = hex::encode(&sweep_session_id),
+                    signing_session_id = hex::encode(&signing_session_id),
                     "Successfully created sweep PSBT with {} inputs, {} outputs",
                     psbt.inputs.len(),
                     psbt.outputs.len()
@@ -172,73 +137,216 @@ where
                 psbt
             }
             Err(e) => {
-                error!(session_id = hex::encode(&session_id), "Failed to create sweep PSBT: {}", e);
-                return;
+                error!(
+                    sweep_session_id = hex::encode(&sweep_session_id),
+                    signing_session_id = hex::encode(&signing_session_id),
+                    "Failed to create sweep PSBT: {}",
+                    e
+                );
+
+                return None;
             }
         };
 
         // Serialize the PSBT for signing
         let psbt_bytes = sweep_psbt.serialize();
 
-        info!(session_id = hex::encode(&session_id), "Initiating FROST signing for sweep PSBT");
-
         // Initiate FROST signing-session with the directly created PSBT
         if let Err(e) = self
             .signing_state_machine
-            .initate_signing_session(session_id, psbt_bytes, SigningPsbtType::Sweep)
+            .initiate_signing_session(signing_session_id, psbt_bytes)
             .await
         {
             error!(
-                session_id = hex::encode(&session_id),
+                sweep_session_id = hex::encode(&sweep_session_id),
+                %signing_session_id,
                 "Failed to initiate FROST signing for sweep PSBT: {}", e
             );
+
+            None
         } else {
-            info!(session_id = hex::encode(&session_id), "Initiating FROST signing for sweep PSBT");
+            info!(
+                sweep_session_id = hex::encode(&sweep_session_id),
+                signing_session_id = hex::encode(&signing_session_id),
+                "Initiated FROST signing for sweep PSBT"
+            );
+
+            Some(signing_session_id)
         }
     }
 
+    async fn handle_psbt_signing_session(&mut self) {
+        trace!("Handle signing session for wallet sweep");
+
+        let (sweep_session_id, sweep_session) = match self
+            .storage
+            .botanix_database_factory
+            .get_wallet_sweep_session()
+        {
+            Ok(Some((session_id, session))) => (session_id, session),
+            Ok(None) => {
+                // If we don't have a wallet sweep session, ensure no signing session is active
+                let mut maybe_signing_session_id = self.signing_session_id.lock().await;
+
+                if let Some(signing_session_id) = *maybe_signing_session_id {
+                    debug!(
+                        signing_session_id = hex::encode(&signing_session_id),
+                        "No wallet sweep session found, but there is an active signing session. Reject it."
+                    );
+
+                    self.signing_state_machine.remove_signing_session(signing_session_id).await;
+
+                    *maybe_signing_session_id = None;
+                } else {
+                    trace!("No wallet sweep session found");
+                }
+
+                return;
+            }
+            Err(e) => {
+                error!("Failed to fetch wallet sweep session from database: {e}");
+
+                return;
+            }
+        };
+
+        // Check if we have an active signing session
+        let mut maybe_signing_session_id = self.signing_session_id.lock().await;
+
+        if let Some(signing_session_id) = *maybe_signing_session_id {
+            // Check if the corresponding signing session exists and its status
+            if let Some(signing_session) =
+                self.signing_state_machine.get_signing_session(signing_session_id).await
+            {
+                if signing_session.state().is_finalized() {
+                    // Signing completed successfully.
+                    info!(
+                        sweep_session_id = hex::encode(&sweep_session_id),
+                        signing_session_id = hex::encode(&signing_session_id),
+                        "Wallet sweep signing session completed successfully"
+                    );
+
+                    *maybe_signing_session_id = None;
+
+                    return;
+                } else if signing_session.state().has_failed() {
+                    warn!(
+                        sweep_session_id = hex::encode(&sweep_session_id),
+                        signing_session_id = hex::encode(&signing_session_id),
+                        "Signing session failed after 1 minute, remove and retry"
+                    );
+
+                    // Remove the failed session
+                    self.signing_state_machine.remove_signing_session(signing_session_id).await;
+                } else if signing_session.state().is_running() {
+                    warn!(
+                        sweep_session_id = hex::encode(&sweep_session_id),
+                        signing_session_id = hex::encode(&signing_session_id),
+                        "Signing session still not completed after 1 minute, reject and retry"
+                    );
+
+                    // Remove the incomplete session
+                    self.signing_state_machine.remove_signing_session(signing_session_id).await;
+                } else {
+                    warn!(
+                            sweep_session_id = hex::encode(&sweep_session_id),
+                            signing_session_id = hex::encode(&signing_session_id),
+                            "Signing session in unexpected state after 1 minute, removing and will retry on next check"
+                        );
+
+                    // Remove the session in unexpected state
+                    self.signing_state_machine.remove_signing_session(signing_session_id).await;
+                }
+            } else {
+                warn!(
+                    sweep_session_id = hex::encode(&sweep_session_id),
+                    signing_session_id = hex::encode(&signing_session_id),
+                    "Signing session not found after 1 minute for some reason, retrying"
+                );
+            }
+        } else {
+            trace!("No active wallet sweep signing session, starting new one");
+        }
+
+        // We borrow mutable self bellow so we can't keep immutable borrowed lock
+        drop(maybe_signing_session_id);
+
+        // Start signing session again
+        let new_signing_session_id =
+            self.initiate_signing_session(sweep_session_id, sweep_session).await;
+
+        let mut maybe_signing_session_id = self.signing_session_id.lock().await;
+        *maybe_signing_session_id = new_signing_session_id;
+    }
+
     pub async fn run(mut self) {
+        let mut signing_check_interval =
+            tokio::time::interval(tokio::time::Duration::from_secs(60));
+
         loop {
             let request = btc_server_client::WalletSweepSessionUpdatesRequest {};
-            let mut stream = match self
-                .btc_server
-                .subscribe_to_wallet_sweep_session_updates(request)
-                .await
-            {
-                Ok(stream) => {
-                    debug!(target: "consensus::authority::frost_task::WalletSweepTask", "Connected to wallet sweep session updates");
+            let mut stream =
+                match self.btc_server.subscribe_to_wallet_sweep_session_updates(request).await {
+                    Ok(stream) => {
+                        debug!("Connected to wallet sweep session updates");
 
-                    stream
-                }
-                Err(_e) => {
-                    error!(target: "consensus::authority::frost_task::WalletSweepTask", "Failed to subscribe to wallet sweep session updates");
-
-                    continue;
-                }
-            };
-
-            pin_mut!(stream);
-
-            while let Some(received) = stream.next().await {
-                let session_update = match received {
-                    Ok(message) => {
-                        trace!(target: "consensus::authority::frost_task::WalletSweepTask", "Received message from wallet sweep session stream");
-
-                        message
+                        stream
                     }
                     Err(e) => {
-                        warn!(target: "consensus::authority::frost_task::WalletSweepTask", "Received error from wallet sweep session stream: {e}");
+                        error!("Failed to subscribe to wallet sweep session updates: {e}");
 
                         continue;
                     }
                 };
 
-                self.handle_wallet_sweep_session_update(session_update).await
-            }
+            pin_mut!(stream);
 
-            warn!(target: "consensus::authority::frost_task::WalletSweepTask", "Wallet sweep session stream disconnected. Reconnect in 1 second");
+            tokio::select! {
+                // Handle incoming wallet sweep session update stream messages
+                received = stream.next() => {
+                    match received {
+                        Some(Ok(message)) => {
+                            trace!("Received message from wallet sweep session stream");
+
+                            self.handle_wallet_sweep_session_update(message).await;
+                        }
+                        Some(Err(e)) => {
+                            error!("Wallet sweep session update stream error: {}", e);
+
+                            continue;
+                        }
+                        None => {
+                            warn!("Wallet sweep session stream disconnected. Reconnect in 1 second");
+
+                            continue;
+                        }
+                    }
+                }
+
+                // Handle periodic timer ticks (every minute)
+                _ = signing_check_interval.tick() => {
+                    self.handle_psbt_signing_session().await;
+                }
+            }
 
             tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
         }
     }
+}
+
+/// Hash wallet sweep session id with current time to get unique signing session id
+fn generate_signing_session_id(sweep_session_id: WalletSweepSessionId) -> SigningSessionId {
+    let signing_session_id_payload = [
+        sweep_session_id.as_slice(),
+        &std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_secs()
+            .to_le_bytes(),
+    ]
+    .concat();
+
+    let signing_session_id_payload = keccak256(signing_session_id_payload);
+
+    SigningSessionId::new_sweep_session(signing_session_id_payload.as_ref())
 }

--- a/crates/net/network/src/frost/mod.rs
+++ b/crates/net/network/src/frost/mod.rs
@@ -116,6 +116,7 @@ pub struct SigningResponse {
     pub signing_session_id: Vec<u8>,
     /// Frost data
     pub psbt: Vec<u8>,
+    // TODO: Remove - we can identify by session id
     /// The type of the PSBT
     /// New field added to distinguish between different PSBT types when we introduced
     /// wallet sweep functionality. This field defaults to `Pegout` for backward compatibility.

--- a/crates/net/network/src/frost/protocol.rs
+++ b/crates/net/network/src/frost/protocol.rs
@@ -27,7 +27,6 @@ use crate::{
 use super::{
     messages::{FrostProtoMessage, FrostProtoMessageKind, SignRequest},
     ConnectionEstablishedStatus, FrostPeerCommand, FrostProtocolEvent, PeerMessageResponse,
-    SigningPsbtType,
 };
 
 /// Frost Protocol Handler


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please provide a link to the issue -->

Not all fed members are activating wallet sweep at the same moment, so we need to retry signing until we have the minimum number of members to complete siging. It also handles all other possible failures during the signing.

## What was done?

<!--- Describe your changes in detail -->
- The coordinator starts a wallet sweep signing every minute until we have it done.
- Introduce `SigningSessionId` to differentiate pegout and sweep signing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

None

## Breaking Changes

<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] I have added or updated relevant unit/integration/functional/e2e tests
-   [x] I have tested my changes running a local network, and they work as expected
-   [x] I have performed a self-review
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
-   [x] I have made corresponding changes to the documentation if needed
-   [x] I have added assignees and reviewers to this pull request
-   [x] I have added the PR to the project board or linked it to an issue from the board
