### PR TITLE
feat(btc-serve): unified pegin/pegout utxo metrics to a single guage

### DIFF
--- a/bin/btc-server/Cargo.toml
+++ b/bin/btc-server/Cargo.toml
@@ -64,9 +64,9 @@ prometheus = { version = "0.14", features = ["process"] }
 prost = "0.13.3"
 prost-types = "0.13.5"
 rand = "0.8.5"
-rpassword = "7.4.0"
 
 reth-fs-util = { workspace = true }
+rpassword = "7.4.0"
 rust_decimal = { version = "1.13" }
 serde = "1.0.171"
 serde_json = "1.0"

--- a/bin/btc-server/src/bin/main.rs
+++ b/bin/btc-server/src/bin/main.rs
@@ -736,7 +736,7 @@ where
             total_utxos.iter().fold(Amount::ZERO, |acc, utxo| acc + utxo.output.value);
         if let Some(telemetry) = self.telemetry.as_ref() {
             // seet attempted pegin height
-            telemetry.update_pegin_utxos(
+            telemetry.update_utxos(
                 self.btc_network,
                 self.config.identifier,
                 total_utxos.len() as i64,

--- a/bin/btc-server/src/pegout_scheduler/mod.rs
+++ b/bin/btc-server/src/pegout_scheduler/mod.rs
@@ -584,7 +584,7 @@ impl PegoutScheduler {
         let utxos = self.db.get_all_utxos()?;
         let utxos_amount = utxos.iter().fold(Amount::ZERO, |acc, utxo| acc + utxo.output.value);
         if let Some(telemetry) = self.telemetry.as_ref() {
-            telemetry.update_pegout_utxos(
+            telemetry.update_utxos(
                 self.bitcoin_network,
                 self.identifier,
                 utxos.len() as i64,

--- a/bin/btc-server/src/telemetry/metrics.rs
+++ b/bin/btc-server/src/telemetry/metrics.rs
@@ -112,10 +112,8 @@ pub struct BtcServerMetrics {
     pub round2_signing_package_size_histogram: HistogramVec,
 
     // Wallet and UTXO Management Metrics
-    pub pegin_utxos_count: IntGaugeVec,
-    pub pegin_utxos_total_value: IntGaugeVec,
-    pub pegout_utxos_count: IntGaugeVec,
-    pub pegout_utxos_total_value: IntGaugeVec,
+    pub multisig_utxos_count: IntGaugeVec,
+    pub multisig_utxos_total_value: IntGaugeVec,
     pub input_selection_time: IntCounterVec, // TODO (to be done once Darius's PR is merged)
 
     // Federation Member Participation Metrics
@@ -254,30 +252,16 @@ impl BtcServerMetrics {
         )
         .expect("metric must be created");
 
-        let pegin_utxos_count = register_int_gauge_vec!(
-            "pegin_utxos_count",
-            "A metric counting the number of pegin UTXOs",
+        let multisig_utxos_count = register_int_gauge_vec!(
+            "multisig_utxos_count",
+            "A metric counting the number of multisig UTXOs",
             &["btc_chain", "self_id"],
         )
         .expect("metric must be created");
 
-        let pegin_utxos_total_value = register_int_gauge_vec!(
-            "pegin_utxos_total_value",
-            "A metric representing the total value of pegin UTXOs in satoshis",
-            &["btc_chain", "self_id"],
-        )
-        .expect("metric must be created");
-
-        let pegout_utxos_count = register_int_gauge_vec!(
-            "pegout_utxos_count",
-            "A metric counting the number of pegout UTXOs",
-            &["btc_chain", "self_id"],
-        )
-        .expect("metric must be created");
-
-        let pegout_utxos_total_value = register_int_gauge_vec!(
-            "pegout_utxos_total_value",
-            "A metric representing the total value of pegout UTXOs in satoshis",
+        let multisig_utxos_total_value = register_int_gauge_vec!(
+            "multisig_utxos_total_value",
+            "A metric representing the total value of multisig UTXOs in satoshis",
             &["btc_chain", "self_id"],
         )
         .expect("metric must be created");
@@ -531,10 +515,8 @@ impl BtcServerMetrics {
         registry.register(Box::new(round2_signing_throughput.clone()))?;
         registry.register(Box::new(round1_signing_package_size_histogram.clone()))?;
         registry.register(Box::new(round2_signing_package_size_histogram.clone()))?;
-        registry.register(Box::new(pegin_utxos_count.clone()))?;
-        registry.register(Box::new(pegin_utxos_total_value.clone()))?;
-        registry.register(Box::new(pegout_utxos_count.clone()))?;
-        registry.register(Box::new(pegout_utxos_total_value.clone()))?;
+        registry.register(Box::new(multisig_utxos_count.clone()))?;
+        registry.register(Box::new(multisig_utxos_total_value.clone()))?;
         registry.register(Box::new(input_selection_time.clone()))?;
         registry.register(Box::new(fee_rate_abnormalities.clone()))?;
 
@@ -586,10 +568,8 @@ impl BtcServerMetrics {
             round2_signing_package_size_histogram,
             total_received_round1_signing_packages,
             total_received_round2_signing_packages,
-            pegin_utxos_count,
-            pegin_utxos_total_value,
-            pegout_utxos_count,
-            pegout_utxos_total_value,
+            multisig_utxos_count,
+            multisig_utxos_total_value,
             input_selection_time,
             member_uptime,
             bitcoind_rpc_latency,

--- a/bin/btc-server/src/telemetry/mod.rs
+++ b/bin/btc-server/src/telemetry/mod.rs
@@ -361,7 +361,7 @@ impl Telemetry {
         });
     }
 
-    pub fn update_pegin_utxos(
+    pub fn update_utxos(
         &self,
         btc_chain: bitcoin::Network,
         self_id: u16,
@@ -370,32 +370,12 @@ impl Telemetry {
     ) {
         self.maybe_use_metrics(|metrics| {
             metrics
-                .pegin_utxos_count
+                .multisig_utxos_count
                 .with_label_values(&[&btc_chain.to_string(), &self_id.to_string()])
                 .set(utxos);
 
             metrics
-                .pegin_utxos_total_value
-                .with_label_values(&[&btc_chain.to_string(), &self_id.to_string()])
-                .set(total_value);
-        });
-    }
-
-    pub fn update_pegout_utxos(
-        &self,
-        btc_chain: bitcoin::Network,
-        self_id: u16,
-        utxos: i64,
-        total_value: i64,
-    ) {
-        self.maybe_use_metrics(|metrics| {
-            metrics
-                .pegout_utxos_count
-                .with_label_values(&[&btc_chain.to_string(), &self_id.to_string()])
-                .set(utxos);
-
-            metrics
-                .pegout_utxos_total_value
+                .multisig_utxos_total_value
                 .with_label_values(&[&btc_chain.to_string(), &self_id.to_string()])
                 .set(total_value);
         });

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -528,10 +528,7 @@ pub trait EthTransactions: LoadTransaction {
     }
 
     /// Returns the signer for the given account, if found in configured signers.
-    fn find_signer(
-        &self,
-        account: &Address,
-    ) -> Result<Box<(dyn EthSigner + 'static)>, Self::Error> {
+    fn find_signer(&self, account: &Address) -> Result<Box<dyn EthSigner + 'static>, Self::Error> {
         self.signers()
             .read()
             .iter()


### PR DESCRIPTION
## Issue being fixed or feature implemented

Consolidated utxo_pegin and utxo_pegout metrics into a common utxo_metric

## What was done?

Consolidated utxo_pegin and utxo_pegout metrics into a common utxo_metric

## How Has This Been Tested?

CI/CD and manual

## Breaking Changes

none

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] I have added or updated relevant unit/integration/functional/e2e tests
-   [x] I have tested my changes running a local network, and they work as expected
-   [x] I have performed a self-review
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
-   [x] I have made corresponding changes to the documentation if needed
-   [x] I have added assignees and reviewers to this pull request
-   [x] I have added the PR to the project board or linked it to an issue from the board


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Telemetry now reports consolidated multisig UTXO metrics, including both count and total value.

- Refactor
  - Replaced separate pegin/pegout UTXO metrics with unified multisig metrics and updated telemetry paths to report total amounts.
  - Telemetry call sites updated to include UTXO total value.

- Breaking Change
  - RPC transaction helper now returns a boxed signer with a simplified trait signature (callers may need minor update).

- Chores
  - Minor dependency reordering (no runtime impact).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->