### PR TITLE
feat(btc-server): exclude eth addresses

### DIFF
--- a/bin/btc-server/src/bin/main.rs
+++ b/bin/btc-server/src/bin/main.rs
@@ -397,6 +397,8 @@ where
             panic!("min_signers should be at least 2");
         }
 
+        info!("excluded eth addresses len = {:?}", config.excluded_eth_addresses.len());
+
         let mut btc_signing_server_jwt_secret = None;
         if let Some(btc_signing_server_jwt_path) = config.btc_signing_server_jwt_secret.as_ref() {
             btc_signing_server_jwt_secret = Some(
@@ -1616,6 +1618,7 @@ where
             &self.db,
             self.min_signers,
             tracked_txs,
+            &self.config,
         )
         .to_status()
         {
@@ -2586,6 +2589,7 @@ mod tests {
             metrics_port: Some(8080),
             fee_rate_diff_percentage: 10,
             fall_back_fee_rate_sat_per_vbyte: 1000,
+            excluded_eth_addresses: vec![],
         };
 
         let app = App::new(config, bitcoind_client, None).expect("btc server");

--- a/bin/btc-server/src/config.rs
+++ b/bin/btc-server/src/config.rs
@@ -11,6 +11,8 @@ use thiserror::Error;
 use tokio::{fs::File, io::AsyncReadExt};
 use url::Url;
 
+use crate::util::{parse_eth_address, ParsingError};
+
 #[derive(Debug, DisplayDoc, Error)]
 pub enum Error {
     /// Open config file: {0}
@@ -27,6 +29,8 @@ pub enum Error {
     Confy(ConfyError),
     /// Missing config element: {0}
     MissingConfigElement(&'static str),
+    /// Invalid Ethereum address: {0}
+    InvalidEthereumAddress(ParsingError),
 }
 
 #[derive(Debug, Default, Deserialize, Clone)]
@@ -141,6 +145,11 @@ async fn read_to_string(path: impl AsRef<Path> + Send) -> Result<String, Error> 
     String::from_utf8(contents).map_err(Error::ParseUtf8)
 }
 
+/// Clap value parser for Ethereum addresses
+fn parse_ethereum_address_for_clap(s: &str) -> Result<[u8; 20], String> {
+    parse_eth_address(s.to_string()).map_err(|e| e.to_string())
+}
+
 // Cli args and config
 
 #[derive(Clone, Debug, Parser)]
@@ -197,6 +206,9 @@ pub struct CliConfig {
     /// http port
     #[arg(long)]
     metrics_port: Option<u16>,
+    /// Comma-separated list of Ethereum addresses to exclude from coin selection
+    #[arg(long, value_delimiter = ',', value_parser = parse_ethereum_address_for_clap)]
+    excluded_eth_addresses: Vec<[u8; 20]>,
 }
 
 #[derive(Clone, Debug)]
@@ -239,6 +251,8 @@ pub struct Config {
     pub fee_rate_diff_percentage: u32,
     /// Fall back fee rate expressed in sat per vbyte
     pub fall_back_fee_rate_sat_per_vbyte: u64,
+    /// Ethereum addresses to exclude from coin selection
+    pub excluded_eth_addresses: Vec<[u8; 20]>,
 }
 
 pub fn load_config() -> Result<Config, Error> {
@@ -263,6 +277,37 @@ pub fn load_config() -> Result<Config, Error> {
         metrics_port: cli_config.metrics_port,
         fee_rate_diff_percentage: cli_config.fee_rate_diff_percentage.unwrap_or(2),
         fall_back_fee_rate_sat_per_vbyte: cli_config.fall_back_fee_rate_sat_per_vbyte.unwrap_or(10),
+        excluded_eth_addresses: cli_config.excluded_eth_addresses,
     };
     Ok(config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_ethereum_address_for_clap_valid() {
+        let result = parse_ethereum_address_for_clap("0x1234567890123456789012345678901234567890");
+        assert!(result.is_ok());
+
+        // Test without 0x prefix
+        let result = parse_ethereum_address_for_clap("1234567890123456789012345678901234567890");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_parse_ethereum_address_for_clap_invalid() {
+        // Test invalid hex
+        let result = parse_ethereum_address_for_clap("invalid");
+        assert!(result.is_err());
+
+        // Test wrong length
+        let result = parse_ethereum_address_for_clap("0x1234");
+        assert!(result.is_err());
+
+        // Test empty string
+        let result = parse_ethereum_address_for_clap("");
+        assert!(result.is_err());
+    }
 }

--- a/bin/btc-server/src/config.rs
+++ b/bin/btc-server/src/config.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 use tokio::{fs::File, io::AsyncReadExt};
 use url::Url;
 
-use crate::util::{parse_eth_address, ParsingError};
+use crate::util::parse_eth_address;
 
 #[derive(Debug, DisplayDoc, Error)]
 pub enum Error {
@@ -29,8 +29,6 @@ pub enum Error {
     Confy(ConfyError),
     /// Missing config element: {0}
     MissingConfigElement(&'static str),
-    /// Invalid Ethereum address: {0}
-    InvalidEthereumAddress(ParsingError),
 }
 
 #[derive(Debug, Default, Deserialize, Clone)]

--- a/bin/btc-server/src/coordinator/mod.rs
+++ b/bin/btc-server/src/coordinator/mod.rs
@@ -1,6 +1,7 @@
 use log::{debug, error, info, warn};
 
 use crate::{
+    config::Config,
     coordinator::error::CoordinatorError,
     database::{Db, Error as DbError, Utxo},
     pegout_id::PegoutId,
@@ -24,6 +25,34 @@ pub mod error;
 
 #[allow(dead_code)]
 const MIN_RELAY_FEE_RATE_SAT_VB: u64 = 1;
+
+/// Filters out UTXOs associated with excluded Ethereum addresses
+fn filter_excluded_utxos(
+    utxos: &HashMap<OutPoint, Utxo>,
+    excluded_addresses: &[[u8; 20]],
+) -> HashMap<OutPoint, Utxo> {
+    if excluded_addresses.is_empty() {
+        info!("No excluded eth addresses provided, returning all utxos");
+        return utxos.clone();
+    }
+
+    info!("Filtering out excluded eth addresses: {} addresses", excluded_addresses.len());
+
+    let filtered_utxos: HashMap<OutPoint, Utxo> = utxos
+        .iter()
+        .filter_map(|(op, utxo)| match utxo.eth_address {
+            Some(addr) if excluded_addresses.contains(&addr) => None,
+            _ => Some((*op, utxo.clone())),
+        })
+        .collect();
+
+    info!(
+        "filtered out {} utxos due to excluded eth addresses",
+        utxos.len() - filtered_utxos.len()
+    );
+
+    filtered_utxos
+}
 
 pub fn add_round1_signing(
     signing_session_id: &[u8; 32],
@@ -82,6 +111,7 @@ pub fn make_tx(
     db: &Db,
     min_signers: u16,
     tracked_txs: Vec<Tx>,
+    config: &Config,
 ) -> Result<Psbt, CoordinatorError> {
     let mut attempted_outputs = outputs.clone();
     loop {
@@ -144,6 +174,9 @@ pub fn attempt_make_tx(
     debug!("utxos len = {:?}", utxos.len());
     debug!("utxos = {:?}", utxos);
 
+    // Exclude UTXOs that have been specifically requested to not be included in the coin selection
+    let filtered_utxos = filter_excluded_utxos(&utxos, &config.excluded_eth_addresses);
+
     let tracked_inputs = tracked_txs
         .iter()
         .flat_map(|tx| tx.inputs().collect::<Vec<OutPoint>>())
@@ -152,8 +185,7 @@ pub fn attempt_make_tx(
     debug!("tracked_inputs = {:?}", tracked_inputs);
 
     // Filter utxos that are still pending and conflict with pending txs.
-    // These utxos are 'optional' in that they are not required to be included in the coin selection
-    let optional_utxos = utxos
+    let mut available_utxos = filtered_utxos
         .clone()
         .into_iter()
         .filter(|(p, _u)| !tracked_inputs.contains(p))
@@ -316,4 +348,57 @@ pub async fn finalize_signing(
     }
 
     Ok(original_psbt)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{database::Utxo, test_utils::random_compute_txid};
+    use bitcoin::{Amount, ScriptBuf, TxOut};
+
+    #[test]
+    fn test_filter_excluded_utxos() {
+        let mut utxos = HashMap::new();
+
+        let outpoint_to_filter = OutPoint::new(random_compute_txid(), 0);
+        let eth_address = [0x12u8; 20]; // Simple test address
+
+        let utxo_to_filter = Utxo::new(
+            outpoint_to_filter,
+            TxOut { value: Amount::from_sat(1000), script_pubkey: ScriptBuf::new() },
+            Some(eth_address),
+            None,
+        );
+
+        let outpoint_to_keep = OutPoint::new(random_compute_txid(), 1);
+        let eth_address_to_keep = [1u8; 20];
+        let utxo_to_keep = Utxo::new(
+            outpoint_to_keep,
+            TxOut { value: Amount::from_sat(1000), script_pubkey: ScriptBuf::new() },
+            Some(eth_address_to_keep),
+            None,
+        );
+
+        let outpoint_change = OutPoint::new(random_compute_txid(), 2);
+        let utxo_change = Utxo::new(
+            outpoint_change,
+            TxOut { value: Amount::from_sat(1000), script_pubkey: ScriptBuf::new() },
+            None,
+            None,
+        );
+
+        utxos.insert(outpoint_to_filter, utxo_to_filter);
+        utxos.insert(outpoint_to_keep, utxo_to_keep);
+        utxos.insert(outpoint_change, utxo_change);
+
+        // Filter out the address
+        let excluded_addresses = vec![[0x12u8; 20]]; // Same as eth_address used above
+        let result = filter_excluded_utxos(&utxos, &excluded_addresses);
+
+        // The UTXO should be filtered out
+        assert_eq!(result.len(), 2);
+        assert!(!result.contains_key(&outpoint_to_filter));
+        assert!(result.contains_key(&outpoint_to_keep));
+        assert!(result.contains_key(&outpoint_change));
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please provide a link to the issue -->

## What was done?

<!--- Describe your changes in detail -->

-

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

-

## Breaking Changes

<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

-

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] I have added or updated relevant unit/integration/functional/e2e tests
-   [ ] I have tested my changes running a local network, and they work as expected
-   [ ] I have performed a self-review
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
-   [ ] I have made corresponding changes to the documentation if needed
-   [ ] I have added assignees and reviewers to this pull request
-   [ ] I have added the PR to the project board or linked it to an issue from the board


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  - Added a CLI option to specify excluded Ethereum addresses (comma-separated) that are ignored during transaction building.
  - Transaction creation now filters out UTXOs linked to excluded addresses, improving control over coin selection.
  - Runtime logs now report the size of the excluded address list during startup.

* Tests
  - Added unit tests for Ethereum address parsing in the CLI.
  - Added tests verifying that excluded addresses are correctly filtered from UTXOs during transaction construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->