### PR TITLE
fix(pegout-scheduler): remove tracked tx if broadcast fails

### DIFF
--- a/bin/btc-server/src/bin/main.rs
+++ b/bin/btc-server/src/bin/main.rs
@@ -1392,6 +1392,10 @@ where
                                 self.config.identifier,
                             );
                         }
+
+                        let mut lock = self.pegout_scheduler.lock().await;
+                        lock.un_track_tx(&tx.compute_txid()).to_status()?;
+
                         Err(CoordinatorError::FailedToBroadcastTx(err))
                     }
                     _ => {
@@ -1403,6 +1407,10 @@ where
                                 self.config.identifier,
                             );
                         }
+
+                        let mut lock = self.pegout_scheduler.lock().await;
+                        lock.un_track_tx(&tx.compute_txid()).to_status()?;
+
                         Err(CoordinatorError::FailedToBroadcastTx(err))
                     }
                 }

--- a/bin/btc-server/src/bin/main.rs
+++ b/bin/btc-server/src/bin/main.rs
@@ -22,7 +22,7 @@ use btc_server_client::jwt::{JwtError, JwtSecret};
 use btcserverlib::{
     badarg,
     config::{Config, Error as ConfigError, GrpcConfig, TomlConfig},
-    coordinator::{self, error::CoordinatorError},
+    coordinator::{self},
     database::{self},
     dkg,
     federation_args::FederationTomlConfig,
@@ -1374,49 +1374,13 @@ where
                         self.config.identifier,
                     );
                 }
-                Ok(Some(tx_id))
+                Some(tx_id)
             }
             Err(err) => {
-                let err_msg = err.to_string();
-                match err_msg.as_str() {
-                    msg if msg.contains("already in chain") => {
-                        info!("Transaction already in chain, skipping");
-                        Ok(None)
-                    }
-                    msg if msg.contains("bad-txns-inputs-missingorspent") => {
-                        error!("Invalid input detected: {}", msg);
-                        self.handle_invalid_inputs(&tx).to_status()?;
-                        if let Some(telemetry) = self.telemetry.as_ref() {
-                            telemetry.increment_failed_broadcasted_pegout_txs_count(
-                                self.btc_network,
-                                self.config.identifier,
-                            );
-                        }
-
-                        let mut lock = self.pegout_scheduler.lock().await;
-                        lock.un_track_tx(&tx.compute_txid()).to_status()?;
-
-                        Err(CoordinatorError::FailedToBroadcastTx(err))
-                    }
-                    _ => {
-                        error!("Failed to broadcast transaction: {}", err_msg);
-                        error!("Failed tx: {:?}", tx);
-                        if let Some(telemetry) = self.telemetry.as_ref() {
-                            telemetry.increment_failed_broadcasted_pegout_txs_count(
-                                self.btc_network,
-                                self.config.identifier,
-                            );
-                        }
-
-                        let mut lock = self.pegout_scheduler.lock().await;
-                        lock.un_track_tx(&tx.compute_txid()).to_status()?;
-
-                        Err(CoordinatorError::FailedToBroadcastTx(err))
-                    }
-                }
+                self.handle_broadcast_error(err, &tx).await?;
+                None
             }
-        }
-        .to_status()?;
+        };
 
         // set last attempted pegout height
         if let Some(telemetry) = self.telemetry.as_ref() {
@@ -2385,6 +2349,52 @@ impl<BitcoindClient: bitcoincore_rpc::RpcApi> App<BitcoindClient> {
         }
         Ok(())
     }
+
+    async fn handle_broadcast_error(
+        &self,
+        err: bitcoincore_rpc::Error,
+        tx: &Transaction,
+    ) -> Result<(), tonic::Status> {
+        let err_msg = err.to_string();
+        match err_msg.as_str() {
+            msg if msg.contains("already in chain") => {
+                warn!("Transaction already in chain, skipping");
+                return Ok(());
+            }
+            msg if msg.contains("bad-txns-inputs-missingorspent") => {
+                error!("Invalid input detected: {}", msg);
+                self.handle_invalid_inputs(&tx).to_status()?;
+
+                let mut lock = self.pegout_scheduler.lock().await;
+                lock.un_track_tx(&tx.compute_txid()).to_status()?;
+                drop(lock);
+
+                if let Some(telemetry) = self.telemetry.as_ref() {
+                    telemetry.increment_failed_broadcasted_pegout_txs_count(
+                        self.btc_network,
+                        self.config.identifier,
+                    );
+                }
+                return Err(tonic::Status::internal("Failed to broadcast tx"));
+            }
+            _ => {
+                error!("Failed to broadcast transaction: {}", err_msg);
+                error!("Failed tx: {:?}", tx);
+
+                let mut lock = self.pegout_scheduler.lock().await;
+                lock.un_track_tx(&tx.compute_txid()).to_status()?;
+                drop(lock);
+
+                if let Some(telemetry) = self.telemetry.as_ref() {
+                    telemetry.increment_failed_broadcasted_pegout_txs_count(
+                        self.btc_network,
+                        self.config.identifier,
+                    );
+                }
+                return Err(tonic::Status::internal("Failed to broadcast tx"));
+            }
+        }
+    }
 }
 
 #[tokio::main]
