### PR TITLE
fix(wallet-sweep): signing session ID is backward incompatible

### DIFF
--- a/bin/btc-server/src/database/mod.rs
+++ b/bin/btc-server/src/database/mod.rs
@@ -1723,7 +1723,7 @@ mod tests {
 
         let tx = create_tx(2, 1, None);
         let psbt = Psbt::from_unsigned_tx(tx).unwrap();
-        let signing_session_id = SigningSessionId::new_pegout_session(&[0; 32]);
+        let signing_session_id = SigningSessionId::new_pegout_session([0; 32]);
 
         db.update_psbt(signing_session_id, &psbt).unwrap();
         db.flush().unwrap();
@@ -1738,13 +1738,13 @@ mod tests {
 
         let tx = create_tx(2, 1, None);
         let psbt = Psbt::from_unsigned_tx(tx).unwrap();
-        let signing_session_id = SigningSessionId::new_pegout_session(&[0; 32]);
+        let signing_session_id = SigningSessionId::new_pegout_session([0; 32]);
         db.update_psbt(signing_session_id, &psbt).unwrap();
         db.flush().unwrap();
 
         let signing_session_id = db.get_session_ids(10).unwrap().first().cloned().unwrap();
         let signing_status = db.get_signing_status(signing_session_id).unwrap();
-        assert!(signing_status == SigningStatus::Running);
+        assert_eq!(signing_status, SigningStatus::Running);
     }
 
     #[test]

--- a/bin/btc-server/src/signer/session_id.rs
+++ b/bin/btc-server/src/signer/session_id.rs
@@ -12,35 +12,32 @@ pub enum SigningSessionType {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct SigningSessionId([u8; 33]);
 
-// TODO: For backward compatibility, pegout session ID must be 32 and sweep session ID must be 33
-//  bytes.
-
 impl SigningSessionId {
-    pub fn new(unique_payload: &[u8; 32], session_type: SigningSessionType) -> Self {
+    pub fn new(unique_payload: [u8; 32], session_type: SigningSessionType) -> Self {
         let mut data = [0u8; 33];
 
-        data[0] = session_type as u8;
-        data[1..33].copy_from_slice(unique_payload);
+        data[0..32].copy_from_slice(&unique_payload);
+        data[32] = session_type as u8;
 
         Self(data)
     }
 
-    pub fn new_pegout_session(unique_payload: &[u8; 32]) -> Self {
+    pub fn new_pegout_session(unique_payload: [u8; 32]) -> Self {
         Self::new(unique_payload, SigningSessionType::Pegout)
     }
 
-    pub fn new_sweep_session(unique_payload: &[u8; 32]) -> Self {
+    pub fn new_sweep_session(unique_payload: [u8; 32]) -> Self {
         Self::new(unique_payload, SigningSessionType::Sweep)
     }
 
     pub fn unique_payload(&self) -> [u8; 32] {
         let mut payload = [0u8; 32];
-        payload.copy_from_slice(&self.0[1..33]);
+        payload.copy_from_slice(&self.0[0..32]);
         payload
     }
 
     pub fn session_type(&self) -> SigningSessionType {
-        match self.0[0] {
+        match self.0[32] {
             0x00 => SigningSessionType::Pegout,
             0x01 => SigningSessionType::Sweep,
             _ => unreachable!("Invalid session type in data"),
@@ -56,7 +53,12 @@ impl SigningSessionId {
     }
 
     pub fn to_vec(&self) -> Vec<u8> {
-        self.0.to_vec()
+        if self.is_pegout_session() {
+            &self.0[0..32] // Pegout session ID is 32 bytes for backward compatibility
+        } else {
+            &self.0 // Sweep session ID is 33 bytes
+        }
+        .to_vec()
     }
 }
 
@@ -70,20 +72,24 @@ impl TryFrom<&[u8]> for SigningSessionId {
     type Error = SigningError;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        if value.len() != 33 {
+        // Session ID normally is 33 bytes: 32 bytes for a unique payload + 1 byte for type
+        // Pegout session ID is 32 bytes for backward compatibility
+        let session_type = if value.len() == 32 {
+            SigningSessionType::Pegout
+        } else if value.len() == 33 {
+            match value.last().ok_or(SigningError::InvalidSigningSessionId)? {
+                0x00 => SigningSessionType::Pegout,
+                0x01 => SigningSessionType::Sweep,
+                _ => return Err(SigningError::InvalidSigningSessionId),
+            }
+        } else {
             return Err(SigningError::InvalidSigningSessionId);
-        }
-
-        let session_type = match value.first().ok_or(SigningError::InvalidSigningSessionId)? {
-            0x00 => SigningSessionType::Pegout,
-            0x01 => SigningSessionType::Sweep,
-            _ => return Err(SigningError::InvalidSigningSessionId),
         };
 
         let mut session_id_array = [0u8; 32];
-        session_id_array.copy_from_slice(&value[1..33]);
+        session_id_array.copy_from_slice(&value[0..32]);
 
-        Ok(SigningSessionId::new(&session_id_array, session_type))
+        Ok(SigningSessionId::new(session_id_array, session_type))
     }
 }
 
@@ -97,7 +103,11 @@ impl TryFrom<Vec<u8>> for SigningSessionId {
 
 impl AsRef<[u8]> for SigningSessionId {
     fn as_ref(&self) -> &[u8] {
-        &self.0
+        if self.is_pegout_session() {
+            &self.0[0..32] // Pegout session ID is 32 bytes for backward compatibility
+        } else {
+            &self.0 // Sweep session ID is 33 bytes
+        }
     }
 }
 
@@ -117,7 +127,7 @@ mod tests {
         #[test]
         fn test_new_with_pegout_type() {
             let payload = [1u8; 32];
-            let session_id = SigningSessionId::new(&payload, SigningSessionType::Pegout);
+            let session_id = SigningSessionId::new(payload, SigningSessionType::Pegout);
 
             assert_eq!(session_id.session_type(), SigningSessionType::Pegout);
             assert_eq!(session_id.unique_payload(), payload);
@@ -126,10 +136,80 @@ mod tests {
         #[test]
         fn test_new_with_sweep_type() {
             let payload = [2u8; 32];
-            let session_id = SigningSessionId::new(&payload, SigningSessionType::Sweep);
+            let session_id = SigningSessionId::new(payload, SigningSessionType::Sweep);
 
             assert_eq!(session_id.session_type(), SigningSessionType::Sweep);
             assert_eq!(session_id.unique_payload(), payload);
+        }
+    }
+
+    mod new_pegout_session {
+        use super::*;
+
+        #[test]
+        fn test_new_pegout_session() {
+            let payload = [123u8; 32];
+            let session_id = SigningSessionId::new_pegout_session(payload);
+
+            assert_eq!(session_id.session_type(), SigningSessionType::Pegout);
+            assert_eq!(session_id.unique_payload(), payload);
+        }
+    }
+
+    mod new_sweep_session {
+        use super::*;
+
+        #[test]
+        fn test_new_sweep_session() {
+            let payload = [67u8; 32];
+            let session_id = SigningSessionId::new_sweep_session(payload);
+
+            assert_eq!(session_id.session_type(), SigningSessionType::Sweep);
+            assert_eq!(session_id.unique_payload(), payload);
+        }
+    }
+
+    mod is_sweep_session {
+        use super::*;
+
+        #[test]
+        fn test_is_sweep_session_true() {
+            let payload = [11u8; 32];
+            let session_id = SigningSessionId::new(payload, SigningSessionType::Sweep);
+
+            assert!(session_id.is_sweep_session());
+            assert!(!session_id.is_pegout_session());
+        }
+
+        #[test]
+        fn test_is_sweep_session_false() {
+            let payload = [22u8; 32];
+            let session_id = SigningSessionId::new(payload, SigningSessionType::Pegout);
+
+            assert!(!session_id.is_sweep_session());
+            assert!(session_id.is_pegout_session());
+        }
+    }
+
+    mod is_pegout_session {
+        use super::*;
+
+        #[test]
+        fn test_is_pegout_session_true() {
+            let payload = [33u8; 32];
+            let session_id = SigningSessionId::new(payload, SigningSessionType::Pegout);
+
+            assert!(session_id.is_pegout_session());
+            assert!(!session_id.is_sweep_session());
+        }
+
+        #[test]
+        fn test_is_pegout_session_false() {
+            let payload = [44u8; 32];
+            let session_id = SigningSessionId::new(payload, SigningSessionType::Sweep);
+
+            assert!(!session_id.is_pegout_session());
+            assert!(session_id.is_sweep_session());
         }
     }
 
@@ -139,23 +219,34 @@ mod tests {
         #[test]
         fn test_to_vec_pegout() {
             let payload = [42u8; 32];
-            let session_id = SigningSessionId::new(&payload, SigningSessionType::Pegout);
+            let session_id = SigningSessionId::new(payload, SigningSessionType::Pegout);
 
             let vec = session_id.to_vec();
-            assert_eq!(vec.len(), 33);
-            assert_eq!(vec[0], 0x00); // Pegout type
-            assert_eq!(&vec[1..33], &payload);
+            assert_eq!(vec.len(), 32); // Pegout returns only 32 bytes for backward compatibility
+            assert_eq!(vec, payload.to_vec());
         }
 
         #[test]
         fn test_to_vec_sweep() {
             let payload = [123u8; 32];
-            let session_id = SigningSessionId::new(&payload, SigningSessionType::Sweep);
+            let session_id = SigningSessionId::new(payload, SigningSessionType::Sweep);
 
             let vec = session_id.to_vec();
-            assert_eq!(vec.len(), 33);
-            assert_eq!(vec[0], 0x01); // Sweep type
-            assert_eq!(&vec[1..33], &payload);
+            assert_eq!(vec.len(), 33); // Sweep returns full 33 bytes
+            assert_eq!(&vec[0..32], &payload);
+            assert_eq!(vec[32], 0x01); // Sweep type
+        }
+
+        #[test]
+        fn test_to_vec_returns_new_vec() {
+            let payload = [99u8; 32];
+            let session_id = SigningSessionId::new(payload, SigningSessionType::Pegout);
+
+            let mut vec1 = session_id.to_vec();
+            let vec2 = session_id.to_vec();
+
+            vec1[0] = 255; // Modify first vec
+            assert_ne!(vec1, vec2); // Should be independent
         }
     }
 
@@ -165,23 +256,22 @@ mod tests {
         #[test]
         fn test_pegout_into_vec() {
             let payload = [55u8; 32];
-            let session_id = SigningSessionId::new(&payload, SigningSessionType::Pegout);
+            let session_id = SigningSessionId::new(payload, SigningSessionType::Pegout);
 
             let vec: Vec<u8> = session_id.into();
-            assert_eq!(vec.len(), 33);
-            assert_eq!(vec[0], 0x00);
-            assert_eq!(&vec[1..33], &payload);
+            assert_eq!(vec.len(), 32); // Pegout returns 32 bytes
+            assert_eq!(vec, payload.to_vec());
         }
 
         #[test]
         fn test_sweep_into_vec() {
             let payload = [77u8; 32];
-            let session_id = SigningSessionId::new(&payload, SigningSessionType::Sweep);
+            let session_id = SigningSessionId::new(payload, SigningSessionType::Sweep);
 
             let vec: Vec<u8> = session_id.into();
-            assert_eq!(vec.len(), 33);
-            assert_eq!(vec[0], 0x01);
-            assert_eq!(&vec[1..33], &payload);
+            assert_eq!(vec.len(), 33); // Sweep returns 33 bytes
+            assert_eq!(&vec[0..32], &payload);
+            assert_eq!(vec[32], 0x01);
         }
     }
 
@@ -189,13 +279,22 @@ mod tests {
         use super::*;
 
         #[test]
-        fn test_try_from_valid_pegout() {
+        fn test_try_from_valid_pegout_33_bytes() {
             let payload = [111u8; 32];
             let mut data = [0u8; 33];
-            data[0] = 0x00; // Pegout
-            data[1..33].copy_from_slice(&payload);
+            data[0..32].copy_from_slice(&payload);
+            data[32] = 0x00; // Pegout type
 
             let session_id = SigningSessionId::try_from(data.as_slice()).unwrap();
+            assert_eq!(session_id.session_type(), SigningSessionType::Pegout);
+            assert_eq!(session_id.unique_payload(), payload);
+        }
+
+        #[test]
+        fn test_try_from_valid_pegout_32_bytes_legacy() {
+            let payload = [111u8; 32];
+
+            let session_id = SigningSessionId::try_from(payload.as_slice()).unwrap();
             assert_eq!(session_id.session_type(), SigningSessionType::Pegout);
             assert_eq!(session_id.unique_payload(), payload);
         }
@@ -204,8 +303,8 @@ mod tests {
         fn test_try_from_valid_sweep() {
             let payload = [222u8; 32];
             let mut data = [0u8; 33];
-            data[0] = 0x01; // Sweep
-            data[1..33].copy_from_slice(&payload);
+            data[0..32].copy_from_slice(&payload);
+            data[32] = 0x01; // Sweep type
 
             let session_id = SigningSessionId::try_from(data.as_slice()).unwrap();
             assert_eq!(session_id.session_type(), SigningSessionType::Sweep);
@@ -221,14 +320,14 @@ mod tests {
 
         #[test]
         fn test_try_from_too_short() {
-            let data = [0u8; 32]; // Only 32 bytes instead of 33
+            let data = [0u8; 31]; // Only 31 bytes
             let result = SigningSessionId::try_from(data.as_slice());
             assert!(matches!(result, Err(SigningError::InvalidSigningSessionId)));
         }
 
         #[test]
         fn test_try_from_too_long() {
-            let data = [0u8; 34]; // 34 bytes instead of 33
+            let data = [0u8; 34]; // 34 bytes instead of 32 or 33
             let result = SigningSessionId::try_from(data.as_slice());
             assert!(matches!(result, Err(SigningError::InvalidSigningSessionId)));
         }
@@ -236,7 +335,7 @@ mod tests {
         #[test]
         fn test_try_from_invalid_session_type() {
             let mut data = [0u8; 33];
-            data[0] = 0x02; // Invalid session type
+            data[32] = 0x02; // Invalid session type
 
             let result = SigningSessionId::try_from(data.as_slice());
             assert!(matches!(result, Err(SigningError::InvalidSigningSessionId)));
@@ -245,7 +344,7 @@ mod tests {
         #[test]
         fn test_try_from_max_invalid_session_type() {
             let mut data = [0u8; 33];
-            data[0] = 255; // Invalid session type
+            data[32] = 255; // Invalid session type
 
             let result = SigningSessionId::try_from(data.as_slice());
             assert!(matches!(result, Err(SigningError::InvalidSigningSessionId)));
@@ -254,7 +353,7 @@ mod tests {
         #[test]
         fn test_try_from_roundtrip_pegout() {
             let payload = [42u8; 32];
-            let original = SigningSessionId::new(&payload, SigningSessionType::Pegout);
+            let original = SigningSessionId::new(payload, SigningSessionType::Pegout);
             let vec = original.to_vec();
             let reconstructed = SigningSessionId::try_from(vec.as_slice()).unwrap();
 
@@ -265,7 +364,7 @@ mod tests {
         #[test]
         fn test_try_from_roundtrip_sweep() {
             let payload = [84u8; 32];
-            let original = SigningSessionId::new(&payload, SigningSessionType::Sweep);
+            let original = SigningSessionId::new(payload, SigningSessionType::Sweep);
             let vec = original.to_vec();
             let reconstructed = SigningSessionId::try_from(vec.as_slice()).unwrap();
 
@@ -280,23 +379,22 @@ mod tests {
         #[test]
         fn test_as_ref_pegout() {
             let payload = [13u8; 32];
-            let session_id = SigningSessionId::new(&payload, SigningSessionType::Pegout);
+            let session_id = SigningSessionId::new(payload, SigningSessionType::Pegout);
 
             let slice: &[u8] = session_id.as_ref();
-            assert_eq!(slice.len(), 33);
-            assert_eq!(slice[0], 0x00); // Pegout type
-            assert_eq!(&slice[1..33], &payload);
+            assert_eq!(slice.len(), 32); // Pegout returns only 32 bytes
+            assert_eq!(slice, &payload);
         }
 
         #[test]
         fn test_as_ref_sweep() {
             let payload = [97u8; 32];
-            let session_id = SigningSessionId::new(&payload, SigningSessionType::Sweep);
+            let session_id = SigningSessionId::new(payload, SigningSessionType::Sweep);
 
             let slice: &[u8] = session_id.as_ref();
-            assert_eq!(slice.len(), 33);
-            assert_eq!(slice[0], 0x01); // Sweep type
-            assert_eq!(&slice[1..33], &payload);
+            assert_eq!(slice.len(), 33); // Sweep returns full 33 bytes
+            assert_eq!(&slice[0..32], &payload);
+            assert_eq!(slice[32], 0x01); // Sweep type
         }
     }
 }

--- a/crates/botanix-storage/src/models/wallet_sweep.rs
+++ b/crates/botanix-storage/src/models/wallet_sweep.rs
@@ -1,8 +1,7 @@
 use bitcoin::{address::NetworkUnchecked, Address, Network};
 use bytes::Buf;
-use reth_db_api::table::{Compress, Decode, Decompress, Encode};
+use reth_db_api::table::{Compress, Decompress};
 use reth_primitives::{keccak256, B256};
-use reth_storage_errors::db::DatabaseError;
 use serde::{Deserialize, Serialize};
 use std::ops::Deref;
 // TODO: TBD

--- a/crates/consensus/authority/src/frost_task.rs
+++ b/crates/consensus/authority/src/frost_task.rs
@@ -413,7 +413,7 @@ where
         );
 
         // Initiate signing session
-        let session_id = SigningSessionId::new_pegout_session(&*header_hash);
+        let session_id = SigningSessionId::new_pegout_session(*header_hash);
 
         if let Err(e) =
             self.signing_state_machine.initiate_signing_session(session_id, psbt_payload.psbt).await

--- a/crates/consensus/authority/src/wallet_sweep_task.rs
+++ b/crates/consensus/authority/src/wallet_sweep_task.rs
@@ -348,5 +348,5 @@ fn generate_signing_session_id(sweep_session_id: WalletSweepSessionId) -> Signin
 
     let signing_session_id_payload = keccak256(signing_session_id_payload);
 
-    SigningSessionId::new_sweep_session(signing_session_id_payload.as_ref())
+    SigningSessionId::new_sweep_session(*signing_session_id_payload)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please provide a link to the issue -->
Previous singing session ID was 32 bytes. A new one is 33 which makes them incompatible (when we read from btc server db for example)

## What was done?

<!--- Describe your changes in detail -->
- For pegout session id we keep 32 bytes such as before the change so existing data will be still accessible

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

WIth unit tests

## Breaking Changes

<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] I have added or updated relevant unit/integration/functional/e2e tests
-   [x] I have tested my changes running a local network, and they work as expected
-   [x] I have performed a self-review
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
-   [x] I have made corresponding changes to the documentation if needed
-   [x] I have added assignees and reviewers to this pull request
-   [x] I have added the PR to the project board or linked it to an issue from the board


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved compatibility for transaction signing sessions: supports legacy 32-byte pegout identifiers and standard 33-byte sweep identifiers seamlessly.
- Refactor
  - Streamlined session ID encoding to enhance robustness and forward compatibility. No user action required.
- Bug Fixes
  - Minor assertion consistency adjustments to improve reliability in edge cases.
- Tests
  - Expanded coverage for mixed-length session IDs to ensure stable behavior across legacy and current formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->