### PR TITLE
feat(wallet-sweep): pause pegouts to do not interfere with sweep signing

### DIFF
--- a/crates/consensus/authority/src/frost_task.rs
+++ b/crates/consensus/authority/src/frost_task.rs
@@ -266,12 +266,27 @@ where
     ) {
         debug_assert_eq!(header_hash, header.hash_slow());
 
-        // TODO: This could abort our sweep signing session
-
         info!(
             target: "consensus::authority::frost_task::handle_canon_state_commit",
             "Handling canon state commit for block number {:?}", header.number
         );
+
+        let active_sweep_session = self
+            .storage
+            .botanix_database_factory
+            .get_wallet_sweep_session()
+            .expect("todo: handle error");
+
+        if let Some((sweep_session_id, _)) = active_sweep_session {
+            warn!(
+                target: "consensus::authority::frost_task::handle_canon_state_commit",
+                eth_block_height = header.number,
+                %sweep_session_id
+                "Wallet sweep session is initiated, pause pegout signing until it's completed."
+            );
+
+            return;
+        }
 
         let edh = match header.deserialize_extra_data_header() {
             Ok(edh) => edh,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please provide a link to the issue -->

`FrostTask` can handle only one signing session at once, so before it start a new one it aborts any existing. It means that pegouts will abort wallet sweep sessions

## What was done?

<!--- Describe your changes in detail -->

- Pause pegouts until wallet sweep is complete

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

None

## Breaking Changes

<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] I have added or updated relevant unit/integration/functional/e2e tests
-   [x] I have tested my changes running a local network, and they work as expected
-   [x] I have performed a self-review
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
-   [x] I have made corresponding changes to the documentation if needed
-   [x] I have added assignees and reviewers to this pull request
-   [x] I have added the PR to the project board or linked it to an issue from the board


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically pauses pegout signing while a wallet sweep is in progress to prevent conflicts and ensure session integrity.
  * Improves reliability during block commits and reduces risk of interrupted or conflicting withdrawals.
  * Adds clear warning messages to logs when pegout signing is skipped due to an active sweep session, aiding operators in troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->