### PR TITLE
feat(btc-utils): Init binary & implement export/import mechanism for Frost keys (back-merge into `dev`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2732,6 +2732,7 @@ dependencies = [
  "prost-types",
  "rand 0.8.5",
  "reth-fs-util",
+ "rpassword",
  "rust_decimal",
  "serde",
  "serde_json",
@@ -12090,12 +12091,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
+name = "rpassword"
+version = "7.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rpds"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7f89f654d51fffdd6026289d07d1fd523244d46ae0a8bc22caa6dd7f9e8cb0b"
 dependencies = [
  "archery",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cc970b249fbe527d6e02e0a227762c9108b2f49d81094fe357ffc6d14d7f6f"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/bin/btc-server/Cargo.toml
+++ b/bin/btc-server/Cargo.toml
@@ -14,6 +14,10 @@ name = "btcserverlib"
 name = "btc-server"
 path = "src/bin/main.rs"
 
+[[bin]]
+name = "btc-utils"
+path = "src/bin/utils.rs"
+
 [features]
 default = []
 
@@ -60,6 +64,7 @@ prometheus = { version = "0.14", features = ["process"] }
 prost = "0.13.3"
 prost-types = "0.13.5"
 rand = "0.8.5"
+rpassword = "7.4.0"
 
 reth-fs-util = { workspace = true }
 rust_decimal = { version = "1.13" }

--- a/bin/btc-server/src/bin/utils.rs
+++ b/bin/btc-server/src/bin/utils.rs
@@ -1,0 +1,138 @@
+use btcserverlib::database;
+use clap::Parser;
+use std::path::PathBuf;
+use zeroize::Zeroizing;
+
+#[derive(Clone, Debug, Parser)]
+#[command(name = "btc-utils")]
+pub struct Cli {
+    #[command(subcommand)]
+    pub cmd: Commands,
+}
+
+#[derive(Clone, Debug, Parser)]
+pub enum Commands {
+    /// Export encrypted key packages to a file.
+    #[command(name = "export-key-package")]
+    ExportKeyPackage(ExportConfig),
+    /// Import encrypted key packages from a file.
+    #[command(name = "import-key-package")]
+    ImportKeyPackage(ImportConfig),
+}
+
+#[derive(Clone, Debug, Parser)]
+pub struct ExportConfig {
+    /// The path to the database containing key packages.
+    #[arg(long)]
+    pub db: PathBuf,
+    /// Output file path for the encrypted export.
+    #[arg(long)]
+    pub output: PathBuf,
+    /// Passphrase as parameter instead of prompt.
+    #[arg(long)]
+    pub passphrase: Option<Zeroizing<String>>,
+    /// Allow using an empty passphrase (NOT recommended).
+    #[arg(long, default_value_t = false)]
+    pub allow_empty_passphrase: bool,
+}
+
+#[derive(Clone, Debug, Parser)]
+pub struct ImportConfig {
+    /// The path to the database to store key packages.
+    #[arg(long)]
+    pub db: PathBuf,
+    /// Input file path containing the encrypted export.
+    #[arg(long)]
+    pub input: PathBuf,
+    /// Passphrase as parameter instead of prompt.
+    #[arg(long)]
+    pub passphrase: Option<Zeroizing<String>>,
+    /// Overwrite existing key packages in the database.
+    #[arg(long, default_value_t = false)]
+    pub force_overwrite: bool,
+}
+
+fn get_passphrase(
+    provided: Option<Zeroizing<String>>,
+    do_confim: bool,
+) -> anyhow::Result<Zeroizing<String>> {
+    match provided {
+        Some(p) => Ok(p.trim().to_string().into()),
+        None => {
+            // Prompt user if CLI was not provided.
+            let p1: Zeroizing<String> = rpassword::prompt_password("Passphrase: ")?.into();
+
+            if do_confim {
+                let p2: Zeroizing<String> =
+                    rpassword::prompt_password("Confirm passphrase: ")?.into();
+
+                if p1 != p2 {
+                    anyhow::bail!("Passphrases do not match!");
+                }
+            }
+
+            // Trim leading and tailing whitespaces.
+            Ok(p1.trim().to_string().into())
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<(), anyhow::Error> {
+    let cli = Cli::parse();
+
+    match cli.cmd {
+        Commands::ExportKeyPackage(c) => {
+            // NOTE: This creates a new database if it does not already exist...
+            let db = database::Db::open(&c.db).expect("failed to open db");
+
+            // Retrieve the passphrase.
+            let do_confirm = true;
+            let passphrase = get_passphrase(c.passphrase, do_confirm)?;
+
+            // Passphrase must not be empty, unless explicitly allowed.
+            if passphrase.is_empty() && !c.allow_empty_passphrase {
+                anyhow::bail!("Passphrase may not be empty unless explicitly allowed");
+            }
+
+            // Create the encrypted export.
+            let Some(export) = db.export_key_package(passphrase)? else {
+                anyhow::bail!("No key package found - correct database path?");
+            };
+
+            // Serialize to bytes and write to file.
+            let mut bytes = Vec::new();
+            ciborium::into_writer(&export, &mut bytes)?;
+            std::fs::write(&c.output, &bytes)?;
+
+            println!("Successfully exported encrypted key package to '{}'", c.output.display());
+        }
+        Commands::ImportKeyPackage(c) => {
+            // NOTE: This creates a new database if it does not already exist...
+            let db = database::Db::open(&c.db).expect("failed to open db");
+
+            if db.get_key_package()?.is_some() && !c.force_overwrite {
+                anyhow::bail!(
+                    "Existing key package may not be overwritten unless explicitly allowed"
+                )
+            }
+
+            // Retrieve the passphrase.
+            let do_confim = false;
+            let passphrase = get_passphrase(c.passphrase, do_confim)?;
+
+            // We don't bother checking whether the passphrase is empty here or
+            // not; decryption (failure) handles that for us implicitly.
+
+            // Read the import, attempt to decrypt and save the key package to
+            // the database.
+            let bytes = std::fs::read(&c.input)?;
+            let import: database::ExportedKeyPackage = ciborium::from_reader(bytes.as_slice())?;
+            db.import_key_package(passphrase, import)?;
+
+            println!("Successfully imported decrypted key package");
+        }
+    }
+
+    Ok(())
+}

--- a/bin/btc-server/src/bin/utils.rs
+++ b/bin/btc-server/src/bin/utils.rs
@@ -54,7 +54,7 @@ pub struct ImportConfig {
 
 fn get_passphrase(
     provided: Option<Zeroizing<String>>,
-    do_confim: bool,
+    do_confirm: bool,
 ) -> anyhow::Result<Zeroizing<String>> {
     match provided {
         Some(p) => Ok(p.trim().to_string().into()),
@@ -62,7 +62,7 @@ fn get_passphrase(
             // Prompt user if CLI was not provided.
             let p1: Zeroizing<String> = rpassword::prompt_password("Passphrase: ")?.into();
 
-            if do_confim {
+            if do_confirm {
                 let p2: Zeroizing<String> =
                     rpassword::prompt_password("Confirm passphrase: ")?.into();
 
@@ -118,8 +118,8 @@ async fn main() -> anyhow::Result<(), anyhow::Error> {
             }
 
             // Retrieve the passphrase.
-            let do_confim = false;
-            let passphrase = get_passphrase(c.passphrase, do_confim)?;
+            let do_confirm = false;
+            let passphrase = get_passphrase(c.passphrase, do_confirm)?;
 
             // We don't bother checking whether the passphrase is empty here or
             // not; decryption (failure) handles that for us implicitly.

--- a/bin/btc-server/src/database/error.rs
+++ b/bin/btc-server/src/database/error.rs
@@ -37,6 +37,8 @@ pub enum Error {
     BitcoindError(#[from] bitcoincore_rpc::Error),
     #[error("Tracked tx not found in Pegout Scheduler")]
     TrackedTxNotFoundInPegoutScheduler,
+    #[error("Bad passphrase for decrypting key-package import")]
+    BadDecryptionPassphrase,
 }
 
 impl PartialEq for Error {

--- a/bin/btc-server/src/database/error.rs
+++ b/bin/btc-server/src/database/error.rs
@@ -39,6 +39,9 @@ pub enum Error {
     TrackedTxNotFoundInPegoutScheduler,
     #[error("Bad passphrase for decrypting key-package import")]
     BadDecryptionPassphrase,
+    /// Related to [`super::ExportedKeyPackage`].
+    #[error("Bad exported package format version")]
+    BadExportedPackageFormatVersion,
 }
 
 impl PartialEq for Error {

--- a/bin/btc-server/src/database/mod.rs
+++ b/bin/btc-server/src/database/mod.rs
@@ -1289,7 +1289,10 @@ mod tests {
 
     use crate::{
         pegout_scheduler::{PegoutRequest, Tx},
-        test_utils::{create_random_pegout_id, create_tx, random_p2wpkh_scriptpubkey, setup_db},
+        test_utils::{
+            create_random_pegout_id, create_tx, random_p2wpkh_scriptpubkey, setup_db,
+            trusted_dealer_setup,
+        },
     };
     use std::{collections::HashSet, time::SystemTime};
 
@@ -2384,5 +2387,60 @@ mod tests {
 
         assert_eq!(deserialized.id, pegout_id);
         assert_eq!(deserialized.block_number, 200);
+    }
+
+    #[tokio::test]
+    async fn test_export_import_key_package() {
+        let (db, _temp_dir) = setup_db();
+
+        let good_pass = Zeroizing::new("good_pass".to_string());
+        let bad_pass = Zeroizing::new("bad_pass".to_string());
+
+        // Key package does not exist yet.
+        let res = db.export_key_package(good_pass.clone()).unwrap();
+        assert!(res.is_none());
+
+        // Generate key packages.
+        let id = frost::Identifier::derive(0_u16.to_le_bytes().as_slice()).unwrap();
+        let (shares, pk_package) = trusted_dealer_setup(2, 3);
+        let key_package = frost::keys::KeyPackage::try_from(shares[&id].clone()).unwrap();
+
+        // Set key packages.
+        db.set_pubkey_package(pk_package.clone()).unwrap();
+        db.set_key_package(key_package.clone()).unwrap();
+
+        let origin_pk_package = pk_package;
+        let origin_key_package = key_package;
+
+        // Each export creates a new nonce.
+        let mut export_1 = db.export_key_package(good_pass.clone()).unwrap().unwrap();
+        let export_2 = db.export_key_package(good_pass.clone()).unwrap().unwrap();
+        //
+        assert_ne!(export_1.iv, export_2.iv);
+        assert_ne!(export_1, export_2);
+
+        let prev_key = db.db.remove(TREE_KEY_PACKAGE).unwrap();
+        let prev_pk = db.db.remove(TREE_PUBKEY_PACKAGE).unwrap();
+        assert!(prev_key.is_some());
+        assert!(prev_pk.is_some());
+
+        // ERR: Bad password!
+        let err = db.import_key_package(bad_pass, export_1.clone()).unwrap_err();
+        assert_eq!(err, Error::BadDecryptionPassphrase);
+
+        // ERR: Bad IV/nonce!
+        export_1.iv = export_2.iv;
+        let err = db.import_key_package(good_pass.clone(), export_1.clone()).unwrap_err();
+        assert_eq!(err, Error::BadDecryptionPassphrase);
+
+        // OK: Successful import with good passphrase and export package.
+        db.import_key_package(good_pass.clone(), export_2.clone()).unwrap();
+
+        // Sanity check.
+        let new_pk_package = db.get_public_key_package().unwrap().unwrap();
+        let new_key_package = db.get_key_package().unwrap().unwrap();
+        //
+        assert_eq!(new_pk_package, origin_pk_package);
+        assert_eq!(new_key_package, origin_key_package);
     }
 }

--- a/bin/btc-server/src/database/mod.rs
+++ b/bin/btc-server/src/database/mod.rs
@@ -2448,6 +2448,11 @@ mod tests {
         let err = db.import_key_package(good_pass.clone(), export_1.clone()).unwrap_err();
         assert_eq!(err, Error::BadDecryptionPassphrase);
 
+        // ERR: Bad version indicator!
+        export_1.version = u16::MAX;
+        let err = db.import_key_package(good_pass.clone(), export_1.clone()).unwrap_err();
+        assert_eq!(err, Error::BadExportedPackageFormatVersion);
+
         // OK: Successful import with good passphrase and export package.
         db.import_key_package(good_pass.clone(), export_2.clone()).unwrap();
 

--- a/bin/btc-server/src/database/mod.rs
+++ b/bin/btc-server/src/database/mod.rs
@@ -18,6 +18,7 @@ use bitcoin::{
     Amount, BlockHash, OutPoint, ScriptBuf, TxOut, Txid,
 };
 use btc_server_client::SigningStatus;
+use chacha20poly1305::{aead::Aead, ChaCha20Poly1305, KeyInit, Nonce};
 use frost_secp256k1_tr as frost;
 use futures::Stream;
 use log::{info, warn};
@@ -28,6 +29,7 @@ pub mod error;
 pub mod version;
 pub use error::Error;
 use version::UtxoVersion;
+use zeroize::Zeroizing;
 
 /// sled tree id for the utxos tree.
 const TREE_UTXOS: &[u8; 5] = b"utxos";
@@ -101,6 +103,23 @@ impl FinalizedPegout {
     pub fn new(id: PegoutId, block_number: u64, timestamp: Option<u64>) -> Self {
         FinalizedPegout { id, block_number, timestamp }
     }
+}
+
+/// Encrypted key package export format for secure backup and transfer.
+///
+/// This structure contains both secret and public key packages encrypted with a
+/// passphrase-derived key. A single random nonce is used for both encryption
+/// operations, with two separately derived keys.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct ExportedKeyPackage {
+    /// Random 96-bit nonce used for both encryption operations, in plaintext.
+    pub iv: [u8; 12],
+    /// Encrypted FROST secret key package. Contains the encrypted secret key
+    /// material with authentication tag.
+    pub enc_key_package: Vec<u8>,
+    /// Encrypted FROST public key package. Contains the encrypted public key
+    /// material with authentication tag.
+    pub enc_pk_package: Vec<u8>,
 }
 
 #[derive(Clone)]
@@ -301,6 +320,164 @@ impl Db {
         ciborium::into_writer(&pk_package, &mut bytes).expect("writing to buffer");
 
         self.db.insert(TREE_PUBKEY_PACKAGE, &bytes[..])?;
+        Ok(())
+    }
+
+    /// Exports the stored key packages as an encrypted, portable format.
+    ///
+    /// Creates an [`ExportedKeyPackage`] containing both the secret and public
+    /// key packages encrypted with a passphrase-derived key. The export can be
+    /// safely stored or transmitted since all sensitive material is encrypted
+    /// with ChaCha20-Poly1305.
+    ///
+    /// # Security Design
+    /// - Uses a single random nonce but derives separate encryption keys to prevent catastrophic
+    ///   nonce reuse
+    /// - Provides authenticated encryption; tampering will cause import to fail
+    /// - Passphrase is combined with random salt (nonce) for key derivation resistance
+    ///
+    /// # Arguments
+    /// * `passphrase` - User-provided passphrase for encryption. Should be strong as it's the
+    ///   primary protection for the exported keys.
+    ///
+    /// # Returns
+    /// * `Ok(Some(export))` - Successfully created encrypted export
+    /// * `Ok(None)` - No key packages available to export
+    /// * `Err(_)` - Database error during key retrieval
+    pub fn export_key_package(
+        &self,
+        passphrase: Zeroizing<String>,
+    ) -> Result<Option<ExportedKeyPackage>, Error> {
+        let Some(key_package) = self.db.get(TREE_KEY_PACKAGE)? else {
+            return Ok(None);
+        };
+
+        let Some(pk_package) = self.db.get(TREE_PUBKEY_PACKAGE)? else {
+            return Ok(None);
+        };
+
+        // Validate retrieved packages.
+        #[cfg(debug_assertions)]
+        {
+            ciborium::from_reader::<frost::keys::KeyPackage, _>(key_package.as_ref())
+                .expect("bad key package");
+
+            ciborium::from_reader::<frost::keys::PublicKeyPackage, _>(pk_package.as_ref())
+                .expect("bad public key package");
+        }
+
+        // IMPORTANT: We randomly generate a single nonce, which is included in
+        // the export and saved alongside the encrypted data in plaintext. Since
+        // we encrypt the secret and public key packages separately with the
+        // same nonce, we deterministically derive separate encryption keys for
+        // each package using the Merlin transcript. This prevents catastrophic
+        // nonce reuse while keeping the export format simple (only one nonce to
+        // store).
+        let iv: [u8; 12] = rand::random();
+        let nonce = Nonce::from_slice(&iv);
+
+        let mut t = merlin::Transcript::new(b"Botanix_Macbeth_BtcServer_ExportedKeyPackage");
+        t.append_message(b"salt", nonce);
+        t.append_message(b"passphrase", passphrase.as_bytes());
+
+        // Scope the `master` key so we don't accidentally reuse it between
+        // separate encryption operations.
+
+        // Encrypt secret key package with derived key.
+        let enc_key_package: Vec<u8> = {
+            let mut master = Zeroizing::new([0; 32]);
+
+            // Derive NEW master key for the secret key package.
+            t.challenge_bytes(b"secret_key_package", master.as_mut_slice());
+            debug_assert_ne!(master.as_slice(), [0; 32]);
+
+            ChaCha20Poly1305::new_from_slice(master.as_slice())
+                .expect("master key must be 32-bytes")
+                .encrypt(nonce, key_package.as_ref())
+                .expect("output buffer must be valid")
+        };
+
+        // Encrypt public key package with derived key.
+        let enc_pk_package: Vec<u8> = {
+            let mut master = Zeroizing::new([0; 32]);
+
+            // Derive NEW master key for the public key package.
+            t.challenge_bytes(b"public_key_package", master.as_mut_slice());
+            debug_assert_ne!(master.as_slice(), [0; 32]);
+
+            ChaCha20Poly1305::new_from_slice(master.as_mut_slice())
+                .expect("master key must be 32-bytes")
+                .encrypt(nonce, pk_package.as_ref())
+                .expect("output buffer must be valid")
+        };
+
+        let export = ExportedKeyPackage { iv, enc_key_package, enc_pk_package };
+
+        Ok(Some(export))
+    }
+
+    /// Imports and validates an encrypted key package export.
+    ///
+    /// Decrypts an [`ExportedKeyPackage`] using the provided passphrase and
+    /// stores the recovered key packages in the database. The decrypted data is
+    /// validated by deserializing it into typed Rust structs, ensuring it's
+    /// well-formed.
+    ///
+    /// # Security Validation
+    /// - Authenticated decryption prevents accepting tampered data
+    /// - Deserialization validates the decrypted data structure
+    /// - Wrong passphrase will cause decryption to fail
+    ///
+    /// # Arguments
+    /// * `passphrase` - The same passphrase used during export
+    /// * `export` - The encrypted key package export to import
+    ///
+    /// # Returns
+    /// * `Ok(())` - Successfully imported and stored key packages
+    /// * `Err(_)` - Decryption failed (wrong passphrase), malformed data, or database error
+    pub fn import_key_package(
+        &self,
+        passphrase: Zeroizing<String>,
+        export: ExportedKeyPackage,
+    ) -> Result<(), Error> {
+        // Retrieve the nonce directly from the exported package.
+        let nonce = Nonce::from_slice(&export.iv);
+
+        let mut t = merlin::Transcript::new(b"Botanix_Macbeth_BtcServer_ExportedKeyPackage");
+        t.append_message(b"salt", nonce);
+        t.append_message(b"passphrase", passphrase.as_bytes());
+
+        let mut master = Zeroizing::new([0u8; 32]);
+
+        // Convert decrypted bytes into typed Rust structs rather than storing
+        // the raw bytes directly. This serves as validation/sanity-check that
+        // ensures the decrypted data is actually valid and not garbage.
+
+        let key_package: frost::keys::KeyPackage = {
+            t.challenge_bytes(b"secret_key_package", master.as_mut_slice());
+
+            let b = ChaCha20Poly1305::new_from_slice(master.as_slice())
+                .expect("master key must be 32-bytes")
+                .decrypt(nonce, export.enc_key_package.as_slice())
+                .map_err(|_| Error::BadDecryptionPassphrase)?;
+
+            ciborium::from_reader(b.as_slice())?
+        };
+
+        let pk_package: frost::keys::PublicKeyPackage = {
+            t.challenge_bytes(b"public_key_package", master.as_mut_slice());
+
+            let b = ChaCha20Poly1305::new_from_slice(master.as_slice())
+                .expect("master key must be 32-bytes")
+                .decrypt(nonce, export.enc_pk_package.as_slice())
+                .map_err(|_| Error::BadDecryptionPassphrase)?;
+
+            ciborium::from_reader(b.as_slice())?
+        };
+
+        self.set_key_package(key_package)?;
+        self.set_pubkey_package(pk_package)?;
+
         Ok(())
     }
 

--- a/bin/btc-server/src/database/mod.rs
+++ b/bin/btc-server/src/database/mod.rs
@@ -105,6 +105,9 @@ impl FinalizedPegout {
     }
 }
 
+/// Current version for [`ExportedKeyPackage`] (future-reserved).
+pub const EXPORTED_PACKAGE_VERSION: u16 = 0;
+
 /// Encrypted key package export format for secure backup and transfer.
 ///
 /// This structure contains both secret and public key packages encrypted with a
@@ -112,6 +115,9 @@ impl FinalizedPegout {
 /// operations, with two separately derived keys.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct ExportedKeyPackage {
+    /// Version indicator (future-reserved), currently it's
+    /// [`EXPORTED_PACKAGE_VERSION`].
+    pub version: u16,
     /// Random 96-bit nonce used for both encryption operations, in plaintext.
     pub iv: [u8; 12],
     /// Encrypted FROST secret key package. Contains the encrypted secret key
@@ -411,7 +417,12 @@ impl Db {
                 .expect("output buffer must be valid")
         };
 
-        let export = ExportedKeyPackage { iv, enc_key_package, enc_pk_package };
+        let export = ExportedKeyPackage {
+            version: EXPORTED_PACKAGE_VERSION,
+            iv,
+            enc_key_package,
+            enc_pk_package,
+        };
 
         Ok(Some(export))
     }
@@ -440,6 +451,10 @@ impl Db {
         passphrase: Zeroizing<String>,
         export: ExportedKeyPackage,
     ) -> Result<(), Error> {
+        if export.version != EXPORTED_PACKAGE_VERSION {
+            return Err(Error::BadExportedPackageFormatVersion);
+        }
+
         // Retrieve the nonce directly from the exported package.
         let nonce = Nonce::from_slice(&export.iv);
 

--- a/bin/btc-server/src/utxo_recovery/mod.rs
+++ b/bin/btc-server/src/utxo_recovery/mod.rs
@@ -14,11 +14,6 @@ pub enum UtxoRecoveryError {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-struct UtxosRecoveryConfig {
-    utxos: Vec<UtxoRecoveryData>,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct UtxoRecoveryData {
     /// Transaction ID as hex string


### PR DESCRIPTION
Merges https://github.com/botanix-labs/Macbeth/pull/973 (`main` branch) into `dev`.

EDIT: Note that I removed the unused `struct UtxosRecoveryConfig` to keep the CI happy: https://github.com/botanix-labs/Macbeth/pull/983/commits/0298b9572504e00452a580220634e79c5d9b7701 (cc @DariusParvin)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a btc-utils CLI to export/import encrypted key packages to/from the server database.
  * Interactive passphrase entry with optional confirmation and option to allow empty passphrases.
  * Import option to force overwrite existing key packages.
  * Portable, authenticated encrypted backups/restores with clear errors for bad passphrases or incompatible formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->