### PR TITLE
fix(utxo-recovery): resolve endian/type conversion issues

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -140,6 +140,7 @@ jobs:
           "signing_flow",
           "test_mempool_gossip",
           "utxo_sync",
+          "utxo_recovery",
           "state_sync",
           "wallet_sync",
           "frost_e2e_stable",

--- a/bin/btc-server/src/bin/main.rs
+++ b/bin/btc-server/src/bin/main.rs
@@ -2146,6 +2146,9 @@ where
         &self,
         request: tonic::Request<RecoverMissingUtxosRequest>,
     ) -> Result<tonic::Response<RecoverMissingUtxosResponse>, tonic::Status> {
+        // print the request
+        info!("BtcServer::recover_missing_utxos: Request: {:?}", request);
+
         self.validate_jwt(&request)?;
 
         let total_requested = request.get_ref().utxos.len() as u64;
@@ -2171,18 +2174,18 @@ where
 
         let mut utxos_to_add = Vec::new();
         for req_utxo in request.into_inner().utxos {
-            info!("Processing UTXO: {:?}", req_utxo.outpoint);
-
             // convert the request outpoint to the database outpoint
             let req_outpoint = req_utxo.outpoint.as_ref().ok_or_else(|| {
                 error!("BtcServer::recover_missing_utxos: UTXO has no outpoint");
                 tonic::Status::invalid_argument("UTXO missing outpoint")
             })?;
-            let txid = bitcoin::Txid::from_slice(&req_outpoint.txid).map_err(|e| {
+
+            let txid = bitcoin::Txid::from_slice(&req_outpoint.txid.clone()).map_err(|e| {
                 error!("BtcServer::recover_missing_utxos: Invalid txid format: {}", e);
                 tonic::Status::invalid_argument(format!("Invalid txid format: {}", e))
             })?;
             let outpoint = bitcoin::OutPoint { txid, vout: req_outpoint.vout };
+            info!("BtcServer::recover_missing_utxos: converted bitcoin::OutPoint: {:?}", outpoint);
 
             // check if the utxo is already in the database
             if db_outpoints.contains(&outpoint) {
@@ -2198,13 +2201,18 @@ where
                 .bitcoind_client
                 .get_tx_out(&outpoint.txid, outpoint.vout, None)
                 .map_err(|e| {
-                    error!("Failed to get tx out for input: {}: {}", outpoint, e);
+                    error!(
+                        "BtcServer::recover_missing_utxos: Failed to get tx out for input: {}: {}",
+                        outpoint, e
+                    );
                     tonic::Status::internal(format!(
                         "Failed to get tx out for input: {}: {}",
                         outpoint, e
                     ))
                 })?;
 
+            debug!("BtcServer::recover_missing_utxos: outpoint: {:?}", outpoint);
+            debug!("BtcServer::recover_missing_utxos: on_chain_utxo: {:?}", on_chain_utxo);
             let Some(on_chain_utxo) = on_chain_utxo else {
                 warn!(
                     "BtcServer::recover_missing_utxos: UTXO {} does not exist on chain, skipping.",
@@ -2218,7 +2226,7 @@ where
                 None
             } else {
                 let parsed_eth_address = parse_eth_address(req_utxo.eth_address).map_err(|e| {
-                    error!("Invalid ETH address format: {}", e);
+                    error!("BtcServer::recover_missing_utxos: Invalid ETH address format: {}", e);
                     tonic::Status::internal(format!("Invalid ETH address format: {}", e))
                 })?;
                 Some(parsed_eth_address)
@@ -2229,7 +2237,9 @@ where
                 outpoint,
                 output: TxOut {
                     value: on_chain_utxo.value,
-                    script_pubkey: bitcoin::ScriptBuf::from_bytes(on_chain_utxo.script_pub_key.hex.clone()),
+                    script_pubkey: bitcoin::ScriptBuf::from_bytes(
+                        on_chain_utxo.script_pub_key.hex.clone(),
+                    ),
                 },
                 eth_address,
                 version: 0,
@@ -2259,13 +2269,13 @@ where
             }
 
             // add the utxo to the list of utxos to be added
-            info!("UTXO {} passed all validations, adding to recovery list", outpoint);
+            println!("BtcServer::recover_missing_utxos: UTXO {} passed all validations, adding to recovery list", outpoint);
             utxos_to_add.push(utxo);
         }
 
         // add the utxos to the database
         let utxo_refs: Vec<&crate::database::Utxo> = utxos_to_add.iter().collect();
-        info!("Storing {} missing UTXOs.", utxo_refs.len());
+        println!("BtcServer::recover_missing_utxos: Storing {} missing UTXOs.", utxo_refs.len());
         self.db.store_utxos(&utxo_refs).to_status()?;
         self.db.update_utxo_merkle_root().to_status()?;
         self.db.flush().to_status()?;
@@ -3208,9 +3218,9 @@ mod tests {
         let mut rng = thread_rng();
 
         // add dummy utxo to db to prevent 'no utxo in db' error
-        let (outpoint1, utxo1_amount, pegin_script_pubkey) =
+        let (dummy_outpoint, dummy_amount, dummy_script_pubkey) =
             create_utxo(&mut rng, 1000, agg_key, None);
-        add_utxo_to_db(&app, outpoint1, utxo1_amount, pegin_script_pubkey, None);
+        add_utxo_to_db(&app, dummy_outpoint, dummy_amount, dummy_script_pubkey, None);
 
         // Onchain UTXO 1: With eth_address (pegin UTXO)
         let eth_address = [1u8; 20];
@@ -3243,6 +3253,16 @@ mod tests {
         let request = tonic::Request::new(RecoverMissingUtxosRequest {
             utxos: vec![utxo_with_eth, utxo_without_eth],
         });
+
+        // use hex encode to print the txid in the request
+        let txid = hex::encode(&outpoint1.txid);
+        println!("hex encoded txid: {}", txid);
+
+        let txid_bytes = bitcoin::consensus::serialize(&outpoint1.txid);
+        println!("txid bytes: {:?}", txid_bytes);
+
+        // print the request
+        println!("request: {:?}", request);
 
         let response = app.recover_missing_utxos(request).await.expect("successful recovery");
         let inner = response.into_inner();

--- a/bin/btc-server/src/bin/main.rs
+++ b/bin/btc-server/src/bin/main.rs
@@ -2154,8 +2154,9 @@ where
         // Get the UTXO set from the db
         let db_utxos = self.db.get_all_utxos().to_status()?;
         if db_utxos.is_empty() {
-            error!("BtcServer::recover_missing_utxos: No UTXOs found in the database.");
-            return Err(tonic::Status::internal("No UTXOs found in the database."));
+            // Not returning an error as it's possible for the db utxos to be empty after a wallet
+            // sweep
+            warn!("BtcServer::recover_missing_utxos: No UTXOs found in the database.");
         }
         info!("BtcServer::recover_missing_utxos: Found {} UTXOs in the database.", db_utxos.len());
 

--- a/bin/btc-server/src/bin/main.rs
+++ b/bin/btc-server/src/bin/main.rs
@@ -13,8 +13,7 @@ use std::{
 
 use base64::{engine::general_purpose, Engine};
 use bitcoin::{
-    consensus::Decodable,
-    secp256k1, Amount, BlockHash, Psbt, ScriptBuf, Transaction, TxOut,
+    consensus::Decodable, secp256k1, Amount, BlockHash, Psbt, ScriptBuf, Transaction, TxOut,
 };
 use bitcoin_hashes::Hash;
 use bitcoincore_rpc::{Auth, RpcApi};

--- a/bin/btc-server/src/bin/main.rs
+++ b/bin/btc-server/src/bin/main.rs
@@ -13,7 +13,7 @@ use std::{
 
 use base64::{engine::general_purpose, Engine};
 use bitcoin::{
-    consensus::{self, Decodable},
+    consensus::Decodable,
     secp256k1, Amount, BlockHash, Psbt, ScriptBuf, Transaction, TxOut,
 };
 use bitcoin_hashes::Hash;

--- a/bin/btc-server/src/bin/main.rs
+++ b/bin/btc-server/src/bin/main.rs
@@ -2267,13 +2267,13 @@ where
             }
 
             // add the utxo to the list of utxos to be added
-            println!("BtcServer::recover_missing_utxos: UTXO {} passed all validations, adding to recovery list", outpoint);
+            info!("BtcServer::recover_missing_utxos: UTXO {} passed all validations, adding to recovery list", outpoint);
             utxos_to_add.push(utxo);
         }
 
         // add the utxos to the database
         let utxo_refs: Vec<&crate::database::Utxo> = utxos_to_add.iter().collect();
-        println!("BtcServer::recover_missing_utxos: Storing {} missing UTXOs.", utxo_refs.len());
+        info!("BtcServer::recover_missing_utxos: Storing {} missing UTXOs.", utxo_refs.len());
         self.db.store_utxos(&utxo_refs).to_status()?;
         self.db.update_utxo_merkle_root().to_status()?;
         self.db.flush().to_status()?;
@@ -3233,34 +3233,18 @@ mod tests {
 
         // Create request utxos
         let utxo_with_eth = rpc::UtxoToRecover {
-            outpoint: Some(rpc::OutPoint {
-                txid: bitcoin::consensus::serialize(&outpoint1.txid),
-                vout: outpoint1.vout,
-            }),
+            outpoint: Some(rpc::OutPoint::from(outpoint1)),
             eth_address: hex::encode(eth_address),
         };
 
         let utxo_without_eth = rpc::UtxoToRecover {
-            outpoint: Some(rpc::OutPoint {
-                txid: bitcoin::consensus::serialize(&outpoint2.txid),
-                vout: outpoint2.vout,
-            }),
+            outpoint: Some(rpc::OutPoint::from(outpoint2)),
             eth_address: String::new(), // Empty for change UTXO
         };
 
         let request = tonic::Request::new(RecoverMissingUtxosRequest {
             utxos: vec![utxo_with_eth, utxo_without_eth],
         });
-
-        // use hex encode to print the txid in the request
-        let txid = hex::encode(&outpoint1.txid);
-        println!("hex encoded txid: {}", txid);
-
-        let txid_bytes = bitcoin::consensus::serialize(&outpoint1.txid);
-        println!("txid bytes: {:?}", txid_bytes);
-
-        // print the request
-        println!("request: {:?}", request);
 
         let response = app.recover_missing_utxos(request).await.expect("successful recovery");
         let inner = response.into_inner();
@@ -3307,38 +3291,26 @@ mod tests {
 
         // Case 1 - utxo exists in db
         let existing_utxo = rpc::UtxoToRecover {
-            outpoint: Some(rpc::OutPoint {
-                txid: bitcoin::consensus::serialize(&existing_outpoint.txid),
-                vout: existing_outpoint.vout,
-            }),
+            outpoint: Some(rpc::OutPoint::from(existing_outpoint)),
             eth_address: String::new(),
         };
 
         // Case 2 - wrong eth address
         let wrong_eth_address = [2u8; 20];
         let utxo_wrong_eth_address = rpc::UtxoToRecover {
-            outpoint: Some(rpc::OutPoint {
-                txid: bitcoin::consensus::serialize(&outpoint1.txid),
-                vout: outpoint1.vout,
-            }),
+            outpoint: Some(rpc::OutPoint::from(outpoint1)),
             eth_address: hex::encode(wrong_eth_address),
         };
 
         // Case 3 - utxo does not match change script pubkey
         let utxo_not_change_script = rpc::UtxoToRecover {
-            outpoint: Some(rpc::OutPoint {
-                txid: bitcoin::consensus::serialize(&outpoint2.txid),
-                vout: outpoint2.vout,
-            }),
+            outpoint: Some(rpc::OutPoint::from(outpoint2)),
             eth_address: String::new(),
         };
 
         // Case 4 - utxo is not found by bitcoind
         let utxo_not_found = rpc::UtxoToRecover {
-            outpoint: Some(rpc::OutPoint {
-                txid: bitcoin::consensus::serialize(&outpoint3.txid),
-                vout: outpoint3.vout,
-            }),
+            outpoint: Some(rpc::OutPoint::from(outpoint3)),
             eth_address: String::new(),
         };
 

--- a/bin/btc-server/src/bin/main.rs
+++ b/bin/btc-server/src/bin/main.rs
@@ -2229,12 +2229,7 @@ where
                 outpoint,
                 output: TxOut {
                     value: on_chain_utxo.value,
-                    script_pubkey: consensus::deserialize::<bitcoin::ScriptBuf>(
-                        &on_chain_utxo.script_pub_key.hex,
-                    )
-                    .map_err(|e| {
-                        tonic::Status::internal(format!("Failed to decode script: {}", e))
-                    })?,
+                    script_pubkey: bitcoin::ScriptBuf::from_bytes(on_chain_utxo.script_pub_key.hex.clone()),
                 },
                 eth_address,
                 version: 0,

--- a/bin/btc-server/src/bin/main.rs
+++ b/bin/btc-server/src/bin/main.rs
@@ -2179,11 +2179,10 @@ where
                 tonic::Status::invalid_argument("UTXO missing outpoint")
             })?;
 
-            let txid = bitcoin::Txid::from_slice(&req_outpoint.txid.clone()).map_err(|e| {
-                error!("BtcServer::recover_missing_utxos: Invalid txid format: {}", e);
-                tonic::Status::invalid_argument(format!("Invalid txid format: {}", e))
+            let outpoint = bitcoin::OutPoint::try_from(req_outpoint.clone()).map_err(|e| {
+                error!("BtcServer::recover_missing_utxos: Invalid outpoint format: {}", e);
+                tonic::Status::invalid_argument(format!("Invalid outpoint format: {}", e))
             })?;
-            let outpoint = bitcoin::OutPoint { txid, vout: req_outpoint.vout };
             info!("BtcServer::recover_missing_utxos: converted bitcoin::OutPoint: {:?}", outpoint);
 
             // check if the utxo is already in the database

--- a/bin/btc-server/src/rpc/type_extensions.rs
+++ b/bin/btc-server/src/rpc/type_extensions.rs
@@ -2,7 +2,7 @@ use crate::{
     pegout_scheduler::{PegoutRequest, Tx},
     rpc::{OutPoint, PendingPegout, ScriptBuf, TrackedTx, Transaction, TxIn, TxOut},
 };
-use bitcoin::{hashes::Hash, TxIn as BtcTxIn, TxOut as BtcTxOut, Txid};
+use bitcoin::{hashes::Hash, OutPoint as BtcOutPoint, TxIn as BtcTxIn, TxOut as BtcTxOut, Txid};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -66,6 +66,12 @@ impl TryFrom<BtcTxOut> for TxOut {
             value: tx_out.value.to_sat(),
             script_pubkey: Some(ScriptBuf { script: tx_out.script_pubkey.to_bytes().to_vec() }),
         })
+    }
+}
+
+impl From<BtcOutPoint> for OutPoint {
+    fn from(outpoint: BtcOutPoint) -> Self {
+        OutPoint { txid: outpoint.txid.to_byte_array().to_vec(), vout: outpoint.vout }
     }
 }
 
@@ -155,8 +161,8 @@ impl TryFrom<Tx> for TrackedTx {
 
 #[cfg(test)]
 mod tests {
-    use crate::rpc::{self, TrackedTx};
-    use bitcoin::Txid;
+    use crate::rpc::{self, OutPoint, TrackedTx};
+    use bitcoin::{OutPoint as BtcOutPoint, Txid};
     use bitcoin_hashes::Hash;
     use prost_types::Timestamp;
     use rand::{thread_rng, Rng};
@@ -264,5 +270,25 @@ mod tests {
 
         let error = tx_out.validate().unwrap_err();
         assert_eq!(error, "script_pubkey field is required");
+    }
+
+    #[test]
+    fn test_bitcoin_outpoint_conversion() {
+        let txid = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+            .parse::<bitcoin::Txid>()
+            .unwrap();
+        let bitcoin_outpoint = BtcOutPoint { txid, vout: 5 };
+
+        let proto_outpoint = OutPoint::from(bitcoin_outpoint);
+
+        assert_eq!(
+            proto_outpoint.txid,
+            hex::decode("1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
+                .unwrap()
+                .into_iter()
+                .rev()
+                .collect::<Vec<u8>>()
+        );
+        assert_eq!(proto_outpoint.vout, 5);
     }
 }

--- a/bin/btc-server/src/rpc/type_extensions.rs
+++ b/bin/btc-server/src/rpc/type_extensions.rs
@@ -75,6 +75,17 @@ impl From<BtcOutPoint> for OutPoint {
     }
 }
 
+impl TryFrom<OutPoint> for BtcOutPoint {
+    type Error = TryFromError;
+
+    fn try_from(outpoint: OutPoint) -> Result<Self, Self::Error> {
+        let txid = bitcoin::Txid::from_slice(&outpoint.txid)
+            .map_err(|_| TryFromError::ConversionError { variant: "invalid_txid" })?;
+
+        Ok(BtcOutPoint { txid, vout: outpoint.vout })
+    }
+}
+
 impl TrackedTx {
     // only validates that optional fields contain values
     pub fn validate(&self) -> Result<(), String> {
@@ -290,5 +301,42 @@ mod tests {
                 .collect::<Vec<u8>>()
         );
         assert_eq!(proto_outpoint.vout, 5);
+    }
+
+    #[test]
+    fn test_protobuf_to_bitcoin_outpoint_conversion() {
+        let proto_outpoint = OutPoint {
+            txid: hex::decode("1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
+                .unwrap()
+                .into_iter()
+                .rev()
+                .collect::<Vec<u8>>(),
+            vout: 5,
+        };
+
+        let bitcoin_outpoint = BtcOutPoint::try_from(proto_outpoint).unwrap();
+
+        assert_eq!(
+            bitcoin_outpoint.txid.to_string(),
+            "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+        );
+        assert_eq!(bitcoin_outpoint.vout, 5);
+    }
+
+    #[test]
+    fn test_outpoint_roundtrip_conversion() {
+        let original_txid = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+            .parse::<bitcoin::Txid>()
+            .unwrap();
+        let original_bitcoin_outpoint = BtcOutPoint { txid: original_txid, vout: 42 };
+
+        // Convert bitcoin -> protobuf -> bitcoin
+        let proto_outpoint = OutPoint::from(original_bitcoin_outpoint);
+        let converted_bitcoin_outpoint = BtcOutPoint::try_from(proto_outpoint).unwrap();
+
+        // Should be identical to original
+        assert_eq!(original_bitcoin_outpoint.txid, converted_bitcoin_outpoint.txid);
+        assert_eq!(original_bitcoin_outpoint.vout, converted_bitcoin_outpoint.vout);
+        assert_eq!(original_bitcoin_outpoint, converted_bitcoin_outpoint);
     }
 }

--- a/bin/btc-server/src/test_utils/mod.rs
+++ b/bin/btc-server/src/test_utils/mod.rs
@@ -50,7 +50,7 @@ impl MockBitcoind {
 
     /// Add a output to the UTXO set
     pub fn add_utxo(&self, outpoint: OutPoint, value: Amount, script_pubkey: ScriptBuf) {
-        let script_hex = bitcoin::consensus::encode::serialize_hex(&script_pubkey);
+        let script_hex = hex::encode(script_pubkey.to_bytes());
         let json_str = format!(
             r#"{{
             "bestblock": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/bin/btc-server/src/utxo_recovery/mod.rs
+++ b/bin/btc-server/src/utxo_recovery/mod.rs
@@ -51,19 +51,21 @@ pub fn read_utxos_from_file(file_path: &Path) -> Vec<UtxoToRecover> {
                 .filter_map(|data| match UtxoToRecover::try_from(data) {
                     Ok(utxo) => Some(utxo),
                     Err(err) => {
-                        error!(target: "reth::cli", "Skipping invalid UTXO: {}", err);
+                        error!("utxo-recovery: Skipping invalid UTXO: {}", err);
                         None
                     }
                 })
                 .collect();
 
-            info!(target: "reth::cli", "Successfully loaded {} valid UTXOs from {:?}", 
-                valid_utxos.len(), file_path);
+            info!(
+                "utxo-recovery: Successfully loaded {} valid UTXOs from {:?}",
+                valid_utxos.len(),
+                file_path
+            );
             valid_utxos
         }
         Err(err) => {
-            error!(target: "reth::cli", "Failed to read UTXO recovery file {:?}: {}", 
-                file_path, err);
+            error!("utxo-recovery: Failed to read UTXO recovery file {:?}: {}", file_path, err);
             vec![]
         }
     }

--- a/bin/btc-server/src/utxo_recovery/mod.rs
+++ b/bin/btc-server/src/utxo_recovery/mod.rs
@@ -149,6 +149,16 @@ mod tests {
         };
 
         let utxo: UtxoToRecover = data.try_into().unwrap();
+
+        let txid_bytes = &utxo.outpoint.as_ref().unwrap().txid;
+        let hex_string = hex::encode(txid_bytes);
+        println!("txid: {}", hex_string);
+
+        assert_eq!(
+            utxo.outpoint.as_ref().unwrap().txid,
+            hex::decode("1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
+                .unwrap()
+        );
         assert_eq!(utxo.eth_address, "0xabcdef");
         assert_eq!(utxo.outpoint.unwrap().vout, 5);
     }

--- a/bin/btc-server/src/utxo_recovery/mod.rs
+++ b/bin/btc-server/src/utxo_recovery/mod.rs
@@ -169,10 +169,6 @@ mod tests {
 
         let utxo: UtxoToRecover = data.try_into().unwrap();
 
-        let txid_bytes = &utxo.outpoint.as_ref().unwrap().txid;
-        let hex_string = hex::encode(txid_bytes);
-        println!("txid: {}", hex_string);
-
         assert_eq!(
             utxo.outpoint.as_ref().unwrap().txid,
             hex::decode("1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")

--- a/bin/btc-server/src/utxo_recovery/mod.rs
+++ b/bin/btc-server/src/utxo_recovery/mod.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::path::Path;
 use thiserror::Error;
 
+use bitcoin_hashes::Hash;
 use btc_server_client::{OutPoint, UtxoToRecover};
 
 #[derive(Debug, Error)]
@@ -32,13 +33,19 @@ impl TryFrom<UtxoRecoveryData> for UtxoToRecover {
     type Error = UtxoRecoveryError;
 
     fn try_from(data: UtxoRecoveryData) -> Result<Self, Self::Error> {
-        let txid = hex::decode(&data.txid)
-            .map_err(|_| UtxoRecoveryError::InvalidTxid { txid: data.txid })?;
+        // Parse the hex string into a bitcoin::Txid first to ensure we handle endianness correctly
+        let txid = data
+            .txid
+            .parse::<bitcoin::Txid>()
+            .map_err(|_| UtxoRecoveryError::InvalidTxid { txid: data.txid.clone() })?;
 
-        Ok(UtxoToRecover {
-            outpoint: Some(OutPoint { txid, vout: data.vout }),
-            eth_address: data.eth_address,
-        })
+        let bitcoin_outpoint = bitcoin::OutPoint { txid, vout: data.vout };
+        let outpoint = OutPoint {
+            txid: bitcoin_outpoint.txid.to_byte_array().to_vec(),
+            vout: bitcoin_outpoint.vout,
+        };
+
+        Ok(UtxoToRecover { outpoint: Some(outpoint), eth_address: data.eth_address })
     }
 }
 
@@ -102,11 +109,15 @@ mod tests {
 
         let utxos = read_utxos_from_file(temp_file.path());
 
+        // compare the txids. Specifically, ensure that they are being stored as little endian.
         assert_eq!(utxos.len(), 3);
         assert_eq!(
             utxos[0].outpoint.as_ref().unwrap().txid,
             hex::decode("7fffc6ffc9db1400ba859447ea1f82946fa3f736f2ad1725cbd4cd1267472a1f")
                 .unwrap()
+                .into_iter()
+                .rev()
+                .collect::<Vec<u8>>()
         );
         assert_eq!(utxos[0].outpoint.as_ref().unwrap().vout, 0);
         assert_eq!(utxos[0].eth_address, "1284fEdeda331BbD0b1a868abFeD9A3Cfb91a677");
@@ -114,6 +125,9 @@ mod tests {
             utxos[1].outpoint.as_ref().unwrap().txid,
             hex::decode("d0204b10e98329ceec73bc50df687416d9c5f28d2e37fa6f1054f170ee0b4442")
                 .unwrap()
+                .into_iter()
+                .rev()
+                .collect::<Vec<u8>>()
         );
         assert_eq!(utxos[1].outpoint.as_ref().unwrap().vout, 0);
         assert_eq!(utxos[1].eth_address, "4837f53DCD09Dca12a4761BEfAd7a2398B96617a");
@@ -121,6 +135,9 @@ mod tests {
             utxos[2].outpoint.as_ref().unwrap().txid,
             hex::decode("f58feb51fbc4d7484975ced7b8649e51ba8f96d7bb00c3e49b396a080e105abf")
                 .unwrap()
+                .into_iter()
+                .rev()
+                .collect::<Vec<u8>>()
         );
         assert_eq!(utxos[2].outpoint.as_ref().unwrap().vout, 5);
         assert_eq!(utxos[2].eth_address, "");
@@ -160,6 +177,9 @@ mod tests {
             utxo.outpoint.as_ref().unwrap().txid,
             hex::decode("1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
                 .unwrap()
+                .into_iter()
+                .rev()
+                .collect::<Vec<u8>>()
         );
         assert_eq!(utxo.eth_address, "0xabcdef");
         assert_eq!(utxo.outpoint.unwrap().vout, 5);

--- a/bin/reth/src/commands/poa/mod.rs
+++ b/bin/reth/src/commands/poa/mod.rs
@@ -87,7 +87,7 @@ use reth_node_builder::{
 };
 use reth_node_core::{node_config::NodeConfig, version};
 use reth_node_ethereum::{EthEngineTypes, EthEvmConfig, EthExecutorProvider};
-use reth_primitives::{constants::ETHEREUM_BLOCK_GAS_LIMIT, Bytes, Head};
+use reth_primitives::{constants::ETHEREUM_BLOCK_GAS_LIMIT, hex, Bytes, Head};
 use reth_provider::{
     providers::{BlockchainProvider2, StaticFileProvider},
     BlockHashReader, CanonStateSubscriptions, DatabaseProviderFactory, HeaderProvider,
@@ -377,7 +377,14 @@ impl<Ext: clap::Args + fmt::Debug> PoaNodeCommand<Ext> {
             if let Some(utxo_recovery_file) = utxo_recovery_file {
                 info!(target: "reth::cli", "Recovering missing UTXOs from file: {}", utxo_recovery_file.display());
                 let utxos = read_utxos_from_file(std::path::Path::new(utxo_recovery_file));
-                info!(target: "reth::cli", "UTXOs to recover: {:?}", utxos);
+                
+                // Print all outpoints with their txids in hex format
+                for (i, utxo) in utxos.iter().enumerate() {
+                    if let Some(outpoint) = &utxo.outpoint {
+                        let txid = hex::encode(&outpoint.txid);
+                        println!("UTXO recovery request number {}: txid: {}, vout: {}, eth_address: {}", i, txid, outpoint.vout, utxo.eth_address );
+                    }
+                }
                 let recover_request = RecoverMissingUtxosRequest { utxos };
                 // Only proceed if we have UTXOs to recover
                 if !recover_request.utxos.is_empty() {

--- a/bin/reth/src/commands/poa/mod.rs
+++ b/bin/reth/src/commands/poa/mod.rs
@@ -377,12 +377,15 @@ impl<Ext: clap::Args + fmt::Debug> PoaNodeCommand<Ext> {
             if let Some(utxo_recovery_file) = utxo_recovery_file {
                 info!(target: "reth::cli", "Recovering missing UTXOs from file: {}", utxo_recovery_file.display());
                 let utxos = read_utxos_from_file(std::path::Path::new(utxo_recovery_file));
-                
+
                 // Print all outpoints with their txids in hex format
                 for (i, utxo) in utxos.iter().enumerate() {
                     if let Some(outpoint) = &utxo.outpoint {
                         let txid = hex::encode(&outpoint.txid);
-                        println!("UTXO recovery request number {}: txid: {}, vout: {}, eth_address: {}", i, txid, outpoint.vout, utxo.eth_address );
+                        info!(
+                            "reth::cli::recover_missing_utxos: UTXO recovery request number {}: txid: {}, vout: {}, eth_address: {}",
+                            i, txid, outpoint.vout, utxo.eth_address
+                        );
                     }
                 }
                 let recover_request = RecoverMissingUtxosRequest { utxos };
@@ -391,19 +394,19 @@ impl<Ext: clap::Args + fmt::Debug> PoaNodeCommand<Ext> {
                     match btc_server_client.recover_missing_utxos(recover_request).await {
                         Ok(response) => {
                             info!(target: "reth::cli",
-                                "UTXO recovery completed successfully. Requested: {}, Recovered: {}",
+                                "reth::cli::recover_missing_utxos: UTXO recovery completed. Requested: {}, Recovered: {}",
                                 response.total_requested, response.total_recovered
                             );
                         }
                         Err(err) => {
-                            error!(target: "reth::cli", "UTXO recovery failed: {}", err);
+                            error!(target: "reth::cli", "reth::cli::recover_missing_utxos: UTXO recovery failed: {}", err);
                         }
                     }
                 } else {
-                    error!(target: "reth::cli", "UTXO_RECOVERY_FILE is provided but no UTXOs to recover");
+                    error!(target: "reth::cli", "reth::cli::recover_missing_utxos: UTXO_RECOVERY_FILE is provided but no UTXOs to recover");
                 }
             } else {
-                info!(target: "reth::cli", "No UTXOs recovery file provided");
+                info!(target: "reth::cli", "reth::cli::recover_missing_utxos:No UTXOs recovery file provided");
             };
 
             Some(btc_server_factory)

--- a/bin/test-suite/src/suite/consensus/frost/mod.rs
+++ b/bin/test-suite/src/suite/consensus/frost/mod.rs
@@ -16,4 +16,5 @@ pub mod test_signing;
 pub mod test_track_mempool;
 pub mod test_tx_weight_limit;
 pub mod test_utxo_commitment;
+pub mod test_utxo_recovery;
 pub mod test_utxo_sync;

--- a/bin/test-suite/src/suite/consensus/frost/test_utxo_recovery.rs
+++ b/bin/test-suite/src/suite/consensus/frost/test_utxo_recovery.rs
@@ -5,7 +5,7 @@ use bitcoincore_rpc::RpcApi;
 use btc_server_client::BtcServerClient;
 use btcserverlib::pegout_id::PegoutId;
 use hex::{self, encode as hex_encode};
-use rand::{rngs::StdRng, Rng, RngCore, SeedableRng};
+use rand::{rngs::StdRng, RngCore, SeedableRng};
 use tonic::transport::Channel;
 
 use crate::{

--- a/bin/test-suite/src/suite/consensus/frost/test_utxo_recovery.rs
+++ b/bin/test-suite/src/suite/consensus/frost/test_utxo_recovery.rs
@@ -133,16 +133,15 @@ pub async fn test_utxo_recovery(
         None,
     )?;
 
-    
     // get vout of the change output
     let change_tx_res = bitcoind.get_raw_transaction(&change_txid, None)?;
     let change_vout = change_tx_res
-    .output
-    .iter()
-    .enumerate()
-    .find(|(_, o)| o.script_pubkey == change_address.script_pubkey())
-    .ok_or_else(|| anyhow::anyhow!("change output not found"))?
-    .0;
+        .output
+        .iter()
+        .enumerate()
+        .find(|(_, o)| o.script_pubkey == change_address.script_pubkey())
+        .ok_or_else(|| anyhow::anyhow!("change output not found"))?
+        .0;
 
     // Generate some block to confirm the pegins
     generate_blocks(&bitcoind, 2).await;
@@ -184,7 +183,7 @@ pub async fn test_utxo_recovery(
     let utxos_to_recover = claimed_utxos
         .iter()
         .map(|utxo| {
-            btc_server_client::UtxoToRecover { 
+            btc_server_client::UtxoToRecover {
                 outpoint: utxo.outpoint.clone(), // note this is little endian
                 eth_address: utxo.eth_address.clone(),
             }
@@ -198,7 +197,7 @@ pub async fn test_utxo_recovery(
         .await?;
     let res = res.into_inner();
     assert_eq!(res.total_requested, NUM_CLAIMED_PEGINS as u64);
-    assert_eq!(res.total_recovered, 0); 
+    assert_eq!(res.total_recovered, 0);
 
     // Test 2: Attempting to recover the unclaimed pegins should add the unclaimed pegins to the
     // utxo set.
@@ -251,7 +250,6 @@ pub async fn test_utxo_recovery(
     // check that the utxo set is correct.
     let total_utxos = get_utxo_count(&mut clients).await?;
     assert_eq!(total_utxos, NUM_CLAIMED_PEGINS + NUM_UNCLAIMED_PEGINS + NUM_UNCLAIMED_CHANGE_UTXOS);
-
 
     // create a pegout that spends from every utxo in the utxo set
     let mut original_pending_pegouts = vec![];

--- a/bin/test-suite/src/suite/consensus/frost/test_utxo_recovery.rs
+++ b/bin/test-suite/src/suite/consensus/frost/test_utxo_recovery.rs
@@ -1,0 +1,344 @@
+use std::str::FromStr;
+
+use bitcoin::{consensus::Encodable, Address};
+use bitcoincore_rpc::RpcApi;
+use btc_server_client::BtcServerClient;
+use btcserverlib::pegout_id::PegoutId;
+use hex::{self, encode as hex_encode};
+use rand::{rngs::StdRng, Rng, RngCore, SeedableRng};
+use tonic::transport::Channel;
+
+use crate::{
+    it_info_print,
+    suite::consensus::{
+        frost::{error::Error, test_dkg::do_dkg, test_signing::do_signing},
+        ConsensusIntegrationTestSuite,
+    },
+    utils::{
+        generate_blocks, get_checkpoint_block_hash, send_pegin_notification,
+        send_pegout_notification, MIN_BLOCKS_COINBASE_MATURE,
+    },
+};
+
+const COORDINATOR_INDEX: usize = 0;
+const NUM_CLAIMED_PEGINS: usize = 1;
+const NUM_UNCLAIMED_PEGINS: usize = 1;
+const NUM_UNCLAIMED_CHANGE_UTXOS: usize = 1;
+const PEGIN_AMOUNT: u64 = 100_000;
+const NUM_PEGOUTS: usize = 1;
+const PEGOUT_AMOUNT: u64 = 250_000; // so that it uses all 3 utxos
+
+pub struct Pegin {
+    pub eth_address: ethers::core::types::Address,
+    pub btc_address: bitcoin::Address,
+    pub outpoint: bitcoin::OutPoint,
+    pub amount: bitcoin::Amount,
+}
+
+/// Assert that all clients have the same UTXO set
+pub async fn all_clients_have_same_wallet_state(
+    _clients: &mut Vec<BtcServerClient<Channel>>,
+) -> Result<(), Error> {
+    // The coordinator will have a different state than the signers
+    // This is b/c the signers are not tracking txs in the current implementation
+    // Everntually they will all converge to the same state
+    Ok(())
+}
+
+#[allow(clippy::too_many_lines)]
+pub async fn test_utxo_recovery(
+    suite: &ConsensusIntegrationTestSuite,
+) -> anyhow::Result<(), anyhow::Error> {
+    let mut rand = StdRng::from_entropy();
+    let secp = bitcoin::secp256k1::Secp256k1::new();
+
+    let bitcoind = suite.global_context.bitcoind_rpc();
+    generate_blocks(&bitcoind, MIN_BLOCKS_COINBASE_MATURE).await;
+
+    // create btc server clients
+    let mut clients = suite
+        .local_context
+        .btc_server_clients
+        .clone()
+        .expect("btc server rpc clients to be defined");
+
+    // run the dkg
+    do_dkg(&mut clients).await?;
+
+    // create pegins
+    let mut claimed_pegin = vec![];
+    let mut unclaimed_pegin = vec![];
+    let amount_to_send = bitcoin::Amount::from_sat(PEGIN_AMOUNT);
+    for _ in 0..(NUM_CLAIMED_PEGINS + NUM_UNCLAIMED_PEGINS) {
+        let eth_address = ethers::core::types::Address::random();
+        // Lets get the gateway address for this eth address
+        let mut client =
+            clients.get(0).cloned().ok_or_else(|| anyhow::anyhow!("client not found"))?;
+        let res = client
+            .get_gateway_address(tonic::Request::new(btc_server_client::GetGatewayAddressRequest {
+                eth_address: hex_encode(eth_address),
+            }))
+            .await
+            .map_err(Error::Request)?
+            .into_inner();
+        let btc_address = Address::from_str(&res.gateway_address)?.assume_checked();
+        let txid = bitcoind.send_to_address(
+            &btc_address,
+            amount_to_send,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )?;
+
+        let tx_res = bitcoind.get_transaction(&txid, None)?;
+        let pegin_tx = tx_res.transaction()?;
+        let spk = btc_address.script_pubkey();
+        let (vout, pegin_output) = pegin_tx
+            .output
+            .iter()
+            .enumerate()
+            .find(|(_, o)| o.script_pubkey == spk)
+            .ok_or_else(|| anyhow::anyhow!("pegin output not found"))?;
+
+        if claimed_pegin.len() < NUM_CLAIMED_PEGINS {
+            claimed_pegin.push(Pegin {
+                eth_address,
+                btc_address,
+                outpoint: bitcoin::OutPoint { txid, vout: vout as u32 },
+                amount: pegin_output.value,
+            });
+        } else {
+            unclaimed_pegin.push(Pegin {
+                eth_address,
+                btc_address,
+                outpoint: bitcoin::OutPoint { txid, vout: vout as u32 },
+                amount: pegin_output.value,
+            });
+        }
+    }
+
+    // send a utxo to the change address that we will claim later
+    let change_address = get_change_address(&mut clients).await?;
+    let change_txid = bitcoind.send_to_address(
+        &change_address,
+        bitcoin::Amount::from_sat(PEGIN_AMOUNT),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )?;
+
+    
+    // get vout of the change output
+    let change_tx_res = bitcoind.get_raw_transaction(&change_txid, None)?;
+    let change_vout = change_tx_res
+    .output
+    .iter()
+    .enumerate()
+    .find(|(_, o)| o.script_pubkey == change_address.script_pubkey())
+    .ok_or_else(|| anyhow::anyhow!("change output not found"))?
+    .0;
+
+    // Generate some block to confirm the pegins
+    generate_blocks(&bitcoind, 2).await;
+
+    // get the checkpoint blockhash
+    let bitcoind = suite.global_context.bitcoind_rpc();
+    let checkpoint_block_hash = get_checkpoint_block_hash(&bitcoind)?;
+
+    // Notify pegins to all nodes
+    for c in clients.iter_mut() {
+        for pegin in claimed_pegin.iter() {
+            let ot = pegin.outpoint;
+            let mut txid_bytes = Vec::with_capacity(32);
+            ot.txid.consensus_encode(&mut txid_bytes)?;
+            send_pegin_notification(
+                c,
+                checkpoint_block_hash.clone(),
+                pegin.btc_address.clone(),
+                hex_encode(pegin.eth_address),
+                txid_bytes.try_into().map_err(|_| anyhow::anyhow!("invalid txid"))?,
+                ot.vout,
+                pegin.amount.to_sat(),
+            )
+            .await?;
+        }
+    }
+
+    // Now the nodes have the claimed pegins, but not the unclaimed pegins.
+    assert_eq!(get_utxo_count(&mut clients).await?, NUM_CLAIMED_PEGINS);
+
+    // Test 1: Attempting to recover an already claimed pegin should not add any new utxos.
+    let claimed_utxos = clients[COORDINATOR_INDEX]
+        .get_all_utxos(tonic::Request::new(btc_server_client::Empty {}))
+        .await?
+        .into_inner()
+        .utxos;
+    assert_eq!(claimed_utxos.len(), NUM_CLAIMED_PEGINS);
+
+    let utxos_to_recover = claimed_utxos
+        .iter()
+        .map(|utxo| {
+            btc_server_client::UtxoToRecover { 
+                outpoint: utxo.outpoint.clone(), // note this is little endian
+                eth_address: utxo.eth_address.clone(),
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let res = clients[COORDINATOR_INDEX]
+        .recover_missing_utxos(btc_server_client::RecoverMissingUtxosRequest {
+            utxos: utxos_to_recover.clone(),
+        })
+        .await?;
+    let res = res.into_inner();
+    assert_eq!(res.total_requested, NUM_CLAIMED_PEGINS as u64);
+    assert_eq!(res.total_recovered, 0); 
+
+    // Test 2: Attempting to recover the unclaimed pegins should add the unclaimed pegins to the
+    // utxo set.
+    let unclaimed_utxos = unclaimed_pegin
+        .iter()
+        .map(|pegin| btc_server_client::UtxoToRecover {
+            outpoint: Some(btc_server_client::OutPoint {
+                txid: {
+                    let mut txid_bytes = Vec::new();
+                    pegin.outpoint.txid.consensus_encode(&mut txid_bytes).unwrap();
+                    txid_bytes
+                },
+                vout: pegin.outpoint.vout,
+            }),
+            eth_address: hex_encode(pegin.eth_address),
+        })
+        .collect::<Vec<_>>();
+
+    let res = clients[COORDINATOR_INDEX]
+        .recover_missing_utxos(btc_server_client::RecoverMissingUtxosRequest {
+            utxos: unclaimed_utxos.clone(),
+        })
+        .await?;
+    let res = res.into_inner();
+    assert_eq!(res.total_requested, NUM_UNCLAIMED_PEGINS as u64);
+    assert_eq!(res.total_recovered, NUM_UNCLAIMED_PEGINS as u64);
+
+    // test 3 is to try and recover the change output (has no eth address)
+    let change_utxos = vec![btc_server_client::UtxoToRecover {
+        outpoint: Some(btc_server_client::OutPoint {
+            txid: {
+                let mut txid_bytes = Vec::new();
+                change_txid.consensus_encode(&mut txid_bytes).unwrap();
+                txid_bytes
+            },
+            vout: change_vout as u32,
+        }),
+        eth_address: "".to_string(), // no eth address for change output
+    }];
+
+    let res = clients[COORDINATOR_INDEX]
+        .recover_missing_utxos(btc_server_client::RecoverMissingUtxosRequest {
+            utxos: change_utxos.clone(),
+        })
+        .await?;
+    let res = res.into_inner();
+    assert_eq!(res.total_requested, NUM_UNCLAIMED_CHANGE_UTXOS as u64);
+    assert_eq!(res.total_recovered, NUM_UNCLAIMED_CHANGE_UTXOS as u64);
+
+    // check that the utxo set is correct.
+    let total_utxos = get_utxo_count(&mut clients).await?;
+    assert_eq!(total_utxos, NUM_CLAIMED_PEGINS + NUM_UNCLAIMED_PEGINS + NUM_UNCLAIMED_CHANGE_UTXOS);
+
+
+    // create a pegout that spends from every utxo in the utxo set
+    let mut original_pending_pegouts = vec![];
+    for _ in 0..NUM_PEGOUTS {
+        let mut pegout_id_bytes = [0u8; 36];
+        rand.fill_bytes(&mut pegout_id_bytes);
+        let pegout_id = PegoutId::from_bytes(&pegout_id_bytes)
+            .map_err(|_| anyhow::anyhow!("invalid pegout id"))?;
+        let amount = bitcoin::Amount::from_sat(PEGOUT_AMOUNT);
+
+        // create a new key for each pending pegout
+        let sk = bitcoin::PrivateKey::generate(bitcoin::Network::Regtest);
+        let pk = sk.public_key(&secp);
+        let spk = pk.p2wpkh_script_code().expect("valid pk");
+
+        original_pending_pegouts.push((pegout_id, amount, spk.clone(), pegout_id));
+    }
+
+    let checkpoint_block_hash = get_checkpoint_block_hash(&bitcoind)?;
+
+    // Notify pending pegouts to all nodes
+    for c in clients.iter_mut() {
+        for pending_pegout in original_pending_pegouts.iter() {
+            send_pegout_notification(
+                c,
+                checkpoint_block_hash.clone(),
+                pending_pegout.1.to_sat(),
+                1,
+                pending_pegout.0,
+                pending_pegout.2.clone(),
+            )
+            .await?;
+        }
+    }
+    let pegout_tx = do_signing(&mut clients, &bitcoind, &[2u8; 32]).await?;
+    it_info_print!(format!("pegout txid: {}", pegout_tx.compute_txid()));
+
+    generate_blocks(&bitcoind, 2).await;
+    let pegout_tx_res =
+        bitcoind.get_raw_transaction(&pegout_tx.compute_txid(), None).expect("valid tx");
+    it_info_print!(format!("pegout tx: {:?}", pegout_tx_res));
+
+    sync_checkpoint(&mut clients, checkpoint_block_hash.clone()).await?;
+
+    // assert that the pegout successfully spent from all the recoveredutxos
+    it_info_print!(format!("pegout tx input len: {}", pegout_tx_res.input.len()));
+    assert_eq!(pegout_tx_res.input.len(), total_utxos);
+
+    Ok(())
+}
+
+async fn get_change_address(
+    clients: &mut Vec<BtcServerClient<Channel>>,
+) -> anyhow::Result<bitcoin::Address> {
+    let public_key_response = clients[COORDINATOR_INDEX]
+        .get_public_key(tonic::Request::new(btc_server_client::Empty {}))
+        .await?;
+    let public_key_bytes = hex::decode(&public_key_response.into_inner().publickey)?;
+    let public_key = secp256k1::PublicKey::from_slice(&public_key_bytes)?;
+    let change_script =
+        btcserverlib::wallet::address::generate_taproot_change_scriptpubkey(&public_key);
+    let change_address = bitcoin::Address::from_script(&change_script, bitcoin::Network::Regtest)?;
+    Ok(change_address)
+}
+
+async fn sync_checkpoint(
+    clients: &mut [BtcServerClient<Channel>],
+    checkpoint_block_hash: Vec<u8>,
+) -> Result<(), Error> {
+    for client in clients.iter_mut() {
+        client
+            .new_consensus_checkpoint(btc_server_client::ConsensusCheckpointRequest {
+                checkpoint_block_hash: checkpoint_block_hash.clone(),
+                pegins: vec![],
+                pending_pegouts: vec![],
+            })
+            .await
+            .map_err(|_| Error::ConsensusCheckpoint)?;
+    }
+    Ok(())
+}
+
+pub async fn get_utxo_count(clients: &mut Vec<BtcServerClient<Channel>>) -> anyhow::Result<usize> {
+    let utxos = clients[COORDINATOR_INDEX]
+        .get_all_utxos(tonic::Request::new(btc_server_client::Empty {}))
+        .await?
+        .into_inner()
+        .utxos;
+    Ok(utxos.len())
+}

--- a/bin/test-suite/src/suite/consensus/mod.rs
+++ b/bin/test-suite/src/suite/consensus/mod.rs
@@ -426,6 +426,15 @@ impl Suite for ConsensusIntegrationTestSuite {
                 },
                 frost::test_utxo_commitment::test_utxo_commitment
             ),
+            "utxo_recovery" => run_test!(
+                self,
+                CreateTestConfig {
+                    create_bitcoind_node: true,
+                    create_btc_servers: true,
+                    ..Default::default()
+                },
+                frost::test_utxo_recovery::test_utxo_recovery
+            ),
             "block_builder" => {
                 run_test!(
                     self,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
https://github.com/botanix-labs/botanix/issues/1089
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please provide a link to the issue -->

## What was done?

<!--- Describe your changes in detail -->

- Fixing a bug where the grpc request was expecting `txid` in little endian, but it was being passed in as big endian.
- Added an integration test

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Integration and unit tests

## Breaking Changes

<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

- None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] I have added or updated relevant unit/integration/functional/e2e tests
-   [ ] I have tested my changes running a local network, and they work as expected
-   [x] I have performed a self-review
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
-   [x] I have made corresponding changes to the documentation if needed
-   [x] I have added assignees and reviewers to this pull request
-   [x] I have added the PR to the project board or linked it to an issue from the board


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Per-UTXO recovery output with hex-encoded txids and clearer per-entry logging.
  - Bidirectional OutPoint conversion support.
  - Recovery response now returns total_requested and total_recovered.
  - Added end-to-end UTXO recovery test and exposed test helpers.

- Bug Fixes
  - Correct txid endianness handling and LE storage.
  - Empty local UTXO sets no longer cause errors; missing on-chain UTXOs are skipped with warnings.
  - Clearer, prefixed error messages for recovery, address and script parsing.

- Refactor
  - Standardized, prefixed logs and adjusted progress visibility.

- CI
  - Added utxo_recovery to integration test matrix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->