@@ -2530,7 +2540,10 @@ async fn main() -> anyhow::Result<(), Box<dyn std::error::Error>> {
 #[cfg(test)]
 mod tests {
     use bitcoin::{secp256k1, OutPoint, Script, Txid};
-    use btcserverlib::{dkg::DkgMessage, wallet::address::generate_taproot_change_scriptpubkey};
+    use btcserverlib::{
+        dkg::DkgMessage, test_utils::pegout_requests_from_tx,
+        wallet::address::generate_taproot_change_scriptpubkey,
+    };
     use frost_secp256k1_tr::keys::dkg::round1;
     use rand::{thread_rng, Rng};
     use std::{str::FromStr, vec};
@@ -3393,5 +3406,71 @@ mod tests {
         let utxos = app.db.get_all_utxos().unwrap();
         assert_eq!(utxos.len(), 1);
         assert_eq!(utxos[0].outpoint, existing_outpoint);
+    }
+
+    #[tokio::test]
+    async fn test_broadcast_failure_untracks_tx() {
+        let app = setup().await;
+
+        // Set up a tracked transaction
+        let mut rng = thread_rng();
+        let tx = create_test_transaction(vec![create_random_outpoint(&mut rng)]);
+        let pegouts = pegout_requests_from_tx(&tx, &[0]);
+
+        // Add the tx to pegout_scheduler
+        let mut lock = app.pegout_scheduler.lock().await;
+        lock.add_tx(tx.clone(), &pegouts, SystemTime::now());
+        assert_eq!(lock.txs.len(), 1); // Verify it's tracked
+        drop(lock);
+
+        // Create an RPC error
+        use bitcoincore_rpc::jsonrpc;
+        let rpc_err = jsonrpc::Error::Rpc(jsonrpc::error::RpcError {
+            code: -26,
+            message: "minrelaytxfee too low".to_string(),
+            data: None,
+        });
+        let err = bitcoincore_rpc::Error::JsonRpc(rpc_err);
+
+        // should return error and untrack tx
+        let result = app.handle_broadcast_error(err, &tx).await;
+        assert!(result.is_err());
+
+        // Verify the tx was untracked
+        let lock = app.pegout_scheduler.lock().await;
+        assert_eq!(lock.txs.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_broadcast_failure_already_in_chain() {
+        let app = setup().await;
+
+        // Set up a tracked transaction
+        let mut rng = thread_rng();
+        let tx = create_test_transaction(vec![create_random_outpoint(&mut rng)]);
+        let pegouts = pegout_requests_from_tx(&tx, &[0]);
+
+        // Add the tx to pegout_scheduler
+        let mut lock = app.pegout_scheduler.lock().await;
+        lock.add_tx(tx.clone(), &pegouts, SystemTime::now());
+        assert_eq!(lock.txs.len(), 1); // Verify it's tracked
+        drop(lock);
+
+        // Create an "already in chain" error
+        use bitcoincore_rpc::jsonrpc;
+        let rpc_err = jsonrpc::Error::Rpc(jsonrpc::error::RpcError {
+            code: -26,
+            message: "already in chain".to_string(),
+            data: None,
+        });
+        let err = bitcoincore_rpc::Error::JsonRpc(rpc_err);
+
+        // should not return error and not untrack tx
+        let result = app.handle_broadcast_error(err, &tx).await;
+        assert!(result.is_ok());
+
+        // Verify the tx was NOT untracked
+        let lock = app.pegout_scheduler.lock().await;
+        assert_eq!(lock.txs.len(), 1);
     }
 }

--- a/bin/btc-server/src/pegout_scheduler/mod.rs
+++ b/bin/btc-server/src/pegout_scheduler/mod.rs
@@ -405,7 +405,7 @@ impl PegoutScheduler {
     /// Note: Technically we should not untrack a tx simply because it was dropped from our local
     /// mempool, as it may still be in other nodes mempools and could still get confirmed.
     /// Leaving this as-is for now as it'll be resolved with the new TEM implementation.
-    fn un_track_tx(&mut self, txid: &Txid) -> Result<(), database::Error> {
+    pub fn un_track_tx(&mut self, txid: &Txid) -> Result<(), database::Error> {
         let tx = self.txs.get(txid).expect("relevant tx should exist");
         info!("PegoutScheduler::un_track_tx: Untracking txid={}", txid);
         for input in tx.inputs() {

--- a/bin/btc-server/src/pegout_scheduler/mod.rs
+++ b/bin/btc-server/src/pegout_scheduler/mod.rs
@@ -208,7 +208,7 @@ pub struct PegoutScheduler {
     /// be added to the UTXO set as a spendable output
     /// If a tracked tx is reorged or dropped from the mempool the application must
     /// Add the non-change outputs back to the pending pegouts set.
-    txs: HashMap<Txid, Tx>,
+    pub txs: HashMap<Txid, Tx>,
     /// A mapping of input to the txs that spend them.
     /// This is used to detect when a tracked tx is reorged or dropped from the mempool.
     txs_by_input: HashMap<OutPoint, Vec<Txid>>,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
https://github.com/botanix-labs/botanix/issues/1128

## What was done?

<!--- Describe your changes in detail -->

If broadcasting a transaction with bitcoind fails ( but not because of 'already in chain'), we should un-track the txid as it's not on chain. It still remains in the pending_pegout list though and will be retried.

The `finalize_signing` method is a bit big so I broke out the handling of failed broadcasts to a new helper method.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- unit tests

## Breaking Changes

<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

- None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] I have added or updated relevant unit/integration/functional/e2e tests
-   [ ] I have tested my changes running a local network, and they work as expected
-   [x] I have performed a self-review
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
-   [x] I have made corresponding changes to the documentation if needed
-   [x] I have added assignees and reviewers to this pull request
-   [x] I have added the PR to the project board or linked it to an issue from the board


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction broadcast error handling: scheduler entries are now cleaned up on failed broadcasts, invalid-input broadcasts trigger proper cleanup and telemetry, while transactions already confirmed are skipped without untracking to avoid accidental removal.
* **Tests**
  * Added tests covering broadcast failure paths to ensure correct untracking behavior and telemetry updates across different error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->