### PR TITLE
feat(foundation): Init `botanix-foundation-layer` crate & DB extensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,10 +381,10 @@ version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413902aa18a97569e60f679c23f46a18db1656d87ab4d4e49d0e1e52042f66df"
 dependencies = [
- "alloy-json-abi",
+ "alloy-json-abi 0.7.7",
  "alloy-primitives 0.7.7",
- "alloy-sol-type-parser",
- "alloy-sol-types",
+ "alloy-sol-type-parser 0.7.7",
+ "alloy-sol-types 0.7.7",
  "const-hex",
  "derive_more 0.99.20",
  "itoa",
@@ -430,7 +430,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc05b04ac331a9f07e3a4036ef7926e49a8bf84a99a1ccfc7e2ab55a5fcbb372"
 dependencies = [
  "alloy-primitives 0.7.7",
- "alloy-sol-type-parser",
+ "alloy-sol-type-parser 0.7.7",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-json-abi"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "125a1c373261b252e53e04d6e92c37d881833afc1315fceab53fd46045695640"
+dependencies = [
+ "alloy-primitives 1.3.1",
+ "alloy-sol-type-parser 1.4.1",
  "serde",
  "serde_json",
 ]
@@ -442,7 +454,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57e2865c4c3bb4cdad3f0d9ec1ab5c0c657ba69a375651bd35e32fb6c180ccc2"
 dependencies = [
  "alloy-primitives 0.7.7",
- "alloy-sol-types",
+ "alloy-sol-types 0.7.7",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -463,7 +475,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-serde",
  "alloy-signer",
- "alloy-sol-types",
+ "alloy-sol-types 0.7.7",
  "async-trait",
  "auto_impl",
  "futures-utils-wasm",
@@ -764,7 +776,7 @@ dependencies = [
  "alloy-primitives 0.7.7",
  "alloy-rlp",
  "alloy-serde",
- "alloy-sol-types",
+ "alloy-sol-types 0.7.7",
  "arbitrary",
  "itertools 0.13.0",
  "jsonrpsee-types",
@@ -862,9 +874,23 @@ version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b40397ddcdcc266f59f959770f601ce1280e699a91fc1862f29cef91707cd09"
 dependencies = [
- "alloy-sol-macro-expander",
- "alloy-sol-macro-input",
+ "alloy-sol-macro-expander 0.7.7",
+ "alloy-sol-macro-input 0.7.7",
  "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "alloy-sol-macro"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ce480400051b5217f19d6e9a82d9010cdde20f1ae9c00d53591e4a1afbb312"
+dependencies = [
+ "alloy-sol-macro-expander 1.4.1",
+ "alloy-sol-macro-input 1.4.1",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -876,7 +902,7 @@ version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "867a5469d61480fea08c7333ffeca52d5b621f5ca2e44f271b117ec1fc9a0525"
 dependencies = [
- "alloy-sol-macro-input",
+ "alloy-sol-macro-input 0.7.7",
  "const-hex",
  "heck 0.5.0",
  "indexmap 2.11.0",
@@ -884,7 +910,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
- "syn-solidity",
+ "syn-solidity 0.7.7",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-sol-macro-expander"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d792e205ed3b72f795a8044c52877d2e6b6e9b1d13f431478121d8d4eaa9028"
+dependencies = [
+ "alloy-sol-macro-input 1.4.1",
+ "const-hex",
+ "heck 0.5.0",
+ "indexmap 2.11.0",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "syn-solidity 1.4.1",
  "tiny-keccak",
 ]
 
@@ -900,7 +944,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
- "syn-solidity",
+ "syn-solidity 0.7.7",
+]
+
+[[package]]
+name = "alloy-sol-macro-input"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bd1247a8f90b465ef3f1207627547ec16940c35597875cdc09c49d58b19693c"
+dependencies = [
+ "const-hex",
+ "dunce",
+ "heck 0.5.0",
+ "macro-string",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "syn-solidity 1.4.1",
 ]
 
 [[package]]
@@ -914,14 +974,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-sol-type-parser"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "954d1b2533b9b2c7959652df3076954ecb1122a28cc740aa84e7b0a49f6ac0a9"
+dependencies = [
+ "serde",
+ "winnow 0.7.13",
+]
+
+[[package]]
 name = "alloy-sol-types"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a91ca40fa20793ae9c3841b83e74569d1cc9af29a2f5237314fd3452d51e38c7"
 dependencies = [
  "alloy-primitives 0.7.7",
- "alloy-sol-macro",
+ "alloy-sol-macro 0.7.7",
  "const-hex",
+ "serde",
+]
+
+[[package]]
+name = "alloy-sol-types"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5383d34ea00079e6dd89c652bcbdb764db160cef84e6250926961a0b2295d04"
+dependencies = [
+ "alloy-json-abi 1.3.1",
+ "alloy-primitives 1.3.1",
+ "alloy-sol-macro 1.4.1",
  "serde",
 ]
 
@@ -1008,9 +1090,25 @@ dependencies = [
  "derive_arbitrary",
  "derive_more 0.99.20",
  "hashbrown 0.14.5",
- "nybbles",
+ "nybbles 0.2.1",
  "proptest",
  "proptest-derive 0.4.0",
+ "serde",
+ "smallvec",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-trie"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3412d52bb97c6c6cc27ccc28d4e6e8cf605469101193b50b0bd5813b1f990b5"
+dependencies = [
+ "alloy-primitives 1.3.1",
+ "alloy-rlp",
+ "arrayvec",
+ "derive_more 2.0.1",
+ "nybbles 0.4.5",
  "serde",
  "smallvec",
  "tracing",
@@ -2391,7 +2489,7 @@ version = "1.2.0-rc.5"
 dependencies = [
  "bitcoin 0.32.7",
  "hex",
- "prost",
+ "prost 0.13.5",
  "reth-primitives",
  "secp256k1 0.29.1",
  "tendermint-light-client",
@@ -2437,7 +2535,7 @@ dependencies = [
  "lazy_static",
  "paste",
  "postcard",
- "prost",
+ "prost 0.13.5",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -2485,6 +2583,18 @@ dependencies = [
  "toml 0.8.23",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "botanix-foundation-layer"
+version = "1.2.0-rc.5"
+dependencies = [
+ "botanix-storage",
+ "botanix-tem",
+ "ciborium",
+ "reth-db",
+ "reth-db-api",
+ "reth-storage-errors",
 ]
 
 [[package]]
@@ -2573,7 +2683,9 @@ dependencies = [
  "arbitrary",
  "auto_impl",
  "botanix-storage",
+ "botanix-tem",
  "bytes",
+ "ciborium",
  "eyre",
  "itertools 0.14.0",
  "modular-bitfield",
@@ -2585,7 +2697,6 @@ dependencies = [
  "reth-primitives",
  "reth-prune-types",
  "reth-storage-errors",
- "secp256k1 0.29.1",
  "serde",
  "sha2 0.10.9",
  "tempfile",
@@ -2606,6 +2717,31 @@ dependencies = [
  "reth-primitives",
  "tempfile",
  "tracing",
+]
+
+[[package]]
+name = "botanix-tem"
+version = "0.1.0"
+source = "git+ssh://git@github.com/lamafab/botanix-tee.git?branch=state-restruct#b7ac6bc5dd83893d6a5b4ce36d03da7c15a8a60e"
+dependencies = [
+ "alloy-primitives 1.3.1",
+ "alloy-rlp",
+ "alloy-sol-types 1.3.1",
+ "alloy-trie 0.9.1",
+ "bitcoin 0.32.7",
+ "hash-db 0.16.0",
+ "lazy_static",
+ "memory-db",
+ "parity-scale-codec",
+ "prost 0.14.1",
+ "prost-types 0.14.1",
+ "rand 0.9.2",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tendermint",
+ "tendermint-light-client-verifier",
+ "trie-db",
 ]
 
 [[package]]
@@ -2727,9 +2863,9 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.4",
  "prometheus",
- "prost",
+ "prost 0.13.5",
  "prost-build",
- "prost-types",
+ "prost-types 0.13.5",
  "rand 0.8.5",
  "reth-fs-util",
  "rpassword",
@@ -2766,8 +2902,8 @@ dependencies = [
  "futures-util",
  "hex",
  "jsonwebtoken 9.3.1",
- "prost",
- "prost-types",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
  "rand 0.8.5",
  "serde",
  "tempfile",
@@ -5383,6 +5519,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d23bd4e7b5eda0d0f3a307e8b381fdc8ba9000f26fbe912250c0a4cc3956364a"
 
 [[package]]
+name = "hash-db"
+version = "0.16.0"
+source = "git+https://github.com/paritytech/trie.git?branch=master#f43bc1251f424f658931e0fa0bf605f90706c12e"
+
+[[package]]
 name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7103,6 +7244,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "macro-string"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7149,6 +7301,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg 1.5.0",
+]
+
+[[package]]
+name = "memory-db"
+version = "0.34.0"
+source = "git+https://github.com/paritytech/trie.git?branch=master#f43bc1251f424f658931e0fa0bf605f90706c12e"
+dependencies = [
+ "foldhash",
+ "hash-db 0.16.0",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -7672,6 +7834,20 @@ dependencies = [
  "arbitrary",
  "const-hex",
  "proptest",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
+name = "nybbles"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa11e84403164a9f12982ab728f3c67c6fd4ab5b5f0254ffc217bdbd3b28ab0"
+dependencies = [
+ "alloy-rlp",
+ "cfg-if 1.0.3",
+ "proptest",
+ "ruint",
  "serde",
  "smallvec",
 ]
@@ -8524,7 +8700,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
+dependencies = [
+ "bytes",
+ "prost-derive 0.14.1",
 ]
 
 [[package]]
@@ -8540,8 +8726,8 @@ dependencies = [
  "once_cell",
  "petgraph 0.7.1",
  "prettyplease",
- "prost",
- "prost-types",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
  "regex",
  "syn 2.0.106",
  "tempfile",
@@ -8561,12 +8747,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
- "prost",
+ "prost 0.13.5",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
+dependencies = [
+ "prost 0.14.1",
 ]
 
 [[package]]
@@ -8786,6 +8994,7 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+ "serde",
 ]
 
 [[package]]
@@ -8868,6 +9077,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
+ "serde",
 ]
 
 [[package]]
@@ -9349,7 +9559,7 @@ dependencies = [
  "futures-util",
  "hex",
  "once_cell",
- "prost",
+ "prost 0.13.5",
  "rand 0.8.5",
  "reth-basic-payload-builder",
  "reth-chain-state",
@@ -9616,7 +9826,7 @@ dependencies = [
  "alloy-genesis",
  "alloy-primitives 0.7.7",
  "alloy-rlp",
- "alloy-trie",
+ "alloy-trie 0.4.1",
  "auto_impl",
  "derive_more 2.0.1",
  "once_cell",
@@ -9704,7 +9914,7 @@ dependencies = [
  "alloy-eips",
  "alloy-genesis",
  "alloy-primitives 0.7.7",
- "alloy-trie",
+ "alloy-trie 0.4.1",
  "arbitrary",
  "bytes",
  "modular-bitfield",
@@ -10366,7 +10576,7 @@ name = "reth-evm-ethereum"
 version = "1.2.0-rc.5"
 dependencies = [
  "alloy-eips",
- "alloy-sol-types",
+ "alloy-sol-types 0.7.7",
  "bitcoin 0.32.7",
  "botanix-authority-edh",
  "botanix-authority-peg",
@@ -10399,7 +10609,7 @@ dependencies = [
  "alloy-rlp",
  "botanix-authority-edh",
  "derive_more 2.0.1",
- "nybbles",
+ "nybbles 0.2.1",
  "reth-consensus",
  "reth-prune-types",
  "reth-storage-errors",
@@ -11401,7 +11611,7 @@ dependencies = [
 name = "reth-rpc-eth-types"
 version = "1.2.0-rc.5"
 dependencies = [
- "alloy-sol-types",
+ "alloy-sol-types 0.7.7",
  "botanix-rpc-config",
  "derive_more 2.0.1",
  "futures",
@@ -11783,13 +11993,13 @@ dependencies = [
  "alloy-genesis",
  "alloy-primitives 0.7.7",
  "alloy-rlp",
- "alloy-trie",
+ "alloy-trie 0.4.1",
  "arbitrary",
  "bytes",
  "derive_more 2.0.1",
- "hash-db",
+ "hash-db 0.15.2",
  "itertools 0.14.0",
- "nybbles",
+ "nybbles 0.2.1",
  "plain_hasher",
  "proptest",
  "proptest-arbitrary-interop",
@@ -11880,7 +12090,7 @@ checksum = "ec16f9b9d3cdaaf2f4b7ceaf004eb2c89df04e7ea29622584c0a6ec676bd0a83"
 dependencies = [
  "alloy-primitives 0.7.7",
  "alloy-rpc-types",
- "alloy-sol-types",
+ "alloy-sol-types 0.7.7",
  "anstyle",
  "boa_engine",
  "boa_gc",
@@ -13383,6 +13593,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn-solidity"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff790eb176cc81bb8936aed0f7b9f14fc4670069a2d371b3e3b0ecce908b2cb3"
+dependencies = [
+ "paste",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13517,7 +13739,7 @@ dependencies = [
  "k256",
  "num-traits",
  "once_cell",
- "prost",
+ "prost 0.13.5",
  "ripemd",
  "serde",
  "serde_bytes",
@@ -13540,7 +13762,7 @@ checksum = "87265abf4063fc70605f33fd0117c0bea375d2b05a269aaf317e3ba9e6b5e6b5"
 dependencies = [
  "bytes",
  "flex-error",
- "prost",
+ "prost 0.13.5",
  "tendermint-proto",
  "tracing",
 ]
@@ -13605,7 +13827,7 @@ checksum = "d2c40e13d39ca19082d8a7ed22de7595979350319833698f8b1080f29620a094"
 dependencies = [
  "bytes",
  "flex-error",
- "prost",
+ "prost 0.13.5",
  "serde",
  "serde_bytes",
  "subtle-encoding",
@@ -14244,7 +14466,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost",
+ "prost 0.13.5",
  "socket2 0.5.10",
  "tokio",
  "tokio-stream",
@@ -14263,7 +14485,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "prost-build",
- "prost-types",
+ "prost-types 0.13.5",
  "quote",
  "syn 2.0.106",
 ]
@@ -14275,7 +14497,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1eaf34ddb812120f5c601162d5429933c9b527d901ab0e7f930d3147e33a09b2"
 dependencies = [
  "async-stream",
- "prost",
+ "prost 0.13.5",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -14287,8 +14509,8 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "878d81f52e7fcfd80026b7fdb6a9b578b3c3653ba987f87f0dce4b64043cba27"
 dependencies = [
- "prost",
- "prost-types",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -14524,12 +14746,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "trie-db"
+version = "0.30.0"
+source = "git+https://github.com/paritytech/trie.git?branch=master#f43bc1251f424f658931e0fa0bf605f90706c12e"
+dependencies = [
+ "hash-db 0.16.0",
+ "log",
+ "rustc-hex",
+ "smallvec",
+]
+
+[[package]]
 name = "triehash"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1631b201eb031b563d2e85ca18ec8092508e262a3196ce9bd10a67ec87b9f5c"
 dependencies = [
- "hash-db",
+ "hash-db 0.15.2",
  "rlp",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
     "crates/botanix-comet-bft-rpc",
     "crates/botanix-configs",
     "crates/botanix-data-parser",
+    "crates/botanix-foundation-layer",
     "crates/botanix-rpc-client",
     "crates/botanix-rpc-config",
     "crates/botanix-rpc-types",

--- a/crates/botanix-foundation-layer/Cargo.toml
+++ b/crates/botanix-foundation-layer/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "botanix-foundation-layer"
+description = "Interface with the Botanix Foundation Layer"
+version = { workspace = true }
+edition = { workspace = true }
+rust-version = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+
+[dependencies]
+botanix-tem = { git = "ssh://git@github.com/lamafab/botanix-tee.git", branch = "state-restruct" }
+botanix-storage = { workspace = true }
+reth-db-api = { workspace = true }
+reth-storage-errors = { workspace = true }
+ciborium = "0.2.1"
+
+[dev-dependencies]
+reth-db = { workspace = true }

--- a/crates/botanix-foundation-layer/src/db_impl.rs
+++ b/crates/botanix-foundation-layer/src/db_impl.rs
@@ -1,0 +1,375 @@
+use botanix_storage::{
+    BotanixDatabaseProviderRW, BotanixProviderFactory, DatabaseProviderFactoryRW,
+    FoundationLayerReader, FoundationLayerWriter,
+};
+// TODO: Consider adding a convenience `prelude::*` export module.
+use botanix_tem::{
+    foundation::{
+        bitcoin::{BlockHash, OutPoint, Txid},
+        hash_db,
+        trie_db::{self, DBValue, HashDB},
+        AtomicCommitLayer, AtomicDataLayer, AtomicError, CommitHasher, CommitLayerError,
+        CommitmentStateRoot, DataSource, DataSourceError, FatDB, OnchainHeaderEntry,
+        OnchainUtxoEntry, ProposalEntry, TrieLayer, UnassignedEntry,
+    },
+    validation::pegout::PegoutId,
+};
+use reth_db_api::Database;
+use reth_storage_errors::provider::ProviderError;
+
+/// A wrapper over the [`BotanixProviderFactory`] that implements both the
+/// [`AtomicCommitLayer`] and [`AtomicDataLayer`] from the Botanix TEM crate.
+///
+/// This is passed-on to the [`botanix_tem::foundation::Foundation`] structure.
+pub struct WBotanixProviderFactory<DB>
+where
+    DB: Database,
+{
+    /// The factory to acquire new database transactions from.
+    factory: BotanixProviderFactory<DB>,
+    /// The handle to the database transaction after calling
+    /// `AtomicCommitLayer::start_trie_tx`.
+    ///
+    /// This is used to commit or rollback any changes made to the foundation
+    /// trie/commitment layer.
+    trie: Option<FatDB<WBotanixDatabaseProvider<DB>>>,
+    /// The cached trie root. Only updated on database commit.
+    cached_root: Option<CommitmentStateRoot>,
+    /// The handle to the database transaction after calling
+    /// `AtomicDataLayer::start_data_tx`.
+    ///
+    /// This is used to commit or rollback any changes made to the foundation
+    /// data storage layer.
+    data: Option<WBotanixDatabaseProvider<DB>>,
+}
+
+impl<DB> WBotanixProviderFactory<DB>
+where
+    DB: Database,
+{
+    /// Returns the latest trie root, using a cached value when available.
+    ///
+    /// The cached root is updated on every database commit. If no cached root
+    /// exists, this method starts a **new database transaction** to fetch and
+    /// cache the last committed root from the database.
+    ///
+    /// If no root exists in the database, this assumes an empty trie and returns
+    /// the hashed null-node as defined by [`CommitHasher::HASHED_NULL_NODE`].
+    ///
+    /// Note: This method only retrieves the root value. Any trie operation
+    /// errors or root computation errors will occur later during actual I/O
+    /// operations on the trie, not in this method.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProviderError`] if the database transaction or root retrieval
+    /// fails.
+    pub fn prepare_cached_root(&mut self) -> Result<CommitmentStateRoot, ProviderError> {
+        if let Some(root) = self.cached_root {
+            return Ok(root)
+        }
+
+        // Start a new database transaction.
+        let provider = WBotanixDatabaseProvider { tx: self.factory.provider_rw()? };
+
+        // Retrieve the root from the local database.
+        let stored_root =
+            provider.tx.get_foundation_commitment_root()?.unwrap_or(CommitHasher::HASHED_NULL_NODE);
+
+        // If this is an empty database, then the null-node must be inserted
+        // into the database if it does not exist yet. This is required by the
+        // `trie-db`.
+        if stored_root == CommitHasher::HASHED_NULL_NODE {
+            provider.tx.insert_foundation_commitment(stored_root, vec![0u8])?;
+        }
+
+        // Retrieve the [`CommitmentStateRoot`] directly from the underlying trie-db.
+        let mut trie = FatDB::from_existing(provider, stored_root);
+        let root = trie.root();
+
+        debug_assert_eq!(root.as_ref(), &stored_root);
+
+        if stored_root == CommitHasher::HASHED_NULL_NODE {
+            // Only commit database transaction if we have a reason to -
+            // otherwise rollback.
+            trie.into_db().tx.commit()?;
+        }
+
+        // Cache the latest root.
+        self.cached_root = Some(root);
+
+        Ok(root)
+    }
+}
+
+impl<DB> From<BotanixProviderFactory<DB>> for WBotanixProviderFactory<DB>
+where
+    DB: Database,
+{
+    fn from(factory: BotanixProviderFactory<DB>) -> Self {
+        WBotanixProviderFactory { factory, trie: None, cached_root: None, data: None }
+    }
+}
+
+impl<DB> AtomicCommitLayer for WBotanixProviderFactory<DB>
+where
+    DB: Database,
+{
+    type BackendError = ProviderError;
+
+    fn commit(&mut self) -> Result<CommitmentStateRoot, CommitLayerError<Self::BackendError>> {
+        let mut trie = self.trie.take().ok_or(AtomicError::CommitmentLayerNotStarted)?;
+        let root = trie.root();
+
+        let provider: WBotanixDatabaseProvider<_> = trie.into_db();
+
+        // Store the latest root directly into the transaction.
+        provider
+            .tx
+            .insert_foundation_commitment_root(*root.as_ref())
+            .map_err(AtomicError::Backend)?;
+
+        // COMMIT the transaction changes to the database.
+        provider.tx.commit().map_err(AtomicError::Backend)?;
+
+        // Cache the latest root.
+        self.cached_root = Some(root);
+
+        debug_assert!(self.trie.is_none());
+        Ok(root)
+    }
+    fn rollback(&mut self) -> Result<CommitmentStateRoot, CommitLayerError<Self::BackendError>> {
+        let trie = self.trie.take().ok_or(AtomicError::CommitmentLayerNotStarted)?;
+
+        // Just drop the database transaction; rollback is implied.
+        let trash: WBotanixDatabaseProvider<_> = trie.into_db();
+        std::mem::drop(trash);
+
+        let root = self.root()?;
+
+        debug_assert!(self.trie.is_none());
+        Ok(root)
+    }
+    fn root(&mut self) -> Result<CommitmentStateRoot, CommitLayerError<Self::BackendError>> {
+        self.prepare_cached_root().map_err(|err| AtomicError::Backend(err).into())
+    }
+    fn start_trie_tx<'db>(
+        &'db mut self,
+    ) -> Result<TrieLayer<'db>, CommitLayerError<Self::BackendError>> {
+        if self.trie.is_some() {
+            return Err(AtomicError::CommitmentLayerAlreadyStarted.into());
+        }
+
+        // NOTE: This starts a new database transaction on startup (only!),
+        // which does result in a dead-lock IF called after the `let provider = ...`
+        // call next.
+        let root = self.root()?;
+
+        // Start a new database transaction.
+        let provider = WBotanixDatabaseProvider {
+            tx: self.factory.provider_rw().map_err(AtomicError::Backend)?,
+        };
+
+        // Setup trie layer.
+        self.trie = Some(FatDB::from_existing(provider, *root.as_ref()));
+        let handle = self.trie.as_mut().expect("trie db must exist");
+
+        Ok(handle.trie_layer())
+    }
+}
+
+impl<DB> AtomicDataLayer for WBotanixProviderFactory<DB>
+where
+    DB: Database,
+{
+    type BackendError = ProviderError;
+    type Transaction = WBotanixDatabaseProvider<DB>;
+
+    // TODO: AtomicError variants should be more generic; rename to
+    // `TransactionAlreadyStarted` or so.
+    fn commit(
+        &mut self,
+    ) -> Result<(), botanix_tem::foundation::DataLayerError<Self::BackendError>> {
+        let provider: WBotanixDatabaseProvider<_> =
+            self.data.take().ok_or(AtomicError::CommitmentLayerNotStarted)?;
+
+        // COMMIT the transaction changes to the database.
+        provider.tx.commit().map_err(AtomicError::Backend)?;
+
+        debug_assert!(self.data.is_none());
+        Ok(())
+    }
+    fn rollback(
+        &mut self,
+    ) -> Result<(), botanix_tem::foundation::DataLayerError<Self::BackendError>> {
+        // Just drop the database transaction; rollback is implied.
+        let trash: WBotanixDatabaseProvider<_> =
+            self.data.take().ok_or(AtomicError::CommitmentLayerNotStarted)?;
+
+        std::mem::drop(trash);
+
+        debug_assert!(self.data.is_none());
+        Ok(())
+    }
+    fn start_data_tx<'tx>(
+        &'tx mut self,
+    ) -> Result<
+        &'tx mut Self::Transaction,
+        botanix_tem::foundation::DataLayerError<Self::BackendError>,
+    > {
+        if self.trie.is_some() {
+            return Err(AtomicError::CommitmentLayerAlreadyStarted.into());
+        }
+
+        // Start a new database transaction.
+        let provider = WBotanixDatabaseProvider {
+            tx: self.factory.provider_rw().map_err(|err| AtomicError::Backend(err))?,
+        };
+
+        // Setup data layer.
+        self.data = Some(provider);
+        let provider = self.data.as_mut().expect("provider must be set");
+
+        Ok(provider)
+    }
+}
+
+/// A wrapper over the [`BotanixDatabaseProviderRW`] that implements both the
+/// [`DataSource`] from the Botanix TEM and the [`trie_db::HashDB`] from the
+/// Parity crate.
+///
+/// This is acquired internally in the [`botanix_tem::foundation::Foundation`]
+/// structure via the [`WBotanixProviderFactory`].
+pub struct WBotanixDatabaseProvider<DB>
+where
+    DB: Database,
+{
+    tx: BotanixDatabaseProviderRW<DB>,
+}
+
+impl<DB> hash_db::AsHashDB<CommitHasher, DBValue> for WBotanixDatabaseProvider<DB>
+where
+    DB: Database,
+{
+    fn as_hash_db(&self) -> &dyn HashDB<CommitHasher, DBValue> {
+        self
+    }
+    fn as_hash_db_mut<'a>(&'a mut self) -> &'a mut (dyn HashDB<CommitHasher, DBValue> + 'a) {
+        self
+    }
+}
+
+impl<DB> trie_db::HashDB<CommitHasher, DBValue> for WBotanixDatabaseProvider<DB>
+where
+    DB: Database,
+{
+    fn get(&self, key: &[u8; 32], _prefix: (&[u8], Option<u8>)) -> Option<DBValue> {
+        self.tx.get_foundation_commitment(*key).expect("failed to get key")
+    }
+    fn contains(&self, key: &[u8; 32], _prefix: (&[u8], Option<u8>)) -> bool {
+        // TODO: Consider implementing explicit `contains` method.
+        let val = self.tx.get_foundation_commitment(*key).expect("failed to get key");
+        val.is_some()
+    }
+    fn insert(&mut self, prefix: (&[u8], Option<u8>), value: &[u8]) -> [u8; 32] {
+        let (slice, byte) = prefix;
+
+        let mut h = CommitHasher::new(b"botanix:trie-database-provider");
+        h.append_message(b"prefix", slice);
+        if let Some(b) = byte {
+            h.append_u64(b"prefix-extra", b as u64);
+        }
+        h.append_message(b"value", value);
+        //
+        let key = h.finalize();
+
+        self.tx.insert_foundation_commitment(key, value.to_vec()).expect("failed to insert key");
+
+        key
+    }
+    fn emplace(&mut self, key: [u8; 32], _prefix: (&[u8], Option<u8>), value: DBValue) {
+        self.tx.insert_foundation_commitment(key, value).expect("failed to insert key");
+    }
+    fn remove(&mut self, key: &[u8; 32], _prefix: (&[u8], Option<u8>)) {
+        let did_remove = self.tx.remove_foundation_commitment(*key).expect("failed to delete key");
+        debug_assert!(did_remove);
+    }
+}
+
+impl<DB> DataSource for WBotanixDatabaseProvider<DB>
+where
+    DB: Database,
+{
+    type Error = ProviderError;
+
+    fn insert_unassigned(
+        &mut self,
+        pegout: &PegoutId,
+        entry: UnassignedEntry,
+    ) -> Result<(), DataSourceError<Self::Error>> {
+        self.tx.insert_unassigned_pegout(*pegout, entry).map_err(Into::into)
+    }
+    fn get_unassigned(
+        &mut self,
+        pegout: &PegoutId,
+    ) -> Result<Option<UnassignedEntry>, DataSourceError<Self::Error>> {
+        self.tx.get_unassigned_pegout(*pegout).map_err(Into::into)
+    }
+    fn remove_unassigned(&mut self, pegout: &PegoutId) -> Result<(), DataSourceError<Self::Error>> {
+        self.tx.remove_unassigned_pegout(*pegout).map(|_| ()).map_err(Into::into)
+    }
+    fn insert_utxo(
+        &mut self,
+        utxo: &OutPoint,
+        entry: OnchainUtxoEntry,
+    ) -> Result<(), DataSourceError<Self::Error>> {
+        self.tx.insert_onchain_utxo(*utxo, entry).map_err(Into::into)
+    }
+    fn get_utxo(
+        &mut self,
+        utxo: &OutPoint,
+    ) -> Result<Option<OnchainUtxoEntry>, DataSourceError<Self::Error>> {
+        self.tx.get_onchain_utxo(*utxo).map_err(Into::into)
+    }
+    fn finalize_utxo(&mut self, utxo: &OutPoint) -> Result<(), DataSourceError<Self::Error>> {
+        self.tx.remove_onchain_utxo(*utxo).map(|_| ()).map_err(Into::into)
+    }
+    fn orphan_utxo(&mut self, utxo: &OutPoint) -> Result<(), DataSourceError<Self::Error>> {
+        self.tx.remove_onchain_utxo(*utxo).map(|_| ()).map_err(Into::into)
+    }
+    fn insert_header(
+        &mut self,
+        block: &BlockHash,
+        entry: OnchainHeaderEntry,
+    ) -> Result<(), DataSourceError<Self::Error>> {
+        self.tx.insert_onchain_header(*block, entry).map_err(Into::into)
+    }
+    fn get_header(
+        &mut self,
+        block: &BlockHash,
+    ) -> Result<Option<OnchainHeaderEntry>, DataSourceError<Self::Error>> {
+        self.tx.get_onchain_header(*block).map_err(Into::into)
+    }
+    fn remove_header(&mut self, block: &BlockHash) -> Result<(), DataSourceError<Self::Error>> {
+        self.tx.remove_onchain_header(*block).map(|_| ()).map_err(Into::into)
+    }
+    fn insert_pegout_proposal(
+        &mut self,
+        txid: &Txid,
+        entry: ProposalEntry,
+    ) -> Result<(), DataSourceError<Self::Error>> {
+        self.tx.insert_pegout_proposal(*txid, entry).map_err(Into::into)
+    }
+    fn get_proposal(
+        &mut self,
+        txid: &Txid,
+    ) -> Result<Option<ProposalEntry>, DataSourceError<Self::Error>> {
+        self.tx.get_pegout_proposal(*txid).map_err(Into::into)
+    }
+    fn finalize_proposal(&mut self, txid: &Txid) -> Result<(), DataSourceError<Self::Error>> {
+        self.tx.remove_pegout_proposal(*txid).map(|_| ()).map_err(Into::into)
+    }
+    fn orphan_proposal(&mut self, txid: &Txid) -> Result<(), DataSourceError<Self::Error>> {
+        self.tx.remove_pegout_proposal(*txid).map(|_| ()).map_err(Into::into)
+    }
+}

--- a/crates/botanix-foundation-layer/src/lib.rs
+++ b/crates/botanix-foundation-layer/src/lib.rs
@@ -1,0 +1,79 @@
+pub mod db_impl;
+
+#[cfg(test)]
+mod tests {
+    use super::db_impl::*;
+    use botanix_storage::{tables::create_botanix_tables, BotanixProviderFactory};
+    use botanix_tem::{
+        foundation::{Error, Foundation, ValidationError},
+        test_utils::*,
+    };
+    use reth_db::DatabaseEnv;
+    use std::sync::Arc;
+
+    #[test]
+    #[ignore]
+    fn foundation_test() {
+        // ## Setup database for data.
+        let mut db: DatabaseEnv =
+            reth_db::init_db("test_foundation_data.db", Default::default()).unwrap();
+        create_botanix_tables(&mut db).unwrap();
+
+        let factory = BotanixProviderFactory::new(Arc::new(db));
+        let data_layer: WBotanixProviderFactory<_> = factory.into();
+        dbg!("db setup");
+
+        // ## Setup database for trie commitments.
+        let mut db: DatabaseEnv =
+            reth_db::init_db("test_foundation_commits.db", Default::default()).unwrap();
+        create_botanix_tables(&mut db).unwrap();
+
+        let factory = BotanixProviderFactory::new(Arc::new(db));
+        let commit_layer: WBotanixProviderFactory<_> = factory.into();
+        dbg!("layers setup");
+
+        let block_a = gen_bitcoin_hash();
+        let block_b = gen_bitcoin_hash();
+        let block_c = gen_bitcoin_hash();
+
+        // FOUNDATION: Setup.
+        let mut f = Foundation::new(data_layer, commit_layer, block_a, 200, 0).unwrap();
+        dbg!("foundation setup");
+
+        let origin_root = f.commitment_root().unwrap();
+        dbg!("computed origin root");
+
+        // PROPOSE: Construct an invalid state transition.
+        let res_err = f
+            .propose_commitments(|c| {
+                // INVALID: block_hash: `B`, parent_hash: `C`
+                c.insert_bitcoin_header_unchecked(block_b, block_c, 201)?;
+                Ok(())
+            })
+            .unwrap_err();
+
+        dbg!("proposed commitments");
+
+        assert_eq!(res_err, Error::ValidationError(ValidationError::BadBitcoinHeader));
+
+        // Commitment state was RESET accordingly.
+        let current_root = f.commitment_root().unwrap();
+        assert_eq!(current_root, origin_root);
+
+        // FINALIZE: Finalize an invalid state transition.
+        let random_root = gen_foundation_state_root();
+        let res_err = f
+            .finalize_commitments(random_root, |c| {
+                // INVALID: block_hash: `B`, parent_hash: `C`
+                c.insert_bitcoin_header_unchecked(block_b, block_c, 201)?;
+                Ok(())
+            })
+            .unwrap_err();
+
+        assert_eq!(res_err, Error::ValidationError(ValidationError::BadBitcoinHeader));
+
+        // Commitment state was RESET accordingly.
+        let current_root = f.commitment_root().unwrap();
+        assert_eq!(current_root, origin_root);
+    }
+}

--- a/crates/botanix-storage/Cargo.toml
+++ b/crates/botanix-storage/Cargo.toml
@@ -26,12 +26,15 @@ reth-db-api = { workspace = true }
 reth-primitives = { workspace = true, features = ["reth-codec"] }
 reth-prune-types = { workspace = true }
 reth-storage-errors = { workspace = true }
-secp256k1 = { workspace = true, features = ["global-context", "rand-std", "recovery"] }
 
 serde = { workspace = true, default-features = false }
 sha2 = { workspace = true }
 tracing = { workspace = true }
 uuid = { version = "1.8.0", features = ["v4"] }
+
+# foundation layer
+botanix-tem = { git = "ssh://git@github.com/lamafab/botanix-tee.git", branch = "state-restruct" }
+ciborium = "0.2.1"
 
 [dev-dependencies]
 arbitrary = { workspace = true, features = ["derive"] }

--- a/crates/botanix-storage/src/lib.rs
+++ b/crates/botanix-storage/src/lib.rs
@@ -64,3 +64,141 @@ pub mod tables;
 pub mod test_utils;
 
 pub use provider::*;
+
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+/// Wrapper for any type that implements `Serialize` and `Deserialize` to be
+/// used as a generic MDBX key. This uses regular CBOR encoding without any
+/// special optimization.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UnoptimizedKey<T>(pub T);
+
+impl<T> From<T> for UnoptimizedKey<T> {
+    fn from(value: T) -> Self {
+        UnoptimizedKey(value)
+    }
+}
+
+/// Keys are de/serialized using the `Encode` and `Decode` traits.
+impl<T> reth_db_api::table::Encode for UnoptimizedKey<T>
+where
+    T: Send + Sync + Sized + std::fmt::Debug + Serialize,
+{
+    type Encoded = Vec<u8>;
+
+    fn encode(self) -> Self::Encoded {
+        let mut bytes = vec![];
+        ciborium::into_writer(&self.0, &mut bytes).expect("writer must not fail");
+        bytes
+    }
+}
+
+/// Keys are de/serialized using the `Encode` and `Decode` traits.
+impl<T> reth_db_api::table::Decode for UnoptimizedKey<T>
+where
+    T: Send + Sync + Sized + std::fmt::Debug + DeserializeOwned,
+{
+    fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, reth_db::DatabaseError> {
+        ciborium::from_reader::<T, _>(value.as_ref())
+            .map(UnoptimizedKey)
+            .map_err(|_| reth_db::DatabaseError::Decode)
+    }
+}
+
+// TODO: Actually need this?
+impl<T> PartialEq for UnoptimizedKey<T>
+where
+    T: Send + Sync + Sized + std::fmt::Debug + Serialize,
+{
+    fn eq(&self, other: &Self) -> bool {
+        let self_bytes = {
+            let mut bytes = vec![];
+            ciborium::into_writer(&self.0, &mut bytes).expect("serialization must not fail");
+            bytes
+        };
+
+        let other_bytes = {
+            let mut bytes = vec![];
+            ciborium::into_writer(&other.0, &mut bytes).expect("serialization must not fail");
+            bytes
+        };
+
+        self_bytes == other_bytes
+    }
+}
+
+// TODO: Actually need this?
+impl<T> Eq for UnoptimizedKey<T> where T: Send + Sync + Sized + std::fmt::Debug + Serialize {}
+
+// TODO: Actually need this?
+impl<T> PartialOrd for UnoptimizedKey<T>
+where
+    T: Send + Sync + Sized + std::fmt::Debug + Serialize,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+// TODO: Actually need this?
+impl<T> Ord for UnoptimizedKey<T>
+where
+    T: Send + Sync + Sized + std::fmt::Debug + Serialize,
+{
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        let self_bytes = {
+            let mut bytes = vec![];
+            ciborium::into_writer(&self.0, &mut bytes).expect("serialization must not fail");
+            bytes
+        };
+
+        let other_bytes = {
+            let mut bytes = vec![];
+            ciborium::into_writer(&other.0, &mut bytes).expect("serialization must not fail");
+            bytes
+        };
+
+        self_bytes.cmp(&other_bytes)
+    }
+}
+
+/// Wrapper for any type that implements `Serialize` and `Deserialize` to be
+/// used as a generic MDBX value. This uses regular CBOR encoding without any
+/// special optimization.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UnoptimizedValue<T>(pub T);
+
+impl<T> From<T> for UnoptimizedValue<T> {
+    fn from(value: T) -> Self {
+        UnoptimizedValue(value)
+    }
+}
+
+/// Values are de/serialized (“compressed”) using the `Compress` and
+/// `Decompress` traits.
+impl<T> reth_db_api::table::Compress for UnoptimizedValue<T>
+where
+    T: Send + Sync + Sized + std::fmt::Debug + Serialize,
+{
+    type Compressed = Vec<u8>;
+
+    fn compress_to_buf<B: bytes::BufMut + AsMut<[u8]>>(self, buf: &mut B) {
+        // TODO: Can this be improved?
+        let mut bytes = vec![];
+        ciborium::into_writer(&self.0, &mut bytes).expect("writer must not fail");
+        buf.put(bytes.as_slice());
+    }
+}
+
+/// Values are de/serialized (“compressed”) using the `Compress` and
+/// `Decompress` traits.
+impl<T> reth_db_api::table::Decompress for UnoptimizedValue<T>
+where
+    T: Send + Sync + Sized + std::fmt::Debug + DeserializeOwned,
+{
+    fn decompress<B: AsRef<[u8]>>(value: B) -> Result<Self, reth_db::DatabaseError> {
+        ciborium::from_reader::<T, _>(value.as_ref())
+            .map(UnoptimizedValue)
+            .map_err(|_| reth_db::DatabaseError::Decode)
+    }
+}

--- a/crates/botanix-storage/src/provider/database/factory.rs
+++ b/crates/botanix-storage/src/provider/database/factory.rs
@@ -6,9 +6,9 @@ use crate::{
     provider::database::provider::{
         BotanixDatabaseProvider, BotanixDatabaseProviderRO, BotanixDatabaseProviderRW,
     },
-    DatabaseProviderFactoryRO, DatabaseProviderFactoryRW, RuntimeTransitionsReadWrite,
-    SnapshotReader, SnapshotWriter, StagedHeaderReader, StagedHeaderWriter, WalletStateSyncReader,
-    WalletStateSyncWriter,
+    DatabaseProviderFactoryRO, DatabaseProviderFactoryRW, FoundationLayerReader,
+    FoundationLayerWriter, RuntimeTransitionsReadWrite, SnapshotReader, SnapshotWriter,
+    StagedHeaderReader, StagedHeaderWriter, WalletStateSyncReader, WalletStateSyncWriter,
 };
 use reth_db::{init_db, mdbx::DatabaseArguments, DatabaseEnv};
 use reth_db_api::database::Database;
@@ -247,6 +247,45 @@ impl<DB: Database> SnapshotReader for BotanixProviderFactory<DB> {
     #[inline(always)]
     fn get_first_chunk_id(&self) -> ProviderResult<Option<ChunkId>> {
         self.provider()?.get_first_chunk_id()
+    }
+}
+
+impl<DB: Database> FoundationLayerReader for BotanixProviderFactory<DB> {
+    #[inline(always)]
+    fn get_unassigned_pegout(
+        &self,
+        id: botanix_tem::validation::pegout::PegoutId,
+    ) -> ProviderResult<Option<botanix_tem::foundation::UnassignedEntry>> {
+        self.provider()?.get_unassigned_pegout(id)
+    }
+    #[inline(always)]
+    fn get_onchain_utxo(
+        &self,
+        utxo: botanix_tem::foundation::bitcoin::OutPoint,
+    ) -> ProviderResult<Option<botanix_tem::foundation::OnchainUtxoEntry>> {
+        self.provider()?.get_onchain_utxo(utxo)
+    }
+    #[inline(always)]
+    fn get_onchain_header(
+        &self,
+        header: botanix_tem::foundation::bitcoin::BlockHash,
+    ) -> ProviderResult<Option<botanix_tem::foundation::OnchainHeaderEntry>> {
+        self.provider()?.get_onchain_header(header)
+    }
+    #[inline(always)]
+    fn get_pegout_proposal(
+        &self,
+        txid: botanix_tem::foundation::bitcoin::Txid,
+    ) -> ProviderResult<Option<botanix_tem::foundation::ProposalEntry>> {
+        self.provider()?.get_pegout_proposal(txid)
+    }
+    #[inline(always)]
+    fn get_foundation_commitment(&self, key: [u8; 32]) -> ProviderResult<Option<Vec<u8>>> {
+        self.provider()?.get_foundation_commitment(key)
+    }
+    #[inline(always)]
+    fn get_foundation_commitment_root(&self) -> ProviderResult<Option<[u8; 32]>> {
+        self.provider()?.get_foundation_commitment_root()
     }
 }
 
@@ -547,6 +586,123 @@ impl<DB: Database> RuntimeTransitionsReadWrite for BotanixProviderFactory<DB> {
 
     fn get_last_runtime_version(&self) -> ProviderResult<Option<RuntimeVersion>> {
         self.provider_rw()?.get_last_runtime_version()
+    }
+}
+
+impl<DB: Database> FoundationLayerWriter for BotanixProviderFactory<DB> {
+    fn insert_unassigned_pegout(
+        &self,
+        id: botanix_tem::validation::pegout::PegoutId,
+        entry: botanix_tem::foundation::UnassignedEntry,
+    ) -> ProviderResult<()> {
+        let provider = self.provider_rw()?;
+        provider.insert_unassigned_pegout(id, entry)?;
+        provider.commit()?;
+        Ok(())
+    }
+    fn remove_unassigned_pegout(
+        &self,
+        id: botanix_tem::validation::pegout::PegoutId,
+    ) -> ProviderResult<bool> {
+        let provider = self.provider_rw()?;
+        let did_remove = provider.remove_unassigned_pegout(id)?;
+
+        if did_remove {
+            provider.commit()?;
+        }
+
+        Ok(did_remove)
+    }
+    fn insert_onchain_utxo(
+        &self,
+        utxo: botanix_tem::foundation::bitcoin::OutPoint,
+        entry: botanix_tem::foundation::OnchainUtxoEntry,
+    ) -> ProviderResult<()> {
+        let provider = self.provider_rw()?;
+        provider.insert_onchain_utxo(utxo, entry)?;
+        provider.commit()?;
+        Ok(())
+    }
+    fn remove_onchain_utxo(
+        &self,
+        utxo: botanix_tem::foundation::bitcoin::OutPoint,
+    ) -> ProviderResult<bool> {
+        let provider = self.provider_rw()?;
+        let did_remove = provider.remove_onchain_utxo(utxo)?;
+
+        if did_remove {
+            provider.commit()?;
+        }
+
+        Ok(did_remove)
+    }
+    fn insert_onchain_header(
+        &self,
+        header: botanix_tem::foundation::bitcoin::BlockHash,
+        entry: botanix_tem::foundation::OnchainHeaderEntry,
+    ) -> ProviderResult<()> {
+        let provider = self.provider_rw()?;
+        provider.insert_onchain_header(header, entry)?;
+        provider.commit()?;
+        Ok(())
+    }
+    fn remove_onchain_header(
+        &self,
+        header: botanix_tem::foundation::bitcoin::BlockHash,
+    ) -> ProviderResult<bool> {
+        let provider = self.provider_rw()?;
+        let did_remove = provider.remove_onchain_header(header)?;
+
+        if did_remove {
+            provider.commit()?;
+        }
+
+        Ok(did_remove)
+    }
+    fn insert_pegout_proposal(
+        &self,
+        txid: botanix_tem::foundation::bitcoin::Txid,
+        entry: botanix_tem::foundation::ProposalEntry,
+    ) -> ProviderResult<()> {
+        let provider = self.provider_rw()?;
+        provider.insert_pegout_proposal(txid, entry)?;
+        provider.commit()?;
+        Ok(())
+    }
+    fn remove_pegout_proposal(
+        &self,
+        txid: botanix_tem::foundation::bitcoin::Txid,
+    ) -> ProviderResult<bool> {
+        let provider = self.provider_rw()?;
+        let did_remove = provider.remove_pegout_proposal(txid)?;
+
+        if did_remove {
+            provider.commit()?;
+        }
+
+        Ok(did_remove)
+    }
+    fn insert_foundation_commitment(&self, key: [u8; 32], value: Vec<u8>) -> ProviderResult<()> {
+        let provider = self.provider_rw()?;
+        provider.insert_foundation_commitment(key, value)?;
+        provider.commit()?;
+        Ok(())
+    }
+    fn remove_foundation_commitment(&self, key: [u8; 32]) -> ProviderResult<bool> {
+        let provider = self.provider_rw()?;
+        let did_remove = provider.remove_foundation_commitment(key)?;
+
+        if did_remove {
+            provider.commit()?;
+        }
+
+        Ok(did_remove)
+    }
+    fn insert_foundation_commitment_root(&self, root: [u8; 32]) -> ProviderResult<()> {
+        let provider = self.provider_rw()?;
+        provider.insert_foundation_commitment_root(root)?;
+        provider.commit()?;
+        Ok(())
     }
 }
 

--- a/crates/botanix-storage/src/provider/database/foundation.rs
+++ b/crates/botanix-storage/src/provider/database/foundation.rs
@@ -1,0 +1,115 @@
+use crate::{
+    tables, BotanixDatabaseProvider, BotanixDatabaseProviderRW, FoundationLayerReader,
+    FoundationLayerWriter,
+};
+use botanix_tem::{
+    foundation::{
+        bitcoin::{BlockHash, OutPoint, Txid},
+        OnchainHeaderEntry, OnchainUtxoEntry, ProposalEntry, UnassignedEntry,
+    },
+    validation::pegout::PegoutId,
+};
+use reth_db_api::{
+    transaction::{DbTx, DbTxMut},
+    Database,
+};
+use reth_storage_errors::provider::ProviderResult;
+
+impl<TX: DbTx> FoundationLayerReader for BotanixDatabaseProvider<TX> {
+    fn get_unassigned_pegout(&self, id: PegoutId) -> ProviderResult<Option<UnassignedEntry>> {
+        Ok(self.tx.get::<tables::UnassignedPegouts>(id.into())?.map(|v| v.0))
+    }
+    fn get_onchain_utxo(&self, utxo: OutPoint) -> ProviderResult<Option<OnchainUtxoEntry>> {
+        Ok(self.tx.get::<tables::OnchainUtxos>(utxo.into())?.map(|v| v.0))
+    }
+    fn get_onchain_header(&self, header: BlockHash) -> ProviderResult<Option<OnchainHeaderEntry>> {
+        Ok(self.tx.get::<tables::OnchainHeaders>(header.into())?.map(|v| v.0))
+    }
+    fn get_pegout_proposal(&self, txid: Txid) -> ProviderResult<Option<ProposalEntry>> {
+        Ok(self.tx.get::<tables::PegoutProposals>(txid.into())?.map(|v| v.0))
+    }
+    fn get_foundation_commitment(&self, key: [u8; 32]) -> ProviderResult<Option<Vec<u8>>> {
+        Ok(self.tx.get::<tables::FoundationCommitments>(key.into())?.map(|v| v.0))
+    }
+    fn get_foundation_commitment_root(&self) -> ProviderResult<Option<[u8; 32]>> {
+        Ok(self.tx.get::<tables::FoundationCommitmentRoots>(().into())?.map(|v| v.0))
+    }
+}
+
+impl<DB: Database> FoundationLayerReader for BotanixDatabaseProviderRW<DB> {
+    #[inline(always)]
+    fn get_unassigned_pegout(&self, id: PegoutId) -> ProviderResult<Option<UnassignedEntry>> {
+        self.0.get_unassigned_pegout(id)
+    }
+    #[inline(always)]
+    fn get_onchain_utxo(&self, utxo: OutPoint) -> ProviderResult<Option<OnchainUtxoEntry>> {
+        self.0.get_onchain_utxo(utxo)
+    }
+    #[inline(always)]
+    fn get_onchain_header(&self, header: BlockHash) -> ProviderResult<Option<OnchainHeaderEntry>> {
+        self.0.get_onchain_header(header)
+    }
+    #[inline(always)]
+    fn get_pegout_proposal(&self, txid: Txid) -> ProviderResult<Option<ProposalEntry>> {
+        self.0.get_pegout_proposal(txid)
+    }
+    #[inline(always)]
+    fn get_foundation_commitment(&self, key: [u8; 32]) -> ProviderResult<Option<Vec<u8>>> {
+        self.0.get_foundation_commitment(key)
+    }
+    #[inline(always)]
+    fn get_foundation_commitment_root(&self) -> ProviderResult<Option<[u8; 32]>> {
+        self.0.get_foundation_commitment_root()
+    }
+}
+
+impl<DB: Database> FoundationLayerWriter for BotanixDatabaseProviderRW<DB> {
+    #[inline(always)]
+    fn insert_unassigned_pegout(&self, id: PegoutId, entry: UnassignedEntry) -> ProviderResult<()> {
+        self.tx.put::<tables::UnassignedPegouts>(id.into(), entry.into()).map_err(Into::into)
+    }
+    #[inline(always)]
+    fn remove_unassigned_pegout(&self, id: PegoutId) -> ProviderResult<bool> {
+        self.tx.delete::<tables::UnassignedPegouts>(id.into(), None).map_err(Into::into)
+    }
+    #[inline(always)]
+    fn insert_onchain_utxo(&self, utxo: OutPoint, entry: OnchainUtxoEntry) -> ProviderResult<()> {
+        self.tx.put::<tables::OnchainUtxos>(utxo.into(), entry.into()).map_err(Into::into)
+    }
+    #[inline(always)]
+    fn remove_onchain_utxo(&self, utxo: OutPoint) -> ProviderResult<bool> {
+        self.tx.delete::<tables::OnchainUtxos>(utxo.into(), None).map_err(Into::into)
+    }
+    #[inline(always)]
+    fn insert_onchain_header(
+        &self,
+        header: BlockHash,
+        entry: OnchainHeaderEntry,
+    ) -> ProviderResult<()> {
+        self.tx.put::<tables::OnchainHeaders>(header.into(), entry.into()).map_err(Into::into)
+    }
+    #[inline(always)]
+    fn remove_onchain_header(&self, header: BlockHash) -> ProviderResult<bool> {
+        self.tx.delete::<tables::OnchainHeaders>(header.into(), None).map_err(Into::into)
+    }
+    #[inline(always)]
+    fn insert_pegout_proposal(&self, txid: Txid, entry: ProposalEntry) -> ProviderResult<()> {
+        self.tx.put::<tables::PegoutProposals>(txid.into(), entry.into()).map_err(Into::into)
+    }
+    #[inline(always)]
+    fn remove_pegout_proposal(&self, txid: Txid) -> ProviderResult<bool> {
+        self.tx.delete::<tables::PegoutProposals>(txid.into(), None).map_err(Into::into)
+    }
+    #[inline(always)]
+    fn insert_foundation_commitment(&self, key: [u8; 32], value: Vec<u8>) -> ProviderResult<()> {
+        self.tx.put::<tables::FoundationCommitments>(key.into(), value.into()).map_err(Into::into)
+    }
+    #[inline(always)]
+    fn remove_foundation_commitment(&self, key: [u8; 32]) -> ProviderResult<bool> {
+        self.tx.delete::<tables::FoundationCommitments>(key.into(), None).map_err(Into::into)
+    }
+    #[inline(always)]
+    fn insert_foundation_commitment_root(&self, root: [u8; 32]) -> ProviderResult<()> {
+        self.tx.put::<tables::FoundationCommitmentRoots>(().into(), root.into()).map_err(Into::into)
+    }
+}

--- a/crates/botanix-storage/src/provider/database/mod.rs
+++ b/crates/botanix-storage/src/provider/database/mod.rs
@@ -33,6 +33,7 @@
 //! database errors in a consistent error type for proper error propagation.
 
 mod factory;
+mod foundation;
 mod provider;
 mod runtime_transitions;
 mod snapshot;
@@ -40,4 +41,5 @@ mod staged_header;
 mod wallet_state_sync;
 
 pub use factory::*;
+pub use foundation::*;
 pub use provider::*;

--- a/crates/botanix-storage/src/provider/traits/factory.rs
+++ b/crates/botanix-storage/src/provider/traits/factory.rs
@@ -1,6 +1,6 @@
 use crate::{
-    SnapshotReader, SnapshotWriter, StagedHeaderReader, StagedHeaderWriter, WalletStateSyncReader,
-    WalletStateSyncWriter,
+    FoundationLayerReader, FoundationLayerWriter, SnapshotReader, SnapshotWriter,
+    StagedHeaderReader, StagedHeaderWriter, WalletStateSyncReader, WalletStateSyncWriter,
 };
 use reth_storage_errors::provider::ProviderResult;
 
@@ -13,7 +13,10 @@ pub trait DatabaseProviderFactoryRO {
     /// The type of provider created by this factory.
     ///
     /// Must implement all reader traits for accessing Botanix storage data.
-    type Provider: WalletStateSyncReader + SnapshotReader + StagedHeaderReader;
+    type Provider: WalletStateSyncReader
+        + SnapshotReader
+        + StagedHeaderReader
+        + FoundationLayerReader;
 
     /// Creates a new read-only database provider.
     ///
@@ -44,7 +47,9 @@ pub trait DatabaseProviderFactoryRW {
         + SnapshotReader
         + SnapshotWriter
         + StagedHeaderWriter
-        + StagedHeaderReader;
+        + StagedHeaderReader
+        + FoundationLayerReader
+        + FoundationLayerWriter;
 
     /// Creates a new read-write database provider.
     ///

--- a/crates/botanix-storage/src/provider/traits/foundation.rs
+++ b/crates/botanix-storage/src/provider/traits/foundation.rs
@@ -1,0 +1,38 @@
+use botanix_tem::{
+    foundation::{
+        bitcoin::{BlockHash, OutPoint, Txid},
+        OnchainHeaderEntry, OnchainUtxoEntry, ProposalEntry, UnassignedEntry,
+    },
+    validation::pegout::PegoutId,
+};
+use reth_storage_errors::provider::ProviderResult;
+
+#[auto_impl::auto_impl(&, Arc, Box)]
+pub trait FoundationLayerReader: Send + Sync {
+    fn get_unassigned_pegout(&self, id: PegoutId) -> ProviderResult<Option<UnassignedEntry>>;
+    fn get_onchain_utxo(&self, utxo: OutPoint) -> ProviderResult<Option<OnchainUtxoEntry>>;
+    fn get_onchain_header(&self, header: BlockHash) -> ProviderResult<Option<OnchainHeaderEntry>>;
+    fn get_pegout_proposal(&self, txid: Txid) -> ProviderResult<Option<ProposalEntry>>;
+    // TODO: Rename those methods (incl. Table names!), should not contain "*foundation*".
+    fn get_foundation_commitment(&self, key: [u8; 32]) -> ProviderResult<Option<Vec<u8>>>;
+    fn get_foundation_commitment_root(&self) -> ProviderResult<Option<[u8; 32]>>;
+}
+
+#[auto_impl::auto_impl(&, Arc, Box)]
+pub trait FoundationLayerWriter: Send + Sync {
+    fn insert_unassigned_pegout(&self, id: PegoutId, entry: UnassignedEntry) -> ProviderResult<()>;
+    fn remove_unassigned_pegout(&self, id: PegoutId) -> ProviderResult<bool>;
+    fn insert_onchain_utxo(&self, utxo: OutPoint, entry: OnchainUtxoEntry) -> ProviderResult<()>;
+    fn remove_onchain_utxo(&self, utxo: OutPoint) -> ProviderResult<bool>;
+    fn insert_onchain_header(
+        &self,
+        header: BlockHash,
+        entry: OnchainHeaderEntry,
+    ) -> ProviderResult<()>;
+    fn remove_onchain_header(&self, header: BlockHash) -> ProviderResult<bool>;
+    fn insert_pegout_proposal(&self, txid: Txid, entry: ProposalEntry) -> ProviderResult<()>;
+    fn remove_pegout_proposal(&self, txid: Txid) -> ProviderResult<bool>;
+    fn insert_foundation_commitment(&self, key: [u8; 32], value: Vec<u8>) -> ProviderResult<()>;
+    fn remove_foundation_commitment(&self, key: [u8; 32]) -> ProviderResult<bool>;
+    fn insert_foundation_commitment_root(&self, root: [u8; 32]) -> ProviderResult<()>;
+}

--- a/crates/botanix-storage/src/provider/traits/mod.rs
+++ b/crates/botanix-storage/src/provider/traits/mod.rs
@@ -18,6 +18,7 @@
 
 mod activation_manager;
 mod factory;
+mod foundation;
 mod runtime_transitions;
 mod snapshot;
 mod staged_header;
@@ -25,6 +26,7 @@ mod wallet_state_sync;
 
 pub use activation_manager::*;
 pub use factory::*;
+pub use foundation::*;
 pub use runtime_transitions::*;
 pub use snapshot::*;
 pub use staged_header::*;

--- a/crates/botanix-storage/src/tables.rs
+++ b/crates/botanix-storage/src/tables.rs
@@ -27,10 +27,42 @@
 //! type-safe access to the underlying MDBX database with automatic serialization
 //! and deserialization of complex data structures.
 
-use super::models::*;
-use reth_db::{tables, TableType, TableViewer};
+use super::{models::*, UnoptimizedKey, UnoptimizedValue};
+use botanix_tem::{
+    foundation::{
+        bitcoin::{BlockHash, OutPoint, Txid},
+        OnchainHeaderEntry, OnchainUtxoEntry, ProposalEntry, UnassignedEntry,
+    },
+    validation::pegout::PegoutId,
+};
+use reth_db::{mdbx::DatabaseFlags, tables, DatabaseEnv, DatabaseError, TableType, TableViewer};
 use reth_primitives::{BlockNumber, B256};
 use std::fmt;
+
+/// Creates all the Botanix-specific tables as defined in [`Tables`], if necessary.
+///
+/// This replicates the logic of [`reth_db::DatabaseEnv::create_tables`].
+pub fn create_botanix_tables(db: &mut DatabaseEnv) -> Result<(), DatabaseError> {
+    let tx = db.begin_rw_txn().map_err(|e| DatabaseError::InitTx(e.into()))?;
+
+    for table in crate::tables::Tables::ALL {
+        let flags = match table.table_type() {
+            TableType::Table => DatabaseFlags::default(),
+            TableType::DupSort => DatabaseFlags::DUP_SORT,
+        };
+
+        tx.create_db(Some(table.name()), flags)
+            .map_err(|e| DatabaseError::CreateTable(e.into()))?;
+    }
+
+    tx.commit().map_err(|e| DatabaseError::Commit(e.into()))?;
+
+    Ok(())
+}
+
+// Aliases for better readability
+type UKey<T> = UnoptimizedKey<T>;
+type UVal<T> = UnoptimizedValue<T>;
 
 tables! {
     /// Store snapshot id to snapshot data.
@@ -83,4 +115,23 @@ tables! {
     /// Tracks the progress of snapshot synchronization operations,
     /// including total chunks, applied chunks, and synchronization state.
     table SnapshotSyncs<Key = SnapshotSyncId, Value = SnapshotSync>;
+
+    /// Table used for unassigned pegouts (foundation layer).
+    table UnassignedPegouts<Key = UKey<PegoutId>, Value = UVal<UnassignedEntry>>;
+
+    /// Table used for onchain utxos (foundation layer).
+    table OnchainUtxos<Key = UKey<OutPoint>, Value = UVal<OnchainUtxoEntry>>;
+
+    /// Table used for onchain headers (foundation layer).
+    table OnchainHeaders<Key = UKey<BlockHash>, Value = UVal<OnchainHeaderEntry>>;
+
+    /// Table used for pegout proposals (foundation layer).
+    table PegoutProposals<Key = UKey<Txid>, Value = UVal<ProposalEntry>>;
+
+    /// Table used for trie commitments (foundation layer).
+    // TODO: Maybe the TEM should export `StorageKey` and `StorageValue`?
+    table FoundationCommitments<Key = UKey<[u8; 32]>, Value = UVal<Vec<u8>>>;
+
+    /// Table used for the trie commitment root (foundation layer).
+    table FoundationCommitmentRoots<Key = UKey<()>, Value = UVal<[u8; 32]>>;
 }


### PR DESCRIPTION
**FYI**: All the CI errors are related to `Cargo.toml` still pulling from a private repo `botanix-tem = { git = "ssh://git@github.com/lamafab/botanix-tee.git", branch = "state-restruct" }`.

***

Implements the necessary changes to interact with the `Foundation` structure: https://github.com/botanix-labs/tem/pull/4

The current draft implements the necessary types and traits such that all the data storage and Trie operations work with our existing `BotanixProviderFactory` and `BotanixDatabaseProvider` structures.

Also, as mentioned in internal comms, the current `botanix-storage` crate still relies on the predefined, upstream tables from the Reth crate. Our custom `Tables` are completely ignored. So I added this convenience function such that we do not have to modify anything upstream:

```rust
// In: crates/botanix-storage/src/tables.rs

/// Creates all the Botanix-specific tables as defined in [`Tables`], if necessary.
///
/// This replicates the logic of [`reth_db::DatabaseEnv::create_tables`].
pub fn create_botanix_tables(db: &mut DatabaseEnv) -> Result<(), DatabaseError> {
    let tx = db.begin_rw_txn().map_err(|e| DatabaseError::InitTx(e.into()))?;

    for table in crate::tables::Tables::ALL {
        let flags = match table.table_type() {
            TableType::Table => DatabaseFlags::default(),
            TableType::DupSort => DatabaseFlags::DUP_SORT,
        };

        tx.create_db(Some(table.name()), flags)
            .map_err(|e| DatabaseError::CreateTable(e.into()))?;
    }

    tx.commit().map_err(|e| DatabaseError::Commit(e.into()))?;

    Ok(())
}
```

Additionally, I added two types for storing generic keys and values into the MDBX database without requiring us to add all the encoding/decoding by hand.

```rust
// In: crates/botanix-storage/src/lib.rs

/// Wrapper for any type that implements `Serialize` and `Deserialize` to be
/// used as a generic MDBX key. This uses regular CBOR encoding without any
/// special optimization.
#[derive(Debug, Clone, Serialize, Deserialize)]
pub struct UnoptimizedKey<T>(pub T);

// ...

/// Wrapper for any type that implements `Serialize` and `Deserialize` to be
/// used as a generic MDBX value. This uses regular CBOR encoding without any
/// special optimization.
#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
pub struct UnoptimizedValue<T>(pub T);
```

More info on current state and next steps are soon to come.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced foundation layer data persistence infrastructure, enabling storage and transactional management of blockchain commitments, UTXOs, onchain headers, and pegout proposals.
  * Added atomic transaction support for foundation layer operations with rollback capabilities.
  * Expanded storage system with new database tables and unified data access interfaces for foundation layer components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->