### PR TITLE
feat(btc-utils): Init binary & implement export/import mechanism for Frost keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2319,6 +2319,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "rand 0.8.5",
+ "rpassword",
  "rust_decimal",
  "serde",
  "serde_json",
@@ -11602,6 +11603,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
+name = "rpassword"
+version = "7.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rpds"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11618,6 +11630,16 @@ checksum = "95538ef5297284300da4c3048a60309027e33bc25d96220429609f3fdb01e188"
 dependencies = [
  "chrono",
  "tokio",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cc970b249fbe527d6e02e0a227762c9108b2f49d81094fe357ffc6d14d7f6f"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/bin/btc-server/Cargo.toml
+++ b/bin/btc-server/Cargo.toml
@@ -10,6 +10,10 @@ name = "btcserverlib"
 name = "btc-server"
 path = "src/bin/main.rs"
 
+[[bin]]
+name = "btc-utils"
+path = "src/bin/utils.rs"
+
 [features]
 default = []
 
@@ -55,6 +59,7 @@ prometheus = { version = "0.13", features = ["process"] }
 prost = "0.13.3"
 prost-types = "0.13.5"
 rand = "0.8.5"
+rpassword = "7.4.0"
 
 rust_decimal = { version = "1.13" }
 serde = "1.0.171"

--- a/bin/btc-server/src/bin/utils.rs
+++ b/bin/btc-server/src/bin/utils.rs
@@ -1,0 +1,138 @@
+use btcserverlib::database;
+use clap::Parser;
+use std::path::PathBuf;
+use zeroize::Zeroizing;
+
+#[derive(Clone, Debug, Parser)]
+#[command(name = "btc-utils")]
+pub struct Cli {
+    #[command(subcommand)]
+    pub cmd: Commands,
+}
+
+#[derive(Clone, Debug, Parser)]
+pub enum Commands {
+    /// Export encrypted key packages to a file.
+    #[command(name = "export-key-package")]
+    ExportKeyPackage(ExportConfig),
+    /// Import encrypted key packages from a file.
+    #[command(name = "import-key-package")]
+    ImportKeyPackage(ImportConfig),
+}
+
+#[derive(Clone, Debug, Parser)]
+pub struct ExportConfig {
+    /// The path to the database containing key packages.
+    #[arg(long)]
+    pub db: PathBuf,
+    /// Output file path for the encrypted export.
+    #[arg(long)]
+    pub output: PathBuf,
+    /// Passphrase as parameter instead of prompt.
+    #[arg(long)]
+    pub passphrase: Option<Zeroizing<String>>,
+    /// Allow using an empty passphrase (NOT recommended).
+    #[arg(long, default_value_t = false)]
+    pub allow_empty_passphrase: bool,
+}
+
+#[derive(Clone, Debug, Parser)]
+pub struct ImportConfig {
+    /// The path to the database to store key packages.
+    #[arg(long)]
+    pub db: PathBuf,
+    /// Input file path containing the encrypted export.
+    #[arg(long)]
+    pub input: PathBuf,
+    /// Passphrase as parameter instead of prompt.
+    #[arg(long)]
+    pub passphrase: Option<Zeroizing<String>>,
+    /// Overwrite existing key packages in the database.
+    #[arg(long, default_value_t = false)]
+    pub force_overwrite: bool,
+}
+
+fn get_passphrase(
+    provided: Option<Zeroizing<String>>,
+    do_confim: bool,
+) -> anyhow::Result<Zeroizing<String>> {
+    match provided {
+        Some(p) => Ok(p.trim().to_string().into()),
+        None => {
+            // Prompt user if CLI was not provided.
+            let p1: Zeroizing<String> = rpassword::prompt_password("Passphrase: ")?.into();
+
+            if do_confim {
+                let p2: Zeroizing<String> =
+                    rpassword::prompt_password("Confirm passphrase: ")?.into();
+
+                if p1 != p2 {
+                    anyhow::bail!("Passphrases do not match!");
+                }
+            }
+
+            // Trim leading and tailing whitespaces.
+            Ok(p1.trim().to_string().into())
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<(), anyhow::Error> {
+    let cli = Cli::parse();
+
+    match cli.cmd {
+        Commands::ExportKeyPackage(c) => {
+            // NOTE: This creates a new database if it does not already exist...
+            let db = database::Db::open(&c.db).expect("failed to open db");
+
+            // Retrieve the passphrase.
+            let do_confirm = true;
+            let passphrase = get_passphrase(c.passphrase, do_confirm)?;
+
+            // Passphrase must not be empty, unless explicitly allowed.
+            if passphrase.is_empty() && !c.allow_empty_passphrase {
+                anyhow::bail!("Passphrase may not be empty unless explicitly allowed");
+            }
+
+            // Create the encrypted export.
+            let Some(export) = db.export_key_package(passphrase)? else {
+                anyhow::bail!("No key package found - correct database path?");
+            };
+
+            // Serialize to bytes and write to file.
+            let mut bytes = Vec::new();
+            ciborium::into_writer(&export, &mut bytes)?;
+            std::fs::write(&c.output, &bytes)?;
+
+            println!("Successfully exported encrypted key package to '{}'", c.output.display());
+        }
+        Commands::ImportKeyPackage(c) => {
+            // NOTE: This creates a new database if it does not already exist...
+            let db = database::Db::open(&c.db).expect("failed to open db");
+
+            if db.get_key_package()?.is_some() && !c.force_overwrite {
+                anyhow::bail!(
+                    "Existing key package may not be overwritten unless explicitly allowed"
+                )
+            }
+
+            // Retrieve the passphrase.
+            let do_confim = false;
+            let passphrase = get_passphrase(c.passphrase, do_confim)?;
+
+            // We don't bother checking whether the passphrase is empty here or
+            // not; decryption (failure) handles that for us implicitly.
+
+            // Read the import, attempt to decrypt and save the key package to
+            // the database.
+            let bytes = std::fs::read(&c.input)?;
+            let import: database::ExportedKeyPackage = ciborium::from_reader(bytes.as_slice())?;
+            db.import_key_package(passphrase, import)?;
+
+            println!("Successfully imported decrypted key package");
+        }
+    }
+
+    Ok(())
+}

--- a/bin/btc-server/src/bin/utils.rs
+++ b/bin/btc-server/src/bin/utils.rs
@@ -54,7 +54,7 @@ pub struct ImportConfig {
 
 fn get_passphrase(
     provided: Option<Zeroizing<String>>,
-    do_confim: bool,
+    do_confirm: bool,
 ) -> anyhow::Result<Zeroizing<String>> {
     match provided {
         Some(p) => Ok(p.trim().to_string().into()),
@@ -62,7 +62,7 @@ fn get_passphrase(
             // Prompt user if CLI was not provided.
             let p1: Zeroizing<String> = rpassword::prompt_password("Passphrase: ")?.into();
 
-            if do_confim {
+            if do_confirm {
                 let p2: Zeroizing<String> =
                     rpassword::prompt_password("Confirm passphrase: ")?.into();
 
@@ -118,8 +118,8 @@ async fn main() -> anyhow::Result<(), anyhow::Error> {
             }
 
             // Retrieve the passphrase.
-            let do_confim = false;
-            let passphrase = get_passphrase(c.passphrase, do_confim)?;
+            let do_confirm = false;
+            let passphrase = get_passphrase(c.passphrase, do_confirm)?;
 
             // We don't bother checking whether the passphrase is empty here or
             // not; decryption (failure) handles that for us implicitly.

--- a/bin/btc-server/src/database/error.rs
+++ b/bin/btc-server/src/database/error.rs
@@ -37,6 +37,9 @@ pub enum Error {
     TrackedTxNotFoundInPegoutScheduler,
     #[error("Bad passphrase for decrypting key-package import")]
     BadDecryptionPassphrase,
+    /// Related to [`super::ExportedKeyPackage`].
+    #[error("Bad exported package format version")]
+    BadExportedPackageFormatVersion,
 }
 
 impl PartialEq for Error {

--- a/bin/btc-server/src/database/error.rs
+++ b/bin/btc-server/src/database/error.rs
@@ -35,6 +35,8 @@ pub enum Error {
     BitcoindError(#[from] bitcoincore_rpc::Error),
     #[error("Tracked tx not found in Pegout Scheduler")]
     TrackedTxNotFoundInPegoutScheduler,
+    #[error("Bad passphrase for decrypting key-package import")]
+    BadDecryptionPassphrase,
 }
 
 impl PartialEq for Error {

--- a/bin/btc-server/src/database/mod.rs
+++ b/bin/btc-server/src/database/mod.rs
@@ -2169,6 +2169,11 @@ mod tests {
         let err = db.import_key_package(good_pass.clone(), export_1.clone()).unwrap_err();
         assert_eq!(err, Error::BadDecryptionPassphrase);
 
+        // ERR: Bad version indicator!
+        export_1.version = u16::MAX;
+        let err = db.import_key_package(good_pass.clone(), export_1.clone()).unwrap_err();
+        assert_eq!(err, Error::BadExportedPackageFormatVersion);
+
         // OK: Successful import with good passphrase and export package.
         db.import_key_package(good_pass.clone(), export_2.clone()).unwrap();
 

--- a/bin/btc-server/src/database/mod.rs
+++ b/bin/btc-server/src/database/mod.rs
@@ -14,7 +14,7 @@ use bitcoin::{
 };
 use chacha20poly1305::{aead::Aead, ChaCha20Poly1305, KeyInit, Nonce};
 use client::SigningStatus;
-use frost_secp256k1_tr as frost;
+use frost_secp256k1_tr::{self as frost};
 use futures::Stream;
 use miniscript::psbt::PsbtExt;
 use serde::{Deserialize, Serialize};
@@ -1202,7 +1202,10 @@ mod tests {
 
     use crate::{
         pegout_scheduler::{PegoutRequest, Tx},
-        test_utils::{create_random_pegout_id, create_tx, random_p2wpkh_script, setup_db},
+        test_utils::{
+            create_random_pegout_id, create_tx, random_p2wpkh_script, setup_db,
+            trusted_dealer_setup,
+        },
     };
     use std::{collections::HashSet, time::SystemTime};
 
@@ -2105,5 +2108,60 @@ mod tests {
         let tracked_txs = db.get_tracked_txs().unwrap();
         assert_eq!(tracked_txs.len(), 1);
         assert_eq!(tracked_txs[0], tracked_tx2);
+    }
+
+    #[tokio::test]
+    async fn test_export_import_key_package() {
+        let (db, _temp_dir) = setup_db();
+
+        let good_pass = Zeroizing::new("good_pass".to_string());
+        let bad_pass = Zeroizing::new("bad_pass".to_string());
+
+        // Key package does not exist yet.
+        let res = db.export_key_package(good_pass.clone()).unwrap();
+        assert!(res.is_none());
+
+        // Generate key packages.
+        let id = frost::Identifier::derive(0_u16.to_le_bytes().as_slice()).unwrap();
+        let (shares, pk_package) = trusted_dealer_setup(2, 3);
+        let key_package = frost::keys::KeyPackage::try_from(shares[&id].clone()).unwrap();
+
+        // Set key packages.
+        db.set_pubkey_package(pk_package.clone()).unwrap();
+        db.set_key_package(key_package.clone()).unwrap();
+
+        let origin_pk_package = pk_package;
+        let origin_key_package = key_package;
+
+        // Each export creates a new nonce.
+        let mut export_1 = db.export_key_package(good_pass.clone()).unwrap().unwrap();
+        let export_2 = db.export_key_package(good_pass.clone()).unwrap().unwrap();
+        //
+        assert_ne!(export_1.iv, export_2.iv);
+        assert_ne!(export_1, export_2);
+
+        let prev_key = db.db.remove(TREE_KEY_PACKAGE).unwrap();
+        let prev_pk = db.db.remove(TREE_PUBKEY_PACKAGE).unwrap();
+        assert!(prev_key.is_some());
+        assert!(prev_pk.is_some());
+
+        // ERR: Bad password!
+        let err = db.import_key_package(bad_pass, export_1.clone()).unwrap_err();
+        assert_eq!(err, Error::BadDecryptionPassphrase);
+
+        // ERR: Bad IV/nonce!
+        export_1.iv = export_2.iv;
+        let err = db.import_key_package(good_pass.clone(), export_1.clone()).unwrap_err();
+        assert_eq!(err, Error::BadDecryptionPassphrase);
+
+        // OK: Successful import with good passphrase and export package.
+        db.import_key_package(good_pass.clone(), export_2.clone()).unwrap();
+
+        // Sanity check.
+        let new_pk_package = db.get_public_key_package().unwrap().unwrap();
+        let new_key_package = db.get_key_package().unwrap().unwrap();
+        //
+        assert_eq!(new_pk_package, origin_pk_package);
+        assert_eq!(new_key_package, origin_key_package);
     }
 }

--- a/bin/btc-server/src/database/mod.rs
+++ b/bin/btc-server/src/database/mod.rs
@@ -12,6 +12,7 @@ use bitcoin::{
     psbt::Psbt,
     Amount, BlockHash, OutPoint, ScriptBuf, TxOut, Txid,
 };
+use chacha20poly1305::{aead::Aead, ChaCha20Poly1305, KeyInit, Nonce};
 use client::SigningStatus;
 use frost_secp256k1_tr as frost;
 use futures::Stream;
@@ -22,6 +23,7 @@ pub mod error;
 pub mod version;
 pub use error::Error;
 use version::UtxoVersion;
+use zeroize::Zeroizing;
 
 /// sled tree id for the utxos tree.
 const TREE_UTXOS: &[u8; 5] = b"utxos";
@@ -88,6 +90,23 @@ impl FinalizedPegout {
     pub fn new(id: PegoutId, block_number: u64) -> Self {
         FinalizedPegout { id, block_number }
     }
+}
+
+/// Encrypted key package export format for secure backup and transfer.
+///
+/// This structure contains both secret and public key packages encrypted with a
+/// passphrase-derived key. A single random nonce is used for both encryption
+/// operations, with two separately derived keys.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct ExportedKeyPackage {
+    /// Random 96-bit nonce used for both encryption operations, in plaintext.
+    pub iv: [u8; 12],
+    /// Encrypted FROST secret key package. Contains the encrypted secret key
+    /// material with authentication tag.
+    pub enc_key_package: Vec<u8>,
+    /// Encrypted FROST public key package. Contains the encrypted public key
+    /// material with authentication tag.
+    pub enc_pk_package: Vec<u8>,
 }
 
 #[derive(Clone)]
@@ -288,6 +307,164 @@ impl Db {
         ciborium::into_writer(&pk_package, &mut bytes).expect("writing to buffer");
 
         self.db.insert(TREE_PUBKEY_PACKAGE, &bytes[..])?;
+        Ok(())
+    }
+
+    /// Exports the stored key packages as an encrypted, portable format.
+    ///
+    /// Creates an [`ExportedKeyPackage`] containing both the secret and public
+    /// key packages encrypted with a passphrase-derived key. The export can be
+    /// safely stored or transmitted since all sensitive material is encrypted
+    /// with ChaCha20-Poly1305.
+    ///
+    /// # Security Design
+    /// - Uses a single random nonce but derives separate encryption keys to prevent catastrophic
+    ///   nonce reuse
+    /// - Provides authenticated encryption; tampering will cause import to fail
+    /// - Passphrase is combined with random salt (nonce) for key derivation resistance
+    ///
+    /// # Arguments
+    /// * `passphrase` - User-provided passphrase for encryption. Should be strong as it's the
+    ///   primary protection for the exported keys.
+    ///
+    /// # Returns
+    /// * `Ok(Some(export))` - Successfully created encrypted export
+    /// * `Ok(None)` - No key packages available to export
+    /// * `Err(_)` - Database error during key retrieval
+    pub fn export_key_package(
+        &self,
+        passphrase: Zeroizing<String>,
+    ) -> Result<Option<ExportedKeyPackage>, Error> {
+        let Some(key_package) = self.db.get(TREE_KEY_PACKAGE)? else {
+            return Ok(None);
+        };
+
+        let Some(pk_package) = self.db.get(TREE_PUBKEY_PACKAGE)? else {
+            return Ok(None);
+        };
+
+        // Validate retrieved packages.
+        #[cfg(debug_assertions)]
+        {
+            ciborium::from_reader::<frost::keys::KeyPackage, _>(key_package.as_ref())
+                .expect("bad key package");
+
+            ciborium::from_reader::<frost::keys::PublicKeyPackage, _>(pk_package.as_ref())
+                .expect("bad public key package");
+        }
+
+        // IMPORTANT: We randomly generate a single nonce, which is included in
+        // the export and saved alongside the encrypted data in plaintext. Since
+        // we encrypt the secret and public key packages separately with the
+        // same nonce, we deterministically derive separate encryption keys for
+        // each package using the Merlin transcript. This prevents catastrophic
+        // nonce reuse while keeping the export format simple (only one nonce to
+        // store).
+        let iv: [u8; 12] = rand::random();
+        let nonce = Nonce::from_slice(&iv);
+
+        let mut t = merlin::Transcript::new(b"Botanix_Macbeth_BtcServer_ExportedKeyPackage");
+        t.append_message(b"salt", nonce);
+        t.append_message(b"passphrase", passphrase.as_bytes());
+
+        // Scope the `master` key so we don't accidentally reuse it between
+        // separate encryption operations.
+
+        // Encrypt secret key package with derived key.
+        let enc_key_package: Vec<u8> = {
+            let mut master = Zeroizing::new([0; 32]);
+
+            // Derive NEW master key for the secret key package.
+            t.challenge_bytes(b"secret_key_package", master.as_mut_slice());
+            debug_assert_ne!(master.as_slice(), [0; 32]);
+
+            ChaCha20Poly1305::new_from_slice(master.as_slice())
+                .expect("master key must be 32-bytes")
+                .encrypt(nonce, key_package.as_ref())
+                .expect("output buffer must be valid")
+        };
+
+        // Encrypt public key package with derived key.
+        let enc_pk_package: Vec<u8> = {
+            let mut master = Zeroizing::new([0; 32]);
+
+            // Derive NEW master key for the public key package.
+            t.challenge_bytes(b"public_key_package", master.as_mut_slice());
+            debug_assert_ne!(master.as_slice(), [0; 32]);
+
+            ChaCha20Poly1305::new_from_slice(master.as_mut_slice())
+                .expect("master key must be 32-bytes")
+                .encrypt(nonce, pk_package.as_ref())
+                .expect("output buffer must be valid")
+        };
+
+        let export = ExportedKeyPackage { iv, enc_key_package, enc_pk_package };
+
+        Ok(Some(export))
+    }
+
+    /// Imports and validates an encrypted key package export.
+    ///
+    /// Decrypts an [`ExportedKeyPackage`] using the provided passphrase and
+    /// stores the recovered key packages in the database. The decrypted data is
+    /// validated by deserializing it into typed Rust structs, ensuring it's
+    /// well-formed.
+    ///
+    /// # Security Validation
+    /// - Authenticated decryption prevents accepting tampered data
+    /// - Deserialization validates the decrypted data structure
+    /// - Wrong passphrase will cause decryption to fail
+    ///
+    /// # Arguments
+    /// * `passphrase` - The same passphrase used during export
+    /// * `export` - The encrypted key package export to import
+    ///
+    /// # Returns
+    /// * `Ok(())` - Successfully imported and stored key packages
+    /// * `Err(_)` - Decryption failed (wrong passphrase), malformed data, or database error
+    pub fn import_key_package(
+        &self,
+        passphrase: Zeroizing<String>,
+        export: ExportedKeyPackage,
+    ) -> Result<(), Error> {
+        // Retrieve the nonce directly from the exported package.
+        let nonce = Nonce::from_slice(&export.iv);
+
+        let mut t = merlin::Transcript::new(b"Botanix_Macbeth_BtcServer_ExportedKeyPackage");
+        t.append_message(b"salt", nonce);
+        t.append_message(b"passphrase", passphrase.as_bytes());
+
+        let mut master = Zeroizing::new([0u8; 32]);
+
+        // Convert decrypted bytes into typed Rust structs rather than storing
+        // the raw bytes directly. This serves as validation/sanity-check that
+        // ensures the decrypted data is actually valid and not garbage.
+
+        let key_package: frost::keys::KeyPackage = {
+            t.challenge_bytes(b"secret_key_package", master.as_mut_slice());
+
+            let b = ChaCha20Poly1305::new_from_slice(master.as_slice())
+                .expect("master key must be 32-bytes")
+                .decrypt(nonce, export.enc_key_package.as_slice())
+                .map_err(|_| Error::BadDecryptionPassphrase)?;
+
+            ciborium::from_reader(b.as_slice())?
+        };
+
+        let pk_package: frost::keys::PublicKeyPackage = {
+            t.challenge_bytes(b"public_key_package", master.as_mut_slice());
+
+            let b = ChaCha20Poly1305::new_from_slice(master.as_slice())
+                .expect("master key must be 32-bytes")
+                .decrypt(nonce, export.enc_pk_package.as_slice())
+                .map_err(|_| Error::BadDecryptionPassphrase)?;
+
+            ciborium::from_reader(b.as_slice())?
+        };
+
+        self.set_key_package(key_package)?;
+        self.set_pubkey_package(pk_package)?;
+
         Ok(())
     }
 

--- a/bin/btc-server/src/database/mod.rs
+++ b/bin/btc-server/src/database/mod.rs
@@ -92,6 +92,9 @@ impl FinalizedPegout {
     }
 }
 
+/// Current version for [`ExportedKeyPackage`] (future-reserved).
+pub const EXPORTED_PACKAGE_VERSION: u16 = 0;
+
 /// Encrypted key package export format for secure backup and transfer.
 ///
 /// This structure contains both secret and public key packages encrypted with a
@@ -99,6 +102,9 @@ impl FinalizedPegout {
 /// operations, with two separately derived keys.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct ExportedKeyPackage {
+    /// Version indicator (future-reserved), currently it's
+    /// [`EXPORTED_PACKAGE_VERSION`].
+    pub version: u16,
     /// Random 96-bit nonce used for both encryption operations, in plaintext.
     pub iv: [u8; 12],
     /// Encrypted FROST secret key package. Contains the encrypted secret key
@@ -398,7 +404,12 @@ impl Db {
                 .expect("output buffer must be valid")
         };
 
-        let export = ExportedKeyPackage { iv, enc_key_package, enc_pk_package };
+        let export = ExportedKeyPackage {
+            version: EXPORTED_PACKAGE_VERSION,
+            iv,
+            enc_key_package,
+            enc_pk_package,
+        };
 
         Ok(Some(export))
     }
@@ -427,6 +438,10 @@ impl Db {
         passphrase: Zeroizing<String>,
         export: ExportedKeyPackage,
     ) -> Result<(), Error> {
+        if export.version != EXPORTED_PACKAGE_VERSION {
+            return Err(Error::BadExportedPackageFormatVersion);
+        }
+
         // Retrieve the nonce directly from the exported package.
         let nonce = Nonce::from_slice(&export.iv);
 


### PR DESCRIPTION
NOTE: `main` branch!

This introduces a convenient mechanism that allows validators to export and import the Frost key package individually (cc @birozuru), primarily intended for backup purposes.

As discussed internally, we created a new binary package titled `btc-utils` - which can also serve as a basis to further build additional extensions and convenience functions ontop of it for anything `btc-server` related, such as adding missing UTXO's, extracting insights, etc (cc @DariusParvin).

```console
$ btc-utils --help
Usage: btc-utils <COMMAND>

Commands:
  export-key-package  Export encrypted key packages to a file
  import-key-package  Import encrypted key packages from a file
  help                Print this message or the help of the given subcommand(s)

Options:
  -h, --help  Print help
```

## Subcommands

```console
$ btc-utils export-key-package --help
Export encrypted key packages to a file

Usage: btc-utils export-key-package [OPTIONS] --db <DB> --output <OUTPUT>

Options:
      --db <DB>                  The path to the database containing key packages
      --output <OUTPUT>          Output file path for the encrypted export
      --passphrase <PASSPHRASE>  Passphrase as parameter instead of prompt
      --allow-empty-passphrase   Allow using an empty passphrase (NOT recommended)
  -h, --help                     Print help
```

```console
$ btc-utils import-key-package --help
Import encrypted key packages from a file

Usage: btc-utils import-key-package [OPTIONS] --db <DB> --input <INPUT>

Options:
      --db <DB>                  The path to the database to store key packages
      --input <INPUT>            Input file path containing the encrypted export
      --passphrase <PASSPHRASE>  Passphrase as parameter instead of prompt
      --force-overwrite          Overwrite existing key packages in the database
  -h, --help                     Print help
```

## Examples

We export the key package from the database to a given file and get prompted for an encryption passphrase:

```console
$ btc-utils export-key-package \
	--db=".local_env/federation/node-3/btc_server/db" \
	--output="exported_key_package.bin"
Passphrase: 
Confirm passphrase: 
Successfully exported encrypted key package to `exported_key_package.bin`
```

When importing, the default behavior is that an existing key package cannot be overwritten unless explicitly allowed:

```console
$ btc-utils import-key-package \
	--db=".local_env/federation/node-3/btc_server/db" \
	--input="exported_key_package.bin"
Error: Existing key package may not be overwritten unless explicitly allowed
```

By passing the `--force-overwrite` parameter, the operation succeeds:

```console
$ btc-utils import-key-package \
	--db=".local_env/federation/node-3/btc_server/db" \
	--input="exported_key_package.bin" \
	--force-overwrite
Passphrase: 
Confirm passphrase: 
Successfully imported decrypted key package
```